### PR TITLE
auto-improve: Fix Edit call failures causing 40% error rate

### DIFF
--- a/prompts/backend-fix.md
+++ b/prompts/backend-fix.md
@@ -19,9 +19,11 @@ Grep, and Glob instead.
 
 ## Hard rules
 
-1. **Read before you edit.** Always inspect the relevant files
-   before making changes. Do not propose edits to files you have
-   not read.
+1. **Read before you edit.** Always Read the target file
+   **immediately** before calling Edit — not just earlier in the
+   session. Use a unique, multi-line `old_string` (3+ lines of
+   surrounding context) to avoid ambiguous-match failures. Do not
+   propose edits to files you have not read.
 2. **Make minimal, targeted changes.** Touch only what the issue
    actually requires. Do not refactor surrounding code, rename
    variables, reformat, add comments, or "improve" things outside

--- a/prompts/backend-revise.md
+++ b/prompts/backend-revise.md
@@ -16,9 +16,11 @@ working on top of the previous fix attempt.
 
 ## Hard rules
 
-1. **Read before you edit.** Always inspect the relevant files
-   before making changes. Do not propose edits to files you have
-   not read.
+1. **Read before you edit.** Always Read the target file
+   **immediately** before calling Edit — not just earlier in the
+   session. Use a unique, multi-line `old_string` (3+ lines of
+   surrounding context) to avoid ambiguous-match failures. Do not
+   propose edits to files you have not read.
 2. **Only address the review comments.** Do not redo the original
    work, reinterpret the issue, or refactor unrelated code. Your
    scope is strictly what the reviewers asked for.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#140

**Issue:** #140 — Fix Edit call failures causing 40% error rate

## PR Summary

### What this fixes
Edit tool calls in claude -p sessions were failing at a 40% rate due to stale file views and non-unique `old_string` matches. The task-specific prompts lacked explicit guidance to prevent these failures.

### What was changed
- **prompts/backend-fix.md**: Strengthened hard rule 1 ("Read before you edit") to require reading the target file **immediately** before calling Edit and using a unique, multi-line `old_string` (3+ lines of context) to avoid match failures.
- **prompts/backend-revise.md**: Applied the same enhancement to hard rule 1, which previously had only the generic "inspect the relevant files before making changes" wording.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
