### PR TITLE
auto-improve: The merge agent should be able to close a MR without merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,14 @@ implement their linked issue. For each open `:pr-open` PR on an
 2. Fetches the linked issue body, PR diff, and PR comments
 3. Pipes them through `claude -p --model claude-opus-4-6` with a
    conservative merge-review prompt
-4. Parses the model's verdict: `high`, `medium`, or `low` confidence
-5. If the verdict meets the threshold, merges via
-   `gh pr merge --merge --delete-branch`
-6. Otherwise, labels the issue `auto-improve:merge-blocked` and
+4. Parses the model's verdict: a confidence level (`high`, `medium`,
+   or `low`) and an independent action (`merge`, `hold`, or `reject`)
+5. If the action is `merge` and confidence meets the threshold,
+   merges via `gh pr merge --merge --delete-branch`
+6. If the action is `reject` and confidence meets the threshold,
+   closes the PR via `gh pr close --delete-branch` and transitions
+   the issue to `auto-improve:no-action`
+7. Otherwise, labels the issue `auto-improve:merge-blocked` and
    posts the verdict reasoning as a PR comment
 
 **Confidence levels:**
@@ -211,13 +215,13 @@ implement their linked issue. For each open `:pr-open` PR on an
 
 | Value | Behavior |
 |---|---|
-| `high` (default) | Only `high` verdicts trigger auto-merge |
-| `medium` | Both `high` and `medium` verdicts trigger auto-merge |
-| `disabled` | Never auto-merge; still posts verdict comments |
+| `high` (default) | Only `high` verdicts trigger auto-merge or auto-close |
+| `medium` | Both `high` and `medium` verdicts trigger auto-merge or auto-close |
+| `disabled` | Never auto-merge/close; still posts verdict comments |
 
 The threshold defaults to `high` — only the most clear-cut PRs merge
-automatically. Relax to `medium` by editing the env var once trust
-builds.
+or close automatically. Relax to `medium` by editing the env var once
+trust builds.
 
 `auto-improve:requested` is a separate entry point: a human applies
 it to an arbitrary issue to opt it into the fix queue. The label is

--- a/cai.py
+++ b/cai.py
@@ -2399,7 +2399,7 @@ def cmd_merge(args) -> int:
             f"{agent_output}\n\n"
             f"---\n"
             f"_Auto-merge review by `cai merge`. "
-            f"Threshold: `{_MERGE_THRESHOLD}`, verdict: `{confidence}`._"
+            f"Threshold: `{_MERGE_THRESHOLD}`, verdict: `{confidence}`, action: `{action}`._"
         )
         _run(
             ["gh", "pr", "comment", str(pr_number),
@@ -2430,8 +2430,9 @@ def cmd_merge(args) -> int:
                     f"[cai merge] PR #{pr_number}: close failed:\n{close_result.stderr}",
                     file=sys.stderr,
                 )
+                _set_labels(issue_number, add=[LABEL_MERGE_BLOCKED])
                 held += 1
-        elif action != "reject" and verdict_rank >= threshold_rank:
+        elif action == "merge" and verdict_rank >= threshold_rank:
             print(
                 f"[cai merge] PR #{pr_number}: verdict={confidence} >= threshold={_MERGE_THRESHOLD}; merging",
                 flush=True,

--- a/cai.py
+++ b/cai.py
@@ -2166,6 +2166,7 @@ def cmd_merge(args) -> int:
     evaluated = 0
     merged = 0
     held = 0
+    closed = 0
 
     for pr in prs:
         pr_number = pr["number"]
@@ -2406,9 +2407,31 @@ def cmd_merge(args) -> int:
             capture_output=True,
         )
 
-        # Decide whether to merge.
+        # Decide whether to merge, hold, or reject.
         verdict_rank = _CONFIDENCE_RANKS.get(confidence, 0)
-        if verdict_rank >= threshold_rank:
+
+        if action == "reject" and verdict_rank >= threshold_rank:
+            # High-confidence reject: close the PR and mark the issue as no-action.
+            print(
+                f"[cai merge] PR #{pr_number}: verdict={confidence} reject >= threshold={_MERGE_THRESHOLD}; closing",
+                flush=True,
+            )
+            close_result = _run(
+                ["gh", "pr", "close", str(pr_number),
+                 "--repo", REPO, "--delete-branch"],
+                capture_output=True,
+            )
+            if close_result.returncode == 0:
+                print(f"[cai merge] PR #{pr_number}: closed successfully", flush=True)
+                _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN])
+                closed += 1
+            else:
+                print(
+                    f"[cai merge] PR #{pr_number}: close failed:\n{close_result.stderr}",
+                    file=sys.stderr,
+                )
+                held += 1
+        elif action != "reject" and verdict_rank >= threshold_rank:
             print(
                 f"[cai merge] PR #{pr_number}: verdict={confidence} >= threshold={_MERGE_THRESHOLD}; merging",
                 flush=True,
@@ -2438,11 +2461,11 @@ def cmd_merge(args) -> int:
 
     dur = f"{int(time.monotonic() - t0)}s"
     print(
-        f"[cai merge] prs_evaluated={evaluated} merged={merged} held={held}",
+        f"[cai merge] prs_evaluated={evaluated} merged={merged} held={held} closed={closed}",
         flush=True,
     )
     log_run("merge", repo=REPO, prs_evaluated=evaluated, merged=merged,
-            held=held, duration=dur, exit=0)
+            held=held, closed=closed, duration=dur, exit=0)
     return 0
 
 

--- a/prompts/backend-merge.md
+++ b/prompts/backend-merge.md
@@ -74,8 +74,14 @@ Emit exactly this structured block — nothing else:
 ```
 
 The action mapping:
-- `high` confidence → `merge`
-- `medium` confidence → `hold`
-- `low` confidence → `reject`
+- `merge` — the PR should be merged. Typically paired with `high` confidence.
+- `hold` — the PR needs more work or human review before merging.
+  Typically paired with `medium` confidence.
+- `reject` — the PR (and the underlying issue) should be **closed
+  without merging**. Use this when the issue itself is invalid,
+  duplicated, no longer relevant, or the PR demonstrates that the
+  requested change is unnecessary or harmful. Can be paired with any
+  confidence level; use `high` confidence when you are certain the
+  issue/PR should be closed outright.
 
 Do not add any text before or after the verdict block.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#153

**Issue:** #153 — The merge agent should be able to close a MR without merging

## PR Summary

### What this fixes
The merge agent could only merge or hold PRs — it had no ability to close a PR without merging, even when the agent determined with high confidence that the issue/PR was useless, invalid, or no longer relevant.

### What was changed
- **`prompts/backend-merge.md`**: Updated the action mapping section to decouple the `reject` action from `low` confidence. The agent can now emit `reject` with any confidence level, including `high`, when it is certain the PR/issue should be closed outright.
- **`cai.py`**: Added a `closed` counter and a new decision branch in `cmd_merge`. When the verdict action is `reject` and confidence meets the threshold, the PR is closed via `gh pr close --delete-branch` and the linked issue is transitioned from `auto-improve:pr-open` to `auto-improve:no-action`. The run summary and `log_run` call now include the `closed` count.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
