### PR TITLE
docs: add Jekyll docs site deployed from /docs folder

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,13 @@
+title: robotsix-cai
+description: Claude Auto Improve — a self-tuning Claude Code analysis backend
+remote_theme: just-the-docs/just-the-docs
+
+# GitHub Pages project site — baseurl is the repo name; url is the
+# user.github.io host. Both are needed for assets and internal links to
+# resolve correctly.
+url: https://damien-robotsix.github.io
+baseurl: /robotsix-cai
+
+# Header link to the source repository
+aux_links:
+  GitHub: https://github.com/damien-robotsix/robotsix-cai

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,47 @@
+---
+title: Home
+---
+
+# robotsix-cai
+
+**Claude Auto Improve** — a self-tuning backend that analyzes its own
+[Claude Code](https://docs.claude.com/en/docs/claude-code/overview)
+runtime sessions and proposes improvements to itself via pull requests.
+
+## Status
+
+**Pre-alpha.** v0 (Lane 1 — self-improvement only) is under active
+development. This documentation will grow as the project matures.
+
+- [v0 development tracker](https://github.com/damien-robotsix/robotsix-cai/issues/1)
+- [Architectural design RFC](https://github.com/damien-robotsix/claude-auto-tune-hub/issues/51)
+- [GitHub repository](https://github.com/damien-robotsix/robotsix-cai)
+
+## What it does
+
+robotsix-cai runs as a long-lived service in a Docker container. On a
+schedule, it:
+
+1. Reads transcripts of its own recent Claude Code runtime sessions
+2. Analyzes them with a Claude prompt to find bugs, inefficiencies, and
+   prompt gaps in its own code
+3. Files issues (and, where confident, opens pull requests) in this
+   repository
+4. After human review and merge, the deploy pipeline rolls out the
+   improvement
+5. The next run uses the improved code, closing the loop
+
+This is **Lane 1** of a two-lane design described in the RFC. Lane 2
+(analyzing other workspaces' Claude Code sessions) is deferred to a
+later milestone.
+
+## Quick start
+
+See the
+[README on GitHub](https://github.com/damien-robotsix/robotsix-cai#readme)
+for the current setup instructions. As v0 stabilizes, those will move
+into a dedicated section here.
+
+## License
+
+[MIT](https://github.com/damien-robotsix/robotsix-cai/blob/main/LICENSE)


### PR DESCRIPTION
## Summary

Adds a documentation site published to GitHub Pages at **https://damien-robotsix.github.io/robotsix-cai/** using the simplest possible mechanism: GitHub Pages' deploy-from-folder mode with [just-the-docs](https://just-the-docs.com/) as a remote Jekyll theme. **No build workflow.** Push Markdown to `docs/`, GitHub auto-builds Jekyll, done.

Independent of damien-robotsix/robotsix-cai#2 (Phase A) — both PRs can land in any order.

## What's in this PR

- **`docs/_config.yml`** — minimal Jekyll config (~10 lines): site title, description, `remote_theme: just-the-docs/just-the-docs`, project-site `baseurl`/`url`, one aux link to the GitHub repo
- **`docs/index.md`** — landing page with Jekyll front matter (`title: Home`), summarizing the project, status, and links to the GitHub repo, the v0 tracker (damien-robotsix/robotsix-cai#1), and the design RFC (damien-robotsix/claude-auto-tune-hub#51)

## Why deploy-from-folder instead of MkDocs Material + Actions

The first version of this PR set up MkDocs Material with a GitHub Actions workflow. That's overkill for a one-page docs site:

| | Deploy from `/docs` (this PR) | MkDocs Material + Actions (previous version) |
|---|---|---|
| Workflow file | None | 60-line `docs.yml` |
| Build config | `_config.yml` (~10 lines) | `mkdocs.yml` |
| CI minutes per push | Zero | A few seconds per push |
| Theme | just-the-docs (purpose-built for project docs) | Material |
| Lean scaffolding | ✅ minimal | ❌ premature |

Material is great, but until the docs site has more than one page and actually exercises the features, it's not justified. just-the-docs gives us search, nav, and callouts when we eventually add more pages — and the migration cost to Material later is one PR if needed.

## ⚠️ Action required before the first deploy

GitHub Pages needs to be told to deploy from `/docs` on the `main` branch. **One-time manual step in the GitHub UI:**

1. Open https://github.com/damien-robotsix/robotsix-cai/settings/pages
2. Under **Build and deployment → Source**, choose **Deploy from a branch**
3. Branch: **`main`** — Folder: **`/docs`**
4. Click **Save**

You can do this either before or after merging:

- **Before merge:** the moment this PR lands on `main`, GitHub auto-builds and serves it
- **After merge:** flip the setting and the next push (or a manual trigger) will deploy

## What this PR does NOT include

- **README link to the docs site** — deferred until after the first deploy is verified live, so the link isn't dead on day one
- **More than one docs page** — lean scaffolding. New pages get added as the project grows
- **Custom CSS, search config, callouts, dark mode** — all available in just-the-docs, none configured until content needs them

## Next steps after merge

1. Configure Pages source to "Deploy from a branch → main → /docs" (if not already)
2. Wait ~30 seconds for GitHub Pages to publish
3. Verify the site renders at https://damien-robotsix.github.io/robotsix-cai/
4. Tiny follow-up PR adds a "Documentation" link to the README pointing at the live site

Refs damien-robotsix/robotsix-cai#1
