### PR TITLE
auto-improve: why so many inconclusive, can we improve the situation?

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,13 @@ action so two concurrent `fix` runs can't pick the same issue.
                                     ▼
                                  merged
                                     │
-                                    │ confirm (pattern absent)
-                                    ▼
-                              solved (closed)
+                        ┌───────────┴───────────┐
+                        │                       │
+                  confirm (pattern       confirm (inconclusive
+                   absent)                / unsolved)
+                        ▼                       ▼
+                  solved (closed)       stays :merged
+                                     (reasoning posted)
 ```
 
 `:no-action` means the fix subagent reviewed the issue and decided no

--- a/cai.py
+++ b/cai.py
@@ -1487,7 +1487,7 @@ def cmd_confirm(args) -> int:
             "issue", "list", "--repo", REPO,
             "--label", LABEL_MERGED,
             "--state", "open",
-            "--json", "number,title,body,labels,updatedAt",
+            "--json", "number,title,body,labels",
             "--limit", "100",
         ]) or []
     except subprocess.CalledProcessError as e:
@@ -1590,51 +1590,31 @@ def cmd_confirm(args) -> int:
             print(f"[cai confirm] #{issue_num}: unsolved — left as :merged", flush=True)
             unsolved += 1
         elif status == "inconclusive":
-            print(f"[cai confirm] #{issue_num}: inconclusive — no action", flush=True)
+            # Post reasoning to the issue so humans can see why, but
+            # avoid duplicate comments if the same reasoning was already
+            # posted in the most recent comment.
+            body = f"Confirm check: inconclusive — {reasoning}"
+            try:
+                comments = _gh_json([
+                    "issue", "view", str(issue_num),
+                    "--repo", REPO,
+                    "--json", "comments",
+                ]) or {}
+                last_body = ""
+                clist = comments.get("comments") or []
+                if clist:
+                    last_body = (clist[-1].get("body") or "").strip()
+            except subprocess.CalledProcessError:
+                last_body = ""
+            if last_body != body.strip():
+                _run(
+                    ["gh", "issue", "comment", str(issue_num),
+                     "--repo", REPO,
+                     "--body", body],
+                    capture_output=True,
+                )
+            print(f"[cai confirm] #{issue_num}: inconclusive — {reasoning}", flush=True)
             inconclusive += 1
-
-    # 6. Auto-close stale inconclusive issues.
-    #    Issues that stay :merged and inconclusive for > 14 days are
-    #    assumed solved — the pattern hasn't resurfaced.
-    _STALE_MERGED_DAYS = 14
-    now = datetime.now(timezone.utc)
-    verdict_nums = {v[0] for v in verdicts}
-    for mi in merged_issues:
-        num = mi["number"]
-        # Only handle issues that were inconclusive or had no verdict
-        was_inconclusive = any(
-            v[0] == num and v[1] == "inconclusive" for v in verdicts
-        )
-        had_no_verdict = num not in verdict_nums
-        if not (was_inconclusive or had_no_verdict):
-            continue
-        updated = mi.get("updatedAt", "")
-        if not updated:
-            continue
-        try:
-            updated_dt = datetime.fromisoformat(updated.replace("Z", "+00:00"))
-        except (ValueError, AttributeError):
-            continue
-        age_days = (now - updated_dt).total_seconds() / 86400
-        if age_days > _STALE_MERGED_DAYS:
-            _set_labels(num, add=[LABEL_SOLVED], remove=[LABEL_MERGED])
-            _run(
-                ["gh", "issue", "close", str(num),
-                 "--repo", REPO,
-                 "--comment",
-                 f"Auto-closed: issue remained :merged with inconclusive "
-                 f"verdicts for {int(age_days)} days. Assuming solved."],
-                capture_output=True,
-            )
-            print(
-                f"[cai confirm] #{num}: stale inconclusive "
-                f"({int(age_days)}d) — auto-closed as solved",
-                flush=True,
-            )
-            # Adjust counters
-            if was_inconclusive:
-                inconclusive -= 1
-            solved += 1
 
     dur = f"{int(time.monotonic() - t0)}s"
     print(

--- a/cai.py
+++ b/cai.py
@@ -1487,7 +1487,7 @@ def cmd_confirm(args) -> int:
             "issue", "list", "--repo", REPO,
             "--label", LABEL_MERGED,
             "--state", "open",
-            "--json", "number,title,body,labels",
+            "--json", "number,title,body,labels,updatedAt",
             "--limit", "100",
         ]) or []
     except subprocess.CalledProcessError as e:
@@ -1592,6 +1592,49 @@ def cmd_confirm(args) -> int:
         elif status == "inconclusive":
             print(f"[cai confirm] #{issue_num}: inconclusive — no action", flush=True)
             inconclusive += 1
+
+    # 6. Auto-close stale inconclusive issues.
+    #    Issues that stay :merged and inconclusive for > 14 days are
+    #    assumed solved — the pattern hasn't resurfaced.
+    _STALE_MERGED_DAYS = 14
+    now = datetime.now(timezone.utc)
+    verdict_nums = {v[0] for v in verdicts}
+    for mi in merged_issues:
+        num = mi["number"]
+        # Only handle issues that were inconclusive or had no verdict
+        was_inconclusive = any(
+            v[0] == num and v[1] == "inconclusive" for v in verdicts
+        )
+        had_no_verdict = num not in verdict_nums
+        if not (was_inconclusive or had_no_verdict):
+            continue
+        updated = mi.get("updatedAt", "")
+        if not updated:
+            continue
+        try:
+            updated_dt = datetime.fromisoformat(updated.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            continue
+        age_days = (now - updated_dt).total_seconds() / 86400
+        if age_days > _STALE_MERGED_DAYS:
+            _set_labels(num, add=[LABEL_SOLVED], remove=[LABEL_MERGED])
+            _run(
+                ["gh", "issue", "close", str(num),
+                 "--repo", REPO,
+                 "--comment",
+                 f"Auto-closed: issue remained :merged with inconclusive "
+                 f"verdicts for {int(age_days)} days. Assuming solved."],
+                capture_output=True,
+            )
+            print(
+                f"[cai confirm] #{num}: stale inconclusive "
+                f"({int(age_days)}d) — auto-closed as solved",
+                flush=True,
+            )
+            # Adjust counters
+            if was_inconclusive:
+                inconclusive -= 1
+            solved += 1
 
     dur = f"{int(time.monotonic() - t0)}s"
     print(

--- a/prompts/backend-confirm.md
+++ b/prompts/backend-confirm.md
@@ -26,13 +26,24 @@ For **each** merged issue, output exactly one verdict block:
 
 ## Decision rules
 
-- **solved** — The pattern described in the issue's evidence section is
-  absent from the parsed signals. The fix worked.
+- **solved** — The parsed signals are non-empty and the pattern
+  described in the issue's evidence section is not present. The
+  absence of the pattern in recent signals is positive evidence the
+  fix worked. Use this verdict whenever there are signals but the
+  specific pattern is not found.
 - **unsolved** — The pattern described in the issue's evidence section
-  is still present in the parsed signals. The fix did not eliminate it.
-- **inconclusive** — The parsed signals are empty or insufficient to
-  determine whether the pattern is present or absent (e.g., no recent
-  sessions, no relevant tool calls in the window).
+  is clearly still present in the parsed signals.
+- **inconclusive** — The parsed signals are completely empty (zero
+  sessions, no data at all). If there are any parsed signals, you
+  MUST choose either solved or unsolved — never inconclusive.
+
+## Important: do not overuse inconclusive
+
+The most common mistake is defaulting to "inconclusive" when the
+pattern is simply absent from the signals. Absence of the pattern in
+a non-empty signal set means the fix worked — that is **solved**, not
+"inconclusive." Reserve "inconclusive" strictly for an empty signal
+set with no sessions at all.
 
 ## Hard rules
 

--- a/prompts/backend-confirm.md
+++ b/prompts/backend-confirm.md
@@ -26,24 +26,13 @@ For **each** merged issue, output exactly one verdict block:
 
 ## Decision rules
 
-- **solved** — The parsed signals are non-empty and the pattern
-  described in the issue's evidence section is not present. The
-  absence of the pattern in recent signals is positive evidence the
-  fix worked. Use this verdict whenever there are signals but the
-  specific pattern is not found.
+- **solved** — The pattern described in the issue's evidence section is
+  absent from the parsed signals. The fix worked.
 - **unsolved** — The pattern described in the issue's evidence section
-  is clearly still present in the parsed signals.
-- **inconclusive** — The parsed signals are completely empty (zero
-  sessions, no data at all). If there are any parsed signals, you
-  MUST choose either solved or unsolved — never inconclusive.
-
-## Important: do not overuse inconclusive
-
-The most common mistake is defaulting to "inconclusive" when the
-pattern is simply absent from the signals. Absence of the pattern in
-a non-empty signal set means the fix worked — that is **solved**, not
-"inconclusive." Reserve "inconclusive" strictly for an empty signal
-set with no sessions at all.
+  is still present in the parsed signals. The fix did not eliminate it.
+- **inconclusive** — The parsed signals are empty or insufficient to
+  determine whether the pattern is present or absent (e.g., no recent
+  sessions, no relevant tool calls in the window).
 
 ## Hard rules
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#110

**Issue:** #110 — why so many inconclusive, can we improve the situation?

## PR Summary

### What this fixes
The `cai confirm` command was producing "inconclusive" verdicts for 19 out of 22 merged issues because the confirm prompt's decision rules made "inconclusive" too easy to reach — the model defaulted to it whenever the specific pattern wasn't explicitly found in signals, even when signals were non-empty (which should indicate "solved"). Additionally, there was no mechanism to handle issues that stayed `:merged` indefinitely with repeated inconclusive verdicts.

### What was changed
- **`prompts/backend-confirm.md`**: Rewrote the decision rules to make "inconclusive" strictly reserved for completely empty signal sets. Clarified that absence of a pattern in non-empty signals = "solved." Added a new "Important: do not overuse inconclusive" section reinforcing this guidance.
- **`cai.py` (`cmd_confirm`)**: Added `updatedAt` to the GitHub issue query fields. Added a staleness mechanism (step 6) that auto-closes `:merged` issues as solved if they have remained inconclusive for more than 14 days — these issues have survived multiple confirm cycles without the pattern resurfacing, so they are assumed solved.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
