### PR TITLE
auto-improve: Issues #110 and #117 carry both `:merged` and `:merge-blocked`

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -1429,7 +1429,7 @@ def cmd_verify(args) -> int:
             continue
         state = (pr.get("state") or "").upper()
         if state == "MERGED":
-            _set_labels(num, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN])
+            _set_labels(num, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED])
             print(f"[cai verify] #{num}: PR #{pr['number']} merged → :merged", flush=True)
             transitioned += 1
         elif state == "CLOSED":
@@ -2517,8 +2517,9 @@ def cmd_merge(args) -> int:
                 f"[cai merge] PR #{pr_number}: verdict={confidence} < threshold={_MERGE_THRESHOLD}; holding",
                 flush=True,
             )
-            # Set merge-blocked label on the issue.
-            _set_labels(issue_number, add=[LABEL_MERGE_BLOCKED])
+            # Set merge-blocked label on the issue, unless already merged.
+            if LABEL_MERGED not in issue_labels:
+                _set_labels(issue_number, add=[LABEL_MERGE_BLOCKED])
             held += 1
 
     dur = f"{int(time.monotonic() - t0)}s"

--- a/cai.py
+++ b/cai.py
@@ -2491,7 +2491,8 @@ def cmd_merge(args) -> int:
                     f"[cai merge] PR #{pr_number}: close failed:\n{close_result.stderr}",
                     file=sys.stderr,
                 )
-                _set_labels(issue_number, add=[LABEL_MERGE_BLOCKED])
+                if LABEL_MERGED not in issue_labels:
+                    _set_labels(issue_number, add=[LABEL_MERGE_BLOCKED])
                 held += 1
         elif action == "merge" and verdict_rank >= threshold_rank:
             print(


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#132

**Issue:** #132 — Issues #110 and #117 carry both `:merged` and `:merge-blocked`

## PR Summary

### What this fixes
Issues could end up carrying both `auto-improve:merged` and `auto-improve:merge-blocked` labels simultaneously, which are mutually exclusive lifecycle states. This happened because (1) the verify step's merged-transition did not strip `:merge-blocked` when adding `:merged`, and (2) the merge step had no guard to prevent applying `:merge-blocked` to already-merged issues.

### What was changed
- **cai.py:1432** — `cmd_verify`: When transitioning an issue to `:merged`, the `_set_labels` call now also removes `LABEL_MERGE_BLOCKED` in addition to `LABEL_PR_OPEN`, ensuring any prior `:merge-blocked` label is cleaned up on merge.
- **cai.py:2520-2522** — `cmd_merge`: Added a guard that skips applying `LABEL_MERGE_BLOCKED` if the issue already carries `LABEL_MERGED`, preventing the conflicting label pair from being created in the first place.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
