### PR TITLE
Phase A: first runnable container that calls claude -p

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to `.env` and fill in the value below, OR delete the
+# .env requirement entirely and use the mounted-credentials auth mode
+# documented in docker-compose.yml.
+
+ANTHROPIC_API_KEY=

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,51 @@
+name: Publish Docker image
+
+# Builds the robotsix-cai container and publishes it to Docker Hub at
+# docker.io/robotsix/cai. Triggers on every push to main and on manual
+# dispatch. Pull requests do NOT trigger this workflow so the PR build
+# stays green even before DOCKERHUB_USERNAME / DOCKERHUB_TOKEN secrets
+# are configured on the repo.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: docker.io/robotsix/cai
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Phase A — first runnable container.
+#
+# Base image is python:3.12-slim. Node.js is installed via apt so we can
+# install the @anthropic-ai/claude-code CLI globally. The backend itself
+# is plain Python (stdlib only at this stage) and shells out to `claude -p`
+# in autonomous mode.
+
+FROM python:3.12-slim
+
+# Pin the claude-code version so the self-improvement loop is reproducible.
+# Bumping this should be a deliberate, reviewed change.
+ARG CLAUDE_CODE_VERSION=2.1.96
+
+# Install Node.js (Bookworm slim ships Node 18, which satisfies claude-code's
+# >=18 requirement) plus npm, then install claude-code globally.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        nodejs \
+        npm \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && claude --version
+
+WORKDIR /app
+COPY cai.py /app/cai.py
+
+CMD ["python", "/app/cai.py"]

--- a/README.md
+++ b/README.md
@@ -42,8 +42,59 @@ milestone.
 
 ## Quick start
 
-(Coming as part of v0 development — see the
-[tracking issue](https://github.com/damien-robotsix/robotsix-cai/issues/1).)
+At Phase A the container is a single-shot smoke test: it invokes
+`claude -p "Say hello in one short sentence."` and prints the response to
+the docker logs. Real analyzer behavior lands in later phases (see the
+[tracking issue](https://github.com/damien-robotsix/robotsix-cai/issues/1)).
+
+### Run the published image (server-style)
+
+```bash
+docker compose pull
+docker compose up
+```
+
+The image at `docker.io/robotsix/cai:latest` is published from this repo on
+every push to `main` (see [`.github/workflows/docker-publish.yml`](.github/workflows/docker-publish.yml)).
+
+### Build and run from source (local dev)
+
+```bash
+git clone git@github.com:damien-robotsix/robotsix-cai.git
+cd robotsix-cai
+docker compose build
+docker compose up
+```
+
+### Authentication — pick one
+
+`claude -p` accepts either an API key in the environment **or** a mounted
+OAuth credentials file from the host. Pick whichever is more convenient.
+
+**Option A — API key in `.env`:**
+
+```bash
+cp .env.example .env
+echo 'ANTHROPIC_API_KEY=sk-ant-...' > .env
+docker compose up
+```
+
+**Option B — mounted OAuth credentials (preferred for self-hosted):**
+
+If you've already run `claude login` interactively on the host, the file
+`~/.claude/.credentials.json` exists and `docker-compose.yml` can mount it
+into the container read-only. Open `docker-compose.yml` and uncomment the
+`volumes:` block. With this mode, no `ANTHROPIC_API_KEY` is needed and no
+static secret is held in the container's environment.
+
+### Expected output
+
+```
+Hello! How can I help you today?
+```
+
+(Or similar — the exact response varies. Any non-empty Claude response in
+the logs means the runtime envelope is working.)
 
 ## License
 

--- a/cai.py
+++ b/cai.py
@@ -1,0 +1,24 @@
+"""Phase A entry point.
+
+The smallest meaningful thing this backend can do: invoke `claude -p` once
+with a trivial prompt and let the response flow to docker logs. This proves
+the runtime envelope (Python, Node, claude-code, container auth) works
+end-to-end before any analyzer logic is added.
+
+No third-party Python dependencies — only stdlib `subprocess`.
+"""
+
+import subprocess
+import sys
+
+
+def main() -> int:
+    result = subprocess.run(
+        ["claude", "-p", "Say hello in one short sentence."],
+        check=False,
+    )
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+# Phase A — runs the first-runnable-container locally or on the server.
+#
+# Two ways to use this file:
+#
+#   * Local development: `docker compose build && docker compose up`
+#     builds the image from the Dockerfile in this directory.
+#
+#   * Self-hosted server: `docker compose pull && docker compose up -d`
+#     pulls the published image from Docker Hub (robotsix/cai:latest).
+#
+# Two auth modes (pick one — see README for details):
+#
+#   * .env file with ANTHROPIC_API_KEY (default below)
+#   * Mounted ~/.claude/.credentials.json from the host (uncomment below)
+
+services:
+  cai:
+    image: robotsix/cai:latest
+    build: .
+    env_file:
+      - .env
+    # Uncomment the volumes block to use OAuth credentials from the host
+    # instead of an API key. Requires `claude login` to have been run on
+    # the host so the credentials file already exists. When this is in
+    # use, ANTHROPIC_API_KEY in .env is unnecessary.
+    #
+    # volumes:
+    #   - ${HOME}/.claude/.credentials.json:/root/.claude/.credentials.json:ro


### PR DESCRIPTION
## Summary

First runnable container for `robotsix-cai`. The smallest meaningful thing the backend can do at this stage: invoke `claude -p` once with a trivial prompt and print the response to docker logs. This validates the entire runtime envelope (Python, Node, `claude-code`, container auth, docker-compose, Docker Hub publish workflow) before any analyzer logic is added.

## What's in this PR

- **`Dockerfile`** — `python:3.12-slim` base, installs Node.js + npm via apt, installs `@anthropic-ai/claude-code@2.1.96` (pinned) via `npm install -g`. Single Python file copied in. Stdlib only — no `pyproject.toml`, no third-party Python deps.
- **`cai.py`** — ~10 lines using stdlib `subprocess` to call `claude -p "Say hello in one short sentence."` and let stdout flow to docker logs.
- **`docker-compose.yml`** — `image: robotsix/cai:latest` + `build: .` so the same file works for local dev (builds from source) and the self-hosted server (pulls from Docker Hub). Two auth modes documented:
  - `env_file: .env` for `ANTHROPIC_API_KEY` (default, uncommented)
  - Mounted `${HOME}/.claude/.credentials.json` volume (commented stanza, preferred for self-hosted use because no static secret lives in the container env)
- **`.env.example`** — one entry: `ANTHROPIC_API_KEY=`
- **`README.md`** — quick-start section covering both auth modes and both run paths (build local / pull from Docker Hub)
- **`.github/workflows/docker-publish.yml`** — builds and publishes to `docker.io/robotsix/cai` on push to `main` and on `workflow_dispatch`. **Does not** trigger on pull requests, so this PR's CI stays green even before Docker Hub secrets are configured.

## Validation

Both validations were performed locally before pushing:

- ✅ `docker build` completes end-to-end. The `RUN` step's final `claude --version` confirms the CLI installed correctly inside the image.
- ✅ `docker compose up` with the credentials volume mount produces a real Claude response in the logs (`Hello! How can I help you today?`) and the container exits cleanly with code 0.

## Action required before merging

Add two repository secrets so the publish workflow can push to Docker Hub:

1. `DOCKERHUB_USERNAME` = `robotsix`
2. `DOCKERHUB_TOKEN` = a Docker Hub access token (https://hub.docker.com/settings/security)

Without these, the publish workflow will fail on the first push to `main` after merge — but nothing else breaks.

## Smoke test on your server

After merge + the publish workflow's first successful run, you should be able to:

```bash
git clone git@github.com:damien-robotsix/robotsix-cai.git
cd robotsix-cai
docker compose pull       # pulls robotsix/cai:latest from Docker Hub
# pick one auth mode (see README), then:
docker compose up
```

Expected output: `cai-1  | Hello! How can I help you today?` (or similar) and the container exits with code 0.

## Next steps (Phase B)

Mount `${HOME}/.claude/projects/` into the container so claude-code's session JSONL files persist and become readable by future analyzer code. See [robotsix-cai#1](https://github.com/damien-robotsix/robotsix-cai/issues/1) for the full phased plan.

Refs damien-robotsix/robotsix-cai#1
