### PR TITLE
Watchtower templates: switch to nickfedor/watchtower fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ automatically pulls + restarts cai when a new image is published.
 Default is **no** (manual updates). If you answer yes, the generated
 `docker-compose.yml` includes a `watchtower` service alongside `cai`.
 
+The image used is
+[`nickfedor/watchtower`](https://hub.docker.com/r/nickfedor/watchtower)
+(pinned to a specific version), an actively-maintained community fork.
+The original `containrrr/watchtower` is no longer being updated and
+its `:latest` tag ships an embedded Docker client too old for modern
+Docker daemons (≥ API 1.44), causing watchtower to crash-loop with
+`client version 1.25 is too old`.
+
 **Mid-fix restart caveat:** if Watchtower restarts cai while a fix
 subagent is running, the in-flight fix is killed and the issue may be
 left stuck in `auto-improve:in-progress`. Manual relabelling back to

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
   # See README for the mid-fix-restart caveat.
   #
   # watchtower:
-  #   image: containrrr/watchtower
+  #   image: nickfedor/watchtower:1.16.1
   #   restart: unless-stopped
   #   volumes:
   #     - /var/run/docker.sock:/var/run/docker.sock

--- a/install.sh
+++ b/install.sh
@@ -97,7 +97,7 @@ case "$ENABLE_WATCHTOWER" in
     WATCHTOWER_SERVICE=$(cat <<'WATCHTOWER'
 
   watchtower:
-    image: containrrr/watchtower
+    image: nickfedor/watchtower:1.16.1
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Summary

`containrrr/watchtower` is no longer actively maintained and its `:latest` tag ships an embedded Docker client too old (API 1.25) for modern Docker daemons (≥ API 1.44). Anyone running `install.sh` today and answering yes to the Watchtower prompt gets a sidecar that crash-loops with:

```
Error response from daemon: client version 1.25 is too old.
Minimum supported API version is 1.44, please upgrade your client to a newer version
```

This was hit on the first real Watchtower deployment after PR #38 merged.

## Fix

Switch to [`nickfedor/watchtower`](https://hub.docker.com/r/nickfedor/watchtower) — an actively-maintained community fork that keeps the embedded Docker client current. Verified the image:

- Exists on Docker Hub with multiple recent tags
- Latest stable is **`1.16.1`** (last pushed 2026-04-01)
- Supports the same flags we use (`--label-enable`, `--interval`, `--cleanup`) — drop-in replacement, no compose changes beyond the image line

Pinned to `nickfedor/watchtower:1.16.1` for reproducibility instead of `:latest`.

## Files changed

- **`install.sh`** — change the `image:` line in the conditional `WATCHTOWER_SERVICE` block
- **`docker-compose.yml`** — same change in the commented-out repo template
- **`README.md`** — short note explaining which image is used and why, with a link to the new image and a callout about the underlying API-version bug so future maintainers don't switch back

Three lines of code change + a paragraph in the README. No `cai.py` / `parse.py` / `publish.py` / prompts changes — pure deployment-layer fix.

## Verification

- [x] Verified `nickfedor/watchtower:1.16.1` exists on Docker Hub via `docker manifest inspect`
- [x] Confirmed the fork supports the same Watchtower CLI flags used by the template
- [x] Diff is minimal (3 files, 10 insertions, 2 deletions)

Manual to do after merge:
- [ ] Operator updates their existing install: edit `~/robotsix-cai/docker-compose.yml`, change the `image:` line on the `watchtower` service to `nickfedor/watchtower:1.16.1`, run `docker compose pull watchtower && docker compose up -d`. (Or re-run `install.sh` with watchtower enabled.)
- [ ] Confirm no API-version errors in `docker compose logs watchtower`

Refs damien-robotsix/robotsix-cai#40

🤖 Generated with [Claude Code](https://claude.com/claude-code)