### PR TITLE
auto-improve: Pre-specify deferred tools in prompts to eliminate ToolSearch overhead

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# Tool bootstrap
+
+Before starting work, run a single `ToolSearch` call to pre-fetch all
+deferred tools you may need during the session:
+`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
+repeated ToolSearch round-trips later.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,0 @@
-# Tool bootstrap
-
-Before starting work, run a single `ToolSearch` call to pre-fetch all
-deferred tools you may need during the session:
-`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
-repeated ToolSearch round-trips later.

--- a/prompts/backend-audit.md
+++ b/prompts/backend-audit.md
@@ -1,5 +1,11 @@
 # Backend Audit
 
+## Tool bootstrap
+
+Before starting work, run a single `ToolSearch` call to pre-fetch the
+deferred tools you will need:
+`ToolSearch(query: "select:TodoWrite", max_results: 1)`.
+
 You are the audit agent for `robotsix-cai`'s self-improvement loop.
 Your job is to analyze the current GitHub issue queue, recent PRs, and
 log tail to find inconsistencies in the lifecycle state machine. You

--- a/prompts/backend-audit.md
+++ b/prompts/backend-audit.md
@@ -6,13 +6,6 @@ log tail to find inconsistencies in the lifecycle state machine. You
 do NOT read JSONL transcripts — that is the analyzer's job. You
 reason purely about GitHub-side state and the run log.
 
-## Tool bootstrap
-
-Before starting work, run a single `ToolSearch` call to pre-fetch all
-deferred tools you may need during the session:
-`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
-repeated ToolSearch round-trips later.
-
 ## What you receive
 
 1. **Open `auto-improve*` issues** — number, title, labels, creation

--- a/prompts/backend-audit.md
+++ b/prompts/backend-audit.md
@@ -6,6 +6,13 @@ log tail to find inconsistencies in the lifecycle state machine. You
 do NOT read JSONL transcripts — that is the analyzer's job. You
 reason purely about GitHub-side state and the run log.
 
+## Tool bootstrap
+
+Before starting work, run a single `ToolSearch` call to pre-fetch all
+deferred tools you may need during the session:
+`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
+repeated ToolSearch round-trips later.
+
 ## What you receive
 
 1. **Open `auto-improve*` issues** — number, title, labels, creation

--- a/prompts/backend-auto-improve.md
+++ b/prompts/backend-auto-improve.md
@@ -1,5 +1,11 @@
 # Backend Auto-Improve
 
+## Tool bootstrap
+
+Before starting work, run a single `ToolSearch` call to pre-fetch the
+deferred tools you will need:
+`ToolSearch(query: "select:TodoWrite", max_results: 1)`.
+
 You are the analyzer for `robotsix-cai`'s self-improvement loop. Your
 job is to look at the parsed signals from the backend's **own** Claude
 Code session transcripts and decide whether anything in the cai code,

--- a/prompts/backend-auto-improve.md
+++ b/prompts/backend-auto-improve.md
@@ -13,13 +13,6 @@ data you receive comes from JSONL files under
 the cai container itself invoked `claude -p`. You do NOT look at
 sessions from outside the container.
 
-## Tool bootstrap
-
-Before starting work, run a single `ToolSearch` call to pre-fetch all
-deferred tools you may need during the session:
-`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
-repeated ToolSearch round-trips later.
-
 ## What to look for
 
 1. **Tool-call errors** — Edit failures, permission errors, repeated

--- a/prompts/backend-auto-improve.md
+++ b/prompts/backend-auto-improve.md
@@ -13,6 +13,13 @@ data you receive comes from JSONL files under
 the cai container itself invoked `claude -p`. You do NOT look at
 sessions from outside the container.
 
+## Tool bootstrap
+
+Before starting work, run a single `ToolSearch` call to pre-fetch all
+deferred tools you may need during the session:
+`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
+repeated ToolSearch round-trips later.
+
 ## What to look for
 
 1. **Tool-call errors** — Edit failures, permission errors, repeated

--- a/prompts/backend-confirm.md
+++ b/prompts/backend-confirm.md
@@ -4,6 +4,13 @@ You are the confirm agent for `robotsix-cai`'s self-improvement loop.
 Your job is to determine whether each `:merged` issue has been
 resolved. You produce exactly one verdict per issue — nothing else.
 
+## Tool bootstrap
+
+Before starting work, run a single `ToolSearch` call to pre-fetch all
+deferred tools you may need during the session:
+`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
+repeated ToolSearch round-trips later.
+
 ## What you receive
 
 1. **Parsed signals** — the JSON output of `parse.py` run against the

--- a/prompts/backend-confirm.md
+++ b/prompts/backend-confirm.md
@@ -1,5 +1,11 @@
 # Backend Confirm
 
+## Tool bootstrap
+
+Before starting work, run a single `ToolSearch` call to pre-fetch the
+deferred tools you will need:
+`ToolSearch(query: "select:TodoWrite", max_results: 1)`.
+
 You are the confirm agent for `robotsix-cai`'s self-improvement loop.
 Your job is to determine whether each `:merged` issue has been
 resolved. You produce exactly one verdict per issue — nothing else.

--- a/prompts/backend-confirm.md
+++ b/prompts/backend-confirm.md
@@ -4,13 +4,6 @@ You are the confirm agent for `robotsix-cai`'s self-improvement loop.
 Your job is to determine whether each `:merged` issue has been
 resolved. You produce exactly one verdict per issue — nothing else.
 
-## Tool bootstrap
-
-Before starting work, run a single `ToolSearch` call to pre-fetch all
-deferred tools you may need during the session:
-`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
-repeated ToolSearch round-trips later.
-
 ## What you receive
 
 1. **Parsed signals** — the JSON output of `parse.py` run against the

--- a/prompts/backend-fix.md
+++ b/prompts/backend-fix.md
@@ -17,6 +17,13 @@ The full source tree is here, including `cai.py`, `parse.py`,
 `.github/workflows/`. Bash is not available — use Read, Edit, Write,
 Grep, and Glob instead.
 
+## Tool bootstrap
+
+Before starting work, run a single `ToolSearch` call to pre-fetch all
+deferred tools you may need during the session:
+`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
+repeated ToolSearch round-trips later.
+
 ## Hard rules
 
 1. **Read before you edit.** Always Read the target file

--- a/prompts/backend-fix.md
+++ b/prompts/backend-fix.md
@@ -17,13 +17,6 @@ The full source tree is here, including `cai.py`, `parse.py`,
 `.github/workflows/`. Bash is not available — use Read, Edit, Write,
 Grep, and Glob instead.
 
-## Tool bootstrap
-
-Before starting work, run a single `ToolSearch` call to pre-fetch all
-deferred tools you may need during the session:
-`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
-repeated ToolSearch round-trips later.
-
 ## Hard rules
 
 1. **Read before you edit.** Always Read the target file

--- a/prompts/backend-fix.md
+++ b/prompts/backend-fix.md
@@ -1,5 +1,11 @@
 # Backend Fix Subagent
 
+## Tool bootstrap
+
+Before starting work, run a single `ToolSearch` call to pre-fetch the
+deferred tools you will need:
+`ToolSearch(query: "select:TodoWrite", max_results: 1)`.
+
 You are the autonomous fix subagent for `robotsix-cai`. The wrapper
 script (`cai.py fix`) has cloned the repository for you, checked out
 a fresh branch, and configured your git identity. **Your job is to

--- a/prompts/backend-rebase.md
+++ b/prompts/backend-rebase.md
@@ -1,5 +1,11 @@
 # Backend Rebase Conflict Resolver
 
+## Tool bootstrap
+
+Before starting work, run a single `ToolSearch` call to pre-fetch the
+deferred tools you will need:
+`ToolSearch(query: "select:TodoWrite", max_results: 1)`.
+
 You are the rebase-conflict-resolution subagent for `robotsix-cai`.
 The wrapper script (`cai.py revise`) has run `git rebase origin/main`
 on the PR branch and the rebase has **stopped because of merge

--- a/prompts/backend-rebase.md
+++ b/prompts/backend-rebase.md
@@ -19,6 +19,13 @@ done. You then exit and the wrapper force-pushes the result.
 - The wrapper handles pushing and PR/comment state. **You must not
   touch the remote.**
 
+## Tool bootstrap
+
+Before starting work, run a single `ToolSearch` call to pre-fetch all
+deferred tools you may need during the session:
+`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
+repeated ToolSearch round-trips later.
+
 ## Hard rules
 
 1. **Never push.** Do not run `git push` in any form. The wrapper

--- a/prompts/backend-rebase.md
+++ b/prompts/backend-rebase.md
@@ -19,13 +19,6 @@ done. You then exit and the wrapper force-pushes the result.
 - The wrapper handles pushing and PR/comment state. **You must not
   touch the remote.**
 
-## Tool bootstrap
-
-Before starting work, run a single `ToolSearch` call to pre-fetch all
-deferred tools you may need during the session:
-`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
-repeated ToolSearch round-trips later.
-
 ## Hard rules
 
 1. **Never push.** Do not run `git push` in any form. The wrapper

--- a/prompts/backend-review-pr.md
+++ b/prompts/backend-review-pr.md
@@ -6,6 +6,13 @@ internally consistent but create inconsistencies with the rest of the
 codebase. You have read-only access to the repository via
 `Read`, `Grep`, `Glob`, and the `Agent` tool.
 
+## Tool bootstrap
+
+Before starting work, run a single `ToolSearch` call to pre-fetch all
+deferred tools you may need during the session:
+`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
+repeated ToolSearch round-trips later.
+
 ## What you receive
 
 1. **PR metadata** — number, title, author, base branch

--- a/prompts/backend-review-pr.md
+++ b/prompts/backend-review-pr.md
@@ -6,13 +6,6 @@ internally consistent but create inconsistencies with the rest of the
 codebase. You have read-only access to the repository via
 `Read`, `Grep`, `Glob`, and the `Agent` tool.
 
-## Tool bootstrap
-
-Before starting work, run a single `ToolSearch` call to pre-fetch all
-deferred tools you may need during the session:
-`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
-repeated ToolSearch round-trips later.
-
 ## What you receive
 
 1. **PR metadata** — number, title, author, base branch

--- a/prompts/backend-revise.md
+++ b/prompts/backend-revise.md
@@ -14,13 +14,6 @@ You are running inside a clone of `damien-robotsix/robotsix-cai` on
 the PR branch. The existing PR diff is already applied -- you are
 working on top of the previous fix attempt.
 
-## Tool bootstrap
-
-Before starting work, run a single `ToolSearch` call to pre-fetch all
-deferred tools you may need during the session:
-`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
-repeated ToolSearch round-trips later.
-
 ## Hard rules
 
 1. **Read before you edit.** Always Read the target file

--- a/prompts/backend-revise.md
+++ b/prompts/backend-revise.md
@@ -1,5 +1,11 @@
 # Backend Revise Subagent
 
+## Tool bootstrap
+
+Before starting work, run a single `ToolSearch` call to pre-fetch the
+deferred tools you will need:
+`ToolSearch(query: "select:TodoWrite", max_results: 1)`.
+
 You are the revise subagent for `robotsix-cai`. The wrapper script
 (`cai.py revise`) has checked out the **existing PR branch** for you
 and configured your git identity. **Your job is to make the smallest

--- a/prompts/backend-revise.md
+++ b/prompts/backend-revise.md
@@ -14,6 +14,13 @@ You are running inside a clone of `damien-robotsix/robotsix-cai` on
 the PR branch. The existing PR diff is already applied -- you are
 working on top of the previous fix attempt.
 
+## Tool bootstrap
+
+Before starting work, run a single `ToolSearch` call to pre-fetch all
+deferred tools you may need during the session:
+`ToolSearch(query: "select:TodoWrite", max_results: 1)`. This avoids
+repeated ToolSearch round-trips later.
+
 ## Hard rules
 
 1. **Read before you edit.** Always Read the target file


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#200

**Issue:** #200 — Pre-specify deferred tools in prompts to eliminate ToolSearch overhead

## PR Summary

### What this fixes
ToolSearch was being called repeatedly (12 calls, 8% of total) across sessions as agents discovered deferred tools on-demand throughout their work, inflating output tokens with redundant JSON schema fetches.

### What was changed
- `prompts/backend-fix.md` — added "Tool bootstrap" section instructing the agent to pre-fetch `TodoWrite` via a single `ToolSearch` call before starting work
- `prompts/backend-revise.md` — same "Tool bootstrap" section added
- `prompts/backend-review-pr.md` — same "Tool bootstrap" section added
- `prompts/backend-auto-improve.md` — same "Tool bootstrap" section added
- `prompts/backend-audit.md` — same "Tool bootstrap" section added
- `prompts/backend-rebase.md` — same "Tool bootstrap" section added

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
