### PR TITLE
auto-improve: Issue #126 absent from open-issues list while PR #130 remains open

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ subprocess with no shared state.
 | `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
 | `cai.py fix` | `15 * * * *` (hourly :15) | Picks the oldest eligible issue, lets a subagent edit the repo with full tool permissions, opens a PR — see lifecycle below |
 | `cai.py revise` | `30 * * * *` (hourly :30) | Watches `:pr-open` PRs for new comments and iterates on the same branch via force-push; also auto-rebases unmergeable PRs onto current main |
-| `cai.py verify` | `45 * * * *` (hourly :45) | Mechanical, no LLM. Walks `auto-improve:pr-open` issues and updates labels based on PR merge state |
+| `cai.py verify` | `45 * * * *` (hourly :45) | Mechanical, no LLM. Walks `auto-improve:pr-open` issues and updates labels based on PR merge state; also recovers issues whose `:pr-open` label was lost |
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` issues, deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |
 | `cai.py review-pr` | `20 * * * *` (hourly :20) | Pre-merge consistency review of open PRs — posts ripple-effect findings as PR comments so the revise subagent can act on them |
 | `cai.py merge` | `35 * * * *` (hourly :35) | Confidence-gated auto-merge — evaluates each bot PR against its linked issue, posts a verdict, and merges when confidence meets the threshold |

--- a/cai.py
+++ b/cai.py
@@ -816,11 +816,27 @@ def cmd_fix(args) -> int:
         pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
 
         # 10. Transition label :in-progress -> :pr-open.
-        _set_labels(
+        #     This is critical — if it fails, the issue becomes orphaned
+        #     from its open PR.  Retry once before giving up.
+        if not _set_labels(
             issue_number,
             add=[LABEL_PR_OPEN],
             remove=[LABEL_IN_PROGRESS],
-        )
+        ):
+            print(
+                f"[cai fix] label transition to :pr-open failed for #{issue_number}; retrying",
+                flush=True,
+            )
+            if not _set_labels(
+                issue_number,
+                add=[LABEL_PR_OPEN],
+                remove=[LABEL_IN_PROGRESS],
+            ):
+                print(
+                    f"[cai fix] WARNING: label transition to :pr-open failed twice for "
+                    f"#{issue_number} — issue may be orphaned from PR {pr_url}",
+                    file=sys.stderr, flush=True,
+                )
         locked = False
         log_run("fix", repo=REPO, issue=issue_number, branch=branch,
                 pr=pr_number, diff_files=diff_files, exit=0)
@@ -1413,12 +1429,9 @@ def cmd_verify(args) -> int:
         log_run("verify", repo=REPO, checked=0, transitioned=0, exit=1)
         return 1
 
-    if not issues:
-        print("[cai verify] no pr-open issues; nothing to do", flush=True)
-        log_run("verify", repo=REPO, checked=0, transitioned=0, exit=0)
-        return 0
-
     transitioned = 0
+    pr_open_issue_nums = {i["number"] for i in issues}
+
     # Handle MERGED transitions inline; CLOSED recovery uses the shared helper.
     remaining = []
     for issue in issues:
@@ -1438,6 +1451,53 @@ def cmd_verify(args) -> int:
             print(f"[cai verify] #{num}: PR #{pr['number']} still {state}", flush=True)
 
     transitioned += len(_recover_stale_pr_open(remaining, log_prefix="cai verify"))
+
+    # Recovery: find open auto-improve PRs whose linked issue is missing
+    # the :pr-open label.  This heals issues where the label transition
+    # in cmd_fix step 10 failed silently.
+    try:
+        open_prs = _gh_json([
+            "pr", "list",
+            "--repo", REPO,
+            "--state", "open",
+            "--base", "main",
+            "--json", "number,headRefName",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError:
+        open_prs = []
+
+    for opr in open_prs:
+        branch = opr.get("headRefName", "")
+        m = re.match(r"^auto-improve/(\d+)-", branch)
+        if not m:
+            continue
+        issue_num = int(m.group(1))
+        if issue_num in pr_open_issue_nums:
+            continue
+        # Check the issue's current state.
+        try:
+            iss = _gh_json([
+                "issue", "view", str(issue_num),
+                "--repo", REPO,
+                "--json", "state,labels",
+            ])
+        except subprocess.CalledProcessError:
+            continue
+        if (iss.get("state") or "").upper() != "OPEN":
+            continue
+        iss_labels = {l["name"] for l in iss.get("labels", [])}
+        if LABEL_PR_OPEN in iss_labels:
+            continue
+        # Issue is open, has an open PR, but missing :pr-open — recover.
+        remove = [l for l in (LABEL_IN_PROGRESS, LABEL_RAISED, LABEL_AUDIT_RAISED) if l in iss_labels]
+        if _set_labels(issue_num, add=[LABEL_PR_OPEN], remove=remove):
+            print(
+                f"[cai verify] recovered #{issue_num}: added :pr-open "
+                f"(open PR #{opr['number']} on branch {branch})",
+                flush=True,
+            )
+            transitioned += 1
 
     print(f"[cai verify] done ({transitioned} transitioned)", flush=True)
     log_run("verify", repo=REPO, checked=len(issues), transitioned=transitioned, exit=0)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#133

**Issue:** #133 — Issue #126 absent from open-issues list while PR #130 remains open

## PR Summary

### What this fixes
Issue #126 could become orphaned from its open PR #130 because the label transition from `:in-progress` to `:pr-open` in `cmd_fix` step 10 did not check its return value. If the GitHub API call failed transiently, the issue stayed at `:in-progress` while the PR was already open. The `cmd_verify` step only queried issues with `:pr-open` label, so it never found or recovered the orphaned issue.

### What was changed
- **cai.py (`cmd_fix`, step 10, ~line 818):** Added return-value check and single retry for the critical `_set_labels` call that transitions an issue from `:in-progress` to `:pr-open` after its PR is created. Logs a clear warning to stderr if both attempts fail.
- **cai.py (`cmd_verify`, ~line 1455):** Added a PR-driven recovery sweep that scans open `auto-improve/*` PRs and checks whether their linked issue has the `:pr-open` label. If an open issue is found with an open PR but missing `:pr-open`, the label is added and any stale state labels (`:in-progress`, `:raised`, `audit:raised`) are removed. Also removed the early return when no `:pr-open` issues exist, so the recovery sweep always runs.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
