### PR TITLE
Phase B: persist claude-code session transcripts in named volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,32 @@ docker compose up
 ```
 
 The repo's `docker-compose.yml` defaults to API-key auth via `.env`. To
-use mounted OAuth credentials instead, uncomment the `volumes:` block.
+use mounted OAuth credentials instead, uncomment the relevant entry in
+the `volumes:` block.
+
+## Persistent data
+
+The container persists Claude Code's session transcripts in a Docker
+named volume called **`cai_transcripts`**, mounted at
+`/root/.claude/projects` inside the container. claude-code writes one
+JSONL file per session under
+`/root/.claude/projects/<sanitized-cwd>/<session-id>.jsonl`, and the
+volume keeps that data across container restarts so future analyzer
+runs can read it.
+
+Inspect the volume from outside the container:
+
+```bash
+docker volume inspect cai_transcripts
+docker run --rm -v cai_transcripts:/data alpine ls -R /data
+```
+
+Wipe the volume (deletes all stored transcripts):
+
+```bash
+docker compose down --volumes        # if you used compose
+docker volume rm cai_transcripts     # standalone
+```
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,19 @@ services:
     build: .
     env_file:
       - .env
-    # Uncomment the volumes block to use OAuth credentials from the host
-    # instead of an API key. Requires `claude login` to have been run on
-    # the host so the credentials file already exists. When this is in
-    # use, ANTHROPIC_API_KEY in .env is unnecessary.
-    #
-    # volumes:
-    #   - ${HOME}/.claude/.credentials.json:/root/.claude/.credentials.json:ro
+    volumes:
+      # Persistent claude-code session transcripts. claude-code writes
+      # session JSONL into ~/.claude/projects/<sanitized-cwd>/<sid>.jsonl
+      # inside the container; this named volume keeps that data across
+      # container restarts so future analyzer runs can read it.
+      - cai_transcripts:/root/.claude/projects
+      # Uncomment to use OAuth credentials from the host instead of an
+      # API key. Requires `claude login` to have been run on the host so
+      # the credentials file already exists. When this is in use,
+      # ANTHROPIC_API_KEY in .env is unnecessary.
+      #
+      # - ${HOME}/.claude/.credentials.json:/root/.claude/.credentials.json:ro
+
+volumes:
+  cai_transcripts:
+    name: cai_transcripts

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,6 +114,30 @@ docker compose build
 docker compose up
 ```
 
+## Persistent data
+
+The container persists Claude Code's session transcripts in a Docker
+named volume called **`cai_transcripts`**, mounted at
+`/root/.claude/projects` inside the container. claude-code writes one
+JSONL file per session under
+`/root/.claude/projects/<sanitized-cwd>/<session-id>.jsonl`, and the
+volume keeps that data across container restarts so future analyzer
+runs can read it.
+
+Inspect the volume from outside the container:
+
+```bash
+docker volume inspect cai_transcripts
+docker run --rm -v cai_transcripts:/data alpine ls -R /data
+```
+
+Wipe the volume (deletes all stored transcripts):
+
+```bash
+docker compose down --volumes        # if you used compose
+docker volume rm cai_transcripts     # standalone
+```
+
 ## License
 
 [MIT](https://github.com/damien-robotsix/robotsix-cai/blob/main/LICENSE)

--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,11 @@ services:
     image: robotsix/cai:${IMAGE_TAG}
     volumes:
       - \${HOME}/.claude/.credentials.json:/root/.claude/.credentials.json:ro
+      - cai_transcripts:/root/.claude/projects
+
+volumes:
+  cai_transcripts:
+    name: cai_transcripts
 YAML
     echo
     echo "[OK] Wrote $INSTALL_DIR/docker-compose.yml (credentials-mount mode)"
@@ -115,6 +120,12 @@ services:
     image: robotsix/cai:${IMAGE_TAG}
     env_file:
       - .env
+    volumes:
+      - cai_transcripts:/root/.claude/projects
+
+volumes:
+  cai_transcripts:
+    name: cai_transcripts
 YAML
     cat > .env <<ENV
 ANTHROPIC_API_KEY=${API_KEY}


### PR DESCRIPTION
## Summary

Phase B of the v0 walking skeleton: persist Claude Code's session transcripts so future analyzer runs (Phase C) can read them. Adds a Docker named volume `cai_transcripts` mounted at `/root/.claude/projects` inside the container — exactly where claude-code naturally writes its session JSONL files (one per `claude -p` run).

## Why a named volume

Three reasons over a host bind mount:

- **No collision** with the host's interactive `~/.claude/projects/`, which already contains the user's other claude-code projects (claude-auto-tune-hub, robotsix-cai itself, etc.) — keeping cai's session data in its own bucket avoids pollution in both directions
- **Container-scoped lifecycle** — `docker volume rm cai_transcripts` cleans it up cleanly without touching anything in the user's home dir
- **Same code reads it in Phase C** — the analyzer will run inside the same container, so it sees the volume just like claude-code does; no cross-container sync needed

The top-level `name: cai_transcripts` keeps the actual volume name stable regardless of the docker compose project name (which would otherwise prefix it as `<project>_cai_transcripts`).

## What's in this PR

- **`docker-compose.yml`** — adds the `volumes:` block on the service plus the top-level `volumes:` declaration. The credentials-mount alternative becomes the second commented entry under the same volumes list.
- **`install.sh`** — generated compose files in both auth modes (mounted credentials and API key) now include the `cai_transcripts` mount and the top-level volume declaration.
- **`README.md`** and **`docs/index.md`** — new **"Persistent data"** subsection explains the volume name, mount path, how to inspect contents from outside the container, and how to delete the volume.

## Verified locally end-to-end

1. **`docker compose up`** with the credentials mount temporarily uncommented:

   ```
   Volume cai_transcripts Created
   Container robotsix-cai-cai-1 Started
   cai-1  | Hello! How can I help you today?
   cai-1 exited with code 0
   ```

2. **Volume contents** via a throwaway alpine container:

   ```
   /data:
   drwxr-xr-x  -app

   /data/-app:
   -rw-------  b0c1be30-872e-44b0-a52f-d81a77971782.jsonl   3152 bytes
   drwxr-xr-x  memory
   ```

   The `-app` is the sanitized form of the container's `/app` workdir; the JSONL is keyed by session UUID exactly as claude-code writes them on a host.

3. **JSONL shape** — standard claude-code session format with `type`, `message`, `timestamp`, `sessionId`, `version` (`2.1.96`, matching our pinned image), `cwd`, etc. This matches what the existing hub `parse-claude-transcript.py` already handles, so Phase C can lift the parser nearly unchanged.

## Out of scope for Phase B

- Actually parsing the JSONL with code → Phase C
- Lifting the hub's `parse-claude-transcript.py` → Phase C
- Running the BackendAutoImprove analyzer → Phase C
- Surfacing token cost from the JSONL → Phase D

Refs damien-robotsix/robotsix-cai#1
