### PR TITLE
auto-improve: can we have a command for cai that do a full cycle? (fix all possible issue, revise, merge, verify, confirm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,14 @@ subprocess with no shared state.
 | `cai.py review-pr` | `20 * * * *` (hourly :20) | Pre-merge consistency review of open PRs — posts ripple-effect findings as PR comments so the revise subagent can act on them |
 | `cai.py merge` | `35 * * * *` (hourly :35) | Confidence-gated auto-merge — evaluates each bot PR against its linked issue, posts a verdict, and merges when confidence meets the threshold |
 | `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → left as `:merged` (Sonnet) |
+| `cai.py cycle` | _(manual/on-demand)_ | Runs fix → revise → review-pr → merge → verify → confirm in sequence. Convenience wrapper for a full pipeline pass; not included in scheduled or startup runs |
 
 On `docker compose up -d` the entrypoint templates the crontab from
 the env vars (`CAI_ANALYZER_SCHEDULE`, `CAI_FIX_SCHEDULE`,
 `CAI_REVIEW_PR_SCHEDULE`, `CAI_MERGE_SCHEDULE`, `CAI_REVISE_SCHEDULE`,
 `CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`), runs each
-subcommand once synchronously so logs show immediate results, then execs
-supercronic.
+scheduled subcommand once synchronously so logs show immediate results, then execs
+supercronic. (`cycle` is on-demand only and is not part of scheduled or startup runs.)
 
 ### Issue lifecycle
 

--- a/cai.py
+++ b/cai.py
@@ -427,7 +427,7 @@ def _git(work_dir: Path, *args: str, check: bool = True) -> subprocess.Completed
 
 def cmd_fix(args) -> int:
     """Run the fix subagent against one eligible issue."""
-    if args.issue is not None:
+    if getattr(args, "issue", None) is not None:
         try:
             issue = _gh_json([
                 "issue", "view", str(args.issue),
@@ -2125,6 +2125,45 @@ def cmd_merge(args) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Cycle (full pipeline without analyze)
+# ---------------------------------------------------------------------------
+
+def cmd_cycle(args) -> int:
+    """Run fix → revise → review-pr → merge → verify → confirm in order."""
+    print("[cai cycle] starting full cycle (no analyze)", flush=True)
+    t0 = time.monotonic()
+
+    steps = [
+        ("fix", cmd_fix),
+        ("revise", cmd_revise),
+        ("review-pr", cmd_review_pr),
+        ("merge", cmd_merge),
+        ("verify", cmd_verify),
+        ("confirm", cmd_confirm),
+    ]
+
+    results = {}
+    failed = False
+    for name, handler in steps:
+        print(f"\n[cai cycle] === running step: {name} ===", flush=True)
+        try:
+            rc = handler(args)
+        except Exception as exc:
+            print(f"[cai cycle] step {name} raised {exc!r}", file=sys.stderr, flush=True)
+            rc = 1
+        results[name] = rc
+        if rc != 0:
+            print(f"[cai cycle] step {name} returned {rc}; continuing", flush=True)
+            failed = True
+
+    dur = f"{time.monotonic() - t0:.1f}s"
+    summary = " ".join(f"{k}={v}" for k, v in results.items())
+    print(f"\n[cai cycle] done in {dur} — {summary}", flush=True)
+    log_run("cycle", repo=REPO, results=summary, duration=dur, exit=1 if failed else 0)
+    return 1 if failed else 0
+
+
+# ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------
 
@@ -2147,6 +2186,7 @@ def main() -> int:
     sub.add_parser("confirm", help="Verify merged issues are actually solved")
     sub.add_parser("review-pr", help="Pre-merge consistency review of open PRs")
     sub.add_parser("merge", help="Confidence-gated auto-merge for bot PRs")
+    sub.add_parser("cycle", help="Full cycle: fix, revise, review-pr, merge, verify, confirm")
 
     args = parser.parse_args()
 
@@ -2164,6 +2204,7 @@ def main() -> int:
         "confirm": cmd_confirm,
         "review-pr": cmd_review_pr,
         "merge": cmd_merge,
+        "cycle": cmd_cycle,
     }
     return handlers[args.command](args)
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#117

**Issue:** #117 — can we have a command for cai that do a full cycle? (fix all possible issue, revise, merge, verify, confirm)

## PR Summary

### What this fixes
Issue #117 requests a `cai cycle` command that runs the full issue-handling pipeline (fix, revise, review-pr, merge, verify, confirm) in a single invocation, without raising new issues (i.e., skipping `analyze`).

### What was changed
- `cai.py`: Added `cmd_cycle()` function (after line 2126) that sequentially runs fix → revise → review-pr → merge → verify → confirm, logging results for each step and continuing on failure
- `cai.py`: Registered the `cycle` subparser and handler in the dispatcher (lines ~2189, ~2207)
- `cai.py:430`: Changed `args.issue` access in `cmd_fix` to `getattr(args, "issue", None)` so the fix step works when invoked from `cmd_cycle` (where args lacks the `--issue` attribute)

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
