### PR TITLE
docs: add server quickstart with one-line docker run smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,29 +47,53 @@ At Phase A the container is a single-shot smoke test: it invokes
 the docker logs. Real analyzer behavior lands in later phases (see the
 [tracking issue](https://github.com/damien-robotsix/robotsix-cai/issues/1)).
 
-### Run the published image (server-style)
+### Smoke test on a fresh server (one `docker run`, no clone)
+
+The fastest way to verify the published image works on your server.
+The image is published to Docker Hub on every push to `main`, so a single
+`docker run` is enough — no repo clone, no `docker-compose.yml`.
+
+**With an API key:**
 
 ```bash
-docker compose pull
-docker compose up
+docker run --rm \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  robotsix/cai:latest
 ```
 
-The image at `docker.io/robotsix/cai:latest` is published from this repo on
-every push to `main` (see [`.github/workflows/docker-publish.yml`](.github/workflows/docker-publish.yml)).
-
-### Build and run from source (local dev)
+**With OAuth credentials from the host** (preferred — no static secret in
+the container env). Requires `claude login` to have been run on the
+server, OR `~/.claude/.credentials.json` copied over from another machine
+where you've already logged in:
 
 ```bash
-git clone git@github.com:damien-robotsix/robotsix-cai.git
+docker run --rm \
+  -v ~/.claude/.credentials.json:/root/.claude/.credentials.json:ro \
+  robotsix/cai:latest
+```
+
+Expected output:
+
+```
+Hello! How can I help you today?
+```
+
+(Or similar — the exact response varies.) If you see a non-empty greeting
+and the container exits with code 0, the published image, your Docker
+setup, and your auth all work end-to-end.
+
+### Persistent setup with `docker-compose`
+
+For repeatable runs and the eventual long-running daemon mode, use the
+published `docker-compose.yml` from the repo:
+
+```bash
+git clone https://github.com/damien-robotsix/robotsix-cai.git
 cd robotsix-cai
-docker compose build
-docker compose up
+docker compose pull
 ```
 
-### Authentication — pick one
-
-`claude -p` accepts either an API key in the environment **or** a mounted
-OAuth credentials file from the host. Pick whichever is more convenient.
+Then pick one auth mode:
 
 **Option A — API key in `.env`:**
 
@@ -79,22 +103,24 @@ echo 'ANTHROPIC_API_KEY=sk-ant-...' > .env
 docker compose up
 ```
 
-**Option B — mounted OAuth credentials (preferred for self-hosted):**
+**Option B — mounted OAuth credentials:**
 
-If you've already run `claude login` interactively on the host, the file
-`~/.claude/.credentials.json` exists and `docker-compose.yml` can mount it
-into the container read-only. Open `docker-compose.yml` and uncomment the
-`volumes:` block. With this mode, no `ANTHROPIC_API_KEY` is needed and no
-static secret is held in the container's environment.
+Open `docker-compose.yml` and uncomment the `volumes:` block. Then:
 
-### Expected output
-
-```
-Hello! How can I help you today?
+```bash
+docker compose up
 ```
 
-(Or similar — the exact response varies. Any non-empty Claude response in
-the logs means the runtime envelope is working.)
+### Build from source (local dev)
+
+```bash
+git clone https://github.com/damien-robotsix/robotsix-cai.git
+cd robotsix-cai
+docker compose build
+docker compose up
+```
+
+Same auth-mode picks as the persistent setup.
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,10 +37,84 @@ later milestone.
 
 ## Quick start
 
-See the
-[README on GitHub](https://github.com/damien-robotsix/robotsix-cai#readme)
-for the current setup instructions. As v0 stabilizes, those will move
-into a dedicated section here.
+At Phase A the container is a single-shot smoke test: it invokes
+`claude -p "Say hello in one short sentence."` and prints the response
+to the docker logs. Real analyzer behavior lands in later phases.
+
+### Smoke test on a fresh server (one `docker run`, no clone)
+
+The fastest way to verify the published image works on your server.
+The image is published to Docker Hub on every push to `main`, so a
+single `docker run` is enough — no repo clone, no `docker-compose.yml`.
+
+**With an API key:**
+
+```bash
+docker run --rm \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  robotsix/cai:latest
+```
+
+**With OAuth credentials from the host** (preferred — no static secret
+in the container env). Requires `claude login` to have been run on the
+server, OR `~/.claude/.credentials.json` copied over from another
+machine where you've already logged in:
+
+```bash
+docker run --rm \
+  -v ~/.claude/.credentials.json:/root/.claude/.credentials.json:ro \
+  robotsix/cai:latest
+```
+
+Expected output:
+
+```
+Hello! How can I help you today?
+```
+
+(Or similar — the exact response varies.) If you see a non-empty
+greeting and the container exits with code 0, the published image,
+your Docker setup, and your auth all work end-to-end.
+
+### Persistent setup with `docker-compose`
+
+For repeatable runs and the eventual long-running daemon mode, use the
+published `docker-compose.yml` from the repo:
+
+```bash
+git clone https://github.com/damien-robotsix/robotsix-cai.git
+cd robotsix-cai
+docker compose pull
+```
+
+Then pick one auth mode:
+
+**Option A — API key in `.env`:**
+
+```bash
+cp .env.example .env
+echo 'ANTHROPIC_API_KEY=sk-ant-...' > .env
+docker compose up
+```
+
+**Option B — mounted OAuth credentials:**
+
+Open `docker-compose.yml` and uncomment the `volumes:` block. Then:
+
+```bash
+docker compose up
+```
+
+### Build from source (local dev)
+
+```bash
+git clone https://github.com/damien-robotsix/robotsix-cai.git
+cd robotsix-cai
+docker compose build
+docker compose up
+```
+
+Same auth-mode picks as the persistent setup.
 
 ## License
 


### PR DESCRIPTION
## Summary

Adds the simplest possible verification path for someone landing on the repo or the docs site: a single `docker run` against the published `robotsix/cai:latest` image, with both auth modes shown side-by-side.

The previous quickstart assumed the user would clone the repo and use `docker-compose`; now we lead with the no-clone smoke test and keep the docker-compose flow as the "persistent setup" alternative for actual deployments.

## What's in this PR

Three sections in the Quick start (mirrored in both `README.md` and `docs/index.md`):

1. **Smoke test on a fresh server (one \`docker run\`, no clone)** — the new section. Single command to pull and run the published image, with both auth modes (API key and OAuth credentials volume mount).
2. **Persistent setup with \`docker-compose\`** — the previous "Run the published image" content, slightly restructured.
3. **Build from source (local dev)** — the previous local-dev content.

## Why mirror in both files

Until the docs site grows past one page, README and `docs/index.md` are both legitimate landing surfaces (README for GitHub visitors, the docs site for documentation readers). Duplication is acceptable cost for v0; we'll extract a shared partial only if it actually becomes painful to maintain.

## What this PR does NOT include

- A separate \`docs/quickstart.md\` page — lean scaffolding. Single-page docs site stays single-page until content forces a split.
- Production-grade server deployment (systemd unit, log rotation, restart policies) — those land in Phase E when the analyzer actually runs as a daemon.

Refs damien-robotsix/robotsix-cai#1