### PR TITLE
auto-improve: Two `:merged` issues persistently confirmed unsolved with no retry PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ subprocess with no shared state.
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` issues, deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |
 | `cai.py review-pr` | `20 * * * *` (hourly :20) | Pre-merge consistency review of open PRs — posts ripple-effect findings as PR comments so the revise subagent can act on them |
 | `cai.py merge` | `35 * * * *` (hourly :35) | Confidence-gated auto-merge — evaluates each bot PR against its linked issue, posts a verdict, and merges when confidence meets the threshold |
-| `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → left as `:merged` (Sonnet) |
+| `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → recycled to `:raised` for retry (up to 2 times), then left as `:merged` for manual review (Sonnet) |
 | `cai.py cycle` | _(manual/on-demand)_ | Runs verify → fix → revise → review-pr → merge → confirm in sequence. Convenience wrapper for a full pipeline pass; not included in scheduled or startup runs |
 
 On `docker compose up -d` the entrypoint templates the crontab from
@@ -90,13 +90,15 @@ action so two concurrent `fix` runs can't pick the same issue.
                                     ▼
                                  merged
                                     │
-                        ┌───────────┴───────────┐
-                        │                       │
-                  confirm (pattern       confirm (inconclusive
-                   absent)                / unsolved)
-                        ▼                       ▼
-                  solved (closed)       stays :merged
-                                     (reasoning posted)
+                        ┌───────────┼───────────┐
+                        │           │           │
+                  confirm      confirm      confirm
+                 (pattern    (unsolved,   (inconclusive/
+                  absent)   retries left) unsolved, max
+                        ▼           │     retries reached)
+                  solved        ▼           ▼
+                 (closed)    raised     stays :merged
+                           (recycled)  (reasoning posted)
 ```
 
 `:no-action` means the fix subagent reviewed the issue and decided no

--- a/cai.py
+++ b/cai.py
@@ -117,6 +117,8 @@ LABEL_REVISING = "auto-improve:revising"
 LABEL_MERGE_BLOCKED = "auto-improve:merge-blocked"
 LABEL_AUDIT_RAISED = "audit:raised"
 
+MAX_UNSOLVED_RETRIES = 2  # recycle :merged → :raised up to this many times
+
 
 # ---------------------------------------------------------------------------
 # Run log
@@ -1960,14 +1962,42 @@ def cmd_confirm(args) -> int:
             print(f"[cai confirm] #{issue_num}: solved — closed", flush=True)
             solved += 1
         elif status == "unsolved":
-            _run(
-                ["gh", "issue", "comment", str(issue_num),
-                 "--repo", REPO,
-                 "--body",
-                 "Confirm check: fix did not eliminate the pattern in the recent window."],
-                capture_output=True,
-            )
-            print(f"[cai confirm] #{issue_num}: unsolved — left as :merged", flush=True)
+            # Count previous unsolved confirmations to decide whether to
+            # recycle back to :raised or give up.
+            prior_unsolved = 0
+            try:
+                comments_data = _gh_json([
+                    "issue", "view", str(issue_num),
+                    "--repo", REPO,
+                    "--json", "comments",
+                ]) or {}
+                for c in comments_data.get("comments") or []:
+                    if "fix did not eliminate the pattern" in (c.get("body") or ""):
+                        prior_unsolved += 1
+            except subprocess.CalledProcessError:
+                pass
+
+            if prior_unsolved < MAX_UNSOLVED_RETRIES:
+                _run(
+                    ["gh", "issue", "comment", str(issue_num),
+                     "--repo", REPO,
+                     "--body",
+                     "Confirm check: fix did not eliminate the pattern in the recent window. "
+                     "Recycling to `:raised` for another fix attempt."],
+                    capture_output=True,
+                )
+                _set_labels(issue_num, add=[LABEL_RAISED], remove=[LABEL_MERGED])
+                print(f"[cai confirm] #{issue_num}: unsolved — recycled to :raised", flush=True)
+            else:
+                _run(
+                    ["gh", "issue", "comment", str(issue_num),
+                     "--repo", REPO,
+                     "--body",
+                     "Confirm check: fix did not eliminate the pattern in the recent window. "
+                     f"Already retried {prior_unsolved} time(s) — leaving as `:merged` for manual review."],
+                    capture_output=True,
+                )
+                print(f"[cai confirm] #{issue_num}: unsolved — max retries reached, left as :merged", flush=True)
             unsolved += 1
         elif status == "inconclusive":
             # Post reasoning to the issue so humans can see why, but

--- a/cai.py
+++ b/cai.py
@@ -1945,6 +1945,7 @@ def cmd_confirm(args) -> int:
 
     solved = 0
     unsolved = 0
+    recycled = 0
     inconclusive = 0
 
     for issue_num, status, reasoning in verdicts:
@@ -1988,6 +1989,7 @@ def cmd_confirm(args) -> int:
                 )
                 _set_labels(issue_num, add=[LABEL_RAISED], remove=[LABEL_MERGED])
                 print(f"[cai confirm] #{issue_num}: unsolved — recycled to :raised", flush=True)
+                recycled += 1
             else:
                 _run(
                     ["gh", "issue", "comment", str(issue_num),
@@ -2029,12 +2031,12 @@ def cmd_confirm(args) -> int:
     dur = f"{int(time.monotonic() - t0)}s"
     print(
         f"[cai confirm] merged_checked={len(merged_issues)} "
-        f"solved={solved} unsolved={unsolved} inconclusive={inconclusive}",
+        f"solved={solved} unsolved={unsolved} recycled={recycled} inconclusive={inconclusive}",
         flush=True,
     )
     log_run("confirm", repo=REPO, merged_checked=len(merged_issues),
-            solved=solved, unsolved=unsolved, inconclusive=inconclusive,
-            duration=dur, exit=0)
+            solved=solved, unsolved=unsolved, recycled=recycled,
+            inconclusive=inconclusive, duration=dur, exit=0)
     return 0
 
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#145

**Issue:** #145 — Two `:merged` issues persistently confirmed unsolved with no retry PRs

## PR Summary

### What this fixes
`:merged` issues confirmed as unsolved by the confirm step were left permanently parked in `:merged` with no mechanism to generate new fix attempts. The fix step only picks up `:raised` issues, so unsolved merged issues were stuck in limbo indefinitely.

### What was changed
- **cai.py:120** — Added `MAX_UNSOLVED_RETRIES = 2` constant controlling how many times a `:merged` issue can be recycled back to `:raised` after being confirmed unsolved.
- **cai.py:1964–2001** — Rewrote the `unsolved` branch in `cmd_confirm` to count prior unsolved confirmation comments on the issue. If under the retry threshold, the issue is transitioned from `:merged` to `:raised` for another fix attempt. If the threshold is reached, the issue remains `:merged` with a comment requesting manual review, preventing infinite retry loops.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
