### PR TITLE
Mount claude credentials read-write so OAuth refresh works

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,13 @@ any files at all, one `docker run` is enough.
 
 ```bash
 docker run --rm \
-  -v ~/.claude/.credentials.json:/root/.claude/.credentials.json:ro \
+  -v ~/.claude/.credentials.json:/root/.claude/.credentials.json \
   robotsix/cai:latest
 ```
+
+(The mount is read-write on purpose — claude-code refreshes the OAuth
+access token in place when it expires. A `:ro` mount blocks the
+refresh and 401s after the token's lifetime is up.)
 
 **With an API key:**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,11 @@ services:
       # Uncomment to use OAuth credentials from the host instead of an
       # API key. Requires `claude login` to have been run on the host so
       # the credentials file already exists. When this is in use,
-      # ANTHROPIC_API_KEY in .env is unnecessary.
+      # ANTHROPIC_API_KEY in .env is unnecessary. Mount is read-write
+      # so claude-code can refresh the OAuth access token in place; a
+      # :ro mount would block refresh and 401 after the token expires.
       #
-      # - ${HOME}/.claude/.credentials.json:/root/.claude/.credentials.json:ro
+      # - ${HOME}/.claude/.credentials.json:/root/.claude/.credentials.json
 
 volumes:
   cai_transcripts:

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,9 +93,13 @@ any files at all, one `docker run` is enough.
 
 ```bash
 docker run --rm \
-  -v ~/.claude/.credentials.json:/root/.claude/.credentials.json:ro \
+  -v ~/.claude/.credentials.json:/root/.claude/.credentials.json \
   robotsix/cai:latest
 ```
+
+(The mount is read-write on purpose — claude-code refreshes the OAuth
+access token in place when it expires. A `:ro` mount blocks the
+refresh and 401s after the token's lifetime is up.)
 
 **With an API key:**
 

--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,11 @@ services:
       # at midnight UTC.
       CAI_ANALYZER_SCHEDULE: "0 0 * * *"
     volumes:
-      - \${HOME}/.claude/.credentials.json:/root/.claude/.credentials.json:ro
+      # Mount is read-write so claude-code can refresh the OAuth
+      # access token when it expires. claude-code writes the refreshed
+      # token back to this file; without :rw, subsequent API calls
+      # would 401 once the token lifetime is up.
+      - \${HOME}/.claude/.credentials.json:/root/.claude/.credentials.json
       - cai_transcripts:/root/.claude/projects
       - cai_gh_config:/root/.config/gh
 


### PR DESCRIPTION
## Summary

Fixes the 401 hit on the first long-lived server deployment after Phase D's scheduler merge:

```
[cai analyze] running self-analyzer
Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}}
```

## Root cause

claude-code refreshes its OAuth access token by **writing the new token back** to `~/.claude/.credentials.json`. The installer (and the `docker run` snippets in the docs) mount that file as `:ro`, which silently blocks the refresh. The first run works because the access token is still fresh; subsequent runs 401 once the access token's short lifetime is up. The transcripts from the early successful runs are why `cai init` correctly skipped the smoke test, masking the auth failure as a "later" problem.

## Fix

Drop `:ro` from the credentials mount in all four spots:

- `install.sh` — generated compose, credentials-mount mode
- `docker-compose.yml` — the commented-out example in the repo template
- `README.md` and `docs/index.md` — the one-shot `docker run` snippets

Each location now has a short comment explaining why the mount is intentionally read-write, so we don't reintroduce `:ro` for "defensive hygiene" later.

API-key mode is unaffected — there's no credentials file in play, just the env var.

## How to recover an existing install

The credentials file on the host may already contain an expired access token (the refresh attempts inside the read-only container were no-ops). Refresh on the host once, then redeploy:

```bash
claude login                       # refresh creds on the host
cd ~/robotsix-cai
docker compose pull                # grab the rw-mount image
docker compose up -d
docker compose logs -f cai
```

After this, the in-container claude-code can refresh tokens itself, and the analyzer should keep working past the access-token lifetime.

Refs damien-robotsix/robotsix-cai#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)