### PR TITLE
Phase C.1: parse own transcripts and run self-analyzer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,7 @@ RUN apt-get update \
 
 WORKDIR /app
 COPY cai.py /app/cai.py
+COPY parse.py /app/parse.py
+COPY prompts /app/prompts
 
 CMD ["python", "/app/cai.py"]

--- a/cai.py
+++ b/cai.py
@@ -1,23 +1,102 @@
-"""Phase A entry point.
+"""Phase C.1 entry point — smoke test + self-analyzer.
 
-The smallest meaningful thing this backend can do: invoke `claude -p` once
-with a trivial prompt and let the response flow to docker logs. This proves
-the runtime envelope (Python, Node, claude-code, container auth) works
-end-to-end before any analyzer logic is added.
+Each `docker compose up` runs two `claude -p` calls in sequence:
 
-No third-party Python dependencies — only stdlib `subprocess`.
+1. **Smoke test.** A trivial "say hello" prompt. Proves the runtime
+   envelope (Python, Node, claude-code, container auth) is healthy and —
+   importantly — produces a fresh JSONL transcript under
+   `/root/.claude/projects/-app/`. That transcript becomes input for the
+   analyzer on the *next* run, which is how Lane 1's recursive
+   self-improvement loop is seeded on first launch.
+
+2. **Analyzer.** Runs `parse.py` against the transcript directory to
+   extract a deterministic activity summary, combines that summary with
+   the prompt at `prompts/backend-auto-improve.md`, and pipes the
+   combined prompt into a second `claude -p` invocation. The model's
+   findings are written to docker logs. Phase C.1 stops here — Phase
+   C.2 will turn those findings into GitHub issues.
+
+No third-party Python dependencies — only stdlib `subprocess`, `pathlib`.
 """
 
 import subprocess
 import sys
+from pathlib import Path
 
 
-def main() -> int:
+SMOKE_PROMPT = "Say hello in one short sentence."
+
+# Where claude-code writes session transcripts when invoked from /app
+# inside the container. The path encodes the cwd: `/app` -> `-app`.
+TRANSCRIPT_DIR = Path("/root/.claude/projects/-app")
+
+# Files baked into the image alongside cai.py.
+PARSE_SCRIPT = Path("/app/parse.py")
+ANALYZER_PROMPT = Path("/app/prompts/backend-auto-improve.md")
+
+
+def run_smoke_test() -> int:
+    """Run the trivial 'say hello' prompt; let output flow to logs."""
+    print("[cai] running smoke test", flush=True)
     result = subprocess.run(
-        ["claude", "-p", "Say hello in one short sentence."],
+        ["claude", "-p", SMOKE_PROMPT],
         check=False,
     )
     return result.returncode
+
+
+def run_analyzer() -> int:
+    """Parse prior transcripts and ask claude to analyze them."""
+    print("[cai] running self-analyzer", flush=True)
+
+    if not TRANSCRIPT_DIR.exists():
+        print(
+            f"[cai] no transcript dir at {TRANSCRIPT_DIR}; nothing to analyze",
+            flush=True,
+        )
+        return 0
+
+    # Parse transcripts deterministically. parse.py emits JSON to stdout.
+    parsed = subprocess.run(
+        ["python", str(PARSE_SCRIPT), str(TRANSCRIPT_DIR)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if parsed.returncode != 0:
+        print(
+            f"[cai] parse.py failed (exit {parsed.returncode}):\n{parsed.stderr}",
+            flush=True,
+        )
+        return parsed.returncode
+
+    parsed_signals = parsed.stdout.strip()
+    prompt_text = ANALYZER_PROMPT.read_text()
+
+    full_prompt = (
+        f"{prompt_text}\n\n"
+        "## Parsed signals\n\n"
+        "```json\n"
+        f"{parsed_signals}\n"
+        "```\n"
+    )
+
+    result = subprocess.run(
+        ["claude", "-p"],
+        input=full_prompt,
+        text=True,
+        check=False,
+    )
+    return result.returncode
+
+
+def main() -> int:
+    smoke_rc = run_smoke_test()
+    if smoke_rc != 0:
+        print(f"[cai] smoke test failed (exit {smoke_rc})", flush=True)
+        return smoke_rc
+
+    return run_analyzer()
 
 
 if __name__ == "__main__":

--- a/parse.py
+++ b/parse.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Deterministic Claude Code session-transcript signal extractor.
+
+Lifted from claude-auto-tune-hub (scripts/parse-claude-transcript.py)
+with minor adaptations for the robotsix-cai context. Pure stdlib —
+no external dependencies, no network, no LLM calls.
+
+Claude Code saves session transcripts as JSONL files under::
+
+    ~/.claude/projects/<encoded-path>/<session-id>.jsonl
+
+Each line is a JSON object representing one turn (user, assistant, or
+tool result). This script walks one or more such files and emits a
+structured JSON summary of tool-call activity: total counts, top tools,
+failed tools, repeated consecutive runs, token usage, and a short
+sequence preview.
+
+The reasoning over this summary is the job of the Claude analyzer that
+calls this script (see prompts/backend-auto-improve.md).
+
+Usage::
+
+    python parse.py /root/.claude/projects/-app/
+    python parse.py <transcript-file.jsonl>
+    cat *.jsonl | python parse.py
+"""
+
+import json
+import pathlib
+import sys
+from collections import Counter
+
+
+# Cap on how many items of each list we include in the output. Counts
+# are always exact; samples are truncated so the downstream prompt stays
+# small.
+TOP_N = 20
+SEQUENCE_PREVIEW_LEN = 100
+
+
+def _extract_error_text(block: dict) -> str:
+    """Extract the text content from a tool_result error block."""
+    content = block.get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                parts.append(item.get("text", ""))
+        return " ".join(parts)
+    return ""
+
+
+# Patterns that indicate network / auth / infrastructure errors — not
+# controllable by prompt guidance or CLAUDE.md rules.
+_NETWORK_AUTH_PATTERNS = [
+    "could not read username",
+    "could not read password",
+    "authentication failed",
+    "bad credentials",
+    "http 401",
+    "http 403",
+    "tls handshake timeout",
+    "connection reset by peer",
+    "connection refused",
+    "connection timed out",
+    "no such host",
+    "network is unreachable",
+    "dns lookup failed",
+    "certificate",
+    "ssl",
+    "econnrefused",
+    "econnreset",
+    "etimedout",
+    "fetch first",
+    "failed to push some refs",
+    "remote: invalid username or password",
+]
+
+
+def _categorize_error(error_text: str) -> str:
+    """Classify an error as 'network_auth' or 'controllable'."""
+    lower = error_text.lower()
+    for pattern in _NETWORK_AUTH_PATTERNS:
+        if pattern in lower:
+            return "network_auth"
+    return "controllable"
+
+
+def extract_tool_calls(lines: list[str]) -> dict:
+    """Walk JSONL lines and return a structured activity summary."""
+    tool_counter: Counter = Counter()
+    error_tools: list[str] = []
+    error_categories: list[str] = []
+    tool_sequences: list[str] = []
+    total_input_tokens = 0
+    total_output_tokens = 0
+
+    for raw in lines:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+        # Claude Code JSONL wraps messages:
+        #   {"type": "assistant", "message": {...}}
+        # Fall back to top-level role/content for older formats.
+        msg = entry.get("message", entry)
+        role = msg.get("role", entry.get("type", ""))
+        content = msg.get("content", [])
+
+        if isinstance(content, str):
+            content = [{"type": "text", "text": content}]
+
+        usage = msg.get("usage") or entry.get("usage", {})
+        if usage:
+            total_input_tokens += usage.get("input_tokens", 0)
+            total_output_tokens += usage.get("output_tokens", 0)
+
+        if role == "assistant":
+            for block in content if isinstance(content, list) else []:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    name = block.get("name", "unknown")
+                    tool_counter[name] += 1
+                    tool_sequences.append(name)
+
+        elif role in ("tool", "user"):
+            # Tool results are delivered as either role="tool" (older)
+            # or role="user" with tool_result blocks (current). Detect
+            # errors either way.
+            for block in content if isinstance(content, list) else []:
+                if isinstance(block, dict) and block.get("type") == "tool_result":
+                    if block.get("is_error") and tool_sequences:
+                        error_tools.append(tool_sequences[-1])
+                        error_text = _extract_error_text(block)
+                        category = _categorize_error(error_text)
+                        error_categories.append(category)
+
+    # Repeated consecutive-run detection: runs of 3+ identical calls in
+    # a row are a strong signal that a loop could be replaced by a
+    # single deterministic script.
+    repeated: list[dict] = []
+    i = 0
+    while i < len(tool_sequences):
+        j = i
+        while j < len(tool_sequences) and tool_sequences[j] == tool_sequences[i]:
+            j += 1
+        run_len = j - i
+        if run_len >= 3:
+            repeated.append({"tool": tool_sequences[i], "run_length": run_len, "start_index": i})
+        i = j
+
+    error_counter = Counter(error_tools)
+    category_counter = Counter(error_categories)
+
+    preview = tool_sequences[:SEQUENCE_PREVIEW_LEN]
+    sequence_preview = " -> ".join(preview)
+    if len(tool_sequences) > SEQUENCE_PREVIEW_LEN:
+        sequence_preview += f" ... (+{len(tool_sequences) - SEQUENCE_PREVIEW_LEN} more)"
+
+    total_errors = len(error_tools)
+    controllable_errors = category_counter.get("controllable", 0)
+    network_auth_errors = category_counter.get("network_auth", 0)
+
+    return {
+        "tool_call_count": sum(tool_counter.values()),
+        "top_tools": [t for t, _ in tool_counter.most_common(5)],
+        "tool_counts": dict(tool_counter.most_common(TOP_N)),
+        "error_tools": dict(error_counter.most_common(TOP_N)),
+        "error_categories": {
+            "total": total_errors,
+            "controllable": controllable_errors,
+            "network_auth": network_auth_errors,
+        },
+        "repeated_sequences": repeated[:TOP_N],
+        "token_usage": {
+            "input_tokens": total_input_tokens,
+            "output_tokens": total_output_tokens,
+        },
+        "tool_sequence_preview": sequence_preview,
+    }
+
+
+def collect_jsonl_lines(source: str) -> list[str]:
+    """Collect all JSONL lines from a file, directory, or stdin sentinel."""
+    p = pathlib.Path(source)
+    if p.is_dir():
+        lines: list[str] = []
+        for jf in sorted(p.rglob("*.jsonl")):
+            lines.extend(jf.read_text(errors="replace").splitlines())
+        return lines
+    if p.is_file():
+        return p.read_text(errors="replace").splitlines()
+    return []
+
+
+def main() -> None:
+    if len(sys.argv) > 1:
+        all_lines: list[str] = []
+        for arg in sys.argv[1:]:
+            all_lines.extend(collect_jsonl_lines(arg))
+    else:
+        all_lines = sys.stdin.read().splitlines()
+
+    if not any(line.strip() for line in all_lines):
+        print(json.dumps({
+            "tool_call_count": 0,
+            "top_tools": [],
+            "tool_counts": {},
+            "error_tools": {},
+            "error_categories": {"total": 0, "controllable": 0, "network_auth": 0},
+            "repeated_sequences": [],
+            "token_usage": {"input_tokens": 0, "output_tokens": 0},
+            "tool_sequence_preview": "",
+            "note": "empty transcript",
+        }))
+        return
+
+    result = extract_tool_calls(all_lines)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/prompts/backend-auto-improve.md
+++ b/prompts/backend-auto-improve.md
@@ -1,0 +1,104 @@
+# Backend Auto-Improve
+
+You are the analyzer for `robotsix-cai`'s self-improvement loop. Your
+job is to look at the parsed signals from the backend's **own** Claude
+Code session transcripts and decide whether anything in the cai code,
+prompts, Dockerfile, installer, or docs should change.
+
+## Scope
+
+You analyze ONLY the cai container's own runtime sessions. The signal
+data you receive comes from JSONL files under
+`/root/.claude/projects/-app/` inside the container — sessions where
+the cai container itself invoked `claude -p`. You do NOT look at
+sessions from outside the container.
+
+## What to look for
+
+1. **Tool-call errors** — Edit failures, permission errors, repeated
+   retries, error patterns visible in the parsed signals
+2. **Prompt issues** — unclear instructions, missing guidance in the
+   prompts cai sends to claude (this prompt itself, or future
+   prompts in `prompts/`)
+3. **Workflow inefficiencies** — token waste, unnecessary calls,
+   sequences that could be replaced by deterministic code
+4. **Container or installer bugs** — issues visible from the JSONL
+   that suggest a `Dockerfile`, `install.sh`, `cai.py`, or
+   `docker-compose.yml` change
+
+## Categories
+
+| Category | Description |
+|----------|-------------|
+| `reliability` | Errors, failures, flaky behavior |
+| `cost_reduction` | Token waste, unnecessary tool calls |
+| `prompt_quality` | Unclear or missing prompt guidance |
+| `workflow_efficiency` | Unnecessary workflow steps or configuration |
+
+## Input format
+
+You will receive a parsed signal summary as part of the prompt context.
+The structure is what `parse.py` outputs:
+
+- `tool_call_count` — total tool calls across all sessions analyzed
+- `top_tools` — top 5 most-used tools
+- `tool_counts` — full tool usage map (capped)
+- `error_tools` — tools that errored, with counts
+- `error_categories` — controllable vs network/auth errors
+- `repeated_sequences` — runs of 3+ identical consecutive calls
+- `token_usage` — input/output token totals
+- `tool_sequence_preview` — first 100 tool calls in sequence
+- `note` (optional) — `"empty transcript"` if there's no data yet
+
+## What to output
+
+If there's no signal data yet (empty transcript or `tool_call_count: 0`
+with no errors), output exactly:
+
+```
+No findings. (No prior tool-call activity in the analyzed sessions.)
+```
+
+Otherwise, for each candidate finding, output a markdown block in this
+format:
+
+```markdown
+### Finding: <short imperative title>
+
+- **Category:** <one of the 4 categories>
+- **Key:** <stable-slug-for-deduplication>
+- **Confidence:** low | medium | high
+- **Evidence:**
+  - <<=160-char excerpt or signal summary>
+- **Remediation:** <concrete fix — exact file and change>
+```
+
+If, after analysis, no issues meet the filter (see below), output
+exactly:
+
+```
+No findings.
+```
+
+## Filter
+
+Only output a finding when:
+
+- You see at least 2 observations of the same pattern, **OR**
+- You have high confidence based on a single observation
+
+Do NOT invent issues. If the parsed signals show nothing actionable,
+output `No findings.` and stop.
+
+## Guardrails
+
+- Every finding must be grounded in actual signal from the parsed
+  transcript data — no speculation about issues you can't see in the
+  signals.
+- Stick to one of the 4 categories above; do not invent new ones.
+- Keep titles short and imperative ("Reduce X", "Fix Y", "Remove Z").
+- Do not include code blocks longer than 10 lines in remediations.
+  Reference the file and the change concept; the human reviewer will
+  read the file directly.
+- Do not output anything other than the markdown finding blocks (or
+  the exact `No findings.` sentinel).


### PR DESCRIPTION
## Summary

Phase C.1 of the v0 tracking issue: cai now does **two** `claude -p` calls per `docker compose up`. The smoke test still runs first (and seeds a JSONL transcript), then a new self-analyzer step parses the on-disk transcripts and asks claude to produce structured findings against them.

- **`parse.py`** — lifted from `claude-auto-tune-hub`'s `parse-claude-transcript.py` with an attribution comment in the module docstring. Pure stdlib (`json`, `pathlib`, `sys`, `collections.Counter`); no third-party deps, no network, no LLM calls. Walks JSONL, counts tools, detects controllable vs network/auth errors, finds runs of 3+ identical consecutive calls, captures token totals, and emits a structured JSON summary on stdout.
- **`prompts/backend-auto-improve.md`** — adapted from the hub's `hub-auto-improve-prompt.md`. Same four categories (`reliability`, `cost_reduction`, `prompt_quality`, `workflow_efficiency`) and the same evidence/filter discipline, but scoped to the cai container's own runtime sessions only. **Critical difference from the hub prompt:** no `gh` CLI calls — the analyzer outputs markdown finding blocks to stdout, and Phase C.2 will turn those into GitHub issues with fingerprint dedup.
- **`cai.py`** — split into `run_smoke_test()` and `run_analyzer()`. The analyzer runs `parse.py` against `/root/.claude/projects/-app/`, builds a combined prompt (analyzer prompt text + parsed-signals JSON in a fenced block), and pipes it into `claude -p` via stdin.
- **`Dockerfile`** — `COPY parse.py /app/parse.py` and `COPY prompts /app/prompts`.

This closes the recursive seed: the very first run has no prior transcripts, so the smoke test creates one and the analyzer reads its own future input on the next run.

## Verification

Tested locally with two consecutive `docker compose up` runs (credentials mount temporarily uncommented, then reverted before the commit):

1. **Run 1** — empty volume. Smoke test prints `Hello! How can I help you today?`, analyzer reads the just-created smoke-test transcript, parser reports `tool_call_count: 0`, prompt correctly emits `No findings. (No prior tool-call activity in the analyzed sessions.)`. Exit 0.
2. **Run 2** — volume now has 2 sessions (run 1's smoke test + run 1's analyzer). Same flow; still no tool calls in any session at this phase, so the empty sentinel still fires correctly.

Confirmed the volume contains 4 JSONL files after both runs (2 smoke tests + 2 analyzer sessions). Ran `parse.py` directly inside the container against the volume to confirm the structured JSON summary.

## Test plan

- [x] Build image with `docker compose build`
- [x] First run produces smoke test output + analyzer empty sentinel
- [x] Second run reads prior session(s) without crashing
- [x] `parse.py` runs cleanly inside the container against the named volume
- [x] No leftover credentials mount or `.env` in the committed files

Refs damien-robotsix/robotsix-cai#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)