### PR TITLE
auto-improve: Bash tool error rate remains critically high despite prior fixes

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -485,7 +485,8 @@ def cmd_fix(args) -> int:
         # claude-code refuses it when running as root inside the container,
         # and `acceptEdits` is sufficient for code-editing fixes.
         agent = _run(
-            ["claude", "-p", "--permission-mode", "acceptEdits"],
+            ["claude", "-p", "--permission-mode", "acceptEdits",
+             "--disallowedTools", "Bash"],
             input=prompt,
             cwd=str(work_dir),
             capture_output=True,


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#42

Auto-generated by `cai fix` against the issue above. Please review the diff carefully — the fix subagent runs autonomously with full tool permissions.
