### PR TITLE
Silence gh auth login browser-open error in slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,12 @@
 
 FROM python:3.12-slim
 
+# Slim images don't ship xdg-open / x-www-browser, so `gh auth login
+# --web` emits a scary "Failed opening a web browser" error even
+# though the device flow is working fine. Point BROWSER at `echo` so
+# gh "opens" the URL by just printing it — same information, no noise.
+ENV BROWSER=echo
+
 # Pin the claude-code version so the self-improvement loop is reproducible.
 # Bumping this should be a deliberate, reviewed change.
 ARG CLAUDE_CODE_VERSION=2.1.96


### PR DESCRIPTION
## Summary

Follow-up to the Phase D scheduler merge (#9). The installer's `gh auth login` step works correctly but spews a scary-looking error at the "press Enter to open in your browser" step because python:3.12-slim doesn't ship `xdg-open` / `x-www-browser` / any of the other browser launchers gh looks for:

```
! Failed opening a web browser at https://github.com/login/device
  exec: "xdg-open,x-www-browser,www-browser,wslview": executable file not found in \$PATH
  Please try entering the URL in your browser manually
```

The device flow itself is unaffected — the user has already seen the code and URL in the preceding lines, and pasting the URL into any browser completes login normally. But the error reads like a failure and is confusing.

## Fix

One line: `ENV BROWSER=echo` in the Dockerfile. `gh` honors `$BROWSER` when launching the browser, so instead of trying `xdg-open`, it runs `echo <url>` — which just prints the URL cleanly as its own line. Same information, no noise, no fake error.

## Verification

- [x] `docker run --rm --entrypoint sh robotsix/cai:latest -c 'echo \$BROWSER'` outputs `echo`
- [x] Image builds without adding any new packages or weight

The next `gh auth login --web` run inside the container will print something like:

```
! First copy your one-time code: XXXX-XXXX
Press Enter to open https://github.com/login/device in your browser...
https://github.com/login/device
```

…instead of the red-looking error block.

Refs damien-robotsix/robotsix-cai#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)