### PR TITLE
auto-improve: analyze in_tokens collapses 96% immediately after PR #72 merges

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -247,8 +247,18 @@ def cmd_analyze(args) -> int:
     in_tokens = token_usage.get("input_tokens", 0)
     out_tokens = token_usage.get("output_tokens", 0)
 
-    # Count sessions by counting .jsonl files under the transcript dir.
-    session_count = sum(1 for _ in TRANSCRIPT_DIR.rglob("*.jsonl"))
+    # Use the session count reported by parse.py (files actually read
+    # after applying time and count windows) instead of counting all
+    # .jsonl files on disk — the latter overstates what was analyzed.
+    session_count = signals.get("session_count", 0)
+
+    if in_tokens > 0 and in_tokens < 500:
+        print(
+            f"[cai analyze] WARNING: in_tokens={in_tokens} is below the "
+            f"expected floor of 500 — the transcript window may be too "
+            f"narrow or session files may be nearly empty",
+            flush=True,
+        )
 
     prompt_text = ANALYZER_PROMPT.read_text()
 

--- a/parse.py
+++ b/parse.py
@@ -212,8 +212,12 @@ def _get_max_files() -> int:
     return max_files
 
 
-def collect_jsonl_lines(source: str) -> list[str]:
-    """Collect all JSONL lines from a file, directory, or stdin sentinel."""
+def collect_jsonl_lines(source: str) -> tuple[list[str], int]:
+    """Collect all JSONL lines from a file, directory, or stdin sentinel.
+
+    Returns (lines, file_count) where file_count is the number of session
+    files actually read (after applying time and count windows).
+    """
     p = pathlib.Path(source)
     cutoff = _get_cutoff_time()
     max_files = _get_max_files()
@@ -230,24 +234,28 @@ def collect_jsonl_lines(source: str) -> list[str]:
         lines: list[str] = []
         for _mtime, jf in candidates:
             lines.extend(jf.read_text(errors="replace").splitlines())
-        return lines
+        return lines, len(candidates)
     if p.is_file():
         if cutoff and p.stat().st_mtime < cutoff:
-            return []
-        return p.read_text(errors="replace").splitlines()
-    return []
+            return [], 0
+        return p.read_text(errors="replace").splitlines(), 1
+    return [], 0
 
 
 def main() -> None:
+    session_count = 0
     if len(sys.argv) > 1:
         all_lines: list[str] = []
         for arg in sys.argv[1:]:
-            all_lines.extend(collect_jsonl_lines(arg))
+            lines, count = collect_jsonl_lines(arg)
+            all_lines.extend(lines)
+            session_count += count
     else:
         all_lines = sys.stdin.read().splitlines()
 
     if not any(line.strip() for line in all_lines):
         print(json.dumps({
+            "session_count": session_count,
             "tool_call_count": 0,
             "top_tools": [],
             "tool_counts": {},
@@ -261,6 +269,7 @@ def main() -> None:
         return
 
     result = extract_tool_calls(all_lines)
+    result["session_count"] = session_count
     print(json.dumps(result, indent=2))
 
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#77

**Issue:** #77 — analyze in_tokens collapses 96% immediately after PR #72 merges

## PR Summary

### What this fixes
The `in_tokens` metric collapsed 96% after PR #72 merged (count-based transcript limit), but the analyzer exited 0 with no warning. Additionally, the logged `sessions=` count was inflated because it counted all `.jsonl` files on disk rather than just the files parse.py actually read after applying time and count windows.

### What was changed
- **parse.py**: Changed `collect_jsonl_lines()` return type from `list[str]` to `tuple[list[str], int]` to also return the number of session files actually read. Added `session_count` field to the JSON output in `main()`.
- **cai.py** (`cmd_analyze`): Replaced the `TRANSCRIPT_DIR.rglob("*.jsonl")` session count with the accurate `session_count` from parse.py's output. Added a `WARNING` log line when `in_tokens` is between 1 and 499, alerting operators that the transcript window may be too narrow.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
