### PR TITLE
auto-improve: Stale `:merge-blocked` label persists after merge on #110 and #117

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -1382,13 +1382,13 @@ def cmd_verify(args) -> int:
             continue
         state = (pr.get("state") or "").upper()
         if state == "MERGED":
-            _set_labels(num, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN])
+            _set_labels(num, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED])
             print(f"[cai verify] #{num}: PR #{pr['number']} merged → :merged", flush=True)
             transitioned += 1
         elif state == "CLOSED":
             issue_labels = {lbl["name"] for lbl in issue.get("labels", [])}
             raised_label = LABEL_AUDIT_RAISED if LABEL_AUDIT_RAISED in issue_labels else LABEL_RAISED
-            _set_labels(num, add=[raised_label], remove=[LABEL_PR_OPEN])
+            _set_labels(num, add=[raised_label], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED])
             print(
                 f"[cai verify] #{num}: PR #{pr['number']} closed unmerged → :raised",
                 flush=True,

--- a/cai.py
+++ b/cai.py
@@ -2442,7 +2442,7 @@ def cmd_merge(args) -> int:
             )
             if close_result.returncode == 0:
                 print(f"[cai merge] PR #{pr_number}: closed successfully", flush=True)
-                _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN])
+                _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED])
                 closed += 1
             else:
                 print(
@@ -2463,6 +2463,7 @@ def cmd_merge(args) -> int:
             )
             if merge_result.returncode == 0:
                 print(f"[cai merge] PR #{pr_number}: merged successfully", flush=True)
+                _set_labels(issue_number, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED])
                 merged += 1
             else:
                 print(


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#128

**Issue:** #128 — Stale `:merge-blocked` label persists after merge on #110 and #117

## PR Summary

### What this fixes
The `cmd_merge` function in `cai.py` did not update issue labels after successfully merging or closing a PR. This caused `auto-improve:merge-blocked` (and `auto-improve:pr-open`) labels to persist on issues even after their PRs were merged, creating contradictory label states like `merged` + `merge-blocked`.

### What was changed
- **cai.py:2466** — Added `_set_labels(issue_number, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED])` after a successful `gh pr merge`, so the issue transitions to `:merged` and any stale `:pr-open` / `:merge-blocked` labels are removed.
- **cai.py:2445** — Added `LABEL_MERGE_BLOCKED` to the `remove` list in the existing `_set_labels` call after a successful PR close (reject path), so `:merge-blocked` is cleaned up there as well.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
