### PR TITLE
auto-improve: cmd_confirm does not log session_count or warn on low in_tokens

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -2068,6 +2068,24 @@ def cmd_confirm(args) -> int:
 
     parsed_signals = parsed.stdout.strip()
 
+    # Extract stats from parse.py's JSON output.
+    try:
+        signals = json.loads(parsed_signals)
+    except (json.JSONDecodeError, ValueError):
+        signals = {}
+    token_usage = signals.get("token_usage", {})
+    in_tokens = token_usage.get("input_tokens", 0)
+    out_tokens = token_usage.get("output_tokens", 0)
+    session_count = signals.get("session_count", 0)
+
+    if in_tokens > 0 and in_tokens < 500:
+        print(
+            f"[cai confirm] WARNING: in_tokens={in_tokens} is below the "
+            f"expected floor of 500 — the transcript window may be too "
+            f"narrow or session files may be nearly empty",
+            flush=True,
+        )
+
     # 2b. For each merged issue, fetch the associated merged PR diff.
     MAX_DIFF_LEN = 8000
     for mi in merged_issues:
@@ -2199,11 +2217,13 @@ def cmd_confirm(args) -> int:
     dur = f"{int(time.monotonic() - t0)}s"
     print(
         f"[cai confirm] merged_checked={len(merged_issues)} "
-        f"solved={solved} unsolved={unsolved} inconclusive={inconclusive}",
+        f"solved={solved} unsolved={unsolved} inconclusive={inconclusive} "
+        f"sessions={session_count} in_tokens={in_tokens} out_tokens={out_tokens}",
         flush=True,
     )
     log_run("confirm", repo=REPO, merged_checked=len(merged_issues),
             solved=solved, unsolved=unsolved, inconclusive=inconclusive,
+            sessions=session_count, in_tokens=in_tokens, out_tokens=out_tokens,
             duration=dur, exit=0)
     return 0
 

--- a/cai.py
+++ b/cai.py
@@ -2152,6 +2152,7 @@ def cmd_confirm(args) -> int:
         dur = f"{int(time.monotonic() - t0)}s"
         log_run("confirm", repo=REPO, merged_checked=len(merged_issues),
                 solved=0, unsolved=0, inconclusive=0,
+                sessions=session_count, in_tokens=in_tokens, out_tokens=out_tokens,
                 duration=dur, exit=confirm.returncode)
         return confirm.returncode
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#165

**Issue:** #165 — cmd_confirm does not log session_count or warn on low in_tokens

## PR Summary

### What this fixes
`cmd_confirm` did not extract or log `session_count`, `in_tokens`, or `out_tokens` from the parse.py output, and did not warn when `in_tokens` was suspiciously low — making it susceptible to the same silent-failure mode that issue #77 identified in `cmd_analyze`.

### What was changed
- `cai.py`: Added JSON extraction of `session_count`, `in_tokens`, and `out_tokens` from parse.py output in `cmd_confirm` (after line 2069), matching the pattern already used in `cmd_analyze`.
- `cai.py`: Added `in_tokens < 500` warning print in the confirm path.
- `cai.py`: Updated the final summary `print` and `log_run` call to include `sessions`, `in_tokens`, and `out_tokens`.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
