### PR TITLE
auto-improve: Guide prompts to use Agent tool for broad exploration

### DIFF
--- a/prompts/backend-fix.md
+++ b/prompts/backend-fix.md
@@ -77,6 +77,11 @@ Grep, and Glob instead.
    in parallel rather than sequentially. Use Glob first to narrow
    the file set, then Grep the results, instead of running
    exploratory Grep calls one at a time.
+8. **Use Agent for broad exploration.** When you need to search
+   broadly across multiple files or directories, use the Agent tool
+   with `subagent_type: Explore` instead of issuing many sequential
+   Grep or Read calls. A single Explore subagent can parallelize
+   the search internally, saving tokens and tool-call rounds.
 
 ## When to make NO changes (and exit cleanly)
 

--- a/prompts/backend-review-pr.md
+++ b/prompts/backend-review-pr.md
@@ -29,7 +29,10 @@ ripple effects in these six categories:
 
 1. Read the diff carefully
 2. For each changed file/function/constant, use `Grep` and `Glob` to
-   find other references in the codebase
+   find other references in the codebase. When you need to search
+   broadly across many files or directories, use the Agent tool with
+   `subagent_type: Explore` instead of issuing many sequential Grep
+   or Read calls.
 3. Check if the PR's changes are consistent with those references
 4. Only report findings where you are confident there is a real
    inconsistency — not hypothetical or stylistic concerns

--- a/prompts/backend-review-pr.md
+++ b/prompts/backend-review-pr.md
@@ -4,7 +4,7 @@ You are the pre-merge review agent for `robotsix-cai`. Your job is to
 review a pull request diff for **ripple effects** — changes that are
 internally consistent but create inconsistencies with the rest of the
 codebase. You have read-only access to the repository via
-`Read`, `Grep`, and `Glob`.
+`Read`, `Grep`, `Glob`, and the `Agent` tool.
 
 ## What you receive
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#159

**Issue:** #159 — Guide prompts to use Agent tool for broad exploration

## PR Summary

### What this fixes
The fix subagent was issuing many sequential Grep/Read calls for broad exploration (~54% of tool calls were in repeated sequences of 3+), instead of delegating to an Explore subagent that can parallelize internally.

### What was changed
- `prompts/backend-fix.md`: Added item 8 to the "Efficiency guidance" section instructing the agent to use `Agent` with `subagent_type: Explore` for broad searches instead of many sequential Grep/Read calls.
- `prompts/backend-review-pr.md`: Added the same guidance to the "How to work" section (step 2), where the agent searches for cross-codebase references.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
