### PR TITLE
merge: re-evaluate when human comments arrive after the verdict

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -2182,19 +2182,48 @@ def cmd_merge(args) -> int:
         if has_unaddressed:
             continue
 
-        # Safety filter 6: already evaluated at this SHA.
-        already_evaluated = False
+        # Safety filter 6: already evaluated at this SHA, AND no new
+        # human comment has been posted since the most recent verdict.
+        #
+        # The original idempotency was SHA-only: once a verdict existed
+        # for the current HEAD SHA, we'd skip forever. That left PRs
+        # parked when the verdict's reasoning was effectively addressed
+        # by conversation (e.g. the user clarifies an ambiguity in a
+        # comment, no code change needed). Now we re-evaluate when
+        # there's any human comment newer than the latest verdict —
+        # the merge agent gets the comment thread as context and can
+        # flip its verdict based on the discussion.
+        latest_verdict_ts = None
         for comment in pr.get("comments", []):
             body = (comment.get("body") or "")
-            if body.startswith(f"{_MERGE_COMMENT_HEADING} \u2014 {head_sha}"):
-                already_evaluated = True
-                break
-        if already_evaluated:
+            if not body.startswith(f"{_MERGE_COMMENT_HEADING} \u2014 {head_sha}"):
+                continue
+            v_ts = _parse_iso_ts(comment.get("createdAt"))
+            if v_ts is None:
+                continue
+            if latest_verdict_ts is None or v_ts > latest_verdict_ts:
+                latest_verdict_ts = v_ts
+
+        if latest_verdict_ts is not None:
+            # Look for any human comment newer than the latest verdict.
+            has_newer_human_comment = False
+            for c in all_comments:
+                if _is_bot_comment(c):
+                    continue
+                c_ts = _parse_iso_ts(c.get("createdAt"))
+                if c_ts is not None and c_ts > latest_verdict_ts:
+                    has_newer_human_comment = True
+                    break
+            if not has_newer_human_comment:
+                print(
+                    f"[cai merge] PR #{pr_number}: already evaluated at {head_sha[:8]}; skipping",
+                    flush=True,
+                )
+                continue
             print(
-                f"[cai merge] PR #{pr_number}: already evaluated at {head_sha[:8]}; skipping",
+                f"[cai merge] PR #{pr_number}: re-evaluating — new human comment since last verdict",
                 flush=True,
             )
-            continue
 
         # All filters passed — evaluate with the model.
         print(f"[cai merge] evaluating PR #{pr_number}: {title}", flush=True)

--- a/prompts/backend-merge.md
+++ b/prompts/backend-merge.md
@@ -26,6 +26,14 @@ in the diff and verify:
 4. **Comments:** If reviewers left comments, were they addressed?
    Unaddressed review comments are a reason to hold.
 
+   The PR comments may include **prior verdicts you posted yourself**
+   in earlier evaluation cycles (recognizable by the `## cai merge
+   verdict — <sha>` heading). Treat those as historical context, NOT
+   as a directive — your job is to make a fresh assessment based on
+   the current state. If a prior verdict held the PR for a concern,
+   check whether the conversation since then resolves that concern;
+   if it does, your new verdict can flip from `hold` to `merge`.
+
 ## Confidence levels
 
 You must emit exactly one of three confidence levels:


### PR DESCRIPTION
## The bug (observed on PR #127)

The merge subagent posted a `medium - hold` verdict at SHA \`752968aa\`. The hold reason was real:

> "the issue spec explicitly lists three namespaces — \`auto-improve\`, \`consistency\`, and \`audit\` — while the diff only includes \`{auto-improve, audit}\`. ... This warrants human confirmation that dropping \`consistency\` is acceptable before merging."

The user then commented: \"lets drop consistency if not used\". Revise verified there are no \`consistency:*\` labels anywhere in the codebase. The hold concern was effectively addressed by the conversation.

**But the merge subcommand never re-evaluated**. SHA-only idempotency: once a verdict existed for the current SHA, every subsequent tick skipped the PR. The PR was parked forever until a human (me, just now) merged it manually.

## Fix

Change the idempotency check from \"verdict exists for this SHA\" to \"verdict exists for this SHA **AND** no human comment is newer than the most recent verdict\".

When a new human comment arrives, the merge agent re-evaluates:
- The comment thread is already in the prompt context (since #113 / PR #114)
- The prompt now explicitly tells the agent to treat prior verdicts in the thread as historical context, not as a directive — it can flip from \`hold\` to \`merge\` if the conversation resolves the original concern
- The new verdict gets posted as a fresh \`## cai merge verdict — <sha>\` comment, which becomes the new \"most recent verdict\" for the next idempotency check

## Edge cases handled

- **No prior verdict** → first evaluation, normal flow
- **Verdict exists, no new comments** → skip (preserves existing behavior, no token waste on unchanged PRs)
- **Verdict exists, new human comment** → re-evaluate with full context
- **Verdict exists, only new bot comments** → skip (bot comments are filtered via \`_is_bot_comment\`)
- **Multiple verdicts on the same SHA** → use the latest by timestamp

## Verification

Replayed PR #127's actual timeline against the new logic:

\`\`\`
latest verdict ts: 2026-04-09 00:07:40+00:00
  newer human comment: 2026-04-09T00:13:24Z lets drop consistency if not used
has newer human comment: True

OUTCOME: re-evaluate (would have unstuck PR #127)
\`\`\`

PR #127 has been manually merged in the meantime. After this fix lands, the same situation will resolve itself automatically — the next merge tick will see the user comment, re-run the agent with the comment thread, and (assuming the agent flips its verdict to \`high\`) auto-merge.

## Companion to PR #134

PR #134 (the loop guard) made revise stop processing comments the bot had already responded to. This PR (the merge re-evaluation) makes merge resume processing PRs the bot had already evaluated when conversation arrives. Together they close two complementary loop holes in the closed-loop chain.

Refs damien-robotsix/robotsix-cai#113

🤖 Generated with [Claude Code](https://claude.com/claude-code)