### PR TITLE
auto-improve: `_set_labels` return value unchecked in `cmd_fix` and `cmd_merge` label transitions

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -747,11 +747,30 @@ def cmd_fix(args) -> int:
                 capture_output=True,
             )
             # Transition: in-progress -> no-action (NOT back to :raised)
-            _set_labels(
+            if not _set_labels(
                 issue_number,
                 add=[LABEL_NO_ACTION],
                 remove=[LABEL_IN_PROGRESS],
-            )
+            ):
+                print(
+                    f"[cai fix] WARNING: label transition to :no-action failed for "
+                    f"#{issue_number}; retrying",
+                    flush=True,
+                )
+                if not _set_labels(
+                    issue_number,
+                    add=[LABEL_NO_ACTION],
+                    remove=[LABEL_IN_PROGRESS],
+                ):
+                    print(
+                        f"[cai fix] WARNING: label transition to :no-action failed twice for "
+                        f"#{issue_number} — issue may be stuck without a lifecycle label",
+                        file=sys.stderr, flush=True,
+                    )
+                    rollback()
+                    log_run("fix", repo=REPO, issue=issue_number,
+                            result="label_transition_failed", exit=1)
+                    return 1
             locked = False
             log_run("fix", repo=REPO, issue=issue_number,
                     result="no_action_needed", exit=0)
@@ -2827,7 +2846,12 @@ def cmd_merge(args) -> int:
                     file=sys.stderr,
                 )
                 if not _issue_has_label(issue_number, LABEL_MERGED):
-                    _set_labels(issue_number, add=[LABEL_MERGE_BLOCKED])
+                    if not _set_labels(issue_number, add=[LABEL_MERGE_BLOCKED]):
+                        print(
+                            f"[cai merge] WARNING: failed to add :merge-blocked label to "
+                            f"#{issue_number} after close failure on PR #{pr_number}",
+                            file=sys.stderr, flush=True,
+                        )
                 # Close failed → PR is still open and needs human attention.
                 _pr_set_needs_human(pr_number, True)
                 held += 1
@@ -2843,7 +2867,21 @@ def cmd_merge(args) -> int:
             )
             if merge_result.returncode == 0:
                 print(f"[cai merge] PR #{pr_number}: merged successfully", flush=True)
-                _set_labels(issue_number, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED])
+                if not _set_labels(issue_number, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED]):
+                    print(
+                        f"[cai merge] WARNING: label transition to :merged failed for "
+                        f"#{issue_number} after merging PR #{pr_number}; retrying",
+                        flush=True,
+                    )
+                    if not _set_labels(issue_number, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED]):
+                        print(
+                            f"[cai merge] WARNING: label transition to :merged failed twice for "
+                            f"#{issue_number} — issue may be stuck without a lifecycle label",
+                            file=sys.stderr, flush=True,
+                        )
+                        _pr_set_needs_human(pr_number, True)
+                        held += 1
+                        continue
                 merged += 1
             else:
                 print(
@@ -2861,7 +2899,12 @@ def cmd_merge(args) -> int:
             # Set merge-blocked label on the issue, unless already merged.
             # Re-fetch to avoid race with a concurrent merge run.
             if not _issue_has_label(issue_number, LABEL_MERGED):
-                _set_labels(issue_number, add=[LABEL_MERGE_BLOCKED])
+                if not _set_labels(issue_number, add=[LABEL_MERGE_BLOCKED]):
+                    print(
+                        f"[cai merge] WARNING: failed to add :merge-blocked label to "
+                        f"#{issue_number} for held PR #{pr_number}",
+                        file=sys.stderr, flush=True,
+                    )
             # Tag the PR itself so humans can filter `label:needs-human-review`.
             _pr_set_needs_human(pr_number, True)
             held += 1

--- a/cai.py
+++ b/cai.py
@@ -2805,7 +2805,21 @@ def cmd_merge(args) -> int:
             )
             if close_result.returncode == 0:
                 print(f"[cai merge] PR #{pr_number}: closed successfully", flush=True)
-                _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN])
+                if not _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN]):
+                    print(
+                        f"[cai merge] WARNING: label transition to :no-action failed for "
+                        f"#{issue_number} after closing PR #{pr_number}; retrying",
+                        flush=True,
+                    )
+                    if not _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN]):
+                        print(
+                            f"[cai merge] WARNING: label transition to :no-action failed twice for "
+                            f"#{issue_number} — issue may be stuck without a lifecycle label",
+                            file=sys.stderr, flush=True,
+                        )
+                        _pr_set_needs_human(pr_number, True)
+                        held += 1
+                        continue
                 closed += 1
             else:
                 print(


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#172

**Issue:** #172 — `_set_labels` return value unchecked in `cmd_fix` and `cmd_merge` label transitions

## PR Summary

### What this fixes
In `cmd_merge`, after closing a rejected PR via `gh pr close`, the `_set_labels` call to transition from `:pr-open` to `:no-action` was not checking the return value. If the label transition failed, the issue could end up with just the bare `auto-improve` label and no lifecycle label — the likely root cause of issue #119. The `cmd_fix` PR-open transition (the other location mentioned in the issue) was already fixed with retry logic in a prior change.

### What was changed
- **`cai.py` line ~2808 (`cmd_merge` reject path)**: Wrapped the `_set_labels(add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN])` call in a return-value check with one retry. On double failure, logs a prominent warning to stderr, marks the PR as needs-human via `_pr_set_needs_human`, increments the `held` counter instead of `closed`, and `continue`s to the next PR. This matches the retry pattern already used in `cmd_fix` for the `:pr-open` transition.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
