### PR TITLE
auto-improve: Issue #135 carries both `:merged` and `:merge-blocked` labels

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -2576,7 +2576,16 @@ def cmd_merge(args) -> int:
                     f"[cai merge] PR #{pr_number}: close failed:\n{close_result.stderr}",
                     file=sys.stderr,
                 )
-                if LABEL_MERGED not in issue_labels:
+                # Re-fetch labels to avoid stale-data race: another run may
+                # have merged the PR (and set :merged) while the model was
+                # evaluating this PR.
+                try:
+                    fresh = _gh_json(["issue", "view", str(issue_number),
+                                      "--repo", REPO, "--json", "labels"])
+                    fresh_labels = [l["name"] for l in fresh.get("labels", [])]
+                except Exception:
+                    fresh_labels = issue_labels
+                if LABEL_MERGED not in fresh_labels:
                     _set_labels(issue_number, add=[LABEL_MERGE_BLOCKED])
                 held += 1
         elif action == "merge" and verdict_rank >= threshold_rank:
@@ -2605,7 +2614,14 @@ def cmd_merge(args) -> int:
                 flush=True,
             )
             # Set merge-blocked label on the issue, unless already merged.
-            if LABEL_MERGED not in issue_labels:
+            # Re-fetch labels to avoid stale-data race (see above).
+            try:
+                fresh = _gh_json(["issue", "view", str(issue_number),
+                                  "--repo", REPO, "--json", "labels"])
+                fresh_labels = [l["name"] for l in fresh.get("labels", [])]
+            except Exception:
+                fresh_labels = issue_labels
+            if LABEL_MERGED not in fresh_labels:
                 _set_labels(issue_number, add=[LABEL_MERGE_BLOCKED])
             held += 1
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#161

**Issue:** #161 — Issue #135 carries both `:merged` and `:merge-blocked` labels

## PR Summary

### What this fixes
The `cmd_merge` function in `cai.py` used stale `issue_labels` (fetched at the start of each PR's loop iteration) to guard whether `merge-blocked` could be added. If another process (e.g., `verify`) merged the PR and set `:merged` while the model was evaluating, the stale guard check would pass and `merge-blocked` would be re-added on top of `:merged`, producing mutually exclusive labels.

### What was changed
- `cai.py`: At both sites where `LABEL_MERGE_BLOCKED` is conditionally added (the reject-close-failure path around line 2579 and the hold path around line 2608), replaced the stale `issue_labels` check with a fresh label re-fetch via `_gh_json` before deciding whether to add `merge-blocked`. Falls back to the original stale labels if the re-fetch fails.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
