### PR TITLE
auto-improve: Add optional Watchtower auto-update via installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,32 @@ The installer asks for the **auth mode**:
 2. **Anthropic API key** — paste an `sk-ant-...` key when prompted; it's
    written to a `.env` file (chmod 600).
 
+The installer also asks whether to enable **Watchtower** — a small
+sidecar container that polls Docker Hub every 30 minutes and
+automatically pulls + restarts cai when a new image is published.
+Default is **no** (manual updates). If you answer yes, the generated
+`docker-compose.yml` includes a `watchtower` service alongside `cai`.
+
+**Mid-fix restart caveat:** if Watchtower restarts cai while a fix
+subagent is running, the in-flight fix is killed and the issue may be
+left stuck in `auto-improve:in-progress`. Manual relabelling back to
+`:raised` is needed until the audit feature (tracked separately) lands
+to handle automatic recovery.
+
+To change the polling interval, edit the `--interval` value (in
+seconds) in the `watchtower` service's `command:` block and run
+`docker compose up -d`.
+
+To **enable Watchtower on an existing install**: re-run `install.sh`
+and answer yes, or manually edit your `docker-compose.yml` — add the
+`watchtower` service and the `com.centurylinklabs.watchtower.enable=true`
+label on the `cai` service (see the repo's `docker-compose.yml` for the
+commented-out template).
+
+To **disable Watchtower**: comment out (or remove) the `watchtower`
+service and the `cai` label in your `docker-compose.yml`, then run
+`docker compose up -d`.
+
 Optional environment variables you can set before running the script:
 
 - `INSTALL_DIR` — directory to install into (default: `./robotsix-cai`)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,24 @@ services:
       # :ro mount would block refresh and 401 after the token expires.
       #
       # - ${HOME}/.claude/.credentials.json:/root/.claude/.credentials.json
+    # Required if Watchtower is enabled (uncommented below):
+    # labels:
+    #   - "com.centurylinklabs.watchtower.enable=true"
+
+  # Optional: Watchtower auto-update sidecar. Uncomment this service AND
+  # add the label above to the `cai` service to enable automatic
+  # updates when a new image is published to docker.io/robotsix/cai.
+  # See README for the mid-fix-restart caveat.
+  #
+  # watchtower:
+  #   image: containrrr/watchtower
+  #   restart: unless-stopped
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock
+  #   command:
+  #     - --label-enable
+  #     - --interval=1800
+  #     - --cleanup
 
 volumes:
   cai_transcripts:

--- a/install.sh
+++ b/install.sh
@@ -78,6 +78,47 @@ echo
 
 prompt AUTH_CHOICE "Choice" "1"
 
+echo
+echo "Enable Watchtower for automatic updates?"
+echo
+echo "Watchtower is a small sidecar container that polls Docker Hub"
+echo "every 30 minutes and automatically pulls + restarts cai when a"
+echo "new image is published. Recommended for hands-off operation."
+echo
+echo "WARNING: if cai is mid-fix when watchtower restarts it, the"
+echo "in-flight fix will be killed and the issue may be left stuck"
+echo "in auto-improve:in-progress. Manual relabel may be needed"
+echo "until the audit feature (tracked separately) lands."
+echo
+prompt ENABLE_WATCHTOWER "Enable Watchtower? [y/N]" "n"
+
+case "$ENABLE_WATCHTOWER" in
+  y|Y|yes|Yes|YES)
+    WATCHTOWER_SERVICE=$(cat <<'WATCHTOWER'
+
+  watchtower:
+    image: containrrr/watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command:
+      - --label-enable
+      - --interval=1800
+      - --cleanup
+WATCHTOWER
+)
+    CAI_LABEL_BLOCK=$(cat <<'LABEL'
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+LABEL
+)
+    ;;
+  *)
+    WATCHTOWER_SERVICE=""
+    CAI_LABEL_BLOCK=""
+    ;;
+esac
+
 case "$AUTH_CHOICE" in
   1)
     CRED_PATH="${HOME}/.claude/.credentials.json"
@@ -112,6 +153,7 @@ services:
       - cai_transcripts:/root/.claude/projects
       - cai_gh_config:/root/.config/gh
       - ./logs:/var/log/cai
+${CAI_LABEL_BLOCK}${WATCHTOWER_SERVICE}
 
 volumes:
   cai_transcripts:
@@ -148,6 +190,7 @@ services:
       - cai_transcripts:/root/.claude/projects
       - cai_gh_config:/root/.config/gh
       - ./logs:/var/log/cai
+${CAI_LABEL_BLOCK}${WATCHTOWER_SERVICE}
 
 volumes:
   cai_transcripts:


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#38

Auto-generated by `cai fix` against the issue above. Please review the diff carefully — the fix subagent runs autonomously with full tool permissions.
