### PR TITLE
auto-improve: Fix bot skipped eligible issue for ~7 hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ subprocess with no shared state.
 | `cai.py review-pr` | `20 * * * *` (hourly :20) | Pre-merge consistency review of open PRs — posts ripple-effect findings as PR comments so the revise subagent can act on them |
 | `cai.py merge` | `35 * * * *` (hourly :35) | Confidence-gated auto-merge — evaluates each bot PR against its linked issue, posts a verdict, and merges when confidence meets the threshold |
 | `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → left as `:merged` (Sonnet) |
-| `cai.py cycle` | _(manual/on-demand)_ | Runs fix → revise → review-pr → merge → verify → confirm in sequence. Convenience wrapper for a full pipeline pass; not included in scheduled or startup runs |
+| `cai.py cycle` | _(manual/on-demand)_ | Runs verify → fix → revise → review-pr → merge → confirm in sequence. Convenience wrapper for a full pipeline pass; not included in scheduled or startup runs |
 
 On `docker compose up -d` the entrypoint templates the crontab from
 the env vars (`CAI_ANALYZER_SCHEDULE`, `CAI_FIX_SCHEDULE`,

--- a/cai.py
+++ b/cai.py
@@ -400,6 +400,39 @@ def _select_fix_target():
             candidates[issue["number"]] = issue
 
     if not candidates:
+        # Recover stale :pr-open issues whose linked PR was closed (unmerged).
+        # This handles cases where the verify step failed to transition them
+        # back to :raised (e.g. due to GitHub search indexing delays).
+        try:
+            pr_open_issues = _gh_json([
+                "issue", "list",
+                "--repo", REPO,
+                "--label", LABEL_PR_OPEN,
+                "--state", "open",
+                "--json", "number,title,body,labels,createdAt,comments",
+                "--limit", "100",
+            ]) or []
+        except subprocess.CalledProcessError:
+            pr_open_issues = []
+        for issue in pr_open_issues:
+            if LABEL_IN_PROGRESS in {lbl["name"] for lbl in issue.get("labels", [])}:
+                continue
+            pr = _find_linked_pr(issue["number"])
+            if pr is None:
+                continue
+            state = (pr.get("state") or "").upper()
+            if state == "CLOSED":
+                issue_labels = {lbl["name"] for lbl in issue.get("labels", [])}
+                raised_label = LABEL_AUDIT_RAISED if LABEL_AUDIT_RAISED in issue_labels else LABEL_RAISED
+                if _set_labels(issue["number"], add=[raised_label], remove=[LABEL_PR_OPEN]):
+                    print(
+                        f"[cai fix] recovered stale :pr-open on #{issue['number']} "
+                        f"(PR #{pr['number']} closed unmerged)",
+                        flush=True,
+                    )
+                    candidates[issue["number"]] = issue
+
+    if not candidates:
         return None
 
     return min(candidates.values(), key=lambda i: i["createdAt"])
@@ -2494,16 +2527,16 @@ def cmd_merge(args) -> int:
 # ---------------------------------------------------------------------------
 
 def cmd_cycle(args) -> int:
-    """Run fix → revise → review-pr → merge → verify → confirm in order."""
+    """Run verify → fix → revise → review-pr → merge → confirm in order."""
     print("[cai cycle] starting full cycle (no analyze)", flush=True)
     t0 = time.monotonic()
 
     steps = [
+        ("verify", cmd_verify),
         ("fix", cmd_fix),
         ("revise", cmd_revise),
         ("review-pr", cmd_review_pr),
         ("merge", cmd_merge),
-        ("verify", cmd_verify),
         ("confirm", cmd_confirm),
     ]
 

--- a/cai.py
+++ b/cai.py
@@ -2584,7 +2584,7 @@ def main() -> int:
     sub.add_parser("confirm", help="Verify merged issues are actually solved")
     sub.add_parser("review-pr", help="Pre-merge consistency review of open PRs")
     sub.add_parser("merge", help="Confidence-gated auto-merge for bot PRs")
-    sub.add_parser("cycle", help="Full cycle: fix, revise, review-pr, merge, verify, confirm")
+    sub.add_parser("cycle", help="Full cycle: verify, fix, revise, review-pr, merge, confirm")
 
     args = parser.parse_args()
 

--- a/cai.py
+++ b/cai.py
@@ -370,11 +370,38 @@ def _gh_user_identity() -> tuple[str, str]:
     return name, email
 
 
+def _recover_stale_pr_open(issues: list[dict], *, log_prefix: str = "cai") -> list[dict]:
+    """Transition :pr-open issues whose linked PR was closed (unmerged) back to :raised.
+
+    Returns the list of issues that were successfully recovered.
+    """
+    recovered: list[dict] = []
+    for issue in issues:
+        if LABEL_IN_PROGRESS in {lbl["name"] for lbl in issue.get("labels", [])}:
+            continue
+        pr = _find_linked_pr(issue["number"])
+        if pr is None:
+            continue
+        state = (pr.get("state") or "").upper()
+        if state == "CLOSED":
+            issue_labels = {lbl["name"] for lbl in issue.get("labels", [])}
+            raised_label = LABEL_AUDIT_RAISED if LABEL_AUDIT_RAISED in issue_labels else LABEL_RAISED
+            if _set_labels(issue["number"], add=[raised_label], remove=[LABEL_PR_OPEN]):
+                print(
+                    f"[{log_prefix}] recovered stale :pr-open on #{issue['number']} "
+                    f"(PR #{pr['number']} closed unmerged)",
+                    flush=True,
+                )
+                recovered.append(issue)
+    return recovered
+
+
 def _select_fix_target():
     """Return the oldest open issue eligible for the fix subagent.
 
     Eligible = labelled `:raised`, `:requested`, or `audit:raised`, NOT labelled
-    `:in-progress` or `:pr-open`.
+    `:in-progress` or `:pr-open`.  If no candidates are found, attempts to
+    recover stale `:pr-open` issues whose linked PR was closed unmerged.
     """
     candidates: dict[int, dict] = {}
     for label in (LABEL_RAISED, LABEL_REQUESTED, LABEL_AUDIT_RAISED):
@@ -414,23 +441,8 @@ def _select_fix_target():
             ]) or []
         except subprocess.CalledProcessError:
             pr_open_issues = []
-        for issue in pr_open_issues:
-            if LABEL_IN_PROGRESS in {lbl["name"] for lbl in issue.get("labels", [])}:
-                continue
-            pr = _find_linked_pr(issue["number"])
-            if pr is None:
-                continue
-            state = (pr.get("state") or "").upper()
-            if state == "CLOSED":
-                issue_labels = {lbl["name"] for lbl in issue.get("labels", [])}
-                raised_label = LABEL_AUDIT_RAISED if LABEL_AUDIT_RAISED in issue_labels else LABEL_RAISED
-                if _set_labels(issue["number"], add=[raised_label], remove=[LABEL_PR_OPEN]):
-                    print(
-                        f"[cai fix] recovered stale :pr-open on #{issue['number']} "
-                        f"(PR #{pr['number']} closed unmerged)",
-                        flush=True,
-                    )
-                    candidates[issue["number"]] = issue
+        for issue in _recover_stale_pr_open(pr_open_issues, log_prefix="cai fix"):
+            candidates[issue["number"]] = issue
 
     if not candidates:
         return None
@@ -1407,6 +1419,8 @@ def cmd_verify(args) -> int:
         return 0
 
     transitioned = 0
+    # Handle MERGED transitions inline; CLOSED recovery uses the shared helper.
+    remaining = []
     for issue in issues:
         num = issue["number"]
         pr = _find_linked_pr(num)
@@ -1419,16 +1433,11 @@ def cmd_verify(args) -> int:
             print(f"[cai verify] #{num}: PR #{pr['number']} merged → :merged", flush=True)
             transitioned += 1
         elif state == "CLOSED":
-            issue_labels = {lbl["name"] for lbl in issue.get("labels", [])}
-            raised_label = LABEL_AUDIT_RAISED if LABEL_AUDIT_RAISED in issue_labels else LABEL_RAISED
-            _set_labels(num, add=[raised_label], remove=[LABEL_PR_OPEN])
-            print(
-                f"[cai verify] #{num}: PR #{pr['number']} closed unmerged → :raised",
-                flush=True,
-            )
-            transitioned += 1
+            remaining.append(issue)
         else:
             print(f"[cai verify] #{num}: PR #{pr['number']} still {state}", flush=True)
+
+    transitioned += len(_recover_stale_pr_open(remaining, log_prefix="cai verify"))
 
     print(f"[cai verify] done ({transitioned} transitioned)", flush=True)
     log_run("verify", repo=REPO, checked=len(issues), transitioned=transitioned, exit=0)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#99

**Issue:** #99 — Fix bot skipped eligible issue for ~7 hours

## PR Summary

### What this fixes
When a PR linked to an auto-improve issue was closed without merging, the issue could remain stuck in `:pr-open` for hours because (1) `cmd_cycle` ran `fix` before `verify`, so the fix step always missed issues that verify had not yet transitioned, and (2) if `_find_linked_pr` failed (e.g. due to GitHub search indexing delays), the verify step silently left the issue in `:pr-open` with no fallback recovery.

### What was changed
- **cai.py `_select_fix_target()`**: Added a stale `:pr-open` recovery block that runs when no normal candidates are found. It queries `:pr-open` issues, checks if their linked PR is closed (unmerged), and if so transitions them back to `:raised` and includes them as eligible candidates.
- **cai.py `cmd_cycle()`**: Reordered the cycle steps so `verify` runs before `fix` (was: fix → revise → review-pr → merge → verify → confirm; now: verify → fix → revise → review-pr → merge → confirm). This ensures closed-PR transitions happen before the fix step looks for candidates.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
