### PR TITLE
auto-improve: we should give the mean to cai confirm to solve the issue

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -1538,6 +1538,33 @@ def cmd_confirm(args) -> int:
 
     parsed_signals = parsed.stdout.strip()
 
+    # 2b. For each merged issue, fetch the associated merged PR diff.
+    MAX_DIFF_LEN = 8000
+    for mi in merged_issues:
+        num = mi["number"]
+        try:
+            prs = _gh_json([
+                "pr", "list", "--repo", REPO,
+                "--search", f"Refs #{num}",
+                "--state", "merged",
+                "--json", "number",
+                "--limit", "1",
+            ]) or []
+        except subprocess.CalledProcessError:
+            prs = []
+        if prs:
+            pr_num = prs[0]["number"]
+            diff_result = _run(
+                ["gh", "pr", "diff", str(pr_num), "--repo", REPO],
+                capture_output=True,
+            )
+            if diff_result.returncode == 0 and diff_result.stdout.strip():
+                diff_text = diff_result.stdout.strip()
+                if len(diff_text) > MAX_DIFF_LEN:
+                    diff_text = diff_text[:MAX_DIFF_LEN] + "\n... (truncated)"
+                mi["_pr_diff"] = diff_text
+                mi["_pr_number"] = pr_num
+
     # 3. Build the confirm prompt.
     prompt_text = CONFIRM_PROMPT.read_text()
 
@@ -1547,6 +1574,11 @@ def cmd_confirm(args) -> int:
             f"### #{mi['number']} — {mi['title']}\n\n"
             f"{mi.get('body') or '(no body)'}\n\n"
         )
+        if mi.get("_pr_diff"):
+            issues_section += (
+                f"#### Merged PR diff (PR #{mi['_pr_number']})\n\n"
+                f"```diff\n{mi['_pr_diff']}\n```\n\n"
+            )
 
     full_prompt = (
         f"{prompt_text}\n\n"

--- a/prompts/backend-confirm.md
+++ b/prompts/backend-confirm.md
@@ -1,9 +1,8 @@
 # Backend Confirm
 
 You are the confirm agent for `robotsix-cai`'s self-improvement loop.
-Your job is to determine whether each `:merged` issue's pattern is
-still present in the recent parsed signals. You produce exactly one
-verdict per issue — nothing else.
+Your job is to determine whether each `:merged` issue has been
+resolved. You produce exactly one verdict per issue — nothing else.
 
 ## What you receive
 
@@ -12,6 +11,9 @@ verdict per issue — nothing else.
 2. **Merged issues** — a list of open issues labelled
    `auto-improve:merged`, each with its number, title, and body
    (including fingerprint, category, evidence, and remediation).
+3. **PR diffs** — when available, the unified diff of the merged pull
+   request associated with each issue. This shows exactly what code
+   was changed to address the issue.
 
 ## What to produce
 
@@ -21,18 +23,22 @@ For **each** merged issue, output exactly one verdict block:
 ### Verdict: #N — <issue title>
 
 - **Status:** solved | unsolved | inconclusive
-- **Reasoning:** <one-sentence explanation grounded in the parsed signals>
+- **Reasoning:** <one-sentence explanation grounded in the available evidence>
 ```
 
 ## Decision rules
 
-- **solved** — The pattern described in the issue's evidence section is
-  absent from the parsed signals. The fix worked.
-- **unsolved** — The pattern described in the issue's evidence section
-  is still present in the parsed signals. The fix did not eliminate it.
-- **inconclusive** — The parsed signals are empty or insufficient to
-  determine whether the pattern is present or absent (e.g., no recent
-  sessions, no relevant tool calls in the window).
+- **solved** — The PR diff shows changes that directly address the
+  issue's remediation, OR the pattern described in the issue's
+  evidence section is absent from the parsed signals.
+- **unsolved** — The PR diff exists but does not address the issue's
+  remediation, OR the pattern is still present in the parsed signals.
+- **inconclusive** — No PR diff is available AND the parsed signals
+  are empty or insufficient to determine whether the pattern is
+  present or absent.
+
+When a PR diff is available, prefer it over parsed signals for your
+verdict. The diff is concrete evidence of what was changed.
 
 ## Hard rules
 
@@ -42,8 +48,8 @@ For **each** merged issue, output exactly one verdict block:
 - Do NOT suggest remediations. Your job is verdicts only.
 - Do NOT reinterpret or expand the scope of an issue. Match the
   pattern as described in the issue body's evidence section.
-- If the parsed signals are empty (no recent data), output
-  **inconclusive** for every issue.
+- If the parsed signals are empty (no recent data) and no PR diff is
+  available, output **inconclusive** for the issue.
 - Do NOT wrap the Status value in backticks. Write it as plain text.
 - Output nothing before the first `### Verdict:` block and nothing
   after the last one.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#129

**Issue:** #129 — we should give the mean to cai confirm to solve the issue

## PR Summary

### What this fixes
The `cai confirm` subcommand returned "inconclusive" for nearly every issue because it only had access to parsed transcript signals (tool call patterns), which are irrelevant for most issues about code changes, prompt updates, or infrastructure modifications.

### What was changed
- **cai.py** (cmd_confirm, ~lines 1541-1566): Added step 2b that, for each merged issue, searches for the associated merged PR via `gh pr list --search "Refs #N"`, fetches its diff with `gh pr diff`, and attaches the diff (truncated to 8000 chars) to the issue data. The diff is then included in the prompt under each issue as a `#### Merged PR diff` section with a fenced diff block.
- **prompts/backend-confirm.md**: Updated the confirm agent prompt to describe the new PR diff input, revised decision rules to prefer PR diffs over parsed signals as concrete evidence, and relaxed the "empty signals = inconclusive" rule so that a PR diff alone can support a solved/unsolved verdict.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
