### PR TITLE
audit-triage: autonomously resolve audit:raised findings

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -105,6 +105,7 @@ REVISE_PROMPT = Path("/app/prompts/backend-revise.md")
 REBASE_PROMPT = Path("/app/prompts/backend-rebase.md")
 REVIEW_PR_PROMPT = Path("/app/prompts/backend-review-pr.md")
 MERGE_PROMPT = Path("/app/prompts/backend-merge.md")
+AUDIT_TRIAGE_PROMPT = Path("/app/prompts/backend-audit-triage.md")
 
 # Issue lifecycle labels.
 LABEL_RAISED = "auto-improve:raised"
@@ -117,6 +118,7 @@ LABEL_NO_ACTION = "auto-improve:no-action"
 LABEL_REVISING = "auto-improve:revising"
 LABEL_MERGE_BLOCKED = "merge-blocked"
 LABEL_AUDIT_RAISED = "audit:raised"
+LABEL_AUDIT_NEEDS_HUMAN = "audit:needs-human"
 
 # PR-level label applied by `cai merge` when the verdict is below the
 # auto-merge threshold. Lets a human filter open PRs that are waiting
@@ -2068,6 +2070,359 @@ def cmd_audit(args) -> int:
 
 
 # ---------------------------------------------------------------------------
+# audit-triage — autonomous resolution of `audit:raised` findings
+# ---------------------------------------------------------------------------
+
+
+def _parse_triage_verdicts(text: str) -> list[dict]:
+    """Parse `### Verdict: #N` blocks emitted by the audit-triage agent.
+
+    Each verdict is a dict with keys: number (int), action (str),
+    target (int|None), confidence (str), reasoning (str). Verdicts
+    that fail to parse the basic shape are skipped.
+    """
+    verdicts: list[dict] = []
+    blocks = re.split(r"^### Verdict:\s*", text, flags=re.MULTILINE)
+    for block in blocks[1:]:
+        lines = block.strip().splitlines()
+        if not lines:
+            continue
+        header_match = re.match(r"#(\d+)", lines[0])
+        if not header_match:
+            continue
+        body = "\n".join(lines[1:])
+        action_m = re.search(
+            r"^- \*\*Action:\*\*\s*`?(\w+)`?", body, flags=re.MULTILINE,
+        )
+        target_m = re.search(
+            r"^- \*\*Target:\*\*\s*#(\d+)", body, flags=re.MULTILINE,
+        )
+        conf_m = re.search(
+            r"^- \*\*Confidence:\*\*\s*`?(high|medium|low)`?",
+            body, flags=re.MULTILINE | re.IGNORECASE,
+        )
+        reason_m = re.search(
+            r"^- \*\*Reasoning:\*\*\s*(.+)$", body, flags=re.MULTILINE,
+        )
+        if not action_m or not conf_m:
+            continue
+        verdicts.append({
+            "number": int(header_match.group(1)),
+            "action": action_m.group(1).lower(),
+            "target": int(target_m.group(1)) if target_m else None,
+            "confidence": conf_m.group(1).lower(),
+            "reasoning": reason_m.group(1).strip() if reason_m else "",
+        })
+    return verdicts
+
+
+def cmd_audit_triage(args) -> int:
+    """Autonomously resolve `audit:raised` findings without opening a PR.
+
+    Calls a triage subagent that classifies each open `audit:raised`
+    issue as one of: close_duplicate, close_resolved, passthrough,
+    escalate. The wrapper then executes deterministically — only
+    `close_*` verdicts at `high` confidence are acted on; everything
+    else is left for the fix subagent or escalated to human triage
+    via the `audit:needs-human` label.
+
+    Refs #193.
+    """
+    print("[cai audit-triage] running audit triage", flush=True)
+    t0 = time.monotonic()
+
+    # 1. List `audit:raised` issues.
+    try:
+        raised_issues = _gh_json([
+            "issue", "list", "--repo", REPO,
+            "--label", LABEL_AUDIT_RAISED,
+            "--state", "open",
+            "--json", "number,title,labels,body,createdAt,updatedAt",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(
+            f"[cai audit-triage] gh issue list failed:\n{e.stderr}",
+            file=sys.stderr,
+        )
+        log_run("audit-triage", repo=REPO, exit=1)
+        return 1
+
+    if not raised_issues:
+        print(
+            "[cai audit-triage] no audit:raised issues; nothing to do",
+            flush=True,
+        )
+        log_run("audit-triage", repo=REPO, raised=0, closed_dup=0,
+                closed_res=0, passthrough=0, escalated=0, exit=0)
+        return 0
+
+    print(
+        f"[cai audit-triage] found {len(raised_issues)} audit:raised issue(s)",
+        flush=True,
+    )
+
+    # 2. Gather context: all OTHER open auto-improve* issues + recent PRs.
+    raised_numbers = {oi["number"] for oi in raised_issues}
+    try:
+        context_issues = _gh_json([
+            "issue", "list", "--repo", REPO,
+            "--label", "auto-improve",
+            "--state", "open",
+            "--json", "number,title,labels,body",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError:
+        context_issues = []
+    try:
+        audit_context = _gh_json([
+            "issue", "list", "--repo", REPO,
+            "--label", "audit",
+            "--state", "open",
+            "--json", "number,title,labels,body",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError:
+        audit_context = []
+    # De-dupe by issue number; keep audit issues that aren't in raised set.
+    seen = set()
+    other_issues: list[dict] = []
+    for oi in context_issues + audit_context:
+        n = oi["number"]
+        if n in seen or n in raised_numbers:
+            continue
+        seen.add(n)
+        other_issues.append(oi)
+
+    try:
+        recent_prs = _gh_json([
+            "pr", "list", "--repo", REPO,
+            "--state", "all",
+            "--json", "number,title,state,mergedAt,createdAt",
+            "--limit", "30",
+        ]) or []
+    except subprocess.CalledProcessError:
+        recent_prs = []
+
+    # 3. Build the prompt.
+    prompt_text = AUDIT_TRIAGE_PROMPT.read_text()
+
+    raised_section = "## audit:raised issues to triage\n\n"
+    for oi in raised_issues:
+        labels = ", ".join(lbl["name"] for lbl in oi.get("labels", []))
+        raised_section += (
+            f"### #{oi['number']} — {oi['title']}\n"
+            f"- **Labels:** {labels}\n"
+            f"- **Created:** {oi['createdAt']}\n"
+            f"- **Body:**\n\n"
+            f"{(oi.get('body') or '(empty)')}\n\n"
+            "---\n\n"
+        )
+
+    other_section = "## Other open issues (for duplicate / state checks)\n\n"
+    if other_issues:
+        for oi in other_issues:
+            labels = ", ".join(lbl["name"] for lbl in oi.get("labels", []))
+            excerpt = (oi.get("body") or "(empty)")[:400]
+            other_section += (
+                f"### #{oi['number']} — {oi['title']}\n"
+                f"- **Labels:** {labels}\n"
+                f"- **Body excerpt:** {excerpt}\n\n"
+            )
+    else:
+        other_section += "(none)\n\n"
+
+    pr_section = "## Recent PRs\n\n"
+    if recent_prs:
+        for pr in recent_prs:
+            merged = (
+                f", merged {pr['mergedAt']}" if pr.get("mergedAt") else ""
+            )
+            pr_section += (
+                f"- PR #{pr['number']}: {pr['title']} "
+                f"[{pr.get('state', 'unknown')}] "
+                f"(created {pr['createdAt']}{merged})\n"
+            )
+    else:
+        pr_section += "(none)\n"
+
+    full_prompt = (
+        f"{prompt_text}\n\n"
+        f"{raised_section}\n"
+        f"{other_section}\n"
+        f"{pr_section}\n"
+    )
+
+    # 4. Run claude with the triage prompt (Sonnet — same tier as audit).
+    triage = _run(
+        ["claude", "-p", "--model", "claude-sonnet-4-6"],
+        input=full_prompt,
+        capture_output=True,
+    )
+    print(triage.stdout, flush=True)
+    if triage.returncode != 0:
+        print(
+            f"[cai audit-triage] claude -p failed (exit {triage.returncode}):\n"
+            f"{triage.stderr}",
+            file=sys.stderr,
+        )
+        log_run("audit-triage", repo=REPO, raised=len(raised_issues),
+                exit=triage.returncode)
+        return triage.returncode
+
+    # 5. Parse and execute verdicts.
+    verdicts = _parse_triage_verdicts(triage.stdout)
+    closed_dup = 0
+    closed_res = 0
+    passthrough = 0
+    escalated = 0
+    skipped = 0
+
+    for v in verdicts:
+        n = v["number"]
+        if n not in raised_numbers:
+            print(
+                f"[cai audit-triage] verdict for #{n} is not in the "
+                "raised set; skipping",
+                flush=True,
+            )
+            skipped += 1
+            continue
+
+        action = v["action"]
+        confidence = v["confidence"]
+        reason = v["reasoning"]
+        target = v["target"]
+
+        if action == "close_duplicate":
+            if confidence != "high" or target is None:
+                print(
+                    f"[cai audit-triage] #{n}: close_duplicate but "
+                    f"confidence={confidence} target={target}; "
+                    "downgrading to passthrough",
+                    flush=True,
+                )
+                passthrough += 1
+                continue
+            comment = (
+                "## Audit triage agent: closing as duplicate\n\n"
+                f"Closing as duplicate of #{target}.\n\n"
+                f"**Reasoning:** {reason}\n\n"
+                "---\n"
+                "_Closed automatically by `cai audit-triage`. "
+                "Reopen if this assessment is wrong._"
+            )
+            close_res = _run(
+                ["gh", "issue", "close", str(n),
+                 "--repo", REPO, "--comment", comment],
+                capture_output=True,
+            )
+            if close_res.returncode == 0:
+                print(
+                    f"[cai audit-triage] #{n}: closed as duplicate of #{target}",
+                    flush=True,
+                )
+                closed_dup += 1
+            else:
+                print(
+                    f"[cai audit-triage] #{n}: gh issue close failed:\n"
+                    f"{close_res.stderr}",
+                    file=sys.stderr,
+                )
+                skipped += 1
+
+        elif action == "close_resolved":
+            if confidence != "high":
+                print(
+                    f"[cai audit-triage] #{n}: close_resolved but "
+                    f"confidence={confidence}; downgrading to passthrough",
+                    flush=True,
+                )
+                passthrough += 1
+                continue
+            comment = (
+                "## Audit triage agent: closing as resolved\n\n"
+                f"**Reasoning:** {reason}\n\n"
+                "---\n"
+                "_Closed automatically by `cai audit-triage` because the "
+                "underlying problem appears to be resolved (PR merged, "
+                "state cleared, etc.). Reopen if this assessment is wrong._"
+            )
+            close_res = _run(
+                ["gh", "issue", "close", str(n),
+                 "--repo", REPO, "--comment", comment],
+                capture_output=True,
+            )
+            if close_res.returncode == 0:
+                print(
+                    f"[cai audit-triage] #{n}: closed as resolved",
+                    flush=True,
+                )
+                closed_res += 1
+            else:
+                print(
+                    f"[cai audit-triage] #{n}: gh issue close failed:\n"
+                    f"{close_res.stderr}",
+                    file=sys.stderr,
+                )
+                skipped += 1
+
+        elif action == "escalate":
+            comment = (
+                "## Audit triage agent: escalating to human\n\n"
+                f"**Reasoning:** {reason}\n\n"
+                "---\n"
+                "_The audit triage agent could not resolve this finding "
+                "autonomously. Re-labelled `audit:needs-human` for human "
+                "triage._"
+            )
+            _run(
+                ["gh", "issue", "comment", str(n),
+                 "--repo", REPO, "--body", comment],
+                capture_output=True,
+            )
+            _set_labels(
+                n,
+                add=[LABEL_AUDIT_NEEDS_HUMAN],
+                remove=[LABEL_AUDIT_RAISED],
+            )
+            print(
+                f"[cai audit-triage] #{n}: escalated to audit:needs-human",
+                flush=True,
+            )
+            escalated += 1
+
+        else:
+            # passthrough — leave the labels alone, fix subagent picks it up.
+            print(
+                f"[cai audit-triage] #{n}: passthrough (action={action}, "
+                f"confidence={confidence})",
+                flush=True,
+            )
+            passthrough += 1
+
+    dur = f"{int(time.monotonic() - t0)}s"
+    print(
+        f"[cai audit-triage] raised={len(raised_issues)} "
+        f"closed_dup={closed_dup} closed_res={closed_res} "
+        f"passthrough={passthrough} escalated={escalated} skipped={skipped}",
+        flush=True,
+    )
+    log_run(
+        "audit-triage", repo=REPO,
+        raised=len(raised_issues),
+        closed_dup=closed_dup,
+        closed_res=closed_res,
+        passthrough=passthrough,
+        escalated=escalated,
+        skipped=skipped,
+        duration=dur,
+        exit=0,
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # confirm
 # ---------------------------------------------------------------------------
 
@@ -3134,6 +3489,10 @@ def main() -> int:
     sub.add_parser("revise", help="Iterate on open PRs based on review comments")
     sub.add_parser("verify", help="Update labels based on PR merge state")
     sub.add_parser("audit", help="Run the queue/PR consistency audit")
+    sub.add_parser(
+        "audit-triage",
+        help="Autonomously resolve audit:raised findings (no PRs)",
+    )
     sub.add_parser("confirm", help="Verify merged issues are actually solved")
     sub.add_parser("review-pr", help="Pre-merge consistency review of open PRs")
     sub.add_parser("merge", help="Confidence-gated auto-merge for bot PRs")
@@ -3152,6 +3511,7 @@ def main() -> int:
         "revise": cmd_revise,
         "verify": cmd_verify,
         "audit": cmd_audit,
+        "audit-triage": cmd_audit_triage,
         "confirm": cmd_confirm,
         "review-pr": cmd_review_pr,
         "merge": cmd_merge,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,7 @@ CAI_ANALYZER_SCHEDULE="${CAI_ANALYZER_SCHEDULE:-0 0 * * *}"
 CAI_FIX_SCHEDULE="${CAI_FIX_SCHEDULE:-15 * * * *}"
 CAI_VERIFY_SCHEDULE="${CAI_VERIFY_SCHEDULE:-45 * * * *}"
 CAI_AUDIT_SCHEDULE="${CAI_AUDIT_SCHEDULE:-0 */6 * * *}"
+CAI_AUDIT_TRIAGE_SCHEDULE="${CAI_AUDIT_TRIAGE_SCHEDULE:-10 */6 * * *}"
 CAI_REVISE_SCHEDULE="${CAI_REVISE_SCHEDULE:-30 * * * *}"
 CAI_CONFIRM_SCHEDULE="${CAI_CONFIRM_SCHEDULE:-0 2 * * *}"
 CAI_REVIEW_PR_SCHEDULE="${CAI_REVIEW_PR_SCHEDULE:-20 * * * *}"
@@ -44,6 +45,7 @@ $CAI_FIX_SCHEDULE python /app/cai.py fix
 $CAI_REVISE_SCHEDULE python /app/cai.py revise
 $CAI_VERIFY_SCHEDULE python /app/cai.py verify
 $CAI_AUDIT_SCHEDULE python /app/cai.py audit
+$CAI_AUDIT_TRIAGE_SCHEDULE python /app/cai.py audit-triage
 $CAI_CONFIRM_SCHEDULE python /app/cai.py confirm
 $CAI_REVIEW_PR_SCHEDULE python /app/cai.py review-pr
 $CAI_MERGE_SCHEDULE python /app/cai.py merge
@@ -87,6 +89,9 @@ python /app/cai.py merge || echo "[entrypoint] merge exited non-zero; continuing
 
 echo "[entrypoint] running initial cai.py audit"
 python /app/cai.py audit || echo "[entrypoint] audit exited non-zero; continuing"
+
+echo "[entrypoint] running initial cai.py audit-triage"
+python /app/cai.py audit-triage || echo "[entrypoint] audit-triage exited non-zero; continuing"
 
 echo "[entrypoint] running initial cai.py confirm"
 python /app/cai.py confirm || echo "[entrypoint] confirm exited non-zero; continuing"

--- a/prompts/backend-audit-triage.md
+++ b/prompts/backend-audit-triage.md
@@ -1,0 +1,103 @@
+# Backend Audit Triage
+
+You are the audit triage agent for `robotsix-cai`. Your job is to
+look at every freshly-raised audit finding (issues labelled
+`audit:raised`) and decide what to do with each one **without
+opening a pull request**. Many audit findings — especially
+duplicates and findings about issues that have already been resolved
+— can be closed directly. Others describe code changes the bot
+should make: pass those through to the regular fix subagent.
+
+You have **no tools**. The full state you need is provided inline
+below: every `audit:raised` issue's full body, the list of all other
+open `auto-improve*` issues for duplicate detection, and the recent
+PRs (so you can see what's already been merged). Decide based on
+that context alone.
+
+## What you receive
+
+1. **`audit:raised` issues** — full title, body, labels, age. These
+   are the issues you must triage.
+2. **Other open `auto-improve*` issues** — number, title, labels,
+   short body excerpt. Use these to detect topic duplicates.
+3. **Recent PRs** — number, title, state, merged date. Use these to
+   detect findings that describe a problem already fixed.
+
+## How to decide
+
+For each `audit:raised` issue, pick exactly one action:
+
+| Action | When to use |
+|---|---|
+| `close_duplicate` | Another open issue (audit OR auto-improve) is clearly about the same underlying problem. The duplicate's content is fully covered by the target. **Always specify the target issue number.** |
+| `close_resolved` | The finding describes a problem that recent PRs have already fixed, OR the underlying state the finding complains about has changed (e.g., a `lock_corruption` finding for an issue that has since moved to `:merged`). |
+| `passthrough` | The finding describes a real problem that requires a code change. The fix subagent should pick it up on its next tick. Do nothing — leave the labels as-is. |
+| `escalate` | The finding is real but cannot be resolved autonomously: it needs human judgement (e.g., a `prompt_contradiction` between two design docs, a stale-lifecycle issue blocked on a deleted PR, an ambiguous remediation). The wrapper will swap `audit:raised` for `audit:needs-human`. |
+
+## Confidence
+
+You must emit exactly one of three confidence levels for each
+verdict:
+
+- **high** — You can trace every claim back to the data above. No
+  reservations.
+- **medium** — Probably correct but you have some doubt.
+- **low** — Significant uncertainty.
+
+**The wrapper only executes `close_duplicate` and `close_resolved`
+verdicts at `high` confidence.** Anything below `high` is downgraded
+to `passthrough` (real issue, fix subagent will handle) or `escalate`
+(judgement call needed). When in doubt, prefer `escalate` over
+guessing.
+
+## Things that must NEVER produce a `close_duplicate` or `close_resolved` verdict at `high` confidence
+
+- The "duplicate" target is itself an `audit:raised` issue you have
+  not yet triaged in this run (you might be closing the wrong side
+  of the pair — escalate instead and let a human pick).
+- The duplicate target's body only superficially matches (same PR
+  number, different category, different remediation).
+- The "already fixed" claim is based on a PR title alone, with no
+  way to verify the PR actually addresses the finding.
+- The finding's category is `silent_failure`, `loop_stuck`, or
+  `prompt_contradiction` — these almost always need a code change,
+  so default to `passthrough` unless the underlying log/state has
+  visibly cleared.
+
+When the same audit finding has been raised multiple times (e.g. the
+audit agent fingerprinted it slightly differently across runs), the
+correct call is `close_duplicate` — keep the OLDEST issue as the
+canonical one and close the newer copies pointing at it.
+
+## Output format
+
+For each `audit:raised` issue, emit exactly one verdict block in
+this format. Output ONLY the verdict blocks — no preamble, no
+trailing summary.
+
+```
+### Verdict: #<N>
+
+- **Action:** close_duplicate | close_resolved | passthrough | escalate
+- **Target:** #<M>           ← only for close_duplicate; omit otherwise
+- **Confidence:** high | medium | low
+- **Reasoning:** <1-3 sentences explaining the call. Be specific —
+  cite the duplicate target, the merged PR, the cleared state, etc.>
+```
+
+If there are no `audit:raised` issues to triage, output exactly:
+
+```
+No issues to triage.
+```
+
+## Guardrails
+
+- Do not invent issue numbers — every `#N` you reference must come
+  from the lists provided below.
+- Do not output anything other than verdict blocks (or the exact
+  `No issues to triage.` sentinel).
+- Stay within the four actions above. Do not propose new lifecycle
+  states or new labels.
+- Do not write code, diffs, or remediation prose — that is the fix
+  subagent's job. Your output is structured verdicts only.


### PR DESCRIPTION
## Summary
Many audit findings — duplicate fingerprints, stale-state findings about issues that have since moved to \`:merged\`, log patterns that have already cleared — do not require a code change. Today the fix subagent picks them up alongside \`auto-improve:raised\` issues and either burns a PR cycle on a no-op or escalates them to \`no-action\`.

This adds a dedicated \`cai audit-triage\` step that classifies each open \`audit:raised\` issue via a Sonnet subagent and executes the verdict deterministically **without ever opening a PR**:

| Action | What the wrapper does |
|---|---|
| \`close_duplicate\` (high confidence, target required) | Close with a \"duplicate of #N\" comment |
| \`close_resolved\` (high confidence) | Close with a \"resolved by recent state change\" comment |
| \`passthrough\` | Leave \`audit:raised\` intact — fix subagent picks it up next tick |
| \`escalate\` | Swap \`audit:raised\` for new \`audit:needs-human\` label + reasoning comment |

Verdicts below \`high\` confidence on \`close_*\` are downgraded to \`passthrough\` (better to burn one fix tick than wrongly close a real finding). The triage agent has no tools — it sees the raised issues, every other open \`auto-improve*\` / \`audit*\` issue (for duplicate detection), and the last 30 PRs (for \"already fixed\" detection).

Wired into the entrypoint init pass and into the crontab right after \`audit\` (default \`10 */6 * * *\`, ten minutes after \`audit\`).

Refs #193

## New label
- \`audit:needs-human\` — created in the repo (red, #e11d48). Set by the wrapper on escalate verdicts.

## Files
- \`prompts/backend-audit-triage.md\` — agent instructions, four-action contract, hard guardrails (must-not-close cases)
- \`cai.py\` — \`cmd_audit_triage\`, \`_parse_triage_verdicts\`, dispatcher entry, label/prompt constants
- \`entrypoint.sh\` — new \`CAI_AUDIT_TRIAGE_SCHEDULE\` env var, crontab line, init-pass call

## Test plan
- [ ] Next \`audit-triage\` tick: any \`audit:raised\` issue with a clear duplicate target should close cleanly with a verdict comment.
- [ ] Findings about \`silent_failure\` / \`loop_stuck\` / \`prompt_contradiction\` should default to \`passthrough\` (per prompt guardrails) so the fix subagent still picks them up.
- [ ] Ambiguous cases get \`audit:needs-human\` instead of being silently dropped.
- [ ] No \`audit:raised\` issue should ever be closed at \`medium\` or \`low\` confidence — verify by reading the wrapper's \"downgrading to passthrough\" log lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)