### PR TITLE
auto-improve: analyze sessions count collapsed after PR #166 merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ the same global window settings.
   history to include in the analysis. Default: `7`. Set to `0` to
   include all sessions (useful for debugging or initial seeding).
 - **`CAI_TRANSCRIPT_MAX_FILES`** — maximum number of transcript files
-  to read (most recent first by mtime). Default: `20`. Set to `0` to
+  to read (most recent first by mtime). Default: `500`. Set to `0` to
   disable the count limit. Both knobs apply together — a file must be
   within the time window AND in the top N most recent to be included.
 - **`CAI_MERGE_CONFIDENCE_THRESHOLD`** — confidence level required for

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly at :35 (auto-merge confident PRs)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
-      CAI_TRANSCRIPT_MAX_FILES: "20"        # read at most N recent transcript files
+      CAI_TRANSCRIPT_MAX_FILES: "500"       # read at most N recent transcript files
     volumes:
       # Persistent claude-code session transcripts. claude-code writes
       # session JSONL into ~/.claude/projects/<sanitized-cwd>/<sid>.jsonl

--- a/install.sh
+++ b/install.sh
@@ -151,7 +151,7 @@ services:
       CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly :35 (auto-merge confident PRs)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
-      CAI_TRANSCRIPT_MAX_FILES: "20"        # read at most N recent transcript files
+      CAI_TRANSCRIPT_MAX_FILES: "500"       # read at most N recent transcript files
     volumes:
       # Mount is read-write so claude-code can refresh the OAuth
       # access token when it expires. claude-code writes the refreshed
@@ -201,7 +201,7 @@ services:
       CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly :35 (auto-merge confident PRs)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
-      CAI_TRANSCRIPT_MAX_FILES: "20"        # read at most N recent transcript files
+      CAI_TRANSCRIPT_MAX_FILES: "500"       # read at most N recent transcript files
     volumes:
       - cai_transcripts:/root/.claude/projects
       - cai_gh_config:/root/.config/gh

--- a/parse.py
+++ b/parse.py
@@ -202,13 +202,13 @@ def _get_cutoff_time() -> float:
 
 def _get_max_files() -> int:
     """Return the maximum number of transcript files to read, or 0 to disable."""
-    raw = os.environ.get("CAI_TRANSCRIPT_MAX_FILES", "20")
+    raw = os.environ.get("CAI_TRANSCRIPT_MAX_FILES", "500")
     try:
         max_files = int(raw)
     except ValueError:
-        max_files = 20
+        max_files = 500
     if max_files < 0:
-        max_files = 20
+        max_files = 500
     return max_files
 
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#171

**Issue:** #171 — analyze sessions count collapsed after PR #166 merged

## PR Summary

### What this fixes
The `CAI_TRANSCRIPT_MAX_FILES` default of 20 caused the analyze sessions count to collapse from 237 to exactly 20 after PR #166 introduced the file-count cap. The cap silently truncated the session set, producing artificially low `in_tokens` values and a misleading sessions count.

### What was changed
- **`parse.py`** — raised the `CAI_TRANSCRIPT_MAX_FILES` default from `20` to `500` in `_get_max_files()` (the env-var fallback and both error/negative-value fallbacks)
- **`install.sh`** — updated both docker-compose template blocks to set `CAI_TRANSCRIPT_MAX_FILES: "500"`
- **`docker-compose.yml`** — updated `CAI_TRANSCRIPT_MAX_FILES` from `"20"` to `"500"`
- **`README.md`** — updated documented default from `20` to `500`

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
