### PR TITLE
auto-improve: audit raised issues may not requiere a MR

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ bot) or re-label to `:raised` to retry.
 The `audit` subcommand uses a **separate label namespace** (`audit:*`)
 to distinguish its findings from analyzer findings (`auto-improve:*`).
 Audit findings flag inconsistencies in the issue/PR lifecycle.
-Issues labelled `audit:raised` are picked up by `cai.py fix` just
-like `auto-improve:raised` issues.
+Issues labelled `audit:raised` go through `cai.py audit-triage`
+first, which relabels eligible ones to `auto-improve:raised` so the
+fix subagent picks them up.
 
 | Label | Meaning |
 |---|---|

--- a/cai.py
+++ b/cai.py
@@ -13,9 +13,9 @@ Subcommands:
                             publish.py.
 
     python cai.py fix       Pick the oldest issue labelled
-                            `auto-improve:raised`, `auto-improve:
-                            requested`, or `audit:raised`,
-                            lock it via the `:in-progress`
+                            `auto-improve:raised` or `auto-improve:
+                            requested` (audit issues reach fix via
+                            triage relabelling), lock it via the `:in-progress`
                             label, clone the repo into /tmp, run the
                             fix subagent (full tool permissions), and
                             open a PR if the agent produced a diff.

--- a/cai.py
+++ b/cai.py
@@ -407,12 +407,15 @@ def _recover_stale_pr_open(issues: list[dict], *, log_prefix: str = "cai") -> li
 def _select_fix_target():
     """Return the oldest open issue eligible for the fix subagent.
 
-    Eligible = labelled `:raised`, `:requested`, or `audit:raised`, NOT labelled
-    `:in-progress` or `:pr-open`.  If no candidates are found, attempts to
-    recover stale `:pr-open` issues whose linked PR was closed unmerged.
+    Eligible = labelled `:raised` or `:requested`, NOT labelled
+    `:in-progress` or `:pr-open`.  `audit:raised` issues are handled
+    exclusively by the audit-triage agent — only issues that triage
+    re-labels to `auto-improve:raised` enter the fix pipeline.
+    If no candidates are found, attempts to recover stale `:pr-open`
+    issues whose linked PR was closed unmerged.
     """
     candidates: dict[int, dict] = {}
-    for label in (LABEL_RAISED, LABEL_REQUESTED, LABEL_AUDIT_RAISED):
+    for label in (LABEL_RAISED, LABEL_REQUESTED):
         try:
             issues = _gh_json([
                 "issue", "list",
@@ -631,15 +634,14 @@ def cmd_fix(args) -> int:
     issue_number = issue["number"]
     title = issue["title"]
     label_names = {lbl["name"] for lbl in issue.get("labels", [])}
-    is_audit = LABEL_AUDIT_RAISED in label_names
-    origin_raised_label = LABEL_AUDIT_RAISED if is_audit else LABEL_RAISED
+    origin_raised_label = LABEL_RAISED
     print(f"[cai fix] picked #{issue_number}: {title}", flush=True)
 
     # 1. Lock — set :in-progress, drop :raised and :requested.
     if not _set_labels(
         issue_number,
         add=[LABEL_IN_PROGRESS],
-        remove=[LABEL_RAISED, LABEL_REQUESTED, LABEL_AUDIT_RAISED],
+        remove=[LABEL_RAISED, LABEL_REQUESTED],
     ):
         print(f"[cai fix] could not lock #{issue_number}", file=sys.stderr)
         log_run("fix", repo=REPO, issue=issue_number, result="lock_failed", exit=1)
@@ -2652,10 +2654,17 @@ def cmd_audit_triage(args) -> int:
             escalated += 1
 
         else:
-            # passthrough — leave the labels alone, fix subagent picks it up.
+            # passthrough — relabel to auto-improve:raised so the fix
+            # subagent picks it up (fix no longer selects audit:raised
+            # directly, ensuring all audit issues go through triage first).
+            _set_labels(
+                n,
+                add=[LABEL_RAISED],
+                remove=[LABEL_AUDIT_RAISED],
+            )
             print(
-                f"[cai audit-triage] #{n}: passthrough (action={action}, "
-                f"confidence={confidence})",
+                f"[cai audit-triage] #{n}: passthrough → auto-improve:raised "
+                f"(action={action}, confidence={confidence})",
                 flush=True,
             )
             passthrough += 1

--- a/prompts/backend-audit-triage.md
+++ b/prompts/backend-audit-triage.md
@@ -31,7 +31,7 @@ For each `audit:raised` issue, pick exactly one action:
 |---|---|
 | `close_duplicate` | Another open issue (audit OR auto-improve) is clearly about the same underlying problem. The duplicate's content is fully covered by the target. **Always specify the target issue number.** |
 | `close_resolved` | The finding describes a problem that recent PRs have already fixed, OR the underlying state the finding complains about has changed (e.g., a `lock_corruption` finding for an issue that has since moved to `:merged`). |
-| `passthrough` | The finding describes a real problem that requires a code change. The fix subagent should pick it up on its next tick. Do nothing — leave the labels as-is. |
+| `passthrough` | The finding describes a real problem that requires a code change. The wrapper will re-label the issue from `audit:raised` to `auto-improve:raised` so the fix subagent picks it up on its next tick. |
 | `escalate` | The finding is real but cannot be resolved autonomously: it needs human judgement (e.g., a `prompt_contradiction` between two design docs, a stale-lifecycle issue blocked on a deleted PR, an ambiguous remediation). The wrapper will swap `audit:raised` for `audit:needs-human`. |
 
 ## Confidence


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#193

**Issue:** #193 — audit raised issues may not requiere a MR

## PR Summary

### What this fixes
`audit:raised` issues (e.g. duplicate findings) were picked up by the fix subagent, which created branches, cloned the repo, ran Claude, and attempted to open MRs — even when the issue could be resolved autonomously without code changes. The audit-triage agent already handled some cases (closing duplicates, closing resolved), but the fix subagent could grab `audit:raised` issues before triage ran or for issues that triage passed through.

### What was changed
- **cai.py `_select_fix_target()`**: Removed `LABEL_AUDIT_RAISED` from the fix subagent's issue selection loop so `audit:raised` issues are no longer picked up directly by the fix pipeline. Updated docstring accordingly.
- **cai.py `cmd_fix()`**: Removed `is_audit` variable and simplified `origin_raised_label` to always use `LABEL_RAISED`. Removed `LABEL_AUDIT_RAISED` from the lock step's label removal list.
- **cai.py `cmd_audit_triage()` passthrough handler**: Changed from leaving labels as-is to relabeling `audit:raised` → `auto-improve:raised` (via `_set_labels`), so that only triage-confirmed code-change issues enter the fix pipeline.
- **prompts/backend-audit-triage.md**: Updated the `passthrough` action description to reflect that the wrapper now relabels the issue to `auto-improve:raised`.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
