### PR TITLE
auto-improve: Add cai.py merge subcommand: confidence-gated auto-merge for bot PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ subprocess with no shared state.
 | `cai.py verify` | `45 * * * *` (hourly :45) | Mechanical, no LLM. Walks `auto-improve:pr-open` issues and updates labels based on PR merge state |
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` issues, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet, report-only) |
 | `cai.py review-pr` | `20 * * * *` (hourly :20) | Pre-merge consistency review of open PRs — posts ripple-effect findings as PR comments so the revise subagent can act on them |
+| `cai.py merge` | `35 * * * *` (hourly :35) | Confidence-gated auto-merge — evaluates each bot PR against its linked issue, posts a verdict, and merges when confidence meets the threshold |
 | `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → left as `:merged` (Sonnet) |
 
 On `docker compose up -d` the entrypoint templates the crontab from
 the env vars (`CAI_ANALYZER_SCHEDULE`, `CAI_FIX_SCHEDULE`,
-`CAI_REVIEW_PR_SCHEDULE`, `CAI_REVISE_SCHEDULE`, `CAI_VERIFY_SCHEDULE`,
-`CAI_AUDIT_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`), runs each
+`CAI_REVIEW_PR_SCHEDULE`, `CAI_MERGE_SCHEDULE`, `CAI_REVISE_SCHEDULE`,
+`CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`), runs each
 subcommand once synchronously so logs show immediate results, then execs
 supercronic.
 
@@ -172,6 +173,45 @@ This replaces the post-merge consistency review originally proposed in
 issue #45. Pre-merge review catches ripple effects before they land in
 `main`, avoiding the extra round-trip of a follow-up fix PR.
 
+### Confidence-gated auto-merge
+
+The `merge` subcommand (default: hourly at `:35`) closes the
+autonomous loop end-to-end by auto-merging bot PRs that clearly
+implement their linked issue. For each open `:pr-open` PR on an
+`auto-improve/<N>-*` branch, it:
+
+1. Applies safety filters (bot branch, `:pr-open` label, no
+   unaddressed comments, no conflicts, no failed CI, not already
+   evaluated at the current SHA)
+2. Fetches the linked issue body, PR diff, and PR comments
+3. Pipes them through `claude -p --model claude-opus-4-6` with a
+   conservative merge-review prompt
+4. Parses the model's verdict: `high`, `medium`, or `low` confidence
+5. If the verdict meets the threshold, merges via
+   `gh pr merge --merge --delete-branch`
+6. Otherwise, labels the issue `auto-improve:merge-blocked` and
+   posts the verdict reasoning as a PR comment
+
+**Confidence levels:**
+
+| Level | Meaning |
+|---|---|
+| `high` | PR correctly implements every remediation step, changes are minimal, no bugs or scope creep. Safe to merge without human review. |
+| `medium` | PR mostly implements the issue but has minor concerns. Better with human review. |
+| `low` | Significant issues — wrong approach, missing functionality, or potential bugs. Should not be merged. |
+
+**Threshold** (`CAI_MERGE_CONFIDENCE_THRESHOLD` env var):
+
+| Value | Behavior |
+|---|---|
+| `high` (default) | Only `high` verdicts trigger auto-merge |
+| `medium` | Both `high` and `medium` verdicts trigger auto-merge |
+| `disabled` | Never auto-merge; still posts verdict comments |
+
+The threshold defaults to `high` — only the most clear-cut PRs merge
+automatically. Relax to `medium` by editing the env var once trust
+builds.
+
 `auto-improve:requested` is a separate entry point: a human applies
 it to an arbitrary issue to opt it into the fix queue. The label is
 restricted to repo admins by `.github/workflows/admin-only-label.yml`
@@ -193,6 +233,7 @@ docker compose exec cai python /app/cai.py revise
 docker compose exec cai python /app/cai.py verify
 docker compose exec cai python /app/cai.py audit
 docker compose exec cai python /app/cai.py confirm
+docker compose exec cai python /app/cai.py merge
 ```
 
 A short alias makes this trivial:
@@ -205,6 +246,7 @@ cai revise
 cai verify
 cai audit
 cai confirm
+cai merge
 ```
 
 See the [tracking issue](https://github.com/damien-robotsix/robotsix-cai/issues/1)
@@ -383,6 +425,10 @@ the same global window settings.
   to read (most recent first by mtime). Default: `20`. Set to `0` to
   disable the count limit. Both knobs apply together — a file must be
   within the time window AND in the top N most recent to be included.
+- **`CAI_MERGE_CONFIDENCE_THRESHOLD`** — confidence level required for
+  auto-merge. One of `high` (default), `medium`, or `disabled`. See
+  the [Confidence-gated auto-merge](#confidence-gated-auto-merge)
+  section for details.
 
 **Troubleshooting: `cannot run ssh` errors.** If `cai.py fix` fails
 with `error: cannot run ssh: No such file or directory`, your
@@ -405,7 +451,7 @@ docker run --rm -v cai_transcripts:/data alpine ls -R /data
 
 A **run log** is written to `./logs/cai.log` (bind-mounted from
 `/var/log/cai/cai.log` inside the container). Each `init`, `analyze`,
-`fix`, `review-pr`, `revise`, `verify`, `audit`, and `confirm` invocation appends one key=value line so you can
+`fix`, `review-pr`, `revise`, `verify`, `audit`, `confirm`, and `merge` invocation appends one key=value line so you can
 watch cycle activity from the host without `docker exec`:
 
 ```bash

--- a/cai.py
+++ b/cai.py
@@ -52,8 +52,13 @@ Subcommands:
                             post findings as PR comments. Skips PRs
                             already reviewed at their current HEAD SHA.
 
+    python cai.py merge     Confidence-gated auto-merge for bot PRs.
+                            Evaluates each :pr-open PR against its
+                            linked issue, posts a verdict comment, and
+                            merges when confidence meets the threshold.
+
 The container runs `entrypoint.sh`, which executes `init`, `analyze`,
-`fix`, `revise`, `verify`, `audit`, `confirm`, and `review-pr` once synchronously at
+`fix`, `revise`, `verify`, `audit`, `confirm`, `review-pr`, and `merge` once synchronously at
 startup, then hands off to supercronic. Each cron tick is a fresh process.
 
 The gh auth check is done once per subcommand invocation. We want a
@@ -65,6 +70,7 @@ No third-party Python dependencies — only stdlib.
 
 import argparse
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -96,6 +102,7 @@ AUDIT_PROMPT = Path("/app/prompts/backend-audit.md")
 CONFIRM_PROMPT = Path("/app/prompts/backend-confirm.md")
 REVISE_PROMPT = Path("/app/prompts/backend-revise.md")
 REVIEW_PR_PROMPT = Path("/app/prompts/backend-review-pr.md")
+MERGE_PROMPT = Path("/app/prompts/backend-merge.md")
 
 # Issue lifecycle labels.
 LABEL_RAISED = "auto-improve:raised"
@@ -106,6 +113,7 @@ LABEL_MERGED = "auto-improve:merged"
 LABEL_SOLVED = "auto-improve:solved"
 LABEL_NO_ACTION = "auto-improve:no-action"
 LABEL_REVISING = "auto-improve:revising"
+LABEL_MERGE_BLOCKED = "auto-improve:merge-blocked"
 
 
 # ---------------------------------------------------------------------------
@@ -685,6 +693,7 @@ _BOT_COMMENT_MARKERS = (
     "## Revise subagent:",
     "## Revision summary",
     "## cai pre-merge review",
+    "## cai merge verdict",
 )
 
 
@@ -1789,6 +1798,333 @@ def cmd_review_pr(args) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Merge — confidence-gated auto-merge for bot PRs
+# ---------------------------------------------------------------------------
+
+_MERGE_COMMENT_HEADING = "## cai merge verdict"
+
+# Confidence threshold: only verdicts at or above this level trigger a merge.
+# "high" = only high merges, "medium" = high + medium merge, "disabled" = never merge.
+_MERGE_THRESHOLD = os.environ.get("CAI_MERGE_CONFIDENCE_THRESHOLD", "high").lower()
+
+_CONFIDENCE_RANKS = {"high": 3, "medium": 2, "low": 1}
+
+
+def _parse_merge_verdict(text: str) -> dict | None:
+    """Extract confidence, action, and reasoning from the agent's output."""
+    conf_m = re.search(r"\*\*Confidence:\*\*\s*(high|medium|low)", text, re.IGNORECASE)
+    act_m = re.search(r"\*\*Action:\*\*\s*(merge|hold|reject)", text, re.IGNORECASE)
+    reason_m = re.search(r"\*\*Reasoning:\*\*\s*(.+)", text, re.IGNORECASE)
+    if not conf_m or not act_m:
+        return None
+    return {
+        "confidence": conf_m.group(1).lower(),
+        "action": act_m.group(1).lower(),
+        "reasoning": reason_m.group(1).strip() if reason_m else "(no reasoning provided)",
+    }
+
+
+def cmd_merge(args) -> int:
+    """Confidence-gated auto-merge for bot PRs."""
+    print("[cai merge] checking open PRs for auto-merge", flush=True)
+    t0 = time.monotonic()
+
+    if _MERGE_THRESHOLD == "disabled":
+        print("[cai merge] CAI_MERGE_CONFIDENCE_THRESHOLD=disabled; skipping", flush=True)
+        log_run("merge", repo=REPO, result="disabled", exit=0)
+        return 0
+
+    if _MERGE_THRESHOLD not in ("high", "medium"):
+        print(
+            f"[cai merge] unknown threshold '{_MERGE_THRESHOLD}'; defaulting to 'high'",
+            flush=True,
+        )
+
+    threshold_rank = _CONFIDENCE_RANKS.get(_MERGE_THRESHOLD, _CONFIDENCE_RANKS["high"])
+
+    # Fetch open PRs.
+    try:
+        prs = _gh_json([
+            "pr", "list",
+            "--repo", REPO,
+            "--state", "open",
+            "--base", "main",
+            "--json", "number,title,headRefName,headRefOid,comments,mergeable",
+            "--limit", "50",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(f"[cai merge] gh pr list failed:\n{e.stderr}", file=sys.stderr)
+        log_run("merge", repo=REPO, result="pr_list_failed", exit=1)
+        return 1
+
+    if not prs:
+        print("[cai merge] no open PRs; nothing to do", flush=True)
+        log_run("merge", repo=REPO, result="no_open_prs", exit=0)
+        return 0
+
+    evaluated = 0
+    merged = 0
+    held = 0
+
+    for pr in prs:
+        pr_number = pr["number"]
+        head_sha = pr["headRefOid"]
+        branch = pr.get("headRefName", "")
+        title = pr["title"]
+
+        # Safety filter 1: only bot PRs.
+        m = re.match(r"^auto-improve/(\d+)-", branch)
+        if not m:
+            continue
+        issue_number = int(m.group(1))
+
+        # Safety filter 4: unmergeable PRs (conflicts).
+        mergeable = pr.get("mergeable", "")
+        if mergeable == "CONFLICTING":
+            print(
+                f"[cai merge] PR #{pr_number}: unmergeable (conflicts); skipping",
+                flush=True,
+            )
+            continue
+
+        # Safety filter 2: linked issue must be in :pr-open state.
+        try:
+            issue = _gh_json([
+                "issue", "view", str(issue_number),
+                "--repo", REPO,
+                "--json", "labels,state",
+            ])
+        except subprocess.CalledProcessError:
+            print(
+                f"[cai merge] PR #{pr_number}: could not fetch issue #{issue_number}; skipping",
+                flush=True,
+            )
+            continue
+
+        issue_labels = [l["name"] for l in issue.get("labels", [])]
+        if LABEL_PR_OPEN not in issue_labels:
+            continue
+        if LABEL_MERGE_BLOCKED in issue_labels:
+            continue
+
+        # Safety filter 3: unaddressed review comments → let revise handle.
+        all_comments = list(pr.get("comments", []))
+        try:
+            all_comments.extend(_fetch_review_comments(pr_number))
+        except Exception:
+            pass
+        human_comments = [c for c in all_comments if not _is_bot_comment(c)]
+        # Check if any human comment is newer than HEAD (unaddressed).
+        has_unaddressed = False
+        for c in human_comments:
+            created = c.get("createdAt", "")
+            # gh returns ISO 8601 timestamps; string compare works for chronological order.
+            if created > head_sha:
+                # Can't reliably compare timestamp to SHA; use the commit timestamp instead.
+                pass
+        # Simpler approach: if there are human comments that aren't bot comments,
+        # check the PR's commit list. For now, we rely on the revise subcommand's
+        # own logic — if revise hasn't cleared the comments yet, we skip.
+        # Actually, mirror the revise target selection logic: any non-bot comment
+        # with createdAt after the last commit means unaddressed.
+        # We need the push date. Fetch from git log of the branch.
+        # For simplicity, fetch the commit date of HEAD via the API.
+        try:
+            commits = _gh_json([
+                "pr", "view", str(pr_number),
+                "--repo", REPO,
+                "--json", "commits",
+            ])
+            commit_list = commits.get("commits", [])
+            if commit_list:
+                last_commit_date = commit_list[-1].get("committedDate", "")
+            else:
+                last_commit_date = ""
+        except (subprocess.CalledProcessError, KeyError):
+            last_commit_date = ""
+
+        if last_commit_date:
+            for c in human_comments:
+                created = c.get("createdAt", "")
+                if created > last_commit_date:
+                    has_unaddressed = True
+                    break
+
+        if has_unaddressed:
+            print(
+                f"[cai merge] PR #{pr_number}: has unaddressed review comments; skipping",
+                flush=True,
+            )
+            continue
+
+        # Safety filter 5: failed CI checks.
+        try:
+            pr_detail = _gh_json([
+                "pr", "view", str(pr_number),
+                "--repo", REPO,
+                "--json", "statusCheckRollup",
+            ])
+            for check in pr_detail.get("statusCheckRollup", []):
+                conclusion = (check.get("conclusion") or "").upper()
+                status = (check.get("status") or "").upper()
+                if conclusion == "FAILURE" or status == "FAILURE":
+                    print(
+                        f"[cai merge] PR #{pr_number}: has failed CI checks; skipping",
+                        flush=True,
+                    )
+                    has_unaddressed = True  # reuse flag to skip
+                    break
+        except (subprocess.CalledProcessError, json.JSONDecodeError, TypeError):
+            pass  # no CI checks is fine
+
+        if has_unaddressed:
+            continue
+
+        # Safety filter 6: already evaluated at this SHA.
+        already_evaluated = False
+        for comment in pr.get("comments", []):
+            body = (comment.get("body") or "")
+            if body.startswith(f"{_MERGE_COMMENT_HEADING} \u2014 {head_sha}"):
+                already_evaluated = True
+                break
+        if already_evaluated:
+            print(
+                f"[cai merge] PR #{pr_number}: already evaluated at {head_sha[:8]}; skipping",
+                flush=True,
+            )
+            continue
+
+        # All filters passed — evaluate with the model.
+        print(f"[cai merge] evaluating PR #{pr_number}: {title}", flush=True)
+
+        # Fetch issue body.
+        try:
+            issue_full = _gh_json([
+                "issue", "view", str(issue_number),
+                "--repo", REPO,
+                "--json", "number,title,body",
+            ])
+        except subprocess.CalledProcessError:
+            issue_full = {"number": issue_number, "title": "(unknown)", "body": ""}
+
+        # Fetch PR diff.
+        diff_result = _run(
+            ["gh", "pr", "diff", str(pr_number), "--repo", REPO],
+            capture_output=True,
+        )
+        if diff_result.returncode != 0:
+            print(
+                f"[cai merge] could not fetch diff for PR #{pr_number}; skipping",
+                file=sys.stderr,
+            )
+            continue
+        pr_diff = diff_result.stdout
+
+        # Gather PR comments for context.
+        comment_texts = []
+        for c in all_comments:
+            body = (c.get("body") or "").strip()
+            if body:
+                comment_texts.append(body)
+        comments_section = "\n\n---\n\n".join(comment_texts) if comment_texts else "(no comments)"
+
+        # Build the prompt.
+        prompt_text = MERGE_PROMPT.read_text()
+        full_prompt = (
+            f"{prompt_text}\n\n"
+            f"## Linked issue\n\n"
+            f"### #{issue_full.get('number', issue_number)} \u2014 {issue_full.get('title', '')}\n\n"
+            f"{issue_full.get('body') or '(no body)'}\n\n"
+            f"## PR diff\n\n"
+            f"```diff\n{pr_diff}\n```\n\n"
+            f"## PR comments\n\n"
+            f"{comments_section}\n"
+        )
+
+        # Run the model (read-only, no tools).
+        agent = _run(
+            ["claude", "-p", "--model", "claude-opus-4-6"],
+            input=full_prompt,
+            capture_output=True,
+        )
+        if agent.returncode != 0:
+            print(
+                f"[cai merge] model failed for PR #{pr_number} "
+                f"(exit {agent.returncode}):\n{agent.stderr}",
+                file=sys.stderr,
+            )
+            continue
+
+        agent_output = (agent.stdout or "").strip()
+        verdict = _parse_merge_verdict(agent_output)
+
+        if not verdict:
+            print(
+                f"[cai merge] PR #{pr_number}: could not parse verdict; skipping",
+                flush=True,
+            )
+            continue
+
+        confidence = verdict["confidence"]
+        action = verdict["action"]
+        reasoning = verdict["reasoning"]
+        evaluated += 1
+
+        # Post the verdict as a PR comment.
+        comment_body = (
+            f"{_MERGE_COMMENT_HEADING} \u2014 {head_sha}\n\n"
+            f"{agent_output}\n\n"
+            f"---\n"
+            f"_Auto-merge review by `cai merge`. "
+            f"Threshold: `{_MERGE_THRESHOLD}`, verdict: `{confidence}`._"
+        )
+        _run(
+            ["gh", "pr", "comment", str(pr_number),
+             "--repo", REPO, "--body", comment_body],
+            capture_output=True,
+        )
+
+        # Decide whether to merge.
+        verdict_rank = _CONFIDENCE_RANKS.get(confidence, 0)
+        if verdict_rank >= threshold_rank:
+            print(
+                f"[cai merge] PR #{pr_number}: verdict={confidence} >= threshold={_MERGE_THRESHOLD}; merging",
+                flush=True,
+            )
+            merge_result = _run(
+                ["gh", "pr", "merge", str(pr_number),
+                 "--repo", REPO, "--merge", "--delete-branch"],
+                capture_output=True,
+            )
+            if merge_result.returncode == 0:
+                print(f"[cai merge] PR #{pr_number}: merged successfully", flush=True)
+                merged += 1
+            else:
+                print(
+                    f"[cai merge] PR #{pr_number}: merge failed:\n{merge_result.stderr}",
+                    file=sys.stderr,
+                )
+                held += 1
+        else:
+            print(
+                f"[cai merge] PR #{pr_number}: verdict={confidence} < threshold={_MERGE_THRESHOLD}; holding",
+                flush=True,
+            )
+            # Set merge-blocked label on the issue.
+            _set_labels(issue_number, add=[LABEL_MERGE_BLOCKED])
+            held += 1
+
+    dur = f"{int(time.monotonic() - t0)}s"
+    print(
+        f"[cai merge] prs_evaluated={evaluated} merged={merged} held={held}",
+        flush=True,
+    )
+    log_run("merge", repo=REPO, prs_evaluated=evaluated, merged=merged,
+            held=held, duration=dur, exit=0)
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------
 
@@ -1810,6 +2146,7 @@ def main() -> int:
     sub.add_parser("audit", help="Run the queue/PR consistency audit")
     sub.add_parser("confirm", help="Verify merged issues are actually solved")
     sub.add_parser("review-pr", help="Pre-merge consistency review of open PRs")
+    sub.add_parser("merge", help="Confidence-gated auto-merge for bot PRs")
 
     args = parser.parse_args()
 
@@ -1826,6 +2163,7 @@ def main() -> int:
         "audit": cmd_audit,
         "confirm": cmd_confirm,
         "review-pr": cmd_review_pr,
+        "merge": cmd_merge,
     }
     return handlers[args.command](args)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet, report-only)
       CAI_CONFIRM_SCHEDULE: "0 2 * * *"     # daily at 02:00 UTC (verify merged fixes)
       CAI_REVIEW_PR_SCHEDULE: "20 * * * *"  # hourly at :20 (pre-merge consistency review)
+      CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly at :35 (auto-merge confident PRs)
+      CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "20"        # read at most N recent transcript files
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,10 +11,11 @@
 #      - verify:    walk pr-open issues and update labels per PR state
 #      - audit:     periodic queue/PR consistency checks
 #      - confirm:   verify merged fixes are actually solved
+#      - merge:     confidence-gated auto-merge for bot PRs
 #    Each is its own crontab line so supercronic runs them as
 #    independent processes — natural concurrency, easy to add more.
 #
-# 2. Do one synchronous pass of init / analyze / fix / review-pr / revise / verify / audit so
+# 2. Do one synchronous pass of init / analyze / fix / review-pr / revise / merge / verify / audit so
 #    `docker compose up -d` produces useful logs immediately rather
 #    than waiting for the first cron tick.
 #
@@ -31,6 +32,7 @@ CAI_AUDIT_SCHEDULE="${CAI_AUDIT_SCHEDULE:-0 */6 * * *}"
 CAI_REVISE_SCHEDULE="${CAI_REVISE_SCHEDULE:-30 * * * *}"
 CAI_CONFIRM_SCHEDULE="${CAI_CONFIRM_SCHEDULE:-0 2 * * *}"
 CAI_REVIEW_PR_SCHEDULE="${CAI_REVIEW_PR_SCHEDULE:-20 * * * *}"
+CAI_MERGE_SCHEDULE="${CAI_MERGE_SCHEDULE:-35 * * * *}"
 
 CRONTAB_PATH=/tmp/crontab
 
@@ -44,6 +46,7 @@ $CAI_VERIFY_SCHEDULE python /app/cai.py verify
 $CAI_AUDIT_SCHEDULE python /app/cai.py audit
 $CAI_CONFIRM_SCHEDULE python /app/cai.py confirm
 $CAI_REVIEW_PR_SCHEDULE python /app/cai.py review-pr
+$CAI_MERGE_SCHEDULE python /app/cai.py merge
 CRONTAB
 
 echo "[entrypoint] crontab:"
@@ -78,6 +81,9 @@ python /app/cai.py review-pr || echo "[entrypoint] review-pr exited non-zero; co
 
 echo "[entrypoint] running initial cai.py revise"
 python /app/cai.py revise || echo "[entrypoint] revise exited non-zero; continuing"
+
+echo "[entrypoint] running initial cai.py merge"
+python /app/cai.py merge || echo "[entrypoint] merge exited non-zero; continuing"
 
 echo "[entrypoint] running initial cai.py audit"
 python /app/cai.py audit || echo "[entrypoint] audit exited non-zero; continuing"

--- a/install.sh
+++ b/install.sh
@@ -148,6 +148,8 @@ services:
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet, report-only)
       CAI_CONFIRM_SCHEDULE: "0 2 * * *"     # daily 02:00 UTC (verify merged fixes)
       CAI_REVIEW_PR_SCHEDULE: "20 * * * *"  # hourly :20 (pre-merge consistency review)
+      CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly :35 (auto-merge confident PRs)
+      CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "20"        # read at most N recent transcript files
     volumes:
@@ -196,6 +198,8 @@ services:
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet, report-only)
       CAI_CONFIRM_SCHEDULE: "0 2 * * *"     # daily 02:00 UTC (verify merged fixes)
       CAI_REVIEW_PR_SCHEDULE: "20 * * * *"  # hourly :20 (pre-merge consistency review)
+      CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly :35 (auto-merge confident PRs)
+      CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "20"        # read at most N recent transcript files
     volumes:

--- a/prompts/backend-merge.md
+++ b/prompts/backend-merge.md
@@ -1,0 +1,73 @@
+# Backend Merge Review
+
+You are the merge review agent for `robotsix-cai`. Your job is to
+assess whether a pull request correctly implements its linked issue
+and decide whether the PR is safe to auto-merge. You have **no
+tools** — the issue body, PR diff, and PR comments are provided
+inline below.
+
+## What you receive
+
+1. **Issue body** — the full original spec the PR is meant to implement
+2. **PR diff** — the complete unified diff
+3. **PR comments** — any issue-level and line-by-line review comments
+
+## How to assess
+
+Read the issue's remediation section carefully. Then read every hunk
+in the diff and verify:
+
+1. **Completeness:** Does the PR implement every concrete step in the
+   issue's remediation? Are any steps missing?
+2. **Scope:** Does the PR touch only what the issue asks for? Are
+   there extra files, refactors, or unrelated changes?
+3. **Correctness:** Do the code changes look correct? Are there
+   obvious bugs, typos, or logic errors?
+4. **Comments:** If reviewers left comments, were they addressed?
+   Unaddressed review comments are a reason to hold.
+
+## Confidence levels
+
+You must emit exactly one of three confidence levels:
+
+| Confidence | When to use |
+|---|---|
+| **high** | The PR correctly implements every remediation step in the issue, changes are minimal and targeted, there are no obvious bugs or scope creep, and you can trace every change back to the issue spec. No reservations. |
+| **medium** | The PR mostly implements the issue but has minor concerns: slightly broader scope, a small ambiguous choice, or one element you're not fully sure about. Probably fine, but better with human review. |
+| **low** | The PR has significant issues: wrong approach, missing core functionality, potential bugs, or substantial scope creep. Should not be merged automatically. |
+
+## Things that must NEVER produce a high verdict
+
+- PR scope is broader than the issue asks for
+- PR introduces new files not mentioned in the issue
+- PR modifies workflow files (`.github/workflows/`)
+- PR modifies files the issue explicitly says not to touch
+- PR adds tests or docstrings unless the issue asked for them
+- PR removes existing functionality not explicitly asked to be removed
+- You cannot trace every change in the diff back to a remediation
+  step in the issue
+- There are unaddressed review comments
+- The diff is empty or trivially wrong
+
+When in doubt, output **medium** or **low**. The default merge
+threshold is `high`, so a `high` verdict should reflect genuine
+certainty — not optimism or best-effort guessing.
+
+## Output format
+
+Emit exactly this structured block — nothing else:
+
+```
+### Merge Verdict: PR #<N>
+
+- **Confidence:** high | medium | low
+- **Action:** merge | hold | reject
+- **Reasoning:** <2-3 sentences explaining your assessment. Be specific about what you checked and why you're confident or not.>
+```
+
+The action mapping:
+- `high` confidence → `merge`
+- `medium` confidence → `hold`
+- `low` confidence → `reject`
+
+Do not add any text before or after the verdict block.

--- a/publish.py
+++ b/publish.py
@@ -65,6 +65,7 @@ LABELS = [
     ("auto-improve:no-action", "c5def5", "Fix subagent reviewed and decided no code change is needed; awaiting human triage"),
     ("auto-improve:revising", "d4c5f9", "Revise subagent is actively iterating on a PR"),
     ("auto-improve:solved", "0e8a16", "Pattern verified absent from recent transcripts"),
+    ("auto-improve:merge-blocked", "e11d48", "Merge subcommand reviewed and decided not to auto-merge; awaiting human"),
     ("category:reliability", "d73a4a", "Errors, failures, flaky behavior"),
     ("category:cost_reduction", "fbca04", "Token waste, unnecessary tool calls"),
     ("category:prompt_quality", "0075ca", "Unclear or missing prompt guidance"),


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#113

**Issue:** #113 — Add cai.py merge subcommand: confidence-gated auto-merge for bot PRs

## PR Summary

### What this fixes
The autonomous loop had a manual hand-off at the end: after the fix subagent opened a PR, a human had to review and merge it. This adds a confidence-gated auto-merge subcommand (`cai.py merge`) that evaluates bot PRs against their linked issues and merges only when the model's confidence meets a configurable threshold (default: `high`).

### What was changed
- **`prompts/backend-merge.md`** (new): merge review prompt instructing the model to assess PR correctness against the linked issue spec, emit a structured verdict (`high`/`medium`/`low` confidence), and be conservative — things like scope creep, unmentioned files, or untraced changes must never produce a `high` verdict
- **`cai.py`**: added `import os`; added `MERGE_PROMPT` path constant; added `LABEL_MERGE_BLOCKED` label constant; added `"## cai merge verdict"` to `_BOT_COMMENT_MARKERS`; added `_MERGE_COMMENT_HEADING`, `_MERGE_THRESHOLD`, `_CONFIDENCE_RANKS`, `_parse_merge_verdict()` helper, and `cmd_merge()` function with 6 safety filters (bot branch, `:pr-open` label, no unaddressed comments, no conflicts, no failed CI, no prior verdict at current SHA); registered `merge` subparser and handler in the dispatcher; updated module docstring
- **`publish.py`**: added `("auto-improve:merge-blocked", "e11d48", ...)` to the `LABELS` list
- **`entrypoint.sh`**: added `CAI_MERGE_SCHEDULE` env var (default `35 * * * *`), added crontab line for `cai.py merge`, added initial synchronous run after `revise` and before `audit`; updated header comments
- **`docker-compose.yml`**: added `CAI_MERGE_SCHEDULE` and `CAI_MERGE_CONFIDENCE_THRESHOLD` environment variables
- **`install.sh`**: added `CAI_MERGE_SCHEDULE` and `CAI_MERGE_CONFIDENCE_THRESHOLD` in both auth mode templates (OAuth and API key)
- **`README.md`**: added schedule table row for `cai.py merge`; added "Confidence-gated auto-merge" section documenting the flow, confidence levels, and threshold configuration; added `CAI_MERGE_CONFIDENCE_THRESHOLD` env var documentation; added `merge` to ad-hoc command examples and alias block; updated env var list in intro paragraph and run log mention

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
