### PR TITLE
publish.py: strip backticks from extracted field values

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -157,13 +157,22 @@ def parse_findings(text: str, valid_categories: set[str] | None = None) -> list[
 
 
 def _extract_field(block: str, name: str) -> str:
-    """Pull a single-line `- **Name:** value` field out of a block."""
+    """Pull a single-line `- **Name:** value` field out of a block.
+
+    Strips surrounding whitespace and backticks from the value — the
+    model sometimes wraps short identifier-like values (categories,
+    keys, confidence levels) in backticks for code formatting, which
+    would otherwise break exact-string validation against the
+    `VALID_CATEGORIES` / `AUDIT_CATEGORIES` sets.
+    """
     match = re.search(
         rf"^- \*\*{re.escape(name)}:\*\*\s*(.+)$",
         block,
         flags=re.MULTILINE,
     )
-    return match.group(1).strip() if match else ""
+    if not match:
+        return ""
+    return match.group(1).strip().strip("`").strip()
 
 
 def _extract_multiline_field(block: str, name: str) -> str:


### PR DESCRIPTION
## Background

The audit feature shipped via PR #63 (#34) ran for the first time and produced two real, actionable findings — but both were **silently rejected** by `publish.py`:

```
[publish] skipping finding with invalid category '`loop_stuck`'
[publish] skipping finding with invalid category '`loop_stuck`'
[publish] no findings parsed; nothing to do
```

The captured category was `` `loop_stuck` `` (with backticks), which doesn't match the literal `loop_stuck` in `AUDIT_CATEGORIES`.

## Root cause

`prompts/backend-audit.md`'s category table uses backticks around the example category names:

```markdown
| Check | Category |
|---|---|
| `:pr-open` issue whose linked PR doesn't exist or was force-deleted | `lock_corruption` |
```

The model copied that formatting into its output — `- **Category:** \`loop_stuck\`` instead of `- **Category:** loop_stuck`.

`publish.py`'s `_extract_field` captured everything between the field marker and end-of-line, stripped whitespace, but **not backticks**. So the validated string was `` `loop_stuck` ``, which failed the exact-match check.

The analyzer prompt doesn't use backticks in its category examples, so analyzer findings have always come through clean. Audit is the first prompt where the formatting bit us.

## Fix

One-line change to `_extract_field`: also strip surrounding backticks from the return value. Identifier-like fields (category, key, confidence) never legitimately contain leading/trailing backticks, so this is safe.

```diff
-    return match.group(1).strip() if match else ""
+    if not match:
+        return ""
+    return match.group(1).strip().strip("`").strip()
```

The `.strip().strip("`").strip()` chain handles all permutations: leading/trailing whitespace, surrounding backticks, and any whitespace between backticks and inner content.

## Verification

Reran the audit's exact failing input through `parse_findings()` against `AUDIT_CATEGORIES` locally:

```
Parsed 2 findings:
  - raised-issues-never-eligible (loop_stuck, high)
  - dedup-failure-issues-50-51-52 (loop_stuck, medium)
```

Both audit findings now extract correctly. Categories match the validation set, keys are clean, confidence is preserved.

## After this lands

The audit feature actually starts producing GitHub issues. The two findings the audit raised earlier today (both `loop_stuck` category) will need to be filed manually since they were dropped — I'll do that as a separate followup.

Refs damien-robotsix/robotsix-cai#34

🤖 Generated with [Claude Code](https://claude.com/claude-code)