### PR TITLE
auto-improve: Several instance of cai may be working on the same /tmp folder

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -77,6 +77,7 @@ import shutil
 import subprocess
 import sys
 import time
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -651,7 +652,8 @@ def cmd_fix(args) -> int:
     # idempotent and lets ad-hoc `docker run` invocations work too.
     _run(["gh", "auth", "setup-git"], capture_output=True)
 
-    work_dir = Path(f"/tmp/cai-fix-{issue_number}")
+    _uid = uuid.uuid4().hex[:8]
+    work_dir = Path(f"/tmp/cai-fix-{issue_number}-{_uid}")
     locked = True
 
     def rollback() -> None:
@@ -1497,7 +1499,8 @@ def cmd_revise(args) -> int:
 
         _run(["gh", "auth", "setup-git"], capture_output=True)
 
-        work_dir = Path(f"/tmp/cai-revise-{issue_number}")
+        _uid = uuid.uuid4().hex[:8]
+        work_dir = Path(f"/tmp/cai-revise-{issue_number}-{_uid}")
 
         try:
             if work_dir.exists():
@@ -3012,7 +3015,8 @@ def cmd_review_pr(args) -> int:
         pr_diff = diff_result.stdout
 
         # Clone the repo for the agent to walk.
-        work_dir = Path(f"/tmp/cai-review-{pr_number}")
+        _uid = uuid.uuid4().hex[:8]
+        work_dir = Path(f"/tmp/cai-review-{pr_number}-{_uid}")
         try:
             if work_dir.exists():
                 shutil.rmtree(work_dir)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#199

**Issue:** #199 — Several instance of cai may be working on the same /tmp folder

## PR Summary

### What this fixes
Multiple concurrent instances of `cai` could use the same `/tmp/cai-fix-{N}`, `/tmp/cai-revise-{N}`, or `/tmp/cai-review-{N}` directory, causing race conditions and potential data corruption when two instances work on the same issue or PR number simultaneously.

### What was changed
- `cai.py`: Added `import uuid` to the imports
- `cai.py:655-656`: Appended a random 8-character hex suffix (`uuid.uuid4().hex[:8]`) to the `fix` work directory path
- `cai.py:1502-1503`: Same suffix added to the `revise` work directory path
- `cai.py:3018-3019`: Same suffix added to the `review` work directory path

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
