### PR TITLE
auto-improve: we should have a system to detect stale issues/PR and find ways to fix them unless they realy require human intervention for decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ subprocess with no shared state.
 | `cai.py fix` | `15 * * * *` (hourly :15) | Picks the oldest eligible issue, lets a subagent edit the repo with full tool permissions, opens a PR — see lifecycle below |
 | `cai.py revise` | `30 * * * *` (hourly :30) | Watches `:pr-open` PRs for new comments and iterates on the same branch via force-push; also auto-rebases unmergeable PRs onto current main |
 | `cai.py verify` | `45 * * * *` (hourly :45) | Mechanical, no LLM. Walks `auto-improve:pr-open` issues and updates labels based on PR merge state; also recovers issues whose `:pr-open` label was lost |
-| `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` issues, deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |
+| `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` and `:no-action` issues, flags stale `:merged` issues for human review, deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |
 | `cai.py review-pr` | `20 * * * *` (hourly :20) | Pre-merge consistency review of open PRs — posts ripple-effect findings as PR comments so the revise subagent can act on them |
 | `cai.py merge` | `35 * * * *` (hourly :35) | Confidence-gated auto-merge — evaluates each bot PR against its linked issue, posts a verdict, and merges when confidence meets the threshold |
 | `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → left as `:merged` (Sonnet) |
@@ -120,13 +120,16 @@ like `auto-improve:raised` issues.
 Audit categories: `stale_lifecycle`, `lock_corruption`, `loop_stuck`,
 `prompt_contradiction`, `topic_duplicate`, `silent_failure`.
 
-There are two exceptions to "report-only": stale `:in-progress`
-rollback and merged-branch cleanup. If an issue has been
-`:in-progress` for more than 6 hours with no recent fix activity in
-the log, the audit subcommand automatically rolls it back to `:raised`
-and creates an audit finding noting the rollback. Additionally, remote
-branches for merged or closed `auto-improve/` PRs are deleted
-automatically.
+There are four exceptions to "report-only": stale `:in-progress`
+rollback, stale `:no-action` rollback, stale `:merged` flagging, and
+merged-branch cleanup. If an issue has been `:in-progress` for more
+than 6 hours with no recent fix activity in the log, the audit
+subcommand automatically rolls it back to `:raised`. Stale
+`:no-action` issues (7+ days) are rolled back to `:raised` so the fix
+agent can retry with new context. Stale `:merged` issues (14+ days)
+are flagged with `needs-human-review` since the automation cannot
+determine whether the fix worked. Additionally, remote branches for
+merged or closed `auto-improve/` PRs are deleted automatically.
 
 ### Comment-driven PR iteration
 

--- a/cai.py
+++ b/cai.py
@@ -1939,8 +1939,8 @@ def _rollback_stale_in_progress() -> list[dict]:
     return rolled_back
 
 
-def _close_stale_no_action() -> list[dict]:
-    """Auto-close :no-action issues that have had no activity for _STALE_NO_ACTION_DAYS."""
+def _unstuck_stale_no_action() -> list[dict]:
+    """Roll stale :no-action issues back to :raised so fix can retry with new context."""
     try:
         issues = _gh_json([
             "issue", "list",
@@ -1959,7 +1959,7 @@ def _close_stale_no_action() -> list[dict]:
 
     now = datetime.now(timezone.utc).timestamp()
     threshold = _STALE_NO_ACTION_DAYS * 86400
-    closed = []
+    unstuck = []
 
     for issue in issues:
         try:
@@ -1972,38 +1972,34 @@ def _close_stale_no_action() -> list[dict]:
         if age <= threshold:
             continue
         issue_num = issue["number"]
-        result = _run(
-            ["gh", "issue", "close", str(issue_num),
-             "--repo", REPO,
-             "--comment",
-             f"Auto-closing: this issue has been in `{LABEL_NO_ACTION}` state "
-             f"for {age / 86400:.0f} days with no activity. "
-             f"The fix agent reviewed it and determined no code change was needed. "
-             f"Reopen if you disagree."],
-            capture_output=True,
+        ok = _set_labels(
+            issue_num,
+            add=[LABEL_RAISED],
+            remove=[LABEL_NO_ACTION],
         )
-        if result.returncode == 0:
-            closed.append(issue)
+        if ok:
+            unstuck.append(issue)
             log_run(
                 "audit",
-                action="stale_no_action_close",
+                action="stale_no_action_unstuck",
                 issue=issue_num,
                 stale_days=f"{age / 86400:.0f}",
             )
             print(
-                f"[cai audit] closed #{issue_num} "
-                f"(stale :no-action, {age / 86400:.0f} days)",
+                f"[cai audit] unstuck #{issue_num} "
+                f"(stale :no-action → :raised, {age / 86400:.0f} days)",
                 flush=True,
             )
 
-    return closed
+    return unstuck
 
 
-def _close_stale_merged() -> list[dict]:
-    """Auto-close :merged issues that have had no activity for _STALE_MERGED_DAYS.
+def _flag_stale_merged() -> list[dict]:
+    """Flag stale :merged issues for human intervention.
 
     These issues had their PRs merged but confirm has not resolved them.
-    After the threshold, assume the fix is in place and close as solved.
+    After the threshold, flag for human review since the automation
+    cannot determine whether the fix actually worked.
     """
     try:
         issues = _gh_json([
@@ -2011,7 +2007,7 @@ def _close_stale_merged() -> list[dict]:
             "--repo", REPO,
             "--label", LABEL_MERGED,
             "--state", "open",
-            "--json", "number,title,updatedAt",
+            "--json", "number,title,updatedAt,labels",
             "--limit", "100",
         ]) or []
     except subprocess.CalledProcessError as e:
@@ -2023,9 +2019,12 @@ def _close_stale_merged() -> list[dict]:
 
     now = datetime.now(timezone.utc).timestamp()
     threshold = _STALE_MERGED_DAYS * 86400
-    closed = []
+    flagged = []
 
     for issue in issues:
+        issue_labels = {lbl["name"] for lbl in issue.get("labels", [])}
+        if LABEL_PR_NEEDS_HUMAN in issue_labels:
+            continue
         try:
             updated = datetime.strptime(
                 issue["updatedAt"], "%Y-%m-%dT%H:%M:%SZ"
@@ -2036,32 +2035,22 @@ def _close_stale_merged() -> list[dict]:
         if age <= threshold:
             continue
         issue_num = issue["number"]
-        _set_labels(issue_num, add=[LABEL_SOLVED], remove=[LABEL_MERGED])
-        result = _run(
-            ["gh", "issue", "close", str(issue_num),
-             "--repo", REPO,
-             "--comment",
-             f"Auto-closing: this issue has been in `{LABEL_MERGED}` state "
-             f"for {age / 86400:.0f} days. The fix was merged and confirm "
-             f"has not flagged it as unsolved — assuming resolved. "
-             f"Reopen if the original problem persists."],
-            capture_output=True,
-        )
-        if result.returncode == 0:
-            closed.append(issue)
+        ok = _set_labels(issue_num, add=[LABEL_PR_NEEDS_HUMAN])
+        if ok:
+            flagged.append(issue)
             log_run(
                 "audit",
-                action="stale_merged_close",
+                action="stale_merged_flag",
                 issue=issue_num,
                 stale_days=f"{age / 86400:.0f}",
             )
             print(
-                f"[cai audit] closed #{issue_num} "
-                f"(stale :merged, {age / 86400:.0f} days → :solved)",
+                f"[cai audit] flagged #{issue_num} for human review "
+                f"(stale :merged, {age / 86400:.0f} days)",
                 flush=True,
             )
 
-    return closed
+    return flagged
 
 
 def cmd_audit(args) -> int:
@@ -2080,21 +2069,11 @@ def cmd_audit(args) -> int:
             flush=True,
         )
 
-    # Step 1c: Auto-close stale :no-action issues.
-    closed_no_action = _close_stale_no_action()
-    if closed_no_action:
-        print(
-            f"[cai audit] closed {len(closed_no_action)} stale :no-action issue(s)",
-            flush=True,
-        )
+    # Step 1c: Unstuck stale :no-action issues (roll back to :raised).
+    unstuck_no_action = _unstuck_stale_no_action()
 
-    # Step 1d: Auto-close stale :merged issues (assume solved).
-    closed_merged = _close_stale_merged()
-    if closed_merged:
-        print(
-            f"[cai audit] closed {len(closed_merged)} stale :merged issue(s)",
-            flush=True,
-        )
+    # Step 1d: Flag stale :merged issues for human review.
+    flagged_merged = _flag_stale_merged()
 
     # Step 2: Gather GitHub state for the claude-driven semantic checks.
 
@@ -2169,14 +2148,14 @@ def cmd_audit(args) -> int:
         for rb in rolled_back:
             deterministic_section += f"- #{rb['number']}: {rb['title']}\n"
         deterministic_section += "\n"
-    if closed_no_action:
-        deterministic_section += "## Stale :no-action issues closed this run\n\n"
-        for ci in closed_no_action:
+    if unstuck_no_action:
+        deterministic_section += "## Stale :no-action issues rolled back to :raised this run\n\n"
+        for ci in unstuck_no_action:
             deterministic_section += f"- #{ci['number']}: {ci['title']}\n"
         deterministic_section += "\n"
-    if closed_merged:
-        deterministic_section += "## Stale :merged issues closed this run\n\n"
-        for ci in closed_merged:
+    if flagged_merged:
+        deterministic_section += "## Stale :merged issues flagged for human review this run\n\n"
+        for ci in flagged_merged:
             deterministic_section += f"- #{ci['number']}: {ci['title']}\n"
         deterministic_section += "\n"
 
@@ -2204,8 +2183,8 @@ def cmd_audit(args) -> int:
         dur = f"{int(time.monotonic() - t0)}s"
         log_run("audit", repo=REPO, duration=dur,
                 branches_cleaned=len(deleted_branches),
-                no_action_closed=len(closed_no_action),
-                merged_closed=len(closed_merged),
+                no_action_unstuck=len(unstuck_no_action),
+                merged_flagged=len(flagged_merged),
                 exit=audit.returncode)
         return audit.returncode
 
@@ -2218,8 +2197,8 @@ def cmd_audit(args) -> int:
     dur = f"{int(time.monotonic() - t0)}s"
     log_run("audit", repo=REPO, rollbacks=len(rolled_back),
             branches_cleaned=len(deleted_branches),
-            no_action_closed=len(closed_no_action),
-            merged_closed=len(closed_merged),
+            no_action_unstuck=len(unstuck_no_action),
+            merged_flagged=len(flagged_merged),
             duration=dur, exit=published.returncode)
     return published.returncode
 

--- a/cai.py
+++ b/cai.py
@@ -1784,6 +1784,8 @@ def cmd_verify(args) -> int:
 # ---------------------------------------------------------------------------
 
 _STALE_IN_PROGRESS_HOURS = 6
+_STALE_NO_ACTION_DAYS = 7
+_STALE_MERGED_DAYS = 14
 
 
 def _cleanup_merged_branches() -> list[str]:
@@ -1937,6 +1939,131 @@ def _rollback_stale_in_progress() -> list[dict]:
     return rolled_back
 
 
+def _close_stale_no_action() -> list[dict]:
+    """Auto-close :no-action issues that have had no activity for _STALE_NO_ACTION_DAYS."""
+    try:
+        issues = _gh_json([
+            "issue", "list",
+            "--repo", REPO,
+            "--label", LABEL_NO_ACTION,
+            "--state", "open",
+            "--json", "number,title,updatedAt",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(
+            f"[cai audit] gh issue list ({LABEL_NO_ACTION}) failed:\n{e.stderr}",
+            file=sys.stderr,
+        )
+        return []
+
+    now = datetime.now(timezone.utc).timestamp()
+    threshold = _STALE_NO_ACTION_DAYS * 86400
+    closed = []
+
+    for issue in issues:
+        try:
+            updated = datetime.strptime(
+                issue["updatedAt"], "%Y-%m-%dT%H:%M:%SZ"
+            ).replace(tzinfo=timezone.utc).timestamp()
+        except (ValueError, KeyError):
+            updated = 0
+        age = now - updated
+        if age <= threshold:
+            continue
+        issue_num = issue["number"]
+        result = _run(
+            ["gh", "issue", "close", str(issue_num),
+             "--repo", REPO,
+             "--comment",
+             f"Auto-closing: this issue has been in `{LABEL_NO_ACTION}` state "
+             f"for {age / 86400:.0f} days with no activity. "
+             f"The fix agent reviewed it and determined no code change was needed. "
+             f"Reopen if you disagree."],
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            closed.append(issue)
+            log_run(
+                "audit",
+                action="stale_no_action_close",
+                issue=issue_num,
+                stale_days=f"{age / 86400:.0f}",
+            )
+            print(
+                f"[cai audit] closed #{issue_num} "
+                f"(stale :no-action, {age / 86400:.0f} days)",
+                flush=True,
+            )
+
+    return closed
+
+
+def _close_stale_merged() -> list[dict]:
+    """Auto-close :merged issues that have had no activity for _STALE_MERGED_DAYS.
+
+    These issues had their PRs merged but confirm has not resolved them.
+    After the threshold, assume the fix is in place and close as solved.
+    """
+    try:
+        issues = _gh_json([
+            "issue", "list",
+            "--repo", REPO,
+            "--label", LABEL_MERGED,
+            "--state", "open",
+            "--json", "number,title,updatedAt",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(
+            f"[cai audit] gh issue list ({LABEL_MERGED}) failed:\n{e.stderr}",
+            file=sys.stderr,
+        )
+        return []
+
+    now = datetime.now(timezone.utc).timestamp()
+    threshold = _STALE_MERGED_DAYS * 86400
+    closed = []
+
+    for issue in issues:
+        try:
+            updated = datetime.strptime(
+                issue["updatedAt"], "%Y-%m-%dT%H:%M:%SZ"
+            ).replace(tzinfo=timezone.utc).timestamp()
+        except (ValueError, KeyError):
+            updated = 0
+        age = now - updated
+        if age <= threshold:
+            continue
+        issue_num = issue["number"]
+        _set_labels(issue_num, add=[LABEL_SOLVED], remove=[LABEL_MERGED])
+        result = _run(
+            ["gh", "issue", "close", str(issue_num),
+             "--repo", REPO,
+             "--comment",
+             f"Auto-closing: this issue has been in `{LABEL_MERGED}` state "
+             f"for {age / 86400:.0f} days. The fix was merged and confirm "
+             f"has not flagged it as unsolved — assuming resolved. "
+             f"Reopen if the original problem persists."],
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            closed.append(issue)
+            log_run(
+                "audit",
+                action="stale_merged_close",
+                issue=issue_num,
+                stale_days=f"{age / 86400:.0f}",
+            )
+            print(
+                f"[cai audit] closed #{issue_num} "
+                f"(stale :merged, {age / 86400:.0f} days → :solved)",
+                flush=True,
+            )
+
+    return closed
+
+
 def cmd_audit(args) -> int:
     """Run the periodic queue/PR consistency audit."""
     print("[cai audit] running audit", flush=True)
@@ -1950,6 +2077,22 @@ def cmd_audit(args) -> int:
     if deleted_branches:
         print(
             f"[cai audit] cleaned up {len(deleted_branches)} merged branch(es)",
+            flush=True,
+        )
+
+    # Step 1c: Auto-close stale :no-action issues.
+    closed_no_action = _close_stale_no_action()
+    if closed_no_action:
+        print(
+            f"[cai audit] closed {len(closed_no_action)} stale :no-action issue(s)",
+            flush=True,
+        )
+
+    # Step 1d: Auto-close stale :merged issues (assume solved).
+    closed_merged = _close_stale_merged()
+    if closed_merged:
+        print(
+            f"[cai audit] closed {len(closed_merged)} stale :merged issue(s)",
             flush=True,
         )
 
@@ -2020,19 +2163,29 @@ def cmd_audit(args) -> int:
 
     log_section = "## Log tail (last ~200 lines)\n\n```\n" + (log_tail or "(empty)") + "\n```\n"
 
-    rollback_section = ""
+    deterministic_section = ""
     if rolled_back:
-        rollback_section = "## Stale in-progress rollbacks performed this run\n\n"
+        deterministic_section += "## Stale in-progress rollbacks performed this run\n\n"
         for rb in rolled_back:
-            rollback_section += f"- #{rb['number']}: {rb['title']}\n"
-        rollback_section += "\n"
+            deterministic_section += f"- #{rb['number']}: {rb['title']}\n"
+        deterministic_section += "\n"
+    if closed_no_action:
+        deterministic_section += "## Stale :no-action issues closed this run\n\n"
+        for ci in closed_no_action:
+            deterministic_section += f"- #{ci['number']}: {ci['title']}\n"
+        deterministic_section += "\n"
+    if closed_merged:
+        deterministic_section += "## Stale :merged issues closed this run\n\n"
+        for ci in closed_merged:
+            deterministic_section += f"- #{ci['number']}: {ci['title']}\n"
+        deterministic_section += "\n"
 
     full_prompt = (
         f"{prompt_text}\n\n"
         f"{issues_section}\n"
         f"{prs_section}\n"
         f"{log_section}\n"
-        f"{rollback_section}"
+        f"{deterministic_section}"
     )
 
     # Step 3: Run claude with the audit prompt (Sonnet).
@@ -2051,6 +2204,8 @@ def cmd_audit(args) -> int:
         dur = f"{int(time.monotonic() - t0)}s"
         log_run("audit", repo=REPO, duration=dur,
                 branches_cleaned=len(deleted_branches),
+                no_action_closed=len(closed_no_action),
+                merged_closed=len(closed_merged),
                 exit=audit.returncode)
         return audit.returncode
 
@@ -2063,6 +2218,8 @@ def cmd_audit(args) -> int:
     dur = f"{int(time.monotonic() - t0)}s"
     log_run("audit", repo=REPO, rollbacks=len(rolled_back),
             branches_cleaned=len(deleted_branches),
+            no_action_closed=len(closed_no_action),
+            merged_closed=len(closed_merged),
             duration=dur, exit=published.returncode)
     return published.returncode
 

--- a/prompts/backend-audit.md
+++ b/prompts/backend-audit.md
@@ -82,6 +82,17 @@ before you run — remote branches for merged/closed `auto-improve/` PRs
 are deleted automatically. The number of branches cleaned appears in
 the log line as the `branches_cleaned` field.
 
+**Note:** stale `:no-action` issues (no activity for 7+ days) are
+auto-closed deterministically before you run. The fix agent already
+reviewed these and decided no code change was needed. Closures appear
+in the log as `[audit] action=stale_no_action_close`.
+
+**Note:** stale `:merged` issues (no activity for 14+ days) are
+auto-closed deterministically before you run, marked as `:solved`.
+The PR was merged and confirm did not flag it as unsolved within the
+threshold. Closures appear in the log as
+`[audit] action=stale_merged_close`.
+
 ## Categories
 
 | Category | Description |

--- a/prompts/backend-audit.md
+++ b/prompts/backend-audit.md
@@ -35,7 +35,9 @@ to issues that have entered an active state.
 
 Active states (`:raised`, `:requested`, `:in-progress`, `:pr-open`,
 `:merged`, `:no-action`, `:revising`) should continue to be checked
-normally against all the rules below.
+normally against all the rules below. (Note: stale `:merged` and
+`:no-action` issues are auto-closed before the LLM audit runs, so
+only non-stale instances of these states will appear in the input.)
 
 ## What to check
 
@@ -134,6 +136,6 @@ No findings.
 - Keep titles short and imperative.
 - These findings are **report-only** — they go to humans for triage.
   Do not suggest automated fixes beyond what the deterministic
-  rollback and branch cleanup already handle.
+  rollback, branch cleanup, and stale issue closures already handle.
 - Do not output anything other than the markdown finding blocks (or
   the exact `No findings.` sentinel).

--- a/prompts/backend-audit.md
+++ b/prompts/backend-audit.md
@@ -35,9 +35,9 @@ to issues that have entered an active state.
 
 Active states (`:raised`, `:requested`, `:in-progress`, `:pr-open`,
 `:merged`, `:no-action`, `:revising`) should continue to be checked
-normally against all the rules below. (Note: stale `:merged` and
-`:no-action` issues are auto-closed before the LLM audit runs, so
-only non-stale instances of these states will appear in the input.)
+normally against all the rules below. (Note: stale `:no-action`
+issues are rolled back to `:raised` before the LLM audit runs, and
+stale `:merged` issues are flagged with `needs-human-review`.)
 
 ## What to check
 
@@ -85,15 +85,15 @@ are deleted automatically. The number of branches cleaned appears in
 the log line as the `branches_cleaned` field.
 
 **Note:** stale `:no-action` issues (no activity for 7+ days) are
-auto-closed deterministically before you run. The fix agent already
-reviewed these and decided no code change was needed. Closures appear
-in the log as `[audit] action=stale_no_action_close`.
+rolled back to `:raised` deterministically before you run, allowing
+the fix agent to retry with new context. These appear in the log as
+`[audit] action=stale_no_action_unstuck`.
 
 **Note:** stale `:merged` issues (no activity for 14+ days) are
-auto-closed deterministically before you run, marked as `:solved`.
-The PR was merged and confirm did not flag it as unsolved within the
-threshold. Closures appear in the log as
-`[audit] action=stale_merged_close`.
+flagged with `needs-human-review` deterministically before you run.
+The PR was merged but confirm has not resolved the issue within the
+threshold — human intervention is needed. These appear in the log as
+`[audit] action=stale_merged_flag`.
 
 ## Categories
 
@@ -136,6 +136,6 @@ No findings.
 - Keep titles short and imperative.
 - These findings are **report-only** — they go to humans for triage.
   Do not suggest automated fixes beyond what the deterministic
-  rollback, branch cleanup, and stale issue closures already handle.
+  rollback, branch cleanup, and stale issue handling already handle.
 - Do not output anything other than the markdown finding blocks (or
   the exact `No findings.` sentinel).


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#183

**Issue:** #183 — we should have a system to detect stale issues/PR and find ways to fix them unless they realy require human intervention for decisions

## PR Summary

### What this fixes
The project lacked deterministic handling for stale `:no-action` and `:merged` issues. Issues marked `:no-action` by the fix agent (no code change needed) would remain open indefinitely, and `:merged` issues that confirm never resolved would sit in limbo forever. The existing stale detection only covered `:in-progress`/`:revising` states.

### What was changed
- **`cai.py`**: Added two new constants (`_STALE_NO_ACTION_DAYS = 7`, `_STALE_MERGED_DAYS = 14`) alongside the existing `_STALE_IN_PROGRESS_HOURS`
- **`cai.py`**: Added `_close_stale_no_action()` function that auto-closes `:no-action` issues with no activity for 7+ days, with an explanatory comment on the issue
- **`cai.py`**: Added `_close_stale_merged()` function that auto-closes `:merged` issues with no activity for 14+ days, transitioning them to `:solved` (the PR was merged and confirm did not flag it as unsolved)
- **`cai.py`**: Integrated both new handlers into `cmd_audit()` as deterministic steps 1c and 1d, including log metrics (`no_action_closed`, `merged_closed`) in the audit log_run calls
- **`cai.py`**: Extended the semantic audit context to report closed `:no-action` and `:merged` issues to the Claude-driven audit pass
- **`prompts/backend-audit.md`**: Added notes documenting that stale `:no-action` and `:merged` issues are now handled deterministically before the semantic audit runs

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
