### PR TITLE
auto-improve: Issue #141 carries two state-prefixed labels simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ implement their linked issue. For each open `:pr-open` PR on an
 6. If the action is `reject` and confidence meets the threshold,
    closes the PR via `gh pr close --delete-branch` and transitions
    the issue to `auto-improve:no-action`
-7. Otherwise, labels the issue `auto-improve:merge-blocked` and
+7. Otherwise, labels the issue `merge-blocked` and
    posts the verdict reasoning as a PR comment
 
 **Confidence levels:**

--- a/cai.py
+++ b/cai.py
@@ -2327,7 +2327,7 @@ def cmd_merge(args) -> int:
         issue_labels = [l["name"] for l in issue.get("labels", [])]
         if LABEL_PR_OPEN not in issue_labels:
             continue
-        # NOTE: do NOT skip on `auto-improve:merge-blocked`. The label
+        # NOTE: do NOT skip on `merge-blocked`. The label
         # is informational only — it records "the last evaluation
         # decided not to merge". Re-evaluation gating is purely
         # SHA-based (see safety filter 6 below): if the PR's HEAD SHA

--- a/cai.py
+++ b/cai.py
@@ -114,7 +114,7 @@ LABEL_MERGED = "auto-improve:merged"
 LABEL_SOLVED = "auto-improve:solved"
 LABEL_NO_ACTION = "auto-improve:no-action"
 LABEL_REVISING = "auto-improve:revising"
-LABEL_MERGE_BLOCKED = "auto-improve:merge-blocked"
+LABEL_MERGE_BLOCKED = "merge-blocked"
 LABEL_AUDIT_RAISED = "audit:raised"
 
 

--- a/publish.py
+++ b/publish.py
@@ -65,7 +65,7 @@ LABELS = [
     ("auto-improve:no-action", "c5def5", "Fix subagent reviewed and decided no code change is needed; awaiting human triage"),
     ("auto-improve:revising", "d4c5f9", "Revise subagent is actively iterating on a PR"),
     ("auto-improve:solved", "0e8a16", "Pattern verified absent from recent transcripts"),
-    ("auto-improve:merge-blocked", "e11d48", "Merge subcommand reviewed and decided not to auto-merge; awaiting human"),
+    ("merge-blocked", "e11d48", "Merge subcommand reviewed and decided not to auto-merge; awaiting human"),
     ("category:reliability", "d73a4a", "Errors, failures, flaky behavior"),
     ("category:cost_reduction", "fbca04", "Token waste, unnecessary tool calls"),
     ("category:prompt_quality", "0075ca", "Unclear or missing prompt guidance"),


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#148

**Issue:** #148 — Issue #141 carries two state-prefixed labels simultaneously

## PR Summary

### What this fixes
Issue #141 carried two `auto-improve:`-prefixed labels simultaneously (`auto-improve:pr-open` and `auto-improve:merge-blocked`), creating an ambiguous dual-state. The `merge-blocked` label is purely informational (gating is SHA-based), so it should not use the `auto-improve:` state-prefix namespace.

### What was changed
- `cai.py:117` — Changed `LABEL_MERGE_BLOCKED` from `"auto-improve:merge-blocked"` to `"merge-blocked"`, removing it from the state-prefix namespace
- `publish.py:68` — Updated the label definition tuple from `"auto-improve:merge-blocked"` to `"merge-blocked"` so the label is created/synced under the new name
- `README.md:203` — Updated documentation reference to use `merge-blocked` instead of `auto-improve:merge-blocked`

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
