### PR TITLE
auto-improve: Investigate and reduce controllable Read errors

### DIFF
--- a/prompts/backend-fix.md
+++ b/prompts/backend-fix.md
@@ -49,10 +49,15 @@ Grep, and Glob instead.
    and line numbers before opening them with Read. Do not
    sequentially Read files to search for content — reserve Read for
    files whose paths and relevance are already known.
-3. **Batch independent Read calls.** When you need to read multiple
+3. **Verify paths with Glob before Read.** When a file path is
+   constructed or inferred (not hard-coded), confirm the file exists
+   using Glob before attempting to Read it. If a Read fails, do not
+   retry the same path — use Glob to find the correct filename
+   first.
+4. **Batch independent Read calls.** When you need to read multiple
    files and the reads are independent, issue all Read calls in a
    single turn rather than one at a time.
-4. **Batch edits to the same file.** Combine multiple changes into
+5. **Batch edits to the same file.** Combine multiple changes into
    as few Edit calls as possible by using larger `old_string` spans.
    Avoid single-line edits when a multi-line replacement achieves
    the same result in one call.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#94

**Issue:** #94 — Investigate and reduce controllable Read errors

## PR Summary

### What this fixes
Read tool errors (~8% failure rate) caused by the fix subagent attempting to Read files at inferred or constructed paths without first verifying they exist, then retrying the same broken path.

### What was changed
- `prompts/backend-fix.md`: Added a new efficiency guideline (item 3) instructing the fix subagent to verify file paths with Glob before attempting Read, and to use Glob to find the correct filename if a Read fails rather than retrying the same path. Renumbered existing items 3–4 to 4–5.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
