### PR TITLE
auto-improve: Reduce consecutive Grep runs by batching or narrowing searches

### DIFF
--- a/prompts/backend-fix.md
+++ b/prompts/backend-fix.md
@@ -66,6 +66,12 @@ Grep, and Glob instead.
    files. When several files are genuinely needed, plan the full set
    first, then issue all independent Write calls in one turn rather
    than creating them one at a time.
+7. **Batch Grep calls.** When searching for multiple patterns or
+   across multiple paths, combine them into a single Grep call using
+   regex alternation (`pat1|pat2`) or issue independent Grep calls
+   in parallel rather than sequentially. Use Glob first to narrow
+   the file set, then Grep the results, instead of running
+   exploratory Grep calls one at a time.
 
 ## When to make NO changes (and exit cleanly)
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#121

**Issue:** #121 — Reduce consecutive Grep runs by batching or narrowing searches

## PR Summary

### What this fixes
The fix subagent was making excessive consecutive Grep calls (runs of 3–6) instead of batching them, leading to unnecessary tool usage and higher cost.

### What was changed
- `prompts/backend-fix.md`: Added item 7 ("Batch Grep calls.") to the Efficiency guidance section, instructing the agent to combine multiple searches using regex alternation or parallel calls, and to use Glob to narrow the file set before grepping.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
