### PR TITLE
auto-improve: Strengthen Grep-before-Read guidance — adoption remains minimal post-merge

### DIFF
--- a/prompts/backend-fix.md
+++ b/prompts/backend-fix.md
@@ -53,9 +53,10 @@ The full source tree is here, including `cai.py`, `parse.py`,
 11. **Batch independent Read calls.** When you need to read multiple
    files and the reads are independent, issue all Read calls in a
    single turn rather than reading files one at a time sequentially.
-12. **Grep before Read.** Before reading multiple files to locate a
-   string or pattern, use Grep to narrow the search first. Reserve
-   consecutive Read calls for files whose paths are already known.
+12. **Grep before Read.** Use Grep to locate the relevant file(s)
+   and line numbers BEFORE opening them with Read. Do NOT sequentially
+   Read files to search for content. Reserve Read calls for files
+   whose paths and relevance are already known.
 
 ## When to make NO changes (and exit cleanly)
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#59

Auto-generated by `cai fix` against the issue above. Please review the diff carefully — the fix subagent runs autonomously with full tool permissions.
