### PR TITLE
auto-improve: Fix agent should consider comments in issues

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -372,7 +372,7 @@ def _select_fix_target():
                 "--repo", REPO,
                 "--label", label,
                 "--state", "open",
-                "--json", "number,title,body,labels,createdAt",
+                "--json", "number,title,body,labels,createdAt,comments",
                 "--limit", "100",
             ]) or []
         except subprocess.CalledProcessError as e:
@@ -429,6 +429,13 @@ def _build_fix_prompt(issue: dict) -> str:
         f"### #{issue['number']} — {issue['title']}\n\n"
         f"{issue.get('body') or '(no body)'}\n"
     )
+    comments = issue.get("comments") or []
+    if comments:
+        issue_block += "\n### Comments\n\n"
+        for c in comments:
+            author = c.get("author", {}).get("login", "unknown")
+            body = c.get("body", "")
+            issue_block += f"**{author}:**\n{body}\n\n"
     return f"{prompt}\n\n{issue_block}"
 
 
@@ -444,7 +451,7 @@ def cmd_fix(args) -> int:
             issue = _gh_json([
                 "issue", "view", str(args.issue),
                 "--repo", REPO,
-                "--json", "number,title,body,labels,state,createdAt",
+                "--json", "number,title,body,labels,state,createdAt,comments",
             ])
         except subprocess.CalledProcessError as e:
             print(f"[cai fix] gh issue view #{args.issue} failed:\n{e.stderr}", file=sys.stderr)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#150

**Issue:** #150 — Fix agent should consider comments in issues

## PR Summary

### What this fixes
The fix agent only read the issue description/body when building its prompt, ignoring all subsequent comments on the issue. Comments often contain additional context, clarifications, or guidance that the agent needs to produce a correct fix.

### What was changed
- `cai.py:_select_fix_target` — added `comments` to the `--json` fields in the `gh issue list` call so comments are fetched alongside other issue data
- `cai.py:cmd_fix` — added `comments` to the `--json` fields in the `gh issue view` call for explicit issue targeting
- `cai.py:_build_fix_prompt` — appends a `### Comments` section to the issue block, listing each comment with its author and body, when the issue has comments

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
