### PR TITLE
auto-improve: Reduce Edit failures by reading target file immediately before editing

### DIFF
--- a/prompts/backend-fix.md
+++ b/prompts/backend-fix.md
@@ -21,9 +21,12 @@ Grep, and Glob instead.
 
 1. **Read before you edit.** Always Read the target file
    **immediately** before calling Edit — not just earlier in the
-   session. Use a unique, multi-line `old_string` (3+ lines of
-   surrounding context) to avoid ambiguous-match failures. Do not
-   propose edits to files you have not read.
+   session. If more than 2 tool calls have occurred since you last
+   Read a file, you **must** re-read it before editing it again, as
+   intervening edits may have changed line content or context. Use a
+   unique, multi-line `old_string` (3+ lines of surrounding context)
+   to avoid ambiguous-match failures. Do not propose edits to files
+   you have not read.
 2. **Make minimal, targeted changes.** Touch only what the issue
    actually requires. Do not refactor surrounding code, rename
    variables, reformat, add comments, or "improve" things outside

--- a/prompts/backend-revise.md
+++ b/prompts/backend-revise.md
@@ -18,9 +18,12 @@ working on top of the previous fix attempt.
 
 1. **Read before you edit.** Always Read the target file
    **immediately** before calling Edit — not just earlier in the
-   session. Use a unique, multi-line `old_string` (3+ lines of
-   surrounding context) to avoid ambiguous-match failures. Do not
-   propose edits to files you have not read.
+   session. If more than 2 tool calls have occurred since you last
+   Read a file, you **must** re-read it before editing it again, as
+   intervening edits may have changed line content or context. Use a
+   unique, multi-line `old_string` (3+ lines of surrounding context)
+   to avoid ambiguous-match failures. Do not propose edits to files
+   you have not read.
 2. **Only address the review comments.** Do not redo the original
    work, reinterpret the issue, or refactor unrelated code. Your
    scope is strictly what the reviewers asked for.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#155

**Issue:** #155 — Reduce Edit failures by reading target file immediately before editing

## PR Summary

### What this fixes
Edit tool calls were failing at an 11.5% rate due to stale content assumptions — the agent would issue multiple consecutive Edits without re-reading the file, causing `old_string` mismatches after intervening edits changed line content.

### What was changed
- `prompts/backend-fix.md`: Strengthened hard rule #1 ("Read before you edit") to explicitly require a fresh Read of the target file if more than 2 tool calls have occurred since the last Read, preventing `old_string` mismatches caused by stale content.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
