### PR TITLE
auto-improve: When to retrigger a new MR on an issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ subprocess with no shared state.
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` issues, deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet, report-only) |
 | `cai.py review-pr` | `20 * * * *` (hourly :20) | Pre-merge consistency review of open PRs — posts ripple-effect findings as PR comments so the revise subagent can act on them |
 | `cai.py merge` | `35 * * * *` (hourly :35) | Confidence-gated auto-merge — evaluates each bot PR against its linked issue, posts a verdict, and merges when confidence meets the threshold |
-| `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → left as `:merged` (Sonnet) |
+| `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist and all parsed transcripts post-date the merge → re-raised (`:merged` → `:raised`); otherwise left as `:merged` (Sonnet) |
 | `cai.py cycle` | _(manual/on-demand)_ | Runs fix → revise → review-pr → merge → verify → confirm in sequence. Convenience wrapper for a full pipeline pass; not included in scheduled or startup runs |
 
 On `docker compose up -d` the entrypoint templates the crontab from
@@ -90,13 +90,17 @@ action so two concurrent `fix` runs can't pick the same issue.
                                     ▼
                                  merged
                                     │
-                        ┌───────────┴───────────┐
-                        │                       │
-                  confirm (pattern       confirm (inconclusive
-                   absent)                / unsolved)
-                        ▼                       ▼
-                  solved (closed)       stays :merged
-                                     (reasoning posted)
+                        ┌───────────┼───────────┐
+                        │           │           │
+                  confirm      confirm      confirm
+                  (pattern    (unsolved,   (inconclusive
+                   absent)    all data      / unsolved,
+                        │     post-merge)   mixed data)
+                        ▼           │           ▼
+                  solved (closed)   │     stays :merged
+                                    │   (reasoning posted)
+                                    ▼
+                              re-raised ──► raised
 ```
 
 `:no-action` means the fix subagent reviewed the issue and decided no

--- a/cai.py
+++ b/cai.py
@@ -79,6 +79,8 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from parse import _get_cutoff_time, _get_max_files
+
 
 REPO = "damien-robotsix/robotsix-cai"
 SMOKE_PROMPT = "Say hello in one short sentence."
@@ -1660,17 +1662,8 @@ def cmd_confirm(args) -> int:
     #     can tell whether all parsed conversations are newer than a merge.
     _oldest_transcript_ts: float | None = None
     if TRANSCRIPT_DIR.is_dir():
-        _window_raw = os.environ.get("CAI_TRANSCRIPT_WINDOW_DAYS", "7")
-        try:
-            _window_days = int(_window_raw)
-        except ValueError:
-            _window_days = 7
-        _cutoff = time.time() - (_window_days * 86400) if _window_days > 0 else 0.0
-        _max_raw = os.environ.get("CAI_TRANSCRIPT_MAX_FILES", "20")
-        try:
-            _max_files = int(_max_raw)
-        except ValueError:
-            _max_files = 20
+        _cutoff = _get_cutoff_time()
+        _max_files = _get_max_files()
         _cands = []
         for _jf in TRANSCRIPT_DIR.rglob("*.jsonl"):
             _mt = _jf.stat().st_mtime
@@ -1749,7 +1742,7 @@ def cmd_confirm(args) -> int:
         )
         dur = f"{int(time.monotonic() - t0)}s"
         log_run("confirm", repo=REPO, merged_checked=len(merged_issues),
-                solved=0, unsolved=0, inconclusive=0,
+                solved=0, unsolved=0, reraised=0, inconclusive=0,
                 duration=dur, exit=confirm.returncode)
         return confirm.returncode
 
@@ -1759,6 +1752,7 @@ def cmd_confirm(args) -> int:
 
     solved = 0
     unsolved = 0
+    reraised = 0
     inconclusive = 0
 
     for issue_num, status, reasoning in verdicts:
@@ -1798,6 +1792,7 @@ def cmd_confirm(args) -> int:
                     capture_output=True,
                 )
                 print(f"[cai confirm] #{issue_num}: unsolved — re-raised", flush=True)
+                reraised += 1
             else:
                 _run(
                     ["gh", "issue", "comment", str(issue_num),
@@ -1807,7 +1802,7 @@ def cmd_confirm(args) -> int:
                     capture_output=True,
                 )
                 print(f"[cai confirm] #{issue_num}: unsolved — left as :merged", flush=True)
-            unsolved += 1
+                unsolved += 1
         elif status == "inconclusive":
             # Post reasoning to the issue so humans can see why, but
             # avoid duplicate comments if the same reasoning was already
@@ -1838,12 +1833,13 @@ def cmd_confirm(args) -> int:
     dur = f"{int(time.monotonic() - t0)}s"
     print(
         f"[cai confirm] merged_checked={len(merged_issues)} "
-        f"solved={solved} unsolved={unsolved} inconclusive={inconclusive}",
+        f"solved={solved} unsolved={unsolved} reraised={reraised} "
+        f"inconclusive={inconclusive}",
         flush=True,
     )
     log_run("confirm", repo=REPO, merged_checked=len(merged_issues),
-            solved=solved, unsolved=unsolved, inconclusive=inconclusive,
-            duration=dur, exit=0)
+            solved=solved, unsolved=unsolved, reraised=reraised,
+            inconclusive=inconclusive, duration=dur, exit=0)
     return 0
 
 

--- a/cai.py
+++ b/cai.py
@@ -1631,13 +1631,13 @@ def cmd_confirm(args) -> int:
     except subprocess.CalledProcessError as e:
         print(f"[cai confirm] gh issue list failed:\n{e.stderr}", file=sys.stderr)
         log_run("confirm", repo=REPO, merged_checked=0, solved=0,
-                unsolved=0, inconclusive=0, exit=1)
+                unsolved=0, reraised=0, inconclusive=0, exit=1)
         return 1
 
     if not merged_issues:
         print("[cai confirm] no merged issues; nothing to do", flush=True)
         log_run("confirm", repo=REPO, merged_checked=0, solved=0,
-                unsolved=0, inconclusive=0, exit=0)
+                unsolved=0, reraised=0, inconclusive=0, exit=0)
         return 0
 
     print(f"[cai confirm] found {len(merged_issues)} merged issue(s)", flush=True)

--- a/cai.py
+++ b/cai.py
@@ -1656,6 +1656,33 @@ def cmd_confirm(args) -> int:
 
     parsed_signals = parsed.stdout.strip()
 
+    # 2a. Determine the oldest transcript mtime in the current window so we
+    #     can tell whether all parsed conversations are newer than a merge.
+    _oldest_transcript_ts: float | None = None
+    if TRANSCRIPT_DIR.is_dir():
+        _window_raw = os.environ.get("CAI_TRANSCRIPT_WINDOW_DAYS", "7")
+        try:
+            _window_days = int(_window_raw)
+        except ValueError:
+            _window_days = 7
+        _cutoff = time.time() - (_window_days * 86400) if _window_days > 0 else 0.0
+        _max_raw = os.environ.get("CAI_TRANSCRIPT_MAX_FILES", "20")
+        try:
+            _max_files = int(_max_raw)
+        except ValueError:
+            _max_files = 20
+        _cands = []
+        for _jf in TRANSCRIPT_DIR.rglob("*.jsonl"):
+            _mt = _jf.stat().st_mtime
+            if _cutoff and _mt < _cutoff:
+                continue
+            _cands.append(_mt)
+        _cands.sort(reverse=True)
+        if _max_files and len(_cands) > _max_files:
+            _cands = _cands[:_max_files]
+        if _cands:
+            _oldest_transcript_ts = min(_cands)
+
     # 2b. For each merged issue, fetch the associated merged PR diff.
     MAX_DIFF_LEN = 8000
     for mi in merged_issues:
@@ -1665,13 +1692,14 @@ def cmd_confirm(args) -> int:
                 "pr", "list", "--repo", REPO,
                 "--search", f"Refs #{num}",
                 "--state", "merged",
-                "--json", "number",
+                "--json", "number,mergedAt",
                 "--limit", "1",
             ]) or []
         except subprocess.CalledProcessError:
             prs = []
         if prs:
             pr_num = prs[0]["number"]
+            mi["_merged_at"] = prs[0].get("mergedAt")
             diff_result = _run(
                 ["gh", "pr", "diff", str(pr_num), "--repo", REPO],
                 capture_output=True,
@@ -1748,14 +1776,37 @@ def cmd_confirm(args) -> int:
             print(f"[cai confirm] #{issue_num}: solved — closed", flush=True)
             solved += 1
         elif status == "unsolved":
-            _run(
-                ["gh", "issue", "comment", str(issue_num),
-                 "--repo", REPO,
-                 "--body",
-                 "Confirm check: fix did not eliminate the pattern in the recent window."],
-                capture_output=True,
+            # If all parsed transcripts are newer than the merge, the
+            # pattern persists in post-merge data → re-raise so a new
+            # fix attempt is triggered.
+            mi_match = next((m for m in merged_issues if m["number"] == issue_num), None)
+            merged_dt = _parse_iso_ts(mi_match.get("_merged_at")) if mi_match else None
+            merged_epoch = merged_dt.timestamp() if merged_dt else None
+            reraise = (
+                merged_epoch is not None
+                and _oldest_transcript_ts is not None
+                and _oldest_transcript_ts > merged_epoch
             )
-            print(f"[cai confirm] #{issue_num}: unsolved — left as :merged", flush=True)
+            if reraise:
+                _set_labels(issue_num, add=[LABEL_RAISED], remove=[LABEL_MERGED])
+                _run(
+                    ["gh", "issue", "comment", str(issue_num),
+                     "--repo", REPO,
+                     "--body",
+                     "Confirm check: pattern persists in all post-merge conversations. "
+                     "Re-raising for a new fix attempt."],
+                    capture_output=True,
+                )
+                print(f"[cai confirm] #{issue_num}: unsolved — re-raised", flush=True)
+            else:
+                _run(
+                    ["gh", "issue", "comment", str(issue_num),
+                     "--repo", REPO,
+                     "--body",
+                     "Confirm check: fix did not eliminate the pattern in the recent window."],
+                    capture_output=True,
+                )
+                print(f"[cai confirm] #{issue_num}: unsolved — left as :merged", flush=True)
             unsolved += 1
         elif status == "inconclusive":
             # Post reasoning to the issue so humans can see why, but


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#146

**Issue:** #146 — When to retrigger a new MR on an issue

## PR Summary

### What this fixes
When `cmd_confirm()` found a merged issue's pattern was "unsolved", it only posted a comment and left the issue as `:merged` indefinitely. There was no mechanism to automatically retrigger a new fix attempt, even when all parsed transcript data was from after the merge — meaning the fix clearly didn't work.

### What was changed
- **cai.py `cmd_confirm()`**: Added step 2a that computes the oldest transcript file mtime in the current window (using the same `CAI_TRANSCRIPT_WINDOW_DAYS` / `CAI_TRANSCRIPT_MAX_FILES` env vars as `parse.py`).
- **cai.py `cmd_confirm()` PR query**: Now also fetches `mergedAt` from the linked PR and stores it as `_merged_at` on each issue dict.
- **cai.py `cmd_confirm()` unsolved branch**: When all parsed transcripts are newer than the PR merge timestamp, the issue is transitioned from `:merged` to `:raised` (with a comment explaining why), enabling a new fix attempt. When pre-merge transcripts are still in the window, the old behavior (comment-only, left as `:merged`) is preserved.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
