### PR TITLE
auto-improve: Uncategorised issues permanently skipped by fix subagent

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -2475,7 +2475,7 @@ def cmd_merge(args) -> int:
             )
             if merge_result.returncode == 0:
                 print(f"[cai merge] PR #{pr_number}: merged successfully", flush=True)
-                _set_labels(issue_number, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN])
+                _set_labels(issue_number, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED])
                 merged += 1
             else:
                 print(

--- a/cai.py
+++ b/cai.py
@@ -434,6 +434,7 @@ def _select_fix_target():
                 flush=True,
             )
             _set_labels(num, add=[raised_label])
+            issue.setdefault("labels", []).append({"name": raised_label})
             candidates[num] = issue
 
     if not candidates:
@@ -2476,7 +2477,6 @@ def cmd_merge(args) -> int:
             )
             if merge_result.returncode == 0:
                 print(f"[cai merge] PR #{pr_number}: merged successfully", flush=True)
-                _set_labels(issue_number, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED])
                 merged += 1
             else:
                 print(

--- a/cai.py
+++ b/cai.py
@@ -2475,6 +2475,7 @@ def cmd_merge(args) -> int:
             )
             if merge_result.returncode == 0:
                 print(f"[cai merge] PR #{pr_number}: merged successfully", flush=True)
+                _set_labels(issue_number, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN])
                 merged += 1
             else:
                 print(

--- a/cai.py
+++ b/cai.py
@@ -116,6 +116,7 @@ LABEL_NO_ACTION = "auto-improve:no-action"
 LABEL_REVISING = "auto-improve:revising"
 LABEL_MERGE_BLOCKED = "auto-improve:merge-blocked"
 LABEL_AUDIT_RAISED = "audit:raised"
+LABEL_AUDIT_SOLVED = "audit:solved"
 
 
 # ---------------------------------------------------------------------------
@@ -363,7 +364,7 @@ def _gh_user_identity() -> tuple[str, str]:
 _LIFECYCLE_LABELS = {
     LABEL_RAISED, LABEL_REQUESTED, LABEL_IN_PROGRESS, LABEL_PR_OPEN,
     LABEL_MERGED, LABEL_SOLVED, LABEL_NO_ACTION, LABEL_REVISING,
-    LABEL_MERGE_BLOCKED, LABEL_AUDIT_RAISED, "audit:solved",
+    LABEL_MERGE_BLOCKED, LABEL_AUDIT_RAISED, LABEL_AUDIT_SOLVED,
 }
 
 

--- a/cai.py
+++ b/cai.py
@@ -360,11 +360,22 @@ def _gh_user_identity() -> tuple[str, str]:
     return name, email
 
 
+_LIFECYCLE_LABELS = {
+    LABEL_RAISED, LABEL_REQUESTED, LABEL_IN_PROGRESS, LABEL_PR_OPEN,
+    LABEL_MERGED, LABEL_SOLVED, LABEL_NO_ACTION, LABEL_REVISING,
+    LABEL_MERGE_BLOCKED, LABEL_AUDIT_RAISED, "audit:solved",
+}
+
+
 def _select_fix_target():
     """Return the oldest open issue eligible for the fix subagent.
 
     Eligible = labelled `:raised`, `:requested`, or `audit:raised`, NOT labelled
     `:in-progress` or `:pr-open`.
+
+    Also picks up "orphaned" issues that carry the base `auto-improve` label
+    but no lifecycle label at all, auto-applying `:raised` so they enter the
+    fix queue.
     """
     candidates: dict[int, dict] = {}
     for label in (LABEL_RAISED, LABEL_REQUESTED, LABEL_AUDIT_RAISED):
@@ -388,6 +399,41 @@ def _select_fix_target():
             if LABEL_IN_PROGRESS in label_names or LABEL_PR_OPEN in label_names:
                 continue
             candidates[issue["number"]] = issue
+
+    # Self-heal: find issues with a base label (`auto-improve` or `audit`)
+    # but no lifecycle label.  Apply the corresponding `:raised` label so
+    # they become eligible instead of being permanently skipped.
+    for base_label, raised_label in (
+        ("auto-improve", LABEL_RAISED),
+        ("audit", LABEL_AUDIT_RAISED),
+    ):
+        try:
+            base_issues = _gh_json([
+                "issue", "list",
+                "--repo", REPO,
+                "--label", base_label,
+                "--state", "open",
+                "--json", "number,title,body,labels,createdAt,comments",
+                "--limit", "100",
+            ]) or []
+        except subprocess.CalledProcessError:
+            base_issues = []
+
+        for issue in base_issues:
+            num = issue["number"]
+            if num in candidates:
+                continue
+            label_names = {lbl["name"] for lbl in issue.get("labels", [])}
+            if label_names & _LIFECYCLE_LABELS:
+                continue
+            # Orphaned — has base label but no lifecycle label.
+            print(
+                f"[cai fix] #{num}: orphaned (no lifecycle label); "
+                f"auto-applying {raised_label}",
+                flush=True,
+            )
+            _set_labels(num, add=[raised_label])
+            candidates[num] = issue
 
     if not candidates:
         return None


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#73

**Issue:** #73 — Uncategorised issues permanently skipped by fix subagent

## PR Summary

### What this fixes
Issues carrying only the base `auto-improve` (or `audit`) label but missing a lifecycle label (e.g. `auto-improve:raised`) were permanently invisible to the fix subagent's eligibility filter in `_select_fix_target`, because that function only queried for specific lifecycle labels.

### What was changed
- **`cai.py`**: Added a `_LIFECYCLE_LABELS` constant (line 363) enumerating all known lifecycle labels.
- **`cai.py`** (`_select_fix_target`, ~line 403): Added a self-healing loop that queries for issues with only the base `auto-improve` or `audit` label, detects those missing any lifecycle label, auto-applies the corresponding `:raised` label via `_set_labels`, and includes them in the candidate set so they enter the fix queue.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
