### PR TITLE
auto-improve: parse.py: also limit transcripts by count, not just time window

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ the same global window settings.
 - **`CAI_TRANSCRIPT_WINDOW_DAYS`** — number of days of transcript
   history to include in the analysis. Default: `7`. Set to `0` to
   include all sessions (useful for debugging or initial seeding).
+- **`CAI_TRANSCRIPT_MAX_FILES`** — maximum number of transcript files
+  to read (most recent first by mtime). Default: `100`. Set to `0` to
+  disable the count limit. Both knobs apply together — a file must be
+  within the time window AND in the top N most recent to be included.
 
 Inspect a volume from outside the container:
 

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ the same global window settings.
   history to include in the analysis. Default: `7`. Set to `0` to
   include all sessions (useful for debugging or initial seeding).
 - **`CAI_TRANSCRIPT_MAX_FILES`** — maximum number of transcript files
-  to read (most recent first by mtime). Default: `100`. Set to `0` to
+  to read (most recent first by mtime). Default: `20`. Set to `0` to
   disable the count limit. Both knobs apply together — a file must be
   within the time window AND in the top N most recent to be included.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet, report-only)
       CAI_CONFIRM_SCHEDULE: "0 2 * * *"     # daily at 02:00 UTC (verify merged fixes)
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
+      CAI_TRANSCRIPT_MAX_FILES: "100"       # read at most N recent transcript files
     volumes:
       # Persistent claude-code session transcripts. claude-code writes
       # session JSONL into ~/.claude/projects/<sanitized-cwd>/<sid>.jsonl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet, report-only)
       CAI_CONFIRM_SCHEDULE: "0 2 * * *"     # daily at 02:00 UTC (verify merged fixes)
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
-      CAI_TRANSCRIPT_MAX_FILES: "100"       # read at most N recent transcript files
+      CAI_TRANSCRIPT_MAX_FILES: "20"        # read at most N recent transcript files
     volumes:
       # Persistent claude-code session transcripts. claude-code writes
       # session JSONL into ~/.claude/projects/<sanitized-cwd>/<sid>.jsonl

--- a/install.sh
+++ b/install.sh
@@ -147,6 +147,7 @@ services:
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet, report-only)
       CAI_CONFIRM_SCHEDULE: "0 2 * * *"     # daily 02:00 UTC (verify merged fixes)
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
+      CAI_TRANSCRIPT_MAX_FILES: "100"       # read at most N recent transcript files
     volumes:
       # Mount is read-write so claude-code can refresh the OAuth
       # access token when it expires. claude-code writes the refreshed
@@ -192,6 +193,7 @@ services:
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet, report-only)
       CAI_CONFIRM_SCHEDULE: "0 2 * * *"     # daily 02:00 UTC (verify merged fixes)
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
+      CAI_TRANSCRIPT_MAX_FILES: "100"       # read at most N recent transcript files
     volumes:
       - cai_transcripts:/root/.claude/projects
       - cai_gh_config:/root/.config/gh

--- a/install.sh
+++ b/install.sh
@@ -147,7 +147,7 @@ services:
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet, report-only)
       CAI_CONFIRM_SCHEDULE: "0 2 * * *"     # daily 02:00 UTC (verify merged fixes)
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
-      CAI_TRANSCRIPT_MAX_FILES: "100"       # read at most N recent transcript files
+      CAI_TRANSCRIPT_MAX_FILES: "20"        # read at most N recent transcript files
     volumes:
       # Mount is read-write so claude-code can refresh the OAuth
       # access token when it expires. claude-code writes the refreshed
@@ -193,7 +193,7 @@ services:
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet, report-only)
       CAI_CONFIRM_SCHEDULE: "0 2 * * *"     # daily 02:00 UTC (verify merged fixes)
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
-      CAI_TRANSCRIPT_MAX_FILES: "100"       # read at most N recent transcript files
+      CAI_TRANSCRIPT_MAX_FILES: "20"        # read at most N recent transcript files
     volumes:
       - cai_transcripts:/root/.claude/projects
       - cai_gh_config:/root/.config/gh

--- a/parse.py
+++ b/parse.py
@@ -200,15 +200,35 @@ def _get_cutoff_time() -> float:
     return time.time() - (window_days * 86400)
 
 
+def _get_max_files() -> int:
+    """Return the maximum number of transcript files to read, or 0 to disable."""
+    raw = os.environ.get("CAI_TRANSCRIPT_MAX_FILES", "100")
+    try:
+        max_files = int(raw)
+    except ValueError:
+        max_files = 100
+    if max_files < 0:
+        max_files = 100
+    return max_files
+
+
 def collect_jsonl_lines(source: str) -> list[str]:
     """Collect all JSONL lines from a file, directory, or stdin sentinel."""
     p = pathlib.Path(source)
     cutoff = _get_cutoff_time()
+    max_files = _get_max_files()
     if p.is_dir():
-        lines: list[str] = []
-        for jf in sorted(p.rglob("*.jsonl")):
-            if cutoff and jf.stat().st_mtime < cutoff:
+        candidates = []
+        for jf in p.rglob("*.jsonl"):
+            st = jf.stat()
+            if cutoff and st.st_mtime < cutoff:
                 continue
+            candidates.append((st.st_mtime, jf))
+        candidates.sort(key=lambda x: x[0], reverse=True)
+        if max_files:
+            candidates = candidates[:max_files]
+        lines: list[str] = []
+        for _mtime, jf in candidates:
             lines.extend(jf.read_text(errors="replace").splitlines())
         return lines
     if p.is_file():

--- a/parse.py
+++ b/parse.py
@@ -202,13 +202,13 @@ def _get_cutoff_time() -> float:
 
 def _get_max_files() -> int:
     """Return the maximum number of transcript files to read, or 0 to disable."""
-    raw = os.environ.get("CAI_TRANSCRIPT_MAX_FILES", "100")
+    raw = os.environ.get("CAI_TRANSCRIPT_MAX_FILES", "20")
     try:
         max_files = int(raw)
     except ValueError:
-        max_files = 100
+        max_files = 20
     if max_files < 0:
-        max_files = 100
+        max_files = 20
     return max_files
 
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#62

Auto-generated by `cai fix` against the issue above. Please review the diff carefully — the fix subagent runs autonomously with full tool permissions.
