### PR TITLE
auto-improve: Force HTTPS for git operations in the cai container

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,18 @@ the same global window settings.
   disable the count limit. Both knobs apply together — a file must be
   within the time window AND in the top N most recent to be included.
 
+**Troubleshooting: `cannot run ssh` errors.** If `cai.py fix` fails
+with `error: cannot run ssh: No such file or directory`, your
+`cai_gh_config` volume has `git_protocol` set to `ssh` (the container
+has no SSH client). Fix it without reinstalling:
+
+```bash
+docker compose exec cai gh config set git_protocol https
+```
+
+New installs set HTTPS automatically via `--git-protocol https` in the
+`gh auth login` step.
+
 Inspect a volume from outside the container:
 
 ```bash

--- a/cai.py
+++ b/cai.py
@@ -484,11 +484,11 @@ def cmd_fix(args) -> int:
 
         # 2. Clone.
         clone = _run(
-            ["gh", "repo", "clone", REPO, str(work_dir), "--", "--depth", "1"],
+            ["git", "clone", "--depth", "1", f"https://github.com/{REPO}.git", str(work_dir)],
             capture_output=True,
         )
         if clone.returncode != 0:
-            print(f"[cai fix] gh repo clone failed:\n{clone.stderr}", file=sys.stderr)
+            print(f"[cai fix] git clone failed:\n{clone.stderr}", file=sys.stderr)
             rollback()
             log_run("fix", repo=REPO, issue=issue_number, result="clone_failed", exit=1)
             return 1

--- a/install.sh
+++ b/install.sh
@@ -249,10 +249,10 @@ echo
 # we redirect stdin from /dev/tty when we have one. Without a TTY, we
 # fall back to printing the command and letting the user run it.
 if [[ "$TTY" == "/dev/tty" ]]; then
-  if ! docker compose run --rm cai gh auth login < /dev/tty; then
+  if ! docker compose run --rm cai gh auth login --git-protocol https < /dev/tty; then
     echo
     echo "[!] gh auth login did not complete. Rerun it yourself:"
-    echo "      cd $INSTALL_DIR && docker compose run --rm cai gh auth login"
+    echo "      cd $INSTALL_DIR && docker compose run --rm cai gh auth login --git-protocol https"
     exit 1
   fi
   echo
@@ -272,6 +272,6 @@ else
   echo "[!] No controlling TTY — skipping the interactive login."
   echo "    Finish authentication yourself before the first run:"
   echo "      cd $INSTALL_DIR"
-  echo "      docker compose run --rm cai gh auth login"
+  echo "      docker compose run --rm cai gh auth login --git-protocol https"
   echo "      docker compose up -d"
 fi


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#16

Auto-generated by `cai fix` against the issue above. Please review the diff carefully — the fix subagent runs autonomously with full tool permissions.
