### PR TITLE
auto-improve: Investigate high Bash tool failure rate

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -324,7 +324,7 @@ def cmd_analyze(args) -> int:
     )
 
     analyzer = _run(
-        ["claude", "-p"],
+        ["claude", "-p", "--disallowedTools", "Bash"],
         input=full_prompt,
         capture_output=True,
     )
@@ -2037,7 +2037,8 @@ def cmd_audit(args) -> int:
 
     # Step 3: Run claude with the audit prompt (Sonnet).
     audit = _run(
-        ["claude", "-p", "--model", "claude-sonnet-4-6"],
+        ["claude", "-p", "--model", "claude-sonnet-4-6",
+         "--disallowedTools", "Bash"],
         input=full_prompt,
         capture_output=True,
     )
@@ -2214,7 +2215,8 @@ def cmd_confirm(args) -> int:
 
     # 4. Run claude with Sonnet.
     confirm = _run(
-        ["claude", "-p", "--model", "claude-sonnet-4-6"],
+        ["claude", "-p", "--model", "claude-sonnet-4-6",
+         "--disallowedTools", "Bash"],
         input=full_prompt,
         capture_output=True,
     )
@@ -2909,7 +2911,8 @@ def cmd_merge(args) -> int:
 
         # Run the model (read-only, no tools).
         agent = _run(
-            ["claude", "-p", "--model", "claude-opus-4-6"],
+            ["claude", "-p", "--model", "claude-opus-4-6",
+             "--disallowedTools", "Bash"],
             input=full_prompt,
             capture_output=True,
         )


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#184

**Issue:** #184 — Investigate high Bash tool failure rate

## PR Summary

### What this fixes
Four subagents (analyze, audit, confirm, merge) were invoked via `claude -p` without `--disallowedTools Bash`, leaving the Bash tool available despite none of them needing shell access. This allowed the agent to attempt Bash calls that failed, producing the observed 43% Bash error rate with retry loops.

### What was changed
- `cai.py` line 327: Added `--disallowedTools Bash` to the **analyze** subagent's `claude -p` invocation
- `cai.py` line 2040: Added `--disallowedTools Bash` to the **audit** subagent's `claude -p` invocation
- `cai.py` line 2217: Added `--disallowedTools Bash` to the **confirm** subagent's `claude -p` invocation
- `cai.py` line 2912: Added `--disallowedTools Bash` to the **merge** subagent's `claude -p` invocation

This makes all subagent invocations consistent with the existing pattern used by fix, rebase, and revise subagents.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
