### PR TITLE
auto-improve: Fix agent should be able to raise issue

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -432,6 +432,79 @@ def _build_fix_prompt(issue: dict) -> str:
     return f"{prompt}\n\n{issue_block}"
 
 
+def _parse_suggested_issues(agent_output: str) -> list[dict]:
+    """Extract suggested issues from the subagent's stdout.
+
+    The subagent can emit blocks like:
+
+        ## Suggested Issue
+        ### Title
+        <title text>
+        ### Body
+        <body text>
+
+    Returns a list of dicts with 'title' and 'body' keys.
+    """
+    issues: list[dict] = []
+    parts = re.split(r"^## Suggested Issue\s*$", agent_output, flags=re.MULTILINE)
+    for part in parts[1:]:  # skip everything before the first marker
+        title = ""
+        body = ""
+        title_match = re.search(
+            r"^### Title\s*\n(.*?)(?=^### |\Z)",
+            part,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        body_match = re.search(
+            r"^### Body\s*\n(.*?)(?=^## |\Z)",
+            part,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        if title_match:
+            title = title_match.group(1).strip()
+        if body_match:
+            body = body_match.group(1).strip()
+        if title:
+            issues.append({"title": title, "body": body})
+    return issues
+
+
+def _create_suggested_issues(
+    suggested: list[dict], source_issue_number: int,
+) -> int:
+    """Create GitHub issues raised by the fix subagent. Returns count created."""
+    created = 0
+    for s in suggested:
+        issue_body = (
+            f"{s['body']}\n\n"
+            f"---\n"
+            f"_Raised by the fix subagent while working on "
+            f"#{source_issue_number}._\n"
+        )
+        labels = ",".join(["auto-improve", LABEL_RAISED])
+        result = _run(
+            [
+                "gh", "issue", "create",
+                "--repo", REPO,
+                "--title", s["title"],
+                "--body", issue_body,
+                "--label", labels,
+            ],
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            url = result.stdout.strip()
+            print(f"[cai fix] created suggested issue: {url}", flush=True)
+            created += 1
+        else:
+            print(
+                f"[cai fix] failed to create suggested issue "
+                f"'{s['title']}': {result.stderr}",
+                file=sys.stderr,
+            )
+    return created
+
+
 def _git(work_dir: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
     cmd = ["git", "-C", str(work_dir)] + list(args)
     return subprocess.run(cmd, text=True, check=check, capture_output=True)
@@ -555,6 +628,13 @@ def cmd_fix(args) -> int:
             log_run("fix", repo=REPO, issue=issue_number,
                     result="subagent_failed", exit=agent.returncode)
             return agent.returncode
+
+        # 5b. Create any suggested issues the subagent raised.
+        agent_text = agent.stdout or ""
+        suggested = _parse_suggested_issues(agent_text)
+        if suggested:
+            n = _create_suggested_issues(suggested, issue_number)
+            print(f"[cai fix] created {n}/{len(suggested)} suggested issue(s)", flush=True)
 
         # 6. Inspect the working tree. Empty diff = deliberate no-action.
         status = _git(work_dir, "status", "--porcelain", check=False)

--- a/cai.py
+++ b/cai.py
@@ -703,6 +703,10 @@ def cmd_fix(args) -> int:
         _marker = "## PR Summary"
         if _marker in agent_output:
             pr_summary = agent_output[agent_output.index(_marker):]
+            # Strip any suggested-issue blocks that appear after the PR Summary.
+            pr_summary = re.split(
+                r"^## Suggested Issue\s*$", pr_summary, flags=re.MULTILINE,
+            )[0].rstrip()
             # Trim a trailing ``` / ~~~ fence if the agent wrapped it.
             for fence in ("```", "~~~"):
                 if pr_summary.rstrip().endswith(fence):

--- a/prompts/backend-fix.md
+++ b/prompts/backend-fix.md
@@ -107,6 +107,30 @@ When the issue clearly identifies:
 …then make exactly that change. Read the file(s), verify the
 remediation matches the current code, edit precisely, and stop.
 
+## Raising complementary issues
+
+While working on the fix, you may notice related problems that are
+outside the scope of the current issue. **Do not fix them in this
+PR** — instead, output a structured block so the wrapper can open a
+separate issue for each one. You can emit zero or more of these
+blocks anywhere in your output (before or after the PR Summary):
+
+~~~
+## Suggested Issue
+
+### Title
+<short, descriptive issue title>
+
+### Body
+<issue body — describe the problem, where it is, and what should
+be done about it>
+~~~
+
+The wrapper will create each suggested issue with the
+`auto-improve:raised` label so it enters the normal fix pipeline.
+Only suggest issues that are concrete and actionable — do not
+suggest vague improvements or things you are unsure about.
+
 ## Final output
 
 When you are done — whether you made changes or not — **end your

--- a/prompts/backend-fix.md
+++ b/prompts/backend-fix.md
@@ -113,7 +113,7 @@ While working on the fix, you may notice related problems that are
 outside the scope of the current issue. **Do not fix them in this
 PR** — instead, output a structured block so the wrapper can open a
 separate issue for each one. You can emit zero or more of these
-blocks anywhere in your output (before or after the PR Summary):
+blocks anywhere in your output **before** the PR Summary:
 
 ~~~
 ## Suggested Issue


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#151

**Issue:** #151 — Fix agent should be able to raise issue

## PR Summary

### What this fixes
The fix subagent had no way to raise complementary issues it discovered while working on a fix. Problems spotted during a fix that were outside the current scope were silently lost.

### What was changed
- `cai.py`: Added `_parse_suggested_issues()` function to extract `## Suggested Issue` blocks (with `### Title` and `### Body` subsections) from the subagent's stdout. Added `_create_suggested_issues()` function to create those issues via `gh issue create` with `auto-improve` and `auto-improve:raised` labels, referencing the source issue. Integrated both into `cmd_fix` at step 5b, after the subagent exits and before the working-tree inspection.
- `prompts/backend-fix.md`: Added a "Raising complementary issues" section documenting the structured block format (`## Suggested Issue` / `### Title` / `### Body`) that the subagent can emit to request new issues.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
