### PR TITLE
auto-improve: Issue #97 lost lifecycle state after PR #102 closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ subprocess with no shared state.
 | `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
 | `cai.py fix` | `15 * * * *` (hourly :15) | Picks the oldest eligible issue, lets a subagent edit the repo with full tool permissions, opens a PR — see lifecycle below |
 | `cai.py revise` | `30 * * * *` (hourly :30) | Watches `:pr-open` PRs for new comments and iterates on the same branch via force-push; also auto-rebases unmergeable PRs onto current main |
-| `cai.py verify` | `45 * * * *` (hourly :45) | Mechanical, no LLM. Walks `auto-improve:pr-open` issues and updates labels based on PR merge state |
+| `cai.py verify` | `45 * * * *` (hourly :45) | Mechanical, no LLM. Walks `auto-improve:pr-open` issues and updates labels based on PR merge state; also re-raises orphaned issues that have a base label but no lifecycle state suffix |
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` issues, deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |
 | `cai.py review-pr` | `20 * * * *` (hourly :20) | Pre-merge consistency review of open PRs — posts ripple-effect findings as PR comments so the revise subagent can act on them |
 | `cai.py merge` | `35 * * * *` (hourly :35) | Confidence-gated auto-merge — evaluates each bot PR against its linked issue, posts a verdict, and merges when confidence meets the threshold |

--- a/cai.py
+++ b/cai.py
@@ -1420,7 +1420,7 @@ def cmd_verify(args) -> int:
         has_state = any(l.startswith("auto-improve:") or l.startswith("audit:") for l in label_names)
         if not has_state:
             raised_label = (
-                LABEL_AUDIT_RAISED if LABEL_AUDIT_RAISED in label_names
+                LABEL_AUDIT_RAISED if "audit" in label_names
                 else LABEL_RAISED
             )
             _set_labels(num, add=[raised_label])

--- a/cai.py
+++ b/cai.py
@@ -1368,11 +1368,6 @@ def cmd_verify(args) -> int:
         log_run("verify", repo=REPO, checked=0, transitioned=0, exit=1)
         return 1
 
-    if not issues:
-        print("[cai verify] no pr-open issues; nothing to do", flush=True)
-        log_run("verify", repo=REPO, checked=0, transitioned=0, exit=0)
-        return 0
-
     transitioned = 0
     for issue in issues:
         num = issue["number"]

--- a/cai.py
+++ b/cai.py
@@ -1411,7 +1411,7 @@ def cmd_verify(args) -> int:
     for issue in all_ai_issues:
         num = issue["number"]
         label_names = {lbl["name"] for lbl in issue.get("labels", [])}
-        has_state = any(l.startswith("auto-improve:") for l in label_names)
+        has_state = any(l.startswith("auto-improve:") or l.startswith("audit:") for l in label_names)
         if not has_state:
             raised_label = (
                 LABEL_AUDIT_RAISED if LABEL_AUDIT_RAISED in label_names

--- a/cai.py
+++ b/cai.py
@@ -1392,24 +1392,30 @@ def cmd_verify(args) -> int:
         else:
             print(f"[cai verify] #{num}: PR #{pr['number']} still {state}", flush=True)
 
-    # Safety net: recover issues that have the base "auto-improve" label but
-    # lost their lifecycle state suffix (e.g. due to a partial label update
-    # when another command closed a PR).  Transition them back to :raised so
-    # they re-enter the fix pipeline.
-    try:
-        all_ai_issues = _gh_json([
-            "issue", "list",
-            "--repo", REPO,
-            "--label", "auto-improve",
-            "--state", "open",
-            "--json", "number,labels",
-            "--limit", "200",
-        ]) or []
-    except subprocess.CalledProcessError:
-        all_ai_issues = []
+    # Safety net: recover issues that have the base "auto-improve" or "audit"
+    # label but lost their lifecycle state suffix (e.g. due to a partial label
+    # update when another command closed a PR).  Transition them back to
+    # :raised so they re-enter the fix pipeline.
+    all_ai_issues: list[dict] = []
+    for base_label in ("auto-improve", "audit"):
+        try:
+            all_ai_issues.extend(_gh_json([
+                "issue", "list",
+                "--repo", REPO,
+                "--label", base_label,
+                "--state", "open",
+                "--json", "number,labels",
+                "--limit", "200",
+            ]) or [])
+        except subprocess.CalledProcessError:
+            pass
 
+    seen_nums: set[int] = set()
     for issue in all_ai_issues:
         num = issue["number"]
+        if num in seen_nums:
+            continue
+        seen_nums.add(num)
         label_names = {lbl["name"] for lbl in issue.get("labels", [])}
         has_state = any(l.startswith("auto-improve:") or l.startswith("audit:") for l in label_names)
         if not has_state:

--- a/cai.py
+++ b/cai.py
@@ -1431,7 +1431,7 @@ def cmd_verify(args) -> int:
             transitioned += 1
 
     print(f"[cai verify] done ({transitioned} transitioned)", flush=True)
-    log_run("verify", repo=REPO, checked=len(issues), transitioned=transitioned, exit=0)
+    log_run("verify", repo=REPO, checked=len(issues) + len(seen_nums), transitioned=transitioned, exit=0)
     return 0
 
 

--- a/cai.py
+++ b/cai.py
@@ -1397,6 +1397,38 @@ def cmd_verify(args) -> int:
         else:
             print(f"[cai verify] #{num}: PR #{pr['number']} still {state}", flush=True)
 
+    # Safety net: recover issues that have the base "auto-improve" label but
+    # lost their lifecycle state suffix (e.g. due to a partial label update
+    # when another command closed a PR).  Transition them back to :raised so
+    # they re-enter the fix pipeline.
+    try:
+        all_ai_issues = _gh_json([
+            "issue", "list",
+            "--repo", REPO,
+            "--label", "auto-improve",
+            "--state", "open",
+            "--json", "number,labels",
+            "--limit", "200",
+        ]) or []
+    except subprocess.CalledProcessError:
+        all_ai_issues = []
+
+    for issue in all_ai_issues:
+        num = issue["number"]
+        label_names = {lbl["name"] for lbl in issue.get("labels", [])}
+        has_state = any(l.startswith("auto-improve:") for l in label_names)
+        if not has_state:
+            raised_label = (
+                LABEL_AUDIT_RAISED if LABEL_AUDIT_RAISED in label_names
+                else LABEL_RAISED
+            )
+            _set_labels(num, add=[raised_label])
+            print(
+                f"[cai verify] #{num}: orphaned (no state label) → {raised_label}",
+                flush=True,
+            )
+            transitioned += 1
+
     print(f"[cai verify] done ({transitioned} transitioned)", flush=True)
     log_run("verify", repo=REPO, checked=len(issues), transitioned=transitioned, exit=0)
     return 0


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#119

**Issue:** #119 — Issue #97 lost lifecycle state after PR #102 closure

## PR Summary

### What this fixes
Issue #97 lost its lifecycle state label after PR #102 was closed, ending up with just the bare `auto-improve` label and no state suffix. This made the issue invisible to `cmd_verify` (which only queries for `:pr-open` issues), leaving it stuck with no way to re-enter the fix pipeline.

### What was changed
- **`cai.py` (`cmd_verify`)**: Added an orphan-recovery pass after the main `:pr-open` loop. It queries all open issues with the `auto-improve` base label, detects any that lack a lifecycle state suffix (`auto-improve:*`), and transitions them back to `:raised` (or `audit:raised` for audit issues). Each recovery is logged as `[cai verify] #N: orphaned (no state label) → <label>` for visibility.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
