### PR TITLE
auto-improve: Issue #123 retains `:merge-blocked` after reaching `:merged` state

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -2566,6 +2566,7 @@ def cmd_merge(args) -> int:
             )
             if merge_result.returncode == 0:
                 print(f"[cai merge] PR #{pr_number}: merged successfully", flush=True)
+                _set_labels(issue_number, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED])
                 merged += 1
             else:
                 print(


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#143

**Issue:** #143 — Issue #123 retains `:merge-blocked` after reaching `:merged` state

## PR Summary

### What this fixes
When `cmd_merge` successfully merges a PR, it did not transition the linked issue's labels — it relied entirely on a future `cmd_verify` run to add `:merged` and remove `:pr-open`/`:merge-blocked`. This left a window where stale labels (like `:merge-blocked`) could survive if the verify step didn't run or if the issue transitioned through a different path.

### What was changed
- `cai.py`: Added a `_set_labels()` call in the `cmd_merge` success path (after `gh pr merge` succeeds) to immediately transition the issue: adds `auto-improve:merged` and removes `auto-improve:pr-open` and `auto-improve:merge-blocked`. This mirrors the same label transition already performed by `cmd_verify` at line 1445, making the merge transition eager rather than deferred.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
