### PR TITLE
Phase C.2: publish analyzer findings as GitHub issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,19 +12,33 @@ FROM python:3.12-slim
 ARG CLAUDE_CODE_VERSION=2.1.96
 
 # Install Node.js (Bookworm slim ships Node 18, which satisfies claude-code's
-# >=18 requirement) plus npm, then install claude-code globally.
+# >=18 requirement) plus npm, then install claude-code globally. Also
+# installs the `gh` CLI from GitHub's official apt repository — the analyzer
+# uses it to create issues from its findings (Phase C.2 onward).
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         nodejs \
         npm \
         ca-certificates \
+        wget \
+        gnupg \
+    && mkdir -p -m 755 /etc/apt/keyrings \
+    && wget -nv -O /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+        https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
-    && claude --version
+    && claude --version \
+    && gh --version
 
 WORKDIR /app
 COPY cai.py /app/cai.py
 COPY parse.py /app/parse.py
+COPY publish.py /app/publish.py
 COPY prompts /app/prompts
 
 CMD ["python", "/app/cai.py"]

--- a/README.md
+++ b/README.md
@@ -42,10 +42,19 @@ milestone.
 
 ## Quick start
 
-At Phase A the container is a single-shot smoke test: it invokes
-`claude -p "Say hello in one short sentence."` and prints the response to
-the docker logs. Real analyzer behavior lands in later phases (see the
-[tracking issue](https://github.com/damien-robotsix/robotsix-cai/issues/1)).
+Each `docker compose up` now runs three things in order:
+
+1. **Auth check** — `gh auth status` must succeed; the installer runs
+   `gh auth login` once and persists credentials in a Docker volume.
+2. **Smoke test** — a trivial `claude -p "say hello"` call that also
+   seeds a transcript for the analyzer to read on the next run.
+3. **Analyzer + publish** — parses prior transcripts with `parse.py`,
+   asks `claude -p` to produce structured findings against the
+   `prompts/backend-auto-improve.md` prompt, and publishes the
+   findings as GitHub issues via `gh` (deduped by fingerprint).
+
+See the [tracking issue](https://github.com/damien-robotsix/robotsix-cai/issues/1)
+for what lands in later phases.
 
 ### Quick install (recommended)
 
@@ -79,16 +88,24 @@ Optional environment variables you can set before running the script:
 - `IMAGE_TAG`   — Docker image tag to pin (default: `latest`; you can
   pin a `sha-<short>` for reproducibility)
 
-After the installer finishes, follow the printed next steps:
+The installer then pulls the image and runs `gh auth login` inside the
+container — pick **GitHub.com → HTTPS → Authenticate via web browser**
+when prompted. gh prints a one-time code and a URL; paste the code into
+the URL from any browser (handy on a headless server). The resulting
+credentials are saved in a Docker volume named `cai_gh_config`, so
+subsequent runs don't need to re-authenticate.
+
+After the installer finishes:
 
 ```bash
 cd robotsix-cai
-docker compose pull
 docker compose up
 ```
 
-Expected output: a single greeting line (`Hello! How can I help you
-today?` or similar) and the container exits with code 0.
+Expected output per run: the smoke-test greeting, a structured findings
+report from the analyzer (or `No findings.`), and — if anything is
+actionable — new issues filed in this repository with labels
+`auto-improve`, `auto-improve:raised`, and `category:<kind>`.
 
 ### One-shot smoke test (no install)
 
@@ -130,26 +147,30 @@ the `volumes:` block.
 
 ## Persistent data
 
-The container persists Claude Code's session transcripts in a Docker
-named volume called **`cai_transcripts`**, mounted at
-`/root/.claude/projects` inside the container. claude-code writes one
-JSONL file per session under
-`/root/.claude/projects/<sanitized-cwd>/<session-id>.jsonl`, and the
-volume keeps that data across container restarts so future analyzer
-runs can read it.
+The container uses two Docker named volumes:
 
-Inspect the volume from outside the container:
+- **`cai_transcripts`** (mounted at `/root/.claude/projects`) —
+  claude-code writes one JSONL file per session under
+  `/root/.claude/projects/<sanitized-cwd>/<session-id>.jsonl`; the
+  volume keeps that data across restarts so future analyzer runs can
+  read it.
+- **`cai_gh_config`** (mounted at `/root/.config/gh`) — the `gh` CLI's
+  credential store. Populated once by the installer's
+  `gh auth login` step and reused on every subsequent run.
+
+Inspect a volume from outside the container:
 
 ```bash
 docker volume inspect cai_transcripts
 docker run --rm -v cai_transcripts:/data alpine ls -R /data
 ```
 
-Wipe the volume (deletes all stored transcripts):
+Wipe everything (deletes transcripts and gh credentials — you'll need
+to re-authenticate afterwards):
 
 ```bash
 docker compose down --volumes        # if you used compose
-docker volume rm cai_transcripts     # standalone
+docker volume rm cai_transcripts cai_gh_config   # standalone
 ```
 
 ## License

--- a/cai.py
+++ b/cai.py
@@ -1,22 +1,26 @@
-"""Phase C.1 entry point — smoke test + self-analyzer.
+"""Phase C.2 entry point — smoke test, self-analyzer, publish findings.
 
-Each `docker compose up` runs two `claude -p` calls in sequence:
+Each `docker compose up` does three things, in order:
 
-1. **Smoke test.** A trivial "say hello" prompt. Proves the runtime
-   envelope (Python, Node, claude-code, container auth) is healthy and —
-   importantly — produces a fresh JSONL transcript under
-   `/root/.claude/projects/-app/`. That transcript becomes input for the
-   analyzer on the *next* run, which is how Lane 1's recursive
-   self-improvement loop is seeded on first launch.
+1. **Auth check.** Verifies `gh auth status` succeeds. The installer
+   runs `gh auth login` once and persists credentials in a Docker
+   volume; if that's been skipped or wiped, we fail fast with a clear
+   pointer back to the install step.
 
-2. **Analyzer.** Runs `parse.py` against the transcript directory to
-   extract a deterministic activity summary, combines that summary with
-   the prompt at `prompts/backend-auto-improve.md`, and pipes the
-   combined prompt into a second `claude -p` invocation. The model's
-   findings are written to docker logs. Phase C.1 stops here — Phase
-   C.2 will turn those findings into GitHub issues.
+2. **Smoke test.** A trivial "say hello" prompt. Proves the runtime
+   envelope (Python, Node, claude-code, container auth) is healthy
+   and — importantly — produces a fresh JSONL transcript under
+   `/root/.claude/projects/-app/`. That transcript becomes input for
+   the analyzer on the *next* run, which seeds Lane 1's recursive
+   self-improvement loop.
 
-No third-party Python dependencies — only stdlib `subprocess`, `pathlib`.
+3. **Analyzer + publish.** Runs `parse.py` against the transcript
+   directory, combines the parsed summary with the prompt at
+   `prompts/backend-auto-improve.md`, pipes it through `claude -p` to
+   produce structured findings, then pipes those findings into
+   `publish.py` to create GitHub issues (deduped by fingerprint).
+
+No third-party Python dependencies — only stdlib.
 """
 
 import subprocess
@@ -32,7 +36,27 @@ TRANSCRIPT_DIR = Path("/root/.claude/projects/-app")
 
 # Files baked into the image alongside cai.py.
 PARSE_SCRIPT = Path("/app/parse.py")
+PUBLISH_SCRIPT = Path("/app/publish.py")
 ANALYZER_PROMPT = Path("/app/prompts/backend-auto-improve.md")
+
+
+def check_gh_auth() -> int:
+    """Fail fast if `gh` is not authenticated."""
+    result = subprocess.run(
+        ["gh", "auth", "status"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print("[cai] ERROR: gh is not authenticated in this container.", file=sys.stderr)
+        print("       Credentials are expected in the cai_gh_config volume.", file=sys.stderr)
+        print("       Run the installer's login step, or do it manually:", file=sys.stderr)
+        print("         docker compose run --rm cai gh auth login", file=sys.stderr)
+        print(file=sys.stderr)
+        print(result.stderr.strip() or result.stdout.strip(), file=sys.stderr)
+        return 1
+    return 0
 
 
 def run_smoke_test() -> int:
@@ -45,8 +69,8 @@ def run_smoke_test() -> int:
     return result.returncode
 
 
-def run_analyzer() -> int:
-    """Parse prior transcripts and ask claude to analyze them."""
+def run_analyzer_and_publish() -> int:
+    """Parse prior transcripts, ask claude to analyze, publish findings."""
     print("[cai] running self-analyzer", flush=True)
 
     if not TRANSCRIPT_DIR.exists():
@@ -56,7 +80,6 @@ def run_analyzer() -> int:
         )
         return 0
 
-    # Parse transcripts deterministically. parse.py emits JSON to stdout.
     parsed = subprocess.run(
         ["python", str(PARSE_SCRIPT), str(TRANSCRIPT_DIR)],
         check=False,
@@ -81,22 +104,45 @@ def run_analyzer() -> int:
         "```\n"
     )
 
-    result = subprocess.run(
+    # Capture the analyzer output so we can both print it to logs and
+    # pipe it into publish.py.
+    analyzer = subprocess.run(
         ["claude", "-p"],
         input=full_prompt,
         text=True,
         check=False,
+        capture_output=True,
     )
-    return result.returncode
+    print(analyzer.stdout, flush=True)
+    if analyzer.returncode != 0:
+        print(
+            f"[cai] analyzer claude -p failed (exit {analyzer.returncode}):\n"
+            f"{analyzer.stderr}",
+            flush=True,
+        )
+        return analyzer.returncode
+
+    print("[cai] publishing findings to GitHub", flush=True)
+    published = subprocess.run(
+        ["python", str(PUBLISH_SCRIPT)],
+        input=analyzer.stdout,
+        text=True,
+        check=False,
+    )
+    return published.returncode
 
 
 def main() -> int:
+    auth_rc = check_gh_auth()
+    if auth_rc != 0:
+        return auth_rc
+
     smoke_rc = run_smoke_test()
     if smoke_rc != 0:
         print(f"[cai] smoke test failed (exit {smoke_rc})", flush=True)
         return smoke_rc
 
-    return run_analyzer()
+    return run_analyzer_and_publish()
 
 
 if __name__ == "__main__":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,11 @@ services:
       # inside the container; this named volume keeps that data across
       # container restarts so future analyzer runs can read it.
       - cai_transcripts:/root/.claude/projects
+      # Persistent gh CLI configuration. The installer runs
+      # `docker compose run --rm cai gh auth login` once and the
+      # resulting credentials land here, so subsequent `docker compose
+      # up` runs don't need to re-authenticate.
+      - cai_gh_config:/root/.config/gh
       # Uncomment to use OAuth credentials from the host instead of an
       # API key. Requires `claude login` to have been run on the host so
       # the credentials file already exists. When this is in use,
@@ -35,3 +40,5 @@ services:
 volumes:
   cai_transcripts:
     name: cai_transcripts
+  cai_gh_config:
+    name: cai_gh_config

--- a/install.sh
+++ b/install.sh
@@ -98,10 +98,13 @@ services:
     volumes:
       - \${HOME}/.claude/.credentials.json:/root/.claude/.credentials.json:ro
       - cai_transcripts:/root/.claude/projects
+      - cai_gh_config:/root/.config/gh
 
 volumes:
   cai_transcripts:
     name: cai_transcripts
+  cai_gh_config:
+    name: cai_gh_config
 YAML
     echo
     echo "[OK] Wrote $INSTALL_DIR/docker-compose.yml (credentials-mount mode)"
@@ -122,10 +125,13 @@ services:
       - .env
     volumes:
       - cai_transcripts:/root/.claude/projects
+      - cai_gh_config:/root/.config/gh
 
 volumes:
   cai_transcripts:
     name: cai_transcripts
+  cai_gh_config:
+    name: cai_gh_config
 YAML
     cat > .env <<ENV
 ANTHROPIC_API_KEY=${API_KEY}
@@ -142,7 +148,48 @@ ENV
 esac
 
 echo
-echo "Next steps:"
-echo "  cd $INSTALL_DIR"
-echo "  docker compose pull"
-echo "  docker compose up"
+echo "Pulling the cai image..."
+echo
+if ! docker compose pull; then
+  echo
+  echo "[!] 'docker compose pull' failed. If you're developing locally, you"
+  echo "    can build from source instead: 'docker compose build'"
+  exit 1
+fi
+
+echo
+echo "Authenticating gh inside the container (interactive)."
+echo "Credentials persist in a Docker volume named 'cai_gh_config' so"
+echo "subsequent 'docker compose up' runs don't need to re-authenticate."
+echo
+echo "When prompted, pick:"
+echo "  * 'GitHub.com'"
+echo "  * 'HTTPS'"
+echo "  * Authenticate via web browser (easiest on a headless server —"
+echo "    gh prints a one-time code and a URL to open)"
+echo
+
+# 'docker compose run' needs a real TTY for the interactive prompts.
+# The piped form of the installer (wget -qO- | bash) consumes stdin, so
+# we redirect stdin from /dev/tty when we have one. Without a TTY, we
+# fall back to printing the command and letting the user run it.
+if [[ "$TTY" == "/dev/tty" ]]; then
+  if ! docker compose run --rm cai gh auth login < /dev/tty; then
+    echo
+    echo "[!] gh auth login did not complete. Rerun it yourself:"
+    echo "      cd $INSTALL_DIR && docker compose run --rm cai gh auth login"
+    exit 1
+  fi
+  echo
+  echo "[OK] gh is authenticated. Credentials persisted in cai_gh_config."
+  echo
+  echo "Next steps:"
+  echo "  cd $INSTALL_DIR"
+  echo "  docker compose up"
+else
+  echo "[!] No controlling TTY — skipping the interactive login."
+  echo "    Finish authentication yourself before the first run:"
+  echo "      cd $INSTALL_DIR"
+  echo "      docker compose run --rm cai gh auth login"
+  echo "      docker compose up"
+fi

--- a/publish.py
+++ b/publish.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+Publish analyzer findings as GitHub issues via the `gh` CLI.
+
+Reads the analyzer's stdout from this script's own stdin, parses
+`### Finding:` markdown blocks produced by `prompts/backend-auto-improve.md`,
+and creates one issue per finding in the `damien-robotsix/robotsix-cai`
+repository. Existing findings are deduped by a fingerprint HTML comment
+embedded in the issue body (`<!-- fingerprint: <key> -->`).
+
+Phase C.2 scope — this is the Lane 1 publish step. Lane 2 (workspace
+targets) is still deferred.
+
+No third-party Python dependencies — only stdlib plus the `gh` CLI.
+
+Usage::
+
+    cat analyzer-output.md | python publish.py
+
+    # Or from cai.py, piped directly:
+    # subprocess.run(["python", "/app/publish.py"], input=analyzer_stdout, ...)
+"""
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+# Lane 1 target — the backend improves itself. When Lane 2 lands, this
+# will be parameterized per workspace.
+REPO = "damien-robotsix/robotsix-cai"
+
+# The set of categories declared in prompts/backend-auto-improve.md. Any
+# finding whose category is outside this set is rejected before we touch
+# GitHub — the analyzer is instructed not to invent new ones.
+VALID_CATEGORIES = {
+    "reliability",
+    "cost_reduction",
+    "prompt_quality",
+    "workflow_efficiency",
+}
+
+# Labels we ensure exist before creating issues. The first two are the
+# state labels; the rest are the category labels. Idempotent — `gh label
+# create` returns non-zero if the label already exists, which we ignore.
+LABELS = [
+    ("auto-improve", "ededed", "Self-improvement finding raised by the analyzer"),
+    ("auto-improve:raised", "0e8a16", "Finding freshly raised; not yet triaged"),
+    ("category:reliability", "d73a4a", "Errors, failures, flaky behavior"),
+    ("category:cost_reduction", "fbca04", "Token waste, unnecessary tool calls"),
+    ("category:prompt_quality", "0075ca", "Unclear or missing prompt guidance"),
+    ("category:workflow_efficiency", "5319e7", "Unnecessary workflow steps or config"),
+]
+
+
+@dataclass
+class Finding:
+    title: str
+    category: str
+    key: str
+    confidence: str
+    evidence: str
+    remediation: str
+
+
+def parse_findings(text: str) -> list[Finding]:
+    """Split analyzer output into Finding blocks.
+
+    The prompt format is::
+
+        ### Finding: <title>
+
+        - **Category:** <category>
+        - **Key:** <key>
+        - **Confidence:** <low|medium|high>
+        - **Evidence:**
+          - <line>
+          - <line>
+        - **Remediation:** <remediation>
+
+    Parsing is deliberately lenient: we split on `### Finding:` headers
+    and then pull fields with regexes. Unknown fields are ignored;
+    missing required fields cause the block to be skipped.
+    """
+    findings: list[Finding] = []
+
+    # Split on the Finding header, keeping the header text itself.
+    blocks = re.split(r"^### Finding:\s*", text, flags=re.MULTILINE)
+    # blocks[0] is everything before the first header (preamble); skip it.
+    for block in blocks[1:]:
+        lines = block.splitlines()
+        if not lines:
+            continue
+        title = lines[0].strip()
+        body = "\n".join(lines[1:])
+
+        category = _extract_field(body, "Category")
+        key = _extract_field(body, "Key")
+        confidence = _extract_field(body, "Confidence")
+        evidence = _extract_multiline_field(body, "Evidence")
+        remediation = _extract_multiline_field(body, "Remediation")
+
+        if not (title and category and key):
+            # Incomplete block — skip rather than post garbage.
+            print(
+                f"[publish] skipping incomplete finding (title={title!r})",
+                file=sys.stderr,
+            )
+            continue
+
+        if category not in VALID_CATEGORIES:
+            print(
+                f"[publish] skipping finding with invalid category {category!r}",
+                file=sys.stderr,
+            )
+            continue
+
+        findings.append(
+            Finding(
+                title=title,
+                category=category,
+                key=key,
+                confidence=confidence or "unspecified",
+                evidence=evidence or "(no evidence provided)",
+                remediation=remediation or "(no remediation provided)",
+            )
+        )
+
+    return findings
+
+
+def _extract_field(block: str, name: str) -> str:
+    """Pull a single-line `- **Name:** value` field out of a block."""
+    match = re.search(
+        rf"^- \*\*{re.escape(name)}:\*\*\s*(.+)$",
+        block,
+        flags=re.MULTILINE,
+    )
+    return match.group(1).strip() if match else ""
+
+
+def _extract_multiline_field(block: str, name: str) -> str:
+    """Pull a multi-line `- **Name:**` field (value may span lines).
+
+    The value is terminated by any of:
+      * the next top-level bullet field (`- **Next:**`)
+      * a blank line (paragraph break — trailing narrative that is not
+        part of the finding)
+      * end of block
+    """
+    pattern = (
+        rf"^- \*\*{re.escape(name)}:\*\*\s*(.*?)"
+        r"(?=\n\n|^- \*\*|\Z)"
+    )
+    match = re.search(pattern, block, flags=re.MULTILINE | re.DOTALL)
+    if not match:
+        return ""
+    return match.group(1).strip()
+
+
+def ensure_labels() -> None:
+    """Create the cai label set if it doesn't exist. Idempotent."""
+    for name, color, description in LABELS:
+        subprocess.run(
+            [
+                "gh", "label", "create", name,
+                "--color", color,
+                "--description", description,
+                "--repo", REPO,
+            ],
+            check=False,
+            capture_output=True,
+        )
+
+
+def issue_exists(key: str) -> bool:
+    """Return True if an issue already carries this fingerprint."""
+    fingerprint = f"<!-- fingerprint: {key} -->"
+    result = subprocess.run(
+        [
+            "gh", "issue", "list",
+            "--repo", REPO,
+            "--search", f'"{fingerprint}" in:body',
+            "--state", "all",
+            "--json", "number",
+            "--limit", "1",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"[publish] gh issue list failed ({result.returncode}):\n"
+            f"{result.stderr}",
+            file=sys.stderr,
+        )
+        return False
+    # Empty list == "[]"
+    return bool(result.stdout.strip() and result.stdout.strip() != "[]")
+
+
+def create_issue(f: Finding) -> int:
+    """Create one issue. Returns gh's exit code."""
+    body = (
+        f"<!-- fingerprint: {f.key} -->\n"
+        f"**Category:** `{f.category}`  \n"
+        f"**Confidence:** `{f.confidence}`\n"
+        f"\n"
+        f"## Evidence\n"
+        f"\n"
+        f"{f.evidence}\n"
+        f"\n"
+        f"## Remediation\n"
+        f"\n"
+        f"{f.remediation}\n"
+        f"\n"
+        f"---\n"
+        f"_Raised automatically by the cai self-analyzer. "
+        f"See `prompts/backend-auto-improve.md`._\n"
+    )
+    labels = ",".join([
+        "auto-improve",
+        "auto-improve:raised",
+        f"category:{f.category}",
+    ])
+    result = subprocess.run(
+        [
+            "gh", "issue", "create",
+            "--repo", REPO,
+            "--title", f.title,
+            "--body", body,
+            "--label", labels,
+        ],
+        check=False,
+    )
+    return result.returncode
+
+
+def main() -> int:
+    text = sys.stdin.read()
+    if not text.strip():
+        print("[publish] empty input; nothing to do")
+        return 0
+
+    findings = parse_findings(text)
+    if not findings:
+        print("[publish] no findings parsed; nothing to do")
+        return 0
+
+    print(f"[publish] parsed {len(findings)} finding(s)")
+    ensure_labels()
+
+    created = 0
+    skipped = 0
+    failed = 0
+    for f in findings:
+        if issue_exists(f.key):
+            print(f"[publish] skip (already exists): {f.key}")
+            skipped += 1
+            continue
+        rc = create_issue(f)
+        if rc == 0:
+            print(f"[publish] created: {f.key}")
+            created += 1
+        else:
+            print(f"[publish] FAILED ({rc}): {f.key}", file=sys.stderr)
+            failed += 1
+
+    print(
+        f"[publish] done. created={created} skipped={skipped} failed={failed}"
+    )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase C.2 closes the Lane 1 loop end-to-end: after the analyzer produces structured findings, they're parsed and filed as issues in this repository. The flow per `docker compose up` is now:

1. **Auth check** — `gh auth status` must succeed, else fail fast with a pointer to the installer's login step
2. **Smoke test** — unchanged; produces a seed transcript on first run
3. **Analyzer** — unchanged; runs `parse.py` + pipes the combined prompt through `claude -p`
4. **Publish** — new; `publish.py` parses `### Finding:` markdown blocks from the analyzer's stdout and creates issues with fingerprint dedup

## Files

- **`publish.py`** (new) — stdlib-only. Parses the finding blocks defined in `prompts/backend-auto-improve.md`, ensures labels exist (idempotent), checks `gh issue list --search '"<!-- fingerprint: KEY -->" in:body'` for dedup, and creates issues with `gh issue create`. Invalid categories or incomplete blocks are skipped with a stderr note.
- **`cai.py`** — adds `check_gh_auth()` at startup (hard fail if unauthenticated), captures the analyzer's stdout instead of letting it flow unbuffered, and pipes it into `publish.py`.
- **`Dockerfile`** — installs the `gh` CLI from GitHub's official apt repository (alongside the existing Node / npm / claude-code install).
- **`docker-compose.yml`** — adds a second named volume, `cai_gh_config`, mounted at `/root/.config/gh` so `gh` credentials persist across runs.
- **`install.sh`** — emits both volumes in the generated compose, then runs `docker compose pull` and `docker compose run --rm cai gh auth login`. The login step redirects stdin from `/dev/tty` so it survives the `wget -qO- ... | bash` form, and falls back to printed instructions when no controlling terminal is available.
- **`README.md`** — documents the new three-step flow, the `cai_gh_config` volume, and the installer's login step.

## Label namespace

Created idempotently by `publish.py` on first issue creation:

| Label | Purpose |
|---|---|
| `auto-improve` | Base label for all analyzer findings |
| `auto-improve:raised` | Freshly raised, not yet triaged |
| `category:reliability` | Errors, failures, flaky behavior |
| `category:cost_reduction` | Token waste, unnecessary tool calls |
| `category:prompt_quality` | Unclear or missing prompt guidance |
| `category:workflow_efficiency` | Unnecessary workflow steps or config |

## Verification

- [x] Image builds cleanly with `gh version 2.89.0` confirmed by the Dockerfile's verification line
- [x] `cai.py` startup check fails fast with the installer pointer when no auth volume is mounted
- [x] `publish.py` parser correctly extracts two synthetic findings and preserves multi-line evidence while stopping cleanly at trailing narrative (regex stops at `\n\n`, next `- **` bullet, or end-of-string)
- [x] Empty sentinel input (`No findings.`) is handled cleanly — no findings parsed, no `gh` calls, exit 0

Not yet tested end-to-end: the full live flow of creating a real GitHub issue from analyzer output, because the analyzer still emits the empty sentinel at this phase (no tool calls happen in any cai session yet, so `tool_call_count: 0`). That path will be exercised naturally as more tools are added in later phases — and if it misbehaves, that itself becomes a finding for the next loop iteration to catch.

## Test plan

- [x] `docker compose build` succeeds with gh installed
- [x] `cai.py` without auth fails with a clear error
- [x] `publish.py` parses synthetic findings correctly
- [x] `publish.py` handles the empty sentinel cleanly
- [ ] Manual: follow the README install path and confirm `gh auth login` persists across a subsequent `docker compose up`

Refs damien-robotsix/robotsix-cai#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)