### PR TITLE
revise: rebase resolver — agent-driven + declarative Claude subagent (Path A phase 1)

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -1058,165 +1058,126 @@ def _rebase_conflict_files(work_dir: Path) -> list[str]:
     return [line for line in res.stdout.strip().splitlines() if line]
 
 
-def _advance_rebase(work_dir: Path):
-    """Advance a stopped rebase via `--continue` or `--skip` as appropriate.
-
-    After conflict resolution + `git add -A`, the staged diff for the
-    current commit may be empty — for example when the agent's merged
-    result already exists upstream, so the commit collapses to a no-op.
-    In that case `git rebase --continue` errors out with "no changes -
-    did you forget to use git add?" and the correct call is `git rebase
-    --skip`. We pick the right one by checking the staged diff.
-
-    GIT_EDITOR/EDITOR are forced to `true` so git never tries to open
-    an editor for the commit message during the continue.
-    """
-    diff_check = _run(
-        ["git", "-C", str(work_dir), "diff", "--cached", "--quiet"],
-        capture_output=True,
-    )
-    env = {**os.environ, "GIT_EDITOR": "true", "EDITOR": "true"}
-    if diff_check.returncode == 0:
-        # Nothing staged → empty commit → skip this commit.
-        return _run(
-            ["git", "-C", str(work_dir), "rebase", "--skip"],
-            capture_output=True,
-            env=env,
-        )
-    return _run(
-        ["git", "-C", str(work_dir), "-c", "core.editor=true",
-         "rebase", "--continue"],
-        capture_output=True,
-        env=env,
-    )
-
-
 def _agent_resolve_rebase(
     work_dir: Path,
     pr_number: int,
     issue_title: str,
     issue_body: str,
 ) -> tuple[bool, str]:
-    """Drive a stopped `git rebase` to completion via the resolve subagent.
+    """Drive a stopped `git rebase` to completion via the resolver subagent.
 
-    The wrapper has just run `git rebase origin/main` and the rebase has
-    stopped on conflicts. We loop: identify conflicted files → invoke
-    claude to edit them → stage → `git rebase --continue`. Each replayed
-    commit may produce a fresh round of conflicts, so we iterate up to
-    MAX_ROUNDS times.
+    The wrapper has just run `git rebase origin/main` and the rebase
+    has stopped on conflicts. We hand the in-progress rebase to a
+    single agent invocation that has Bash access (so it can run `git`
+    itself) and tell it to resolve every conflict, stage, and
+    `--continue`/`--skip` until the rebase is fully done. The agent's
+    own prompt (`prompts/backend-rebase.md`) carries the loop logic
+    and the safety rules.
+
+    Bash patterns block `git push`, `git remote …`, and `gh` so the
+    agent cannot touch the remote or PR state — pushing is the
+    wrapper's job, and we verify the worktree state ourselves before
+    trusting the agent's "done" signal.
 
     Returns (success, agent_summary). On failure the rebase is left
-    aborted and the caller should fall back to the manual-rebase comment
-    path. On success the rebase is fully complete and the worktree is
-    clean (apart from the unpushed commits).
+    aborted and the caller falls back to the manual-rebase comment
+    path. On success the rebase is fully complete and the worktree
+    is clean.
     """
-    MAX_ROUNDS = 5
-    summaries: list[str] = []
-
-    for round_num in range(1, MAX_ROUNDS + 1):
-        conflict_files = _rebase_conflict_files(work_dir)
-        if not conflict_files:
-            # No conflicts but rebase still in progress — try to advance.
-            cont = _advance_rebase(work_dir)
-            if cont.returncode == 0:
-                return True, "\n\n".join(summaries)
-            # Continue/skip produced new conflicts; loop again.
-            if not _rebase_conflict_files(work_dir):
-                summaries.append(
-                    "git rebase --continue/--skip failed with no "
-                    "conflicts:\n" + (cont.stderr or "").strip()[:1000]
-                )
-                _git(work_dir, "rebase", "--abort", check=False)
-                return False, "\n\n".join(summaries)
-            continue
-
-        print(
-            f"[cai revise] PR #{pr_number}: rebase round {round_num} — "
-            f"{len(conflict_files)} conflicted file(s); invoking agent",
-            flush=True,
-        )
-
-        prompt_text = REBASE_PROMPT.read_text()
-        full_prompt = (
-            f"{prompt_text}\n\n"
-            f"## Conflicted files (round {round_num} of up to {MAX_ROUNDS})\n\n"
-            + "".join(f"- `{f}`\n" for f in conflict_files)
-            + f"\n## Original PR issue context\n\n"
-            f"### {issue_title}\n\n"
-            f"{issue_body or '(no body)'}\n"
-        )
-
-        agent = _run(
-            ["claude", "-p", "--permission-mode", "acceptEdits",
-             "--disallowedTools", "Bash"],
-            input=full_prompt,
-            cwd=str(work_dir),
-            capture_output=True,
-        )
-        if agent.stdout:
-            print(agent.stdout, flush=True)
-        if agent.returncode != 0:
-            print(
-                f"[cai revise] rebase resolver subagent failed "
-                f"(exit {agent.returncode}):\n{agent.stderr}",
-                file=sys.stderr,
-            )
-            _git(work_dir, "rebase", "--abort", check=False)
-            return False, "\n\n".join(summaries)
-
-        summaries.append((agent.stdout or "").strip()[:2000])
-
-        # Stage the agent's edits first. The resolver runs with Bash
-        # disallowed so it cannot `git add` itself; until we stage,
-        # `git diff --diff-filter=U` will still report every touched
-        # file as unmerged (the index still holds stages 1/2/3) and
-        # the verification check below would spuriously fail.
-        _git(work_dir, "add", "-A")
-
-        # Verify the agent fully resolved this round.
-        remaining = _rebase_conflict_files(work_dir)
-        if remaining:
-            print(
-                f"[cai revise] PR #{pr_number}: agent left "
-                f"{len(remaining)} unresolved conflict(s); aborting",
-                file=sys.stderr,
-            )
-            _git(work_dir, "rebase", "--abort", check=False)
-            return False, "\n\n".join(summaries)
-
-        # Advance the rebase. _advance_rebase picks --skip over
-        # --continue when the resolution collapsed this commit's diff
-        # to zero (e.g. main already contained the same change).
-        cont = _advance_rebase(work_dir)
-        if cont.returncode == 0:
-            return True, "\n\n".join(summaries)
-        # Continue/skip might have surfaced new conflicts in the next
-        # commit; the next loop iteration will pick them up. If neither
-        # conflicts nor success, something else went wrong — bail and
-        # surface the stderr in the resolver-failed comment so it's
-        # debuggable.
-        if not _rebase_conflict_files(work_dir):
-            err_tail = (cont.stderr or "").strip()[:1000]
-            print(
-                f"[cai revise] PR #{pr_number}: rebase --continue/--skip "
-                f"failed with no conflicts:\n{err_tail}",
-                file=sys.stderr,
-            )
-            summaries.append(
-                "git rebase --continue/--skip failed with no "
-                f"conflicts:\n{err_tail}"
-            )
-            _git(work_dir, "rebase", "--abort", check=False)
-            return False, "\n\n".join(summaries)
-
-    # Hit the round cap with the rebase still in progress.
-    print(
-        f"[cai revise] PR #{pr_number}: rebase resolver exceeded "
-        f"{MAX_ROUNDS} rounds; aborting",
-        file=sys.stderr,
+    prompt_text = REBASE_PROMPT.read_text()
+    full_prompt = (
+        f"{prompt_text}\n\n"
+        f"## Original PR issue context\n\n"
+        f"### {issue_title}\n\n"
+        f"{issue_body or '(no body)'}\n"
     )
-    _git(work_dir, "rebase", "--abort", check=False)
-    return False, "\n\n".join(summaries)
+
+    print(
+        f"[cai revise] PR #{pr_number}: invoking rebase resolver agent",
+        flush=True,
+    )
+
+    # Block remote-touching commands. The agent gets Bash for `git`
+    # but must not push, fetch from a different remote, rewrite the
+    # remote URL, or call `gh`. Patterns are comma-separated per
+    # claude-code's flag parser (see the cai review-pr block for the
+    # same convention).
+    disallowed = ",".join([
+        "Bash(git push:*)",
+        "Bash(git remote:*)",
+        "Bash(gh:*)",
+    ])
+
+    agent = _run(
+        ["claude", "-p", "--permission-mode", "acceptEdits",
+         "--disallowedTools", disallowed],
+        input=full_prompt,
+        cwd=str(work_dir),
+        capture_output=True,
+    )
+    if agent.stdout:
+        print(agent.stdout, flush=True)
+    summary = (agent.stdout or "").strip()[:4000]
+
+    if agent.returncode != 0:
+        print(
+            f"[cai revise] PR #{pr_number}: rebase resolver agent failed "
+            f"(exit {agent.returncode}):\n{agent.stderr}",
+            file=sys.stderr,
+        )
+        _git(work_dir, "rebase", "--abort", check=False)
+        return False, summary
+
+    # Trust but verify. The agent claims success — confirm before
+    # we let the wrapper push:
+    #   1. No rebase still in progress.
+    #   2. No unmerged paths in the index.
+    #   3. Working tree is clean (no stray edits).
+    #   4. Branch contains origin/main (i.e. the rebase actually
+    #      happened, not just got aborted into a passing state).
+    rebase_merge = work_dir / ".git" / "rebase-merge"
+    rebase_apply = work_dir / ".git" / "rebase-apply"
+    if rebase_merge.exists() or rebase_apply.exists():
+        print(
+            f"[cai revise] PR #{pr_number}: agent exited but rebase "
+            "still in progress; aborting",
+            file=sys.stderr,
+        )
+        _git(work_dir, "rebase", "--abort", check=False)
+        return False, summary
+
+    if _rebase_conflict_files(work_dir):
+        print(
+            f"[cai revise] PR #{pr_number}: agent exited with "
+            "unmerged paths still present",
+            file=sys.stderr,
+        )
+        _git(work_dir, "rebase", "--abort", check=False)
+        return False, summary
+
+    status = _git(work_dir, "status", "--porcelain", check=False)
+    if status.stdout.strip():
+        print(
+            f"[cai revise] PR #{pr_number}: agent left working tree "
+            f"dirty:\n{status.stdout}",
+            file=sys.stderr,
+        )
+        return False, summary
+
+    ancestry = _run(
+        ["git", "-C", str(work_dir), "merge-base", "--is-ancestor",
+         "origin/main", "HEAD"],
+        capture_output=True,
+    )
+    if ancestry.returncode != 0:
+        print(
+            f"[cai revise] PR #{pr_number}: agent finished but HEAD "
+            "is not on top of origin/main (rebase likely aborted)",
+            file=sys.stderr,
+        )
+        return False, summary
+
+    return True, summary
 
 
 def _select_revise_targets() -> list[dict]:

--- a/prompts/backend-rebase.md
+++ b/prompts/backend-rebase.md
@@ -1,80 +1,118 @@
 # Backend Rebase Conflict Resolver
 
 You are the rebase-conflict-resolution subagent for `robotsix-cai`.
-The wrapper script (`cai.py revise`) has cloned the PR branch, run
-`git rebase origin/main`, and the rebase has **stopped because of
-merge conflicts**. The conflicted files are listed below. **Your job
-is to resolve every conflict in place** so the wrapper can stage the
-files and run `git rebase --continue`.
+The wrapper script (`cai.py revise`) has run `git rebase origin/main`
+on the PR branch and the rebase has **stopped because of merge
+conflicts**. **Your job is to drive the rebase to completion** —
+resolve the conflicts, stage the resolutions, and run `git rebase
+--continue` (or `--skip` for empty commits) until the rebase is fully
+done. You then exit and the wrapper force-pushes the result.
 
-## Your current working directory
+## Your environment
 
-You are inside a clone of `damien-robotsix/robotsix-cai` with a
-rebase in progress. The conflicted files contain standard git
-conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`). The wrapper will
-handle all git operations after you exit. Bash is not available —
-use Read, Edit, Write, Grep, and Glob instead.
+- You are inside a clone of `damien-robotsix/robotsix-cai` at the PR
+  branch tip. A `git rebase origin/main` is currently in progress and
+  is paused on conflicts.
+- `origin/main` has already been fetched. You do not need network
+  access.
+- You have Bash, Read, Edit, Write, Grep, and Glob.
+- The wrapper handles pushing and PR/comment state. **You must not
+  touch the remote.**
 
 ## Hard rules
 
-1. **Read each conflicted file before editing it.** Always Read the
-   target file **immediately** before calling Edit. Use a unique,
-   multi-line `old_string` (3+ lines of surrounding context) to avoid
-   ambiguous-match failures.
-2. **Resolve every conflict marker.** When you finish, no file should
-   contain `<<<<<<<`, `=======`, or `>>>>>>>` lines. Both sides of
-   the conflict must be considered — preserve the intent of BOTH the
-   incoming changes from `main` AND the local PR changes wherever
-   possible.
-3. **Edit files in place — do not stage, commit, abort, or
-   `--continue` the rebase.** The wrapper handles all git operations.
-   You have no Bash access anyway.
-4. **Touch only the conflicted files listed below.** Do not modify
-   files outside the conflict set, do not refactor, do not reformat,
-   do not add docstrings or comments outside the merge resolution
-   itself.
-5. **Do not delete files** unless one side of the conflict was a
-   deletion and that is clearly the right resolution.
-6. **If a conflict is genuinely ambiguous** and you cannot make a
-   confident judgement about how to merge the two sides, leave that
-   file as-is, print a short paragraph to stdout explaining which
-   file and which hunk you couldn't resolve, and exit. The wrapper
-   will detect the unresolved markers and fall back to manual
-   handling — that is a valid outcome.
-7. **Stay inside the repo.** Don't touch anything outside the
-   working directory.
+1. **Never push.** Do not run `git push` in any form. The wrapper
+   pushes after you exit. Pushing yourself is blocked anyway, but
+   don't try.
+2. **Never use `gh`.** Do not run `gh` (any subcommand). The wrapper
+   handles all PR and comment state.
+3. **Never modify the remote.** Do not run `git remote …`, do not
+   edit `.git/config`, do not change any URL.
+4. **Stay inside the working directory.** Do not `cd` out, do not
+   touch files outside the worktree.
+5. **Resolve every conflict marker.** When you finish, no file under
+   the working directory may contain `<<<<<<<`, `=======`, or
+   `>>>>>>>` lines that came from the merge. Verify with
+   `git diff --name-only --diff-filter=U` (must be empty) before
+   declaring success.
+6. **Preserve intent from BOTH sides** wherever possible — combine
+   main's incoming changes with the PR's local changes rather than
+   blindly picking one side. The PR exists to add value, but main
+   has moved for a reason; reconcile both.
+7. **Touch only conflicted files.** Do not refactor, reformat, or
+   edit files outside the conflict set. Do not add docstrings or
+   comments unrelated to the merge resolution.
+8. **Use `--skip` for empty commits.** If your resolution collapses
+   a replayed commit's diff to zero (because main already contained
+   the same change), `git rebase --continue` errors with "no changes
+   - did you forget to use git add?". The correct call is
+   `git rebase --skip`. See the loop below for how to detect this.
 
-## How to resolve a conflict
+## How to run the rebase to completion
 
-For each conflicted file:
+Repeat until the rebase is fully done (no `.git/rebase-merge` and no
+`.git/rebase-apply` directory):
 
-1. Read the file. Locate every `<<<<<<<` / `=======` / `>>>>>>>`
-   block.
-2. Identify what each side is doing — the section above `=======`
-   is the **current branch** (the rebase target, i.e. main), the
-   section below is **incoming** (the PR commit being replayed).
-3. Decide how to merge them:
-   - If the two sides edit unrelated nearby lines, keep both.
-   - If the two sides edit the same construct, combine them so the
-     final code reflects both intents.
-   - If one side supersedes the other (e.g. the PR rewrites a
-     function that main also touched cosmetically), prefer the PR
-     side but apply main's substantive changes on top.
-4. Replace the entire `<<<<<<< ... >>>>>>>` block with the resolved
-   version, removing all marker lines. The result must be valid,
-   working code.
-5. Move on to the next block.
+1. **List conflicted files:** `git diff --name-only --diff-filter=U`
+2. **Resolve each one in place:**
+   - Read the file. Locate every `<<<<<<< / ======= / >>>>>>>` block.
+   - The section above `=======` is the **current branch** (the
+     rebase target — `main`). The section below is **incoming** (the
+     PR commit being replayed).
+   - Decide how to merge them per rule 6 above. Replace the entire
+     `<<<<<<< … >>>>>>>` block with the resolved version, removing
+     all marker lines. The result must be valid, working code.
+3. **Stage the resolutions:** `git add -A`
+4. **Verify no markers remain:** re-run
+   `git diff --name-only --diff-filter=U` — it must be empty.
+5. **Decide continue vs skip:**
+   - Run: `git diff --cached --quiet`
+   - If exit code is `0` (no staged changes → empty commit), run:
+     `git rebase --skip`
+   - Otherwise run:
+     `GIT_EDITOR=true git -c core.editor=true rebase --continue`
+     (the editor override prevents git from opening an interactive
+     prompt for the commit message).
+6. **If new conflicts surface** on the next replayed commit, loop
+   back to step 1. There may be several rounds — each commit being
+   replayed is a fresh chance to conflict.
+
+The rebase is fully done when neither `.git/rebase-merge` nor
+`.git/rebase-apply` exists. Confirm with:
+
+```
+test ! -d .git/rebase-merge && test ! -d .git/rebase-apply && echo done
+```
+
+## When you cannot resolve a conflict
+
+If a conflict is genuinely ambiguous and you cannot make a confident
+judgement about how to merge the two sides:
+
+1. Run `git rebase --abort` to leave the worktree in a clean state.
+2. Print a one-paragraph explanation to stdout naming the file, the
+   hunk, and why you couldn't resolve it.
+3. Exit. The wrapper will detect the failure (no rebase in progress
+   but the branch is not on top of `origin/main`) and post a
+   manual-rebase comment on the PR.
+
+Bailing is a valid outcome — it is much better than merging wrong
+code.
 
 ## Final output
 
-When you are done — whether you resolved everything or bailed —
-print a one-paragraph summary to stdout describing what you did:
-which files you touched, what the conflict was about, and how you
-resolved it (or why you couldn't). Be specific and concise. The
-wrapper will include this in the post-rebase PR comment.
+When you exit (success or failure), print a one-paragraph summary to
+stdout describing:
 
-## Conflicted files
+- which files you touched and which conflicts you resolved
+- how you decided each resolution (which side won, and why)
+- whether the rebase completed cleanly or you had to abort
 
-The list of files with merge conflicts (and the original PR issue
-context, for understanding what the PR is trying to do) is appended
-to this prompt below. Read it carefully before doing anything else.
+Be specific and concise. The wrapper will include this summary in
+the post-rebase PR comment so reviewers can audit the merge.
+
+## PR context
+
+The original PR's issue title and body are appended below — read
+them before doing anything else so you understand the PR's intent
+and which side of each conflict to favor.


### PR DESCRIPTION
Refs #270. First phase of the Path A architectural migration; also supersedes the original single-commit agent-driven-rebase rewrite with the declarative form on top.

## Two bundled changes (two commits)

### 1. Agent drives the whole rebase, not just file edits (10400ab)
Replace the wrapper-orchestrated rebase resolver with a single agent invocation that has Bash access and runs the rebase to completion itself. The wrapper still runs `git rebase origin/main` first to detect whether a rebase is needed, but on conflict it now hands the in-progress rebase to the agent and lets the agent loop through edit → add → continue/skip → next conflict on its own.

**Why:** the previous design split the loop between wrapper and agent — the agent edited files (Bash disallowed), the wrapper ran git, and they had to stay in lockstep across multiple rounds. Every join point was a chance to get the order wrong (e.g. the staging-vs-verification bug fixed in #251). Empty-commit `--skip` is just another tool call inside the agent, not wrapper logic.

### 2. Migrate to declarative Claude subagent (e77f7cf)
Move the rebase resolver from `claude -p PROMPT_STRING + prompts/backend-rebase.md + --disallowedTools` to `claude --agent cai-rebase-resolver` with a declarative agent file.

- **New `.claude/agents/cai-rebase-resolver.md`** (renamed from `prompts/backend-rebase.md`) — declarative agent with tool allowlist in frontmatter and system prompt in the body.
- **New `.claude/settings.json`** — repo-wide deny rules for `Bash(git push:*)`, `Bash(git remote:*)`, `Bash(gh:*)`. Protects ALL future subagents (no subagent in cai.py needs to push or call `gh` — wrapper responsibilities).
- **`cai.py _agent_resolve_rebase`** — invokes `claude --agent cai-rebase-resolver`, passes only the dynamic context (issue title + body) as stdin. The `--disallowedTools` flag list disappears.
- **`Dockerfile`** — `COPY .claude /app/.claude`.
- **`prompts/backend-rebase.md`** — deleted (content now lives in the agent file).
- **`REBASE_PROMPT` constant** — removed from cai.py.

## Why Path A at all

The `claude -p PROMPT_STRING` pattern generates band-aids:
- #261 (closed) added "Tool bootstrap" paragraphs to every prompt because tools were being re-discovered each invocation
- #262 implements memory as prompt injection because there's no real per-agent memory
- `--disallowedTools` flag strings scattered across every call site

Declarative subagents retire the whole class. Tool allowlists are config. System prompts live in agent files. Memory is a frontmatter field. Pattern-based Bash restrictions move to `.claude/settings.json` or `PreToolUse` hooks. The wrapper becomes a thin dispatcher.

## Safety model (unchanged)

The agent runs in a throwaway clone (`/tmp/cai-revise-N/`) so blast radius is bounded. Bash is allowed for `git`, but the settings.json deny rules block:
- `Bash(git push:*)` and `Bash(git push)` — pushing is the wrapper's job
- `Bash(git remote:*)` and `Bash(git remote)` — no URL tampering
- `Bash(gh:*)` and `Bash(gh)` — no PR/comment state changes

The wrapper *trusts but verifies* before letting the push happen — `_agent_resolve_rebase` returns `False` unless **all** of these hold:
1. No rebase still in progress (`.git/rebase-merge` and `.git/rebase-apply` both absent)
2. No unmerged paths (`git diff --diff-filter=U` is empty)
3. Working tree clean (`git status --porcelain` is empty)
4. HEAD contains `origin/main` as an ancestor (so an aborted rebase can't masquerade as success)

## Test plan
- [ ] Trigger `cai revise` against a freshly-conflicting auto-improve PR and confirm the declared `cai-rebase-resolver` agent rebases cleanly through multiple replayed commits.
- [ ] **Validate `claude --agent <name>` works in headless mode with Claude Code 2.1.96** — this is an open question from #270. If it fails, bump the pinned version or fall back to `--agents '<json>'` inline.
- [ ] **Validate `.claude/settings.json` deny rules apply to the subagent** — introduce a `git push origin main` instruction in a test prompt and confirm the deny rule blocks it.
- [ ] Confirm the agent handles the `--skip` case for empty commits (main already contains the PR's change).
- [ ] Confirm ambiguous conflicts still fall through to the manual-rebase comment path (agent runs `git rebase --abort`, wrapper detects "HEAD not on top of origin/main", posts the failure comment).

## Notes
- The `## Revise subagent: rebase resolution failed` marker string is unchanged, so the loop guard at cai.py:1316 and the auto-recovery in `_recover_stuck_rebase_prs` still trigger correctly.
- `_rebase_conflict_files` is kept (used by the post-agent verification).
- `_advance_rebase` was deleted in commit 1 (the wrapper no longer advances the rebase — the agent does).
- This PR is deliberately narrow: it migrates ONE subagent to validate the pattern. If the validation passes in production, the remaining subagents follow in #270's phased migration order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)