### PR TITLE
auto-improve: PR #147 caught in recurring revise-review cycle without merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ references, etc.).
 Findings are posted as a single PR comment starting with
 `## cai pre-merge review — <sha>`. The SHA prevents re-reviewing PRs
 that haven't changed. To prevent review→revise→review loops from
-cycling indefinitely, `review-pr` also caps total reviews per PR at 3;
-PRs that have already been reviewed 3 times are skipped regardless of
-new commits. Because findings are PR comments, the `revise`
+cycling indefinitely, `review-pr` also caps total reviews per PR at 3
+(regardless of whether findings were posted); PRs that have already
+been reviewed 3 times are skipped regardless of new commits. Because findings are PR comments, the `revise`
 subagent picks them up on the next tick and can address them
 automatically — no separate issue is created.
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,10 @@ references, etc.).
 
 Findings are posted as a single PR comment starting with
 `## cai pre-merge review — <sha>`. The SHA prevents re-reviewing PRs
-that haven't changed. Because findings are PR comments, the `revise`
+that haven't changed. To prevent review→revise→review loops from
+cycling indefinitely, `review-pr` also caps total reviews per PR at 3;
+PRs that have already been reviewed 3 times are skipped regardless of
+new commits. Because findings are PR comments, the `revise`
 subagent picks them up on the next tick and can address them
 automatically — no separate issue is created.
 

--- a/cai.py
+++ b/cai.py
@@ -2054,6 +2054,12 @@ def cmd_confirm(args) -> int:
 _REVIEW_COMMENT_HEADING_FINDINGS = "## cai pre-merge review"
 _REVIEW_COMMENT_HEADING_CLEAN = "## cai pre-merge review (clean)"
 
+# Maximum number of review-pr reviews per PR. After this many reviews
+# (with or without findings), review-pr will stop re-reviewing the PR
+# to prevent review→revise→review loops from cycling indefinitely.
+# See issue #158.
+_MAX_REVIEWS_PER_PR = 3
+
 
 def cmd_review_pr(args) -> int:
     """Review open PRs for ripple effects and post findings as PR comments."""
@@ -2104,6 +2110,25 @@ def cmd_review_pr(args) -> int:
         if already_reviewed:
             print(
                 f"[cai review-pr] PR #{pr_number}: already reviewed at {head_sha[:8]}; skipping",
+                flush=True,
+            )
+            skipped += 1
+            continue
+
+        # Loop guard: cap the total number of reviews per PR to prevent
+        # review→revise→review cycles from running indefinitely.
+        # Count all prior review comments (both findings and clean).
+        # See issue #158.
+        prior_reviews = sum(
+            1 for c in pr.get("comments", [])
+            if (c.get("body") or "").lstrip().startswith(
+                _REVIEW_COMMENT_HEADING_FINDINGS
+            )
+        )
+        if prior_reviews >= _MAX_REVIEWS_PER_PR:
+            print(
+                f"[cai review-pr] PR #{pr_number}: already reviewed {prior_reviews} "
+                f"times (cap={_MAX_REVIEWS_PER_PR}); skipping to avoid review loop",
                 flush=True,
             )
             skipped += 1

--- a/cai.py
+++ b/cai.py
@@ -2117,8 +2117,10 @@ def cmd_review_pr(args) -> int:
 
         # Loop guard: cap the total number of reviews per PR to prevent
         # review→revise→review cycles from running indefinitely.
-        # Count all prior review comments (both findings and clean).
-        # See issue #158.
+        # Match either heading variant (findings or clean) —
+        # _REVIEW_COMMENT_HEADING_CLEAN starts with
+        # _REVIEW_COMMENT_HEADING_FINDINGS, so a single startswith
+        # check covers both.  See issue #158.
         prior_reviews = sum(
             1 for c in pr.get("comments", [])
             if (c.get("body") or "").lstrip().startswith(


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#158

**Issue:** #158 — PR #147 caught in recurring revise-review cycle without merging

## PR Summary

### What this fixes
PR #147 was caught in a recurring review→revise→review cycle: after each revise push (new HEAD SHA), review-pr would re-review and potentially post new findings, triggering another revise iteration indefinitely. There was no cap on the number of review-pr reviews per PR.

### What was changed
- **cai.py**: Added `_MAX_REVIEWS_PER_PR = 3` constant (after line ~2055) that caps how many times `review-pr` will review a single PR.
- **cai.py**: Added a loop guard in `cmd_review_pr` (after the existing SHA-idempotency check) that counts prior review comments on the PR and skips it once the cap is reached, breaking the review→revise→review cycle.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
