### PR TITLE
auto-improve: Add an additional agent for deep insight of issues if requested

### DIFF
--- a/.github/workflows/admin-only-label.yml
+++ b/.github/workflows/admin-only-label.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   enforce:
     if: >-
-      contains(fromJSON('["auto-improve:requested","auto-improve:raised","consistency:raised","audit:raised"]'), github.event.label.name)
+      contains(fromJSON('["auto-improve:requested","auto-improve:raised","auto-improve:diagnose-requested","consistency:raised","audit:raised"]'), github.event.label.name)
     runs-on: ubuntu-latest
     steps:
       - name: Check sender's permission

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ subprocess with no shared state.
 | `cai.py review-pr` | `20 * * * *` (hourly :20) | Pre-merge consistency review of open PRs — posts ripple-effect findings as PR comments so the revise subagent can act on them |
 | `cai.py merge` | `35 * * * *` (hourly :35) | Confidence-gated auto-merge — evaluates each bot PR against its linked issue, posts a verdict, and merges when confidence meets the threshold |
 | `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → left as `:merged` (Sonnet) |
-| `cai.py diagnose` | _(manual/on-demand)_ | Deep diagnostic analysis of a single issue — gathers issue body, comments, linked PR diffs, and parsed signals, then posts a root-cause report as a comment (Sonnet) |
+| `cai.py diagnose` | `50 * * * *` (hourly :50) | Deep diagnostic analysis — scans for issues labeled `:diagnose-requested`, or pass `--issue N` for manual use. Gathers issue body, comments, linked PR diffs, and parsed signals, then posts a root-cause report as a comment (Sonnet) |
 | `cai.py cycle` | _(manual/on-demand)_ | Runs verify → fix → revise → review-pr → merge → confirm in sequence. Convenience wrapper for a full pipeline pass; not included in scheduled or startup runs |
 
 On `docker compose up -d` the entrypoint templates the crontab from

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ subprocess with no shared state.
 | `cai.py review-pr` | `20 * * * *` (hourly :20) | Pre-merge consistency review of open PRs — posts ripple-effect findings as PR comments so the revise subagent can act on them |
 | `cai.py merge` | `35 * * * *` (hourly :35) | Confidence-gated auto-merge — evaluates each bot PR against its linked issue, posts a verdict, and merges when confidence meets the threshold |
 | `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → left as `:merged` (Sonnet) |
+| `cai.py diagnose` | _(manual/on-demand)_ | Deep diagnostic analysis of a single issue — gathers issue body, comments, linked PR diffs, and parsed signals, then posts a root-cause report as a comment (Sonnet) |
 | `cai.py cycle` | _(manual/on-demand)_ | Runs verify → fix → revise → review-pr → merge → confirm in sequence. Convenience wrapper for a full pipeline pass; not included in scheduled or startup runs |
 
 On `docker compose up -d` the entrypoint templates the crontab from
@@ -462,7 +463,7 @@ docker run --rm -v cai_transcripts:/data alpine ls -R /data
 
 A **run log** is written to `./logs/cai.log` (bind-mounted from
 `/var/log/cai/cai.log` inside the container). Each `init`, `analyze`,
-`fix`, `review-pr`, `revise`, `verify`, `audit`, `confirm`, and `merge` invocation appends one key=value line so you can
+`fix`, `review-pr`, `revise`, `verify`, `audit`, `confirm`, `merge`, and `diagnose` invocation appends one key=value line so you can
 watch cycle activity from the host without `docker exec`:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ subprocess with no shared state.
 On `docker compose up -d` the entrypoint templates the crontab from
 the env vars (`CAI_ANALYZER_SCHEDULE`, `CAI_FIX_SCHEDULE`,
 `CAI_REVIEW_PR_SCHEDULE`, `CAI_MERGE_SCHEDULE`, `CAI_REVISE_SCHEDULE`,
-`CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`), runs each
+`CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`,
+`CAI_DIAGNOSE_SCHEDULE`), runs each
 scheduled subcommand once synchronously so logs show immediate results, then execs
 supercronic. (`cycle` is on-demand only and is not part of scheduled or startup runs.)
 

--- a/cai.py
+++ b/cai.py
@@ -48,6 +48,13 @@ Subcommands:
                             with `:solved`; patterns that persist stay
                             as `:merged`.
 
+    python cai.py diagnose  Deep diagnostic analysis of a single issue
+                            on user request (--issue required). Gathers
+                            the issue body, comments, linked PR diffs,
+                            and parsed transcript signals, then runs a
+                            Sonnet agent to produce a root-cause report
+                            posted as a comment on the issue.
+
     python cai.py review-pr Walk open PRs against main, run a
                             consistency review for ripple effects, and
                             post findings as PR comments. Skips PRs
@@ -104,6 +111,7 @@ CONFIRM_PROMPT = Path("/app/prompts/backend-confirm.md")
 REVISE_PROMPT = Path("/app/prompts/backend-revise.md")
 REVIEW_PR_PROMPT = Path("/app/prompts/backend-review-pr.md")
 MERGE_PROMPT = Path("/app/prompts/backend-merge.md")
+DIAGNOSE_PROMPT = Path("/app/prompts/backend-diagnose.md")
 
 # Issue lifecycle labels.
 LABEL_RAISED = "auto-improve:raised"
@@ -2009,6 +2017,159 @@ def cmd_confirm(args) -> int:
 
 
 # ---------------------------------------------------------------------------
+# diagnose
+# ---------------------------------------------------------------------------
+
+def cmd_diagnose(args) -> int:
+    """Deep diagnostic analysis of a single issue on user request."""
+    issue_number = args.issue
+    print(f"[cai diagnose] running deep diagnostic on #{issue_number}", flush=True)
+    t0 = time.monotonic()
+
+    # 1. Fetch the issue.
+    try:
+        issue = _gh_json([
+            "issue", "view", str(issue_number),
+            "--repo", REPO,
+            "--json", "number,title,body,labels,state,createdAt,comments",
+        ])
+    except subprocess.CalledProcessError as e:
+        print(f"[cai diagnose] gh issue view #{issue_number} failed:\n{e.stderr}",
+              file=sys.stderr)
+        log_run("diagnose", repo=REPO, issue=issue_number, result="issue_lookup_failed", exit=1)
+        return 1
+
+    if issue.get("state", "").upper() != "OPEN":
+        print(f"[cai diagnose] issue #{issue_number} is not open; nothing to do", flush=True)
+        log_run("diagnose", repo=REPO, issue=issue_number, result="not_open", exit=0)
+        return 0
+
+    title = issue["title"]
+    print(f"[cai diagnose] issue: #{issue_number} — {title}", flush=True)
+
+    # 2. Find all PRs that reference this issue (merged and open).
+    MAX_DIFF_LEN = 12000
+    pr_sections = ""
+    for pr_state in ("merged", "open"):
+        try:
+            prs = _gh_json([
+                "pr", "list", "--repo", REPO,
+                "--search", f"Refs #{issue_number}",
+                "--state", pr_state,
+                "--json", "number,title,state",
+                "--limit", "10",
+            ]) or []
+        except subprocess.CalledProcessError:
+            prs = []
+        for pr in prs:
+            pr_num = pr["number"]
+            pr_title = pr["title"]
+            pr_sections += f"### PR #{pr_num} — {pr_title} ({pr_state})\n\n"
+            diff_result = _run(
+                ["gh", "pr", "diff", str(pr_num), "--repo", REPO],
+                capture_output=True,
+            )
+            if diff_result.returncode == 0 and diff_result.stdout.strip():
+                diff_text = diff_result.stdout.strip()
+                if len(diff_text) > MAX_DIFF_LEN:
+                    diff_text = diff_text[:MAX_DIFF_LEN] + "\n... (truncated)"
+                pr_sections += f"```diff\n{diff_text}\n```\n\n"
+            else:
+                pr_sections += "(no diff available)\n\n"
+
+    # 3. Run parse.py for transcript signals.
+    parsed_signals = ""
+    parsed = _run(
+        ["python", str(PARSE_SCRIPT), str(TRANSCRIPT_DIR)],
+        capture_output=True,
+    )
+    if parsed.returncode == 0 and parsed.stdout.strip():
+        parsed_signals = parsed.stdout.strip()
+    else:
+        print("[cai diagnose] parse.py returned no signals (continuing)", flush=True)
+
+    # 4. Build the diagnose prompt.
+    prompt_text = DIAGNOSE_PROMPT.read_text()
+
+    issue_section = (
+        f"## Issue\n\n"
+        f"### #{issue['number']} — {title}\n\n"
+        f"{issue.get('body') or '(no body)'}\n\n"
+    )
+
+    comments = issue.get("comments") or []
+    if comments:
+        issue_section += "### Comments\n\n"
+        for c in comments:
+            author = c.get("author", {}).get("login", "unknown")
+            body = c.get("body", "")
+            created = c.get("createdAt", "")
+            issue_section += f"**{author}** ({created}):\n{body}\n\n"
+
+    linked_prs_section = ""
+    if pr_sections:
+        linked_prs_section = f"## Linked PRs\n\n{pr_sections}"
+
+    signals_section = ""
+    if parsed_signals:
+        signals_section = (
+            "## Parsed signals\n\n"
+            "```json\n"
+            f"{parsed_signals}\n"
+            "```\n\n"
+        )
+
+    full_prompt = (
+        f"{prompt_text}\n\n"
+        f"{issue_section}"
+        f"{linked_prs_section}"
+        f"{signals_section}"
+    )
+
+    # 5. Run claude with Sonnet.
+    diagnose = _run(
+        ["claude", "-p", "--model", "claude-sonnet-4-6"],
+        input=full_prompt,
+        capture_output=True,
+    )
+    if diagnose.returncode != 0:
+        print(
+            f"[cai diagnose] claude -p failed (exit {diagnose.returncode}):\n"
+            f"{diagnose.stderr}",
+            flush=True,
+        )
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run("diagnose", repo=REPO, issue=issue_number,
+                duration=dur, result="claude_failed", exit=diagnose.returncode)
+        return diagnose.returncode
+
+    report = diagnose.stdout.strip()
+    print(f"[cai diagnose] diagnostic report:\n{report}", flush=True)
+
+    # 6. Post the diagnostic report as a comment on the issue.
+    comment_result = _run(
+        ["gh", "issue", "comment", str(issue_number),
+         "--repo", REPO,
+         "--body", report],
+        capture_output=True,
+    )
+    if comment_result.returncode != 0:
+        print(
+            f"[cai diagnose] failed to post comment:\n{comment_result.stderr}",
+            file=sys.stderr,
+        )
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run("diagnose", repo=REPO, issue=issue_number,
+                duration=dur, result="comment_failed", exit=1)
+        return 1
+
+    dur = f"{int(time.monotonic() - t0)}s"
+    print(f"[cai diagnose] posted diagnostic to #{issue_number}", flush=True)
+    log_run("diagnose", repo=REPO, issue=issue_number, duration=dur, exit=0)
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # review-pr
 # ---------------------------------------------------------------------------
 
@@ -2653,6 +2814,13 @@ def main() -> int:
     sub.add_parser("verify", help="Update labels based on PR merge state")
     sub.add_parser("audit", help="Run the queue/PR consistency audit")
     sub.add_parser("confirm", help="Verify merged issues are actually solved")
+
+    diagnose_parser = sub.add_parser("diagnose", help="Deep diagnostic analysis of a single issue")
+    diagnose_parser.add_argument(
+        "--issue", type=int, required=True,
+        help="Issue number to diagnose",
+    )
+
     sub.add_parser("review-pr", help="Pre-merge consistency review of open PRs")
     sub.add_parser("merge", help="Confidence-gated auto-merge for bot PRs")
     sub.add_parser("cycle", help="Full cycle: verify, fix, revise, review-pr, merge, confirm")
@@ -2671,6 +2839,7 @@ def main() -> int:
         "verify": cmd_verify,
         "audit": cmd_audit,
         "confirm": cmd_confirm,
+        "diagnose": cmd_diagnose,
         "review-pr": cmd_review_pr,
         "merge": cmd_merge,
         "cycle": cmd_cycle,

--- a/cai.py
+++ b/cai.py
@@ -48,12 +48,14 @@ Subcommands:
                             with `:solved`; patterns that persist stay
                             as `:merged`.
 
-    python cai.py diagnose  Deep diagnostic analysis of a single issue
-                            on user request (--issue required). Gathers
-                            the issue body, comments, linked PR diffs,
-                            and parsed transcript signals, then runs a
-                            Sonnet agent to produce a root-cause report
-                            posted as a comment on the issue.
+    python cai.py diagnose  Deep diagnostic analysis. Without --issue,
+                            scans for open issues labeled
+                            :diagnose-requested and processes each one.
+                            With --issue N, diagnoses that specific
+                            issue. Gathers issue body, comments, linked
+                            PR diffs, and parsed transcript signals, then
+                            runs a Sonnet agent to produce a root-cause
+                            report posted as a comment on the issue.
 
     python cai.py review-pr Walk open PRs against main, run a
                             consistency review for ripple effects, and
@@ -66,8 +68,8 @@ Subcommands:
                             merges when confidence meets the threshold.
 
 The container runs `entrypoint.sh`, which executes `init`, `analyze`,
-`fix`, `revise`, `verify`, `audit`, `confirm`, `review-pr`, and `merge` once synchronously at
-startup, then hands off to supercronic. Each cron tick is a fresh process.
+`fix`, `revise`, `verify`, `audit`, `confirm`, `review-pr`, `merge`, and `diagnose` once
+synchronously at startup, then hands off to supercronic. Each cron tick is a fresh process.
 
 The gh auth check is done once per subcommand invocation. We want a
 clear error message in docker logs if credentials ever disappear from
@@ -123,6 +125,7 @@ LABEL_SOLVED = "auto-improve:solved"
 LABEL_NO_ACTION = "auto-improve:no-action"
 LABEL_REVISING = "auto-improve:revising"
 LABEL_MERGE_BLOCKED = "auto-improve:merge-blocked"
+LABEL_DIAGNOSE_REQUESTED = "auto-improve:diagnose-requested"
 LABEL_AUDIT_RAISED = "audit:raised"
 
 
@@ -2020,9 +2023,8 @@ def cmd_confirm(args) -> int:
 # diagnose
 # ---------------------------------------------------------------------------
 
-def cmd_diagnose(args) -> int:
-    """Deep diagnostic analysis of a single issue on user request."""
-    issue_number = args.issue
+def _diagnose_issue(issue_number: int) -> int:
+    """Run diagnostic analysis on a single issue. Returns exit code."""
     print(f"[cai diagnose] running deep diagnostic on #{issue_number}", flush=True)
     t0 = time.monotonic()
 
@@ -2167,6 +2169,43 @@ def cmd_diagnose(args) -> int:
     print(f"[cai diagnose] posted diagnostic to #{issue_number}", flush=True)
     log_run("diagnose", repo=REPO, issue=issue_number, duration=dur, exit=0)
     return 0
+
+
+def cmd_diagnose(args) -> int:
+    """Deep diagnostic analysis of a single issue, or scan for labeled issues."""
+    # Manual mode: --issue was provided.
+    if args.issue is not None:
+        return _diagnose_issue(args.issue)
+
+    # Scan mode: find issues labeled :diagnose-requested.
+    print("[cai diagnose] scanning for issues with "
+          f"{LABEL_DIAGNOSE_REQUESTED}", flush=True)
+    try:
+        issues = _gh_json([
+            "issue", "list", "--repo", REPO,
+            "--label", LABEL_DIAGNOSE_REQUESTED,
+            "--state", "open",
+            "--json", "number",
+            "--limit", "20",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(f"[cai diagnose] failed to list labeled issues:\n{e.stderr}",
+              file=sys.stderr)
+        return 1
+
+    if not issues:
+        print("[cai diagnose] no issues with diagnose-requested label", flush=True)
+        return 0
+
+    worst_rc = 0
+    for entry in issues:
+        issue_number = entry["number"]
+        # Remove the trigger label before running so we don't re-process.
+        _set_labels(issue_number, remove=[LABEL_DIAGNOSE_REQUESTED])
+        rc = _diagnose_issue(issue_number)
+        if rc != 0:
+            worst_rc = rc
+    return worst_rc
 
 
 # ---------------------------------------------------------------------------
@@ -2817,8 +2856,8 @@ def main() -> int:
 
     diagnose_parser = sub.add_parser("diagnose", help="Deep diagnostic analysis of a single issue")
     diagnose_parser.add_argument(
-        "--issue", type=int, required=True,
-        help="Issue number to diagnose",
+        "--issue", type=int, default=None,
+        help="Issue number to diagnose (omit to scan for :diagnose-requested label)",
     )
 
     sub.add_parser("review-pr", help="Pre-merge consistency review of open PRs")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       CAI_CONFIRM_SCHEDULE: "0 2 * * *"     # daily at 02:00 UTC (verify merged fixes)
       CAI_REVIEW_PR_SCHEDULE: "20 * * * *"  # hourly at :20 (pre-merge consistency review)
       CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly at :35 (auto-merge confident PRs)
+      CAI_DIAGNOSE_SCHEDULE: "50 * * * *"   # hourly at :50 (scan for :diagnose-requested)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "20"        # read at most N recent transcript files

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,7 @@ CAI_REVISE_SCHEDULE="${CAI_REVISE_SCHEDULE:-30 * * * *}"
 CAI_CONFIRM_SCHEDULE="${CAI_CONFIRM_SCHEDULE:-0 2 * * *}"
 CAI_REVIEW_PR_SCHEDULE="${CAI_REVIEW_PR_SCHEDULE:-20 * * * *}"
 CAI_MERGE_SCHEDULE="${CAI_MERGE_SCHEDULE:-35 * * * *}"
+CAI_DIAGNOSE_SCHEDULE="${CAI_DIAGNOSE_SCHEDULE:-50 * * * *}"
 
 CRONTAB_PATH=/tmp/crontab
 
@@ -47,6 +48,7 @@ $CAI_AUDIT_SCHEDULE python /app/cai.py audit
 $CAI_CONFIRM_SCHEDULE python /app/cai.py confirm
 $CAI_REVIEW_PR_SCHEDULE python /app/cai.py review-pr
 $CAI_MERGE_SCHEDULE python /app/cai.py merge
+$CAI_DIAGNOSE_SCHEDULE python /app/cai.py diagnose
 CRONTAB
 
 echo "[entrypoint] crontab:"
@@ -90,6 +92,9 @@ python /app/cai.py audit || echo "[entrypoint] audit exited non-zero; continuing
 
 echo "[entrypoint] running initial cai.py confirm"
 python /app/cai.py confirm || echo "[entrypoint] confirm exited non-zero; continuing"
+
+echo "[entrypoint] running initial cai.py diagnose"
+python /app/cai.py diagnose || echo "[entrypoint] diagnose exited non-zero; continuing"
 
 echo "[entrypoint] handing off to supercronic"
 exec supercronic "$CRONTAB_PATH"

--- a/install.sh
+++ b/install.sh
@@ -149,6 +149,7 @@ services:
       CAI_CONFIRM_SCHEDULE: "0 2 * * *"     # daily 02:00 UTC (verify merged fixes)
       CAI_REVIEW_PR_SCHEDULE: "20 * * * *"  # hourly :20 (pre-merge consistency review)
       CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly :35 (auto-merge confident PRs)
+      CAI_DIAGNOSE_SCHEDULE: "50 * * * *"   # hourly :50 (scan for :diagnose-requested)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "20"        # read at most N recent transcript files
@@ -199,6 +200,7 @@ services:
       CAI_CONFIRM_SCHEDULE: "0 2 * * *"     # daily 02:00 UTC (verify merged fixes)
       CAI_REVIEW_PR_SCHEDULE: "20 * * * *"  # hourly :20 (pre-merge consistency review)
       CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly :35 (auto-merge confident PRs)
+      CAI_DIAGNOSE_SCHEDULE: "50 * * * *"   # hourly :50 (scan for :diagnose-requested)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "20"        # read at most N recent transcript files

--- a/prompts/backend-diagnose.md
+++ b/prompts/backend-diagnose.md
@@ -1,0 +1,69 @@
+# Backend Diagnose
+
+You are the diagnostic agent for `robotsix-cai`'s self-improvement loop.
+Your job is to perform a deep analysis of a single issue and produce a
+comprehensive diagnostic report explaining why the issue remains
+unresolved, what has been tried so far, and what should be done next.
+
+## What you receive
+
+1. **Issue** — the full issue body including its number, title,
+   fingerprint, category, evidence, and remediation.
+2. **Comments** — the full comment history on the issue, showing prior
+   agent runs, review feedback, and any human input.
+3. **Linked PRs** — for each PR that references this issue (merged or
+   open), you receive the PR title, state, and unified diff.
+4. **Parsed signals** — the JSON output of `parse.py` run against the
+   recent transcript window, showing tool usage patterns, errors, and
+   repeated sequences.
+
+## What to produce
+
+Output a single diagnostic report in this exact format:
+
+```
+## Diagnostic Report: #N — <issue title>
+
+### Timeline
+
+<Chronological summary of what has happened on this issue: when it was
+raised, what PRs were opened, what review comments were left, what was
+merged, and where things stand now.>
+
+### Root Cause Analysis
+
+<Deep analysis of why the issue remains unresolved. Consider:
+- Did the PR(s) actually address the remediation described in the issue?
+- Is the issue description itself unclear or incomplete?
+- Did review comments identify problems that were not addressed?
+- Is the pattern still present in the parsed signals?
+- Are there dependencies or interactions with other parts of the codebase
+  that prevent a clean fix?>
+
+### Current State
+
+<What is the current state of the issue? What labels does it have?
+Is there an open PR? A merged PR that didn't solve it? No PR at all?>
+
+### Recommended Next Steps
+
+<Concrete, actionable recommendations. For each recommendation, explain
+what should be done and why it would help resolve the issue. Be specific
+about files, functions, or patterns involved.>
+```
+
+## Hard rules
+
+- Focus exclusively on the issue you are given. Do NOT raise new
+  findings or discuss unrelated issues.
+- Ground every claim in the evidence provided (issue body, comments,
+  PR diffs, or parsed signals). Do not speculate without evidence.
+- Be direct and specific. Name files, functions, line numbers, and
+  exact patterns when possible.
+- If the evidence is insufficient to determine the root cause, say so
+  explicitly and recommend what additional information would help.
+- Do NOT suggest remediations that have already been tried and failed,
+  unless you can explain what was wrong with the previous attempt and
+  how to do it differently.
+- Output nothing before the `## Diagnostic Report:` heading and nothing
+  after the `### Recommended Next Steps` section.

--- a/publish.py
+++ b/publish.py
@@ -66,6 +66,7 @@ LABELS = [
     ("auto-improve:revising", "d4c5f9", "Revise subagent is actively iterating on a PR"),
     ("auto-improve:solved", "0e8a16", "Pattern verified absent from recent transcripts"),
     ("auto-improve:merge-blocked", "e11d48", "Merge subcommand reviewed and decided not to auto-merge; awaiting human"),
+    ("auto-improve:diagnose-requested", "1d76db", "Human-requested deep diagnostic (admin-only label)"),
     ("category:reliability", "d73a4a", "Errors, failures, flaky behavior"),
     ("category:cost_reduction", "fbca04", "Token waste, unnecessary tool calls"),
     ("category:prompt_quality", "0075ca", "Unclear or missing prompt guidance"),


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#138

**Issue:** #138 — Add an additional agent for deep insight of issues if requested

## PR Summary

### What this fixes
Issue #138 requests an additional agent for deep diagnostic analysis of issues that seem unresolved even after PRs are merged. Users need a way to request a deeper investigation into why an issue persists.

### What was changed
- **`prompts/backend-diagnose.md`** — New prompt file for the diagnostic agent. Instructs the agent to produce a structured report with timeline, root cause analysis, current state, and recommended next steps, grounded in the issue body, comments, PR diffs, and parsed transcript signals.
- **`cai.py`** — Added `DIAGNOSE_PROMPT` path constant (line 114). Added `cmd_diagnose()` function (~150 lines) that fetches the target issue, gathers linked PR diffs (merged and open), runs `parse.py` for transcript signals, invokes `claude -p --model claude-sonnet-4-6` with the assembled prompt, and posts the diagnostic report as a comment on the issue. Registered the `diagnose` subcommand in the argparse dispatcher with a required `--issue` argument. Updated the module docstring to document the new command.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
