### PR TITLE
auto-improve: Revise step on PR #144 reported rebase failure with exit 0

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -1142,6 +1142,7 @@ def cmd_revise(args) -> int:
 
     print(f"[cai revise] found {len(targets)} PR(s) to revise", flush=True)
 
+    had_failure = False
     for target in targets:
         pr_number = target["pr_number"]
         issue_number = target["issue_number"]
@@ -1233,7 +1234,8 @@ def cmd_revise(args) -> int:
                     )
                     _set_labels(issue_number, remove=[LABEL_REVISING])
                     log_run("revise", repo=REPO, pr=pr_number,
-                            result="rebase_failed", exit=0)
+                            result="rebase_failed", exit=1)
+                    had_failure = True
                     continue
 
                 # Rebase succeeded — force-push.
@@ -1402,11 +1404,12 @@ def cmd_revise(args) -> int:
             _set_labels(issue_number, remove=[LABEL_REVISING])
             log_run("revise", repo=REPO, pr=pr_number,
                     result="unexpected_error", exit=1)
+            had_failure = True
         finally:
             if work_dir.exists():
                 shutil.rmtree(work_dir, ignore_errors=True)
 
-    return 0
+    return 1 if had_failure else 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#162

**Issue:** #162 — Revise step on PR #144 reported rebase failure with exit 0

## PR Summary

### What this fixes
The `cmd_revise` function in `cai.py` exited with code 0 even when a rebase failure occurred, causing the `rebase_failed` result to appear as a success to the scheduler and alerting pipeline.

### What was changed
- `cai.py`: Added `had_failure = False` tracker before the revision loop (line 1145)
- `cai.py`: Changed `log_run` for `rebase_failed` from `exit=0` to `exit=1` (line 1237) and set `had_failure = True`
- `cai.py`: Added `had_failure = True` to the existing `unexpected_error` handler (line 1407)
- `cai.py`: Changed `return 0` at the end of `cmd_revise` to `return 1 if had_failure else 0` (line 1412)

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
