### PR TITLE
auto-improve: audi: raised request should be considered and fixed

### DIFF
--- a/.github/workflows/admin-only-label.yml
+++ b/.github/workflows/admin-only-label.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   enforce:
     if: >-
-      contains(fromJSON('["auto-improve:requested","auto-improve:raised","consistency:raised"]'), github.event.label.name)
+      contains(fromJSON('["auto-improve:requested","auto-improve:raised","consistency:raised","audit:raised"]'), github.event.label.name)
     runs-on: ubuntu-latest
     steps:
       - name: Check sender's permission

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ subprocess with no shared state.
 | `cai.py fix` | `15 * * * *` (hourly :15) | Picks the oldest eligible issue, lets a subagent edit the repo with full tool permissions, opens a PR — see lifecycle below |
 | `cai.py revise` | `30 * * * *` (hourly :30) | Watches `:pr-open` PRs for new comments and iterates on the same branch via force-push; also auto-rebases unmergeable PRs onto current main |
 | `cai.py verify` | `45 * * * *` (hourly :45) | Mechanical, no LLM. Walks `auto-improve:pr-open` issues and updates labels based on PR merge state |
-| `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` issues, deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet, report-only) |
+| `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` issues, deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |
 | `cai.py review-pr` | `20 * * * *` (hourly :20) | Pre-merge consistency review of open PRs — posts ripple-effect findings as PR comments so the revise subagent can act on them |
 | `cai.py merge` | `35 * * * *` (hourly :35) | Confidence-gated auto-merge — evaluates each bot PR against its linked issue, posts a verdict, and merges when confidence meets the threshold |
 | `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → left as `:merged` (Sonnet) |
@@ -108,9 +108,9 @@ bot) or re-label to `:raised` to retry.
 
 The `audit` subcommand uses a **separate label namespace** (`audit:*`)
 to distinguish its findings from analyzer findings (`auto-improve:*`).
-Audit findings are report-only — they flag inconsistencies in the
-issue/PR lifecycle for human triage and are **not** picked up by
-`cai.py fix`.
+Audit findings flag inconsistencies in the issue/PR lifecycle.
+Issues labelled `audit:raised` are picked up by `cai.py fix` just
+like `auto-improve:raised` issues.
 
 | Label | Meaning |
 |---|---|

--- a/cai.py
+++ b/cai.py
@@ -114,6 +114,7 @@ LABEL_SOLVED = "auto-improve:solved"
 LABEL_NO_ACTION = "auto-improve:no-action"
 LABEL_REVISING = "auto-improve:revising"
 LABEL_MERGE_BLOCKED = "auto-improve:merge-blocked"
+LABEL_AUDIT_RAISED = "audit:raised"
 
 
 # ---------------------------------------------------------------------------
@@ -365,7 +366,7 @@ def _select_fix_target():
     `:in-progress` or `:pr-open`.
     """
     candidates: dict[int, dict] = {}
-    for label in (LABEL_RAISED, LABEL_REQUESTED):
+    for label in (LABEL_RAISED, LABEL_REQUESTED, LABEL_AUDIT_RAISED):
         try:
             issues = _gh_json([
                 "issue", "list",
@@ -472,13 +473,16 @@ def cmd_fix(args) -> int:
 
     issue_number = issue["number"]
     title = issue["title"]
+    label_names = {lbl["name"] for lbl in issue.get("labels", [])}
+    is_audit = LABEL_AUDIT_RAISED in label_names
+    origin_raised_label = LABEL_AUDIT_RAISED if is_audit else LABEL_RAISED
     print(f"[cai fix] picked #{issue_number}: {title}", flush=True)
 
     # 1. Lock — set :in-progress, drop :raised and :requested.
     if not _set_labels(
         issue_number,
         add=[LABEL_IN_PROGRESS],
-        remove=[LABEL_RAISED, LABEL_REQUESTED],
+        remove=[LABEL_RAISED, LABEL_REQUESTED, LABEL_AUDIT_RAISED],
     ):
         print(f"[cai fix] could not lock #{issue_number}", file=sys.stderr)
         log_run("fix", repo=REPO, issue=issue_number, result="lock_failed", exit=1)
@@ -499,7 +503,7 @@ def cmd_fix(args) -> int:
             return
         _set_labels(
             issue_number,
-            add=[LABEL_RAISED],
+            add=[origin_raised_label],
             remove=[LABEL_IN_PROGRESS],
         )
         locked = False
@@ -572,7 +576,7 @@ def cmd_fix(args) -> int:
                 f"---\n"
                 f"_Set by `cai fix` after the subagent reviewed and decided "
                 f"no code change was needed. Re-label to "
-                f"`auto-improve:raised` to retry, or close if you agree._"
+                f"`{origin_raised_label}` to retry, or close if you agree._"
             )
             _run(
                 ["gh", "issue", "comment", str(issue_number),
@@ -1254,7 +1258,7 @@ def cmd_verify(args) -> int:
             "--repo", REPO,
             "--label", LABEL_PR_OPEN,
             "--state", "open",
-            "--json", "number,title",
+            "--json", "number,title,labels",
             "--limit", "100",
         ]) or []
     except subprocess.CalledProcessError as e:
@@ -1280,7 +1284,9 @@ def cmd_verify(args) -> int:
             print(f"[cai verify] #{num}: PR #{pr['number']} merged → :merged", flush=True)
             transitioned += 1
         elif state == "CLOSED":
-            _set_labels(num, add=[LABEL_RAISED], remove=[LABEL_PR_OPEN])
+            issue_labels = {lbl["name"] for lbl in issue.get("labels", [])}
+            raised_label = LABEL_AUDIT_RAISED if "audit" in issue_labels else LABEL_RAISED
+            _set_labels(num, add=[raised_label], remove=[LABEL_PR_OPEN])
             print(
                 f"[cai verify] #{num}: PR #{pr['number']} closed unmerged → :raised",
                 flush=True,
@@ -1427,9 +1433,11 @@ def _rollback_stale_in_progress() -> list[dict]:
                 ok = _set_labels(issue_num, remove=[LABEL_REVISING])
             else:
                 # In-progress lock: roll back to :raised.
+                issue_labels = {lbl["name"] for lbl in issue.get("labels", [])}
+                raised_label = LABEL_AUDIT_RAISED if "audit" in issue_labels else LABEL_RAISED
                 ok = _set_labels(
                     issue_num,
-                    add=[LABEL_RAISED],
+                    add=[raised_label],
                     remove=[LABEL_IN_PROGRESS],
                 )
             if ok:

--- a/cai.py
+++ b/cai.py
@@ -13,8 +13,9 @@ Subcommands:
                             publish.py.
 
     python cai.py fix       Pick the oldest issue labelled
-                            `auto-improve:raised` or `auto-improve:
-                            requested`, lock it via the `:in-progress`
+                            `auto-improve:raised`, `auto-improve:
+                            requested`, or `audit:raised`,
+                            lock it via the `:in-progress`
                             label, clone the repo into /tmp, run the
                             fix subagent (full tool permissions), and
                             open a PR if the agent produced a diff.

--- a/cai.py
+++ b/cai.py
@@ -1286,7 +1286,7 @@ def cmd_verify(args) -> int:
             transitioned += 1
         elif state == "CLOSED":
             issue_labels = {lbl["name"] for lbl in issue.get("labels", [])}
-            raised_label = LABEL_AUDIT_RAISED if "audit" in issue_labels else LABEL_RAISED
+            raised_label = LABEL_AUDIT_RAISED if LABEL_AUDIT_RAISED in issue_labels else LABEL_RAISED
             _set_labels(num, add=[raised_label], remove=[LABEL_PR_OPEN])
             print(
                 f"[cai verify] #{num}: PR #{pr['number']} closed unmerged → :raised",
@@ -1435,7 +1435,7 @@ def _rollback_stale_in_progress() -> list[dict]:
             else:
                 # In-progress lock: roll back to :raised.
                 issue_labels = {lbl["name"] for lbl in issue.get("labels", [])}
-                raised_label = LABEL_AUDIT_RAISED if "audit" in issue_labels else LABEL_RAISED
+                raised_label = LABEL_AUDIT_RAISED if LABEL_AUDIT_RAISED in issue_labels else LABEL_RAISED
                 ok = _set_labels(
                     issue_num,
                     add=[raised_label],

--- a/cai.py
+++ b/cai.py
@@ -363,7 +363,7 @@ def _gh_user_identity() -> tuple[str, str]:
 def _select_fix_target():
     """Return the oldest open issue eligible for the fix subagent.
 
-    Eligible = labelled `:raised` or `:requested`, NOT labelled
+    Eligible = labelled `:raised`, `:requested`, or `audit:raised`, NOT labelled
     `:in-progress` or `:pr-open`.
     """
     candidates: dict[int, dict] = {}


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#135

**Issue:** #135 — audi: raised request should be considered and fixed

## PR Summary

### What this fixes
Issues labelled `audit:raised` were never picked up by the fix subagent because `_select_fix_target()` only searched for `auto-improve:raised` and `auto-improve:requested` issues. Audit findings were raised but never automatically fixed.

### What was changed
- **cai.py:117** — Added `LABEL_AUDIT_RAISED = "audit:raised"` constant.
- **cai.py:369** (`_select_fix_target`) — Added `LABEL_AUDIT_RAISED` to the list of labels searched for eligible fix targets.
- **cai.py:474-485** (`cmd_fix`) — Detect whether the selected issue is an audit issue, track its origin raised label, and include `LABEL_AUDIT_RAISED` in the labels removed during lock.
- **cai.py:500-509** (`cmd_fix` rollback) — Roll back to the correct raised label (`audit:raised` for audit issues, `auto-improve:raised` otherwise).
- **cai.py:576** (`cmd_fix` no-action comment) — Use the correct raised label in the retry instructions.
- **cai.py:1261** (`cmd_verify`) — Fetch `labels` field so verify can distinguish audit issues.
- **cai.py:1288** (`cmd_verify`) — Roll back closed-unmerged audit issues to `audit:raised` instead of `auto-improve:raised`.
- **cai.py:1435-1437** (`_rollback_stale_in_progress`) — Roll back stale audit issues to `audit:raised` instead of `auto-improve:raised`.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
