### PR TITLE
auto-improve: All labels that trigger CAI scripts using claude should not be accessible to non repo-admin users

### DIFF
--- a/.github/workflows/admin-only-label.yml
+++ b/.github/workflows/admin-only-label.yml
@@ -1,9 +1,10 @@
-name: Admin-only auto-improve:requested label
+name: Admin-only label guard
 
-# Restricts the `auto-improve:requested` label to repo admins. When a
-# non-admin applies it, this workflow removes it and posts a comment
-# explaining why. Without this guard, anyone with read access could
-# queue arbitrary issues into the cai fix subagent.
+# Restricts labels that trigger autonomous claude execution to repo
+# admins. When a non-admin applies one of the restricted labels, this
+# workflow removes it and posts a comment explaining why. Without this
+# guard, anyone with read access could queue arbitrary issues into the
+# cai fix subagent.
 #
 # Triggers only on the `labeled` event for issues, so it's a no-op for
 # all other label changes.
@@ -17,7 +18,8 @@ permissions:
 
 jobs:
   enforce:
-    if: github.event.label.name == 'auto-improve:requested'
+    if: >-
+      contains(fromJSON('["auto-improve:requested","auto-improve:raised","consistency:raised"]'), github.event.label.name)
     runs-on: ubuntu-latest
     steps:
       - name: Check sender's permission
@@ -37,8 +39,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh api -X DELETE \
-            "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/auto-improve:requested"
+            "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/${{ github.event.label.name }}"
 
           gh issue comment "${{ github.event.issue.number }}" \
             --repo "${{ github.repository }}" \
-            --body "@${{ github.event.sender.login }} only repo admins can apply the \`auto-improve:requested\` label — it queues the issue into the autonomous fix subagent. The label has been removed."
+            --body "@${{ github.event.sender.login }} only repo admins can apply the \`${{ github.event.label.name }}\` label — it triggers autonomous code execution by the cai fix subagent. The label has been removed."


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#104

**Issue:** #104 — All labels that trigger CAI scripts using claude should not be accessible to non repo-admin users

## PR Summary

### What this fixes
Only the `auto-improve:requested` label was restricted to admins, but `auto-improve:raised` and `consistency:raised` also trigger autonomous code execution and were unguarded — any collaborator could apply them to queue arbitrary issues into the fix subagent.

### What was changed
- **`.github/workflows/admin-only-label.yml`**:
  - Renamed workflow from "Admin-only auto-improve:requested label" to "Admin-only label guard" and updated the header comment.
  - Changed the `if:` condition from `github.event.label.name == 'auto-improve:requested'` to `contains(fromJSON('["auto-improve:requested","auto-improve:raised","consistency:raised"]'), github.event.label.name)`.
  - Replaced hardcoded `auto-improve:requested` in the `gh api -X DELETE` call with `${{ github.event.label.name }}`.
  - Replaced hardcoded label name in the warning comment with `${{ github.event.label.name }}` and updated the message text.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
