### PR TITLE
auto-improve: CAI fix should also be able to rebase MR when they are not mergeable anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ subprocess with no shared state.
 |---|---|---|
 | `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
 | `cai.py fix` | `15 * * * *` (hourly :15) | Picks the oldest eligible issue, lets a subagent edit the repo with full tool permissions, opens a PR — see lifecycle below |
-| `cai.py revise` | `30 * * * *` (hourly :30) | Watches `:pr-open` PRs for new comments and iterates on the same branch via force-push |
+| `cai.py revise` | `30 * * * *` (hourly :30) | Watches `:pr-open` PRs for new comments and iterates on the same branch via force-push; also auto-rebases unmergeable PRs onto current main |
 | `cai.py verify` | `45 * * * *` (hourly :45) | Mechanical, no LLM. Walks `auto-improve:pr-open` issues and updates labels based on PR merge state |
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` issues, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet, report-only) |
 | `cai.py review-pr` | `20 * * * *` (hourly :20) | Pre-merge consistency review of open PRs — posts ripple-effect findings as PR comments so the revise subagent can act on them |
@@ -125,7 +125,10 @@ rollback.
 When the bot opens a PR, you can leave a comment asking for changes
 instead of closing it. The `revise` subcommand (default: hourly at
 `:30`) picks up any PR comment posted **after the most recent commit**
-on the branch and feeds it to the revise subagent.
+on the branch and feeds it to the revise subagent. It also
+auto-rebases unmergeable PRs onto current main before processing
+comments; if the rebase has conflicts it posts a comment for human
+triage instead.
 
 How it works:
 

--- a/cai.py
+++ b/cai.py
@@ -797,7 +797,7 @@ def _select_revise_targets() -> list[dict]:
             pr_detail = _gh_json([
                 "pr", "view", str(pr["number"]),
                 "--repo", REPO,
-                "--json", "commits",
+                "--json", "commits,mergeable,mergeStateStatus",
             ])
             commits = pr_detail.get("commits", [])
             if commits:
@@ -838,7 +838,11 @@ def _select_revise_targets() -> list[dict]:
                 continue
             unaddressed.append(c)
 
-        if not unaddressed:
+        # Determine if the PR needs a rebase (unmergeable).
+        needs_rebase = pr_detail.get("mergeable") == "CONFLICTING" or \
+            pr_detail.get("mergeStateStatus") == "DIRTY"
+
+        if not unaddressed and not needs_rebase:
             continue
 
         targets.append({
@@ -846,6 +850,7 @@ def _select_revise_targets() -> list[dict]:
             "issue_number": issue_number,
             "branch": branch,
             "comments": unaddressed,
+            "needs_rebase": needs_rebase,
         })
 
     return targets
@@ -915,6 +920,75 @@ def cmd_revise(args) -> int:
             name, email = _gh_user_identity()
             _git(work_dir, "config", "user.name", name)
             _git(work_dir, "config", "user.email", email)
+
+            # 3b. Rebase onto current main if the PR is unmergeable.
+            if target.get("needs_rebase"):
+                print(
+                    f"[cai revise] PR #{pr_number} is unmergeable, "
+                    "attempting rebase onto main",
+                    flush=True,
+                )
+                _git(work_dir, "fetch", "origin", "main")
+                rebase = _git(
+                    work_dir, "rebase", "origin/main", check=False,
+                )
+                if rebase.returncode != 0:
+                    # Rebase failed — find conflicting files, abort, comment.
+                    conflict_status = _git(
+                        work_dir, "diff", "--name-only", "--diff-filter=U",
+                        check=False,
+                    )
+                    conflict_files = conflict_status.stdout.strip() or "(unknown)"
+                    _git(work_dir, "rebase", "--abort", check=False)
+                    comment_body = (
+                        "## Revise subagent: rebase failed\n\n"
+                        "Could not auto-rebase against current main "
+                        "due to conflicts in:\n```\n"
+                        f"{conflict_files}\n```\n"
+                        "Please rebase manually."
+                    )
+                    _run(
+                        ["gh", "pr", "comment", str(pr_number),
+                         "--repo", REPO, "--body", comment_body],
+                        capture_output=True,
+                    )
+                    print(
+                        f"[cai revise] rebase failed for PR #{pr_number}; "
+                        "posted comment",
+                        flush=True,
+                    )
+                    _set_labels(issue_number, remove=[LABEL_REVISING])
+                    log_run("revise", repo=REPO, pr=pr_number,
+                            result="rebase_failed", exit=0)
+                    continue
+
+                # Rebase succeeded — force-push.
+                push = _run(
+                    ["git", "-C", str(work_dir), "push",
+                     "--force-with-lease", "origin", branch],
+                    capture_output=True,
+                )
+                if push.returncode != 0:
+                    print(
+                        f"[cai revise] rebase push failed:\n{push.stderr}",
+                        file=sys.stderr,
+                    )
+                    _set_labels(issue_number, remove=[LABEL_REVISING])
+                    log_run("revise", repo=REPO, pr=pr_number,
+                            result="rebase_push_failed", exit=1)
+                    continue
+
+                print(
+                    f"[cai revise] rebased PR #{pr_number} onto main",
+                    flush=True,
+                )
+                log_run("revise", repo=REPO, pr=pr_number,
+                        result="rebased", exit=0)
+
+                # If there are no comments to address, we're done with this PR.
+                if not comments:
+                    _set_labels(issue_number, remove=[LABEL_REVISING])
+                    continue
 
             # 4. Fetch original issue body.
             try:


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#106

**Issue:** #106 — CAI fix should also be able to rebase MR when they are not mergeable anymore

## PR Summary

### What this fixes
Open `:pr-open` PRs could become unmergeable when main moved ahead (e.g., another PR merged), with no automated recovery path — a human had to manually rebase or re-trigger the fix.

### What was changed
- **`cai.py` `_select_revise_targets`**: Added `mergeable,mergeStateStatus` to the `gh pr view --json` query. PRs are now included as targets when they are unmergeable (even without unaddressed comments). Each target dict includes a `needs_rebase` flag.
- **`cai.py` `cmd_revise`**: Added rebase logic (step 3b) after git identity setup but before comment processing. If `needs_rebase` is true: fetches `origin/main`, runs `git rebase origin/main`. On success, force-pushes with `--force-with-lease` and logs `result="rebased"`. On failure, aborts the rebase, posts a PR comment listing conflicting files, and logs `result="rebase_failed"`. If rebase succeeded but there are no comments, the PR is done for this run.
- **`README.md`**: Updated the `cai.py revise` table row and the "Comment-driven PR iteration" section to document the auto-rebase behavior.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
