### PR TITLE
analyze: feed closed-issue rationales + design decisions to subagents

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -106,6 +106,7 @@ REBASE_PROMPT = Path("/app/prompts/backend-rebase.md")
 REVIEW_PR_PROMPT = Path("/app/prompts/backend-review-pr.md")
 MERGE_PROMPT = Path("/app/prompts/backend-merge.md")
 AUDIT_TRIAGE_PROMPT = Path("/app/prompts/backend-audit-triage.md")
+DESIGN_DECISIONS = Path("/app/prompts/design-decisions.md")
 
 # Issue lifecycle labels.
 LABEL_RAISED = "auto-improve:raised"
@@ -216,6 +217,116 @@ def cmd_init(args) -> int:
 # analyze
 # ---------------------------------------------------------------------------
 
+def _design_decisions_block() -> str:
+    """Return the design-decisions file as a prompt section, or "".
+
+    Read by every subagent that decides what to raise, fix, or skip
+    (analyze, audit, fix). The file lives at `prompts/design-decisions.md`
+    and contains durable, supervisor-curated rules that override any
+    signal from parsed transcripts. See #260.
+    """
+    if not DESIGN_DECISIONS.exists():
+        return ""
+    try:
+        text = DESIGN_DECISIONS.read_text().strip()
+    except OSError:
+        return ""
+    if not text:
+        return ""
+    return (
+        "\n\n## Durable design decisions\n\n"
+        "The following entries are supervisor-curated rules. They "
+        "override any signal from parsed transcripts: if your finding "
+        "or proposed action overlaps with an entry below, do NOT raise "
+        "or act on it. The only exception is the explicit exit "
+        "condition stated in each entry. Read every entry before "
+        "deciding.\n\n"
+        f"{text}\n"
+    )
+
+
+def _fetch_closed_auto_improve_issues(limit: int = 50) -> list[dict]:
+    """Return recently closed `auto-improve` issues with closing rationale.
+
+    For each closed issue, the "rationale" is the last comment posted
+    before the issue was closed by a non-bot author. Bot comments are
+    skipped because they are status updates, not reasoning. If no
+    human rationale comment exists, the rationale is left empty and
+    the analyzer can fall back to the issue body.
+    """
+    try:
+        issues = _gh_json([
+            "issue", "list",
+            "--repo", REPO,
+            "--label", "auto-improve",
+            "--state", "closed",
+            "--json",
+            "number,title,labels,closedAt,comments",
+            "--limit", str(limit),
+        ]) or []
+    except subprocess.CalledProcessError:
+        return []
+
+    result = []
+    for issue in issues:
+        comments = issue.get("comments") or []
+        rationale = ""
+        rationale_author = ""
+        # Walk comments newest-first; pick the first non-bot.
+        for c in reversed(comments):
+            author = (c.get("author") or {}).get("login", "")
+            if not author or author.endswith("[bot]") or author == "github-actions":
+                continue
+            body = (c.get("body") or "").strip()
+            if not body:
+                continue
+            rationale = body[:600]
+            rationale_author = author
+            break
+        result.append({
+            "number": issue["number"],
+            "title": issue["title"],
+            "labels": [lbl["name"] for lbl in issue.get("labels", [])],
+            "closedAt": issue.get("closedAt", ""),
+            "rationale": rationale,
+            "rationale_author": rationale_author,
+        })
+    return result
+
+
+def _closed_issues_block(closed: list[dict]) -> str:
+    """Format closed issues + their rationales as a prompt section."""
+    if not closed:
+        return ""
+    lines = [
+        "\n\n## Previously closed auto-improve issues",
+        "",
+        "These auto-improve issues have already been considered and "
+        "closed. Before raising any new finding, check the rationale "
+        "for each closed issue below. If your proposed finding "
+        "overlaps with one of these by topic, do NOT re-raise it — "
+        "the supervisor's reasoning still applies. The only exception: "
+        "you have concrete new evidence that the prior reasoning is "
+        "wrong, in which case raise a finding that explicitly "
+        "references the prior issue number and explains what changed.",
+        "",
+    ]
+    for ci in closed:
+        labels_str = ", ".join(ci["labels"]) if ci["labels"] else "(none)"
+        lines.append(f"### #{ci['number']} — {ci['title']}")
+        lines.append(f"- **Closed:** {ci['closedAt']}")
+        lines.append(f"- **Labels:** {labels_str}")
+        if ci["rationale"]:
+            lines.append(
+                f"- **Closing rationale (@{ci['rationale_author']}):** "
+                f"{ci['rationale']}"
+            )
+        else:
+            lines.append("- **Closing rationale:** (none recorded)")
+        lines.append("")
+    return "\n".join(lines)
+
+
 def cmd_analyze(args) -> int:
     """Parse prior transcripts, ask claude to analyze, publish findings."""
     print("[cai analyze] running self-analyzer", flush=True)
@@ -316,13 +427,25 @@ def cmd_analyze(args) -> int:
             + "\n"
         )
 
+    # Closed-issue rationales — so the analyzer doesn't re-raise
+    # findings the supervisor has already reasoned through and
+    # rejected. See #260.
+    closed_issues = _fetch_closed_auto_improve_issues(limit=50)
+    closed_block = _closed_issues_block(closed_issues)
+
+    # Durable design decisions — load-bearing rules that override
+    # any signal from parsed transcripts. See #260.
+    decisions_block = _design_decisions_block()
+
     full_prompt = (
-        f"{prompt_text}\n\n"
+        f"{prompt_text}"
+        f"{decisions_block}\n\n"
         "## Parsed signals\n\n"
         "```json\n"
         f"{parsed_signals}\n"
         "```\n"
         f"{issues_block}"
+        f"{closed_block}"
     )
 
     analyzer = _run(
@@ -502,6 +625,11 @@ def _issue_has_label(issue_number: int, label: str) -> bool:
 
 def _build_fix_prompt(issue: dict) -> str:
     prompt = FIX_PROMPT.read_text()
+    # Durable design decisions — defense in depth. If a finding slips
+    # past `analyze` but overlaps a design-decision entry, the fix
+    # subagent should refuse to act and surface the conflict instead.
+    # See #260.
+    decisions_block = _design_decisions_block()
     issue_block = (
         f"## Issue\n\n"
         f"### #{issue['number']} — {issue['title']}\n\n"
@@ -514,7 +642,7 @@ def _build_fix_prompt(issue: dict) -> str:
             author = c.get("author", {}).get("login", "unknown")
             body = c.get("body", "")
             issue_block += f"**{author}:**\n{body}\n\n"
-    return f"{prompt}\n\n{issue_block}"
+    return f"{prompt}{decisions_block}\n\n{issue_block}"
 
 
 def _parse_suggested_issues(agent_output: str) -> list[dict]:
@@ -2283,8 +2411,14 @@ def cmd_audit(args) -> int:
             deterministic_section += f"- #{ci['number']}: {ci['title']}\n"
         deterministic_section += "\n"
 
+    # Durable design decisions — the audit subagent should not flag
+    # patterns of dysfunction that the supervisor has explicitly
+    # accepted. See #260.
+    decisions_block = _design_decisions_block()
+
     full_prompt = (
-        f"{prompt_text}\n\n"
+        f"{prompt_text}"
+        f"{decisions_block}\n\n"
         f"{issues_section}\n"
         f"{prs_section}\n"
         f"{log_section}\n"

--- a/prompts/backend-audit.md
+++ b/prompts/backend-audit.md
@@ -8,11 +8,16 @@ reason purely about GitHub-side state and the run log.
 
 ## What you receive
 
-1. **Open `auto-improve*` issues** — number, title, labels, creation
+1. **Durable design decisions** (if any) — supervisor-curated rules
+   that override audit-side findings. If a pattern of dysfunction
+   you would otherwise flag overlaps with a design decision (the
+   supervisor has explicitly accepted that pattern), do not flag it.
+   Read every entry before scanning the rest of the input.
+2. **Open `auto-improve*` issues** — number, title, labels, creation
    date, last update date, body
-2. **Recent PRs** — last 30 or last 7 days (whichever is larger),
+3. **Recent PRs** — last 30 or last 7 days (whichever is larger),
    with state, merge status, linked issue references
-3. **Log tail** — last ~200 lines of `logs/cai.log`
+4. **Log tail** — last ~200 lines of `logs/cai.log`
 
 ## Lifecycle states — tracking vs active
 

--- a/prompts/backend-auto-improve.md
+++ b/prompts/backend-auto-improve.md
@@ -82,16 +82,37 @@ No findings.
 
 ## Filter
 
-Before raising any new finding, check the "Currently open
-auto-improve issues" list at the end of the prompt. If your proposed
-finding overlaps with **any** listed issue — by topic, not just by
-fingerprint — do NOT output it. This includes issues labelled
-`merged`: a merged fix may still appear in the analyzed transcripts
-because historical sessions predate the fix. An issue is only
-considered fully resolved once it is **closed**, not when its PR
-merges. Until then, treat the topic as still in flight and do not
-re-raise it. Only raise findings whose pattern has no related open
-issue at all.
+Before raising any new finding, check **all three** of the following
+sections at the end of the prompt:
+
+1. **Durable design decisions** — supervisor-curated rules. If your
+   proposed finding overlaps with an entry, do NOT output it. The
+   only exception is the explicit exit condition stated in the
+   entry. Treat these as load-bearing.
+
+2. **Currently open auto-improve issues** — if your proposed finding
+   overlaps with any listed issue by topic (not just fingerprint),
+   do NOT output it. This includes issues labelled `merged`: a
+   merged fix may still appear in the analyzed transcripts because
+   historical sessions predate the fix. An issue is only considered
+   fully resolved once it is **closed**, not when its PR merges.
+
+3. **Previously closed auto-improve issues** — closed issues carry
+   the supervisor's reasoning for closure (the "Closing rationale"
+   field). If your proposed finding overlaps with a closed issue's
+   rationale, do NOT re-raise it. The supervisor has already thought
+   about this signal and decided not to act on it.
+
+   The only exception: you have **concrete new evidence** that the
+   prior reasoning is wrong (for example, a precondition stated in
+   the rationale has changed, or a bug the rationale blamed has
+   been fixed). In that case, output a finding that **explicitly
+   names the prior issue number**, quotes the rationale, and
+   explains what changed. Do not silently re-raise under a fresh
+   slug.
+
+Only raise findings whose pattern has no related open issue, no
+related closed-issue rationale, and no overlapping design decision.
 
 Only output a finding when:
 

--- a/prompts/backend-fix.md
+++ b/prompts/backend-fix.md
@@ -83,6 +83,25 @@ Grep, and Glob instead.
    Grep or Read calls. A single Explore subagent can parallelize
    the search internally, saving tokens and tool-call rounds.
 
+## Check the design decisions first
+
+If a `## Durable design decisions` section is appended to this
+prompt, **read every entry before doing anything else**. Those
+entries are supervisor-curated rules that override the issue you've
+been handed. If the issue you're working on overlaps with a design
+decision (the issue is asking you to do something the decision
+explicitly forbids), do not make the change. Instead, exit with
+**zero diff** and print a short paragraph to stdout that:
+
+1. Names the design-decision entry by title
+2. Quotes the relevant rule
+3. Explains how the issue overlaps it
+4. Suggests the issue should be closed referencing the decision
+
+This is the analyzer's safety net: a finding may have slipped past
+the analyze step's filters, and refusing to act on it here is the
+defense-in-depth that breaks the spin loop.
+
 ## When to make NO changes (and exit cleanly)
 
 Producing **zero diff** is a valid outcome — the wrapper detects an
@@ -96,6 +115,7 @@ another run can try later. You should exit without changes when:
   or any of the GitHub workflows in a way you're not confident about
 - The remediation in the issue body is vague enough that you can't
   confidently translate it into code
+- The issue overlaps a durable design decision (see above)
 - You'd be guessing
 
 In all of these cases, **print a short paragraph to stdout

--- a/prompts/design-decisions.md
+++ b/prompts/design-decisions.md
@@ -1,0 +1,66 @@
+# Design decisions
+
+This file is a curated, durable record of design decisions that have
+been made for `robotsix-cai`. Subagents that decide what to raise or
+fix (`analyze`, `audit`, `fix`) read this file before making any
+raise/skip/fix decision. Entries override and supersede any signal
+from parsed transcripts: if a finding overlaps with an entry below,
+do **not** raise or act on it.
+
+The format for each entry:
+
+- **Decision:** the rule, stated in one or two sentences.
+- **Why:** the reasoning, including any prior incident or signal
+  this rule was created in response to.
+- **Related:** links to issues / PRs that produced or reinforce this
+  decision.
+- **Exit condition:** what would have to change for this rule to be
+  worth revisiting. Without this, decisions calcify forever.
+
+If a finding seems to contradict an entry below, you have two
+choices:
+
+1. **Skip the finding** (default). Output `No findings.` for that
+   pattern.
+2. **Raise a meta-issue** that explicitly names the design-decision
+   entry, presents the new evidence, and argues the exit condition
+   has been met. Do not silently re-raise the original finding.
+
+---
+
+## Do not inline file contents into `-p` prompts to "reduce exploration"
+
+**Decision:** Reject any finding that proposes adding file paths,
+file contents, or a project layout manifest to subagent prompts on
+the basis of "low input tokens", "blind exploration", or
+"prompt-quality" evidence derived from the parsed transcript signals.
+
+**Why:** The "low input tokens" / "tools-per-input-token" signal
+comes from a `parse.py` token-counting bug — the parser omits the
+system prompt and most assistant message contributions, so the
+reported input-token count for a session can be 1-2 orders of
+magnitude lower than the prompt the subagent actually received.
+Numbers like "97 input tokens across 41 tool calls" or "141 input
+tokens across 51 tool calls" are mathematically incompatible with
+the multi-thousand-token system prompts and issue bodies that the
+fix subagent receives as its first message.
+
+The analyzer's interpretation ("the prompt has insufficient
+context") is downstream of the parser bug, not a real code issue.
+The proposed remediation (inline more file paths or content into
+prompts) would bloat every fix-subagent invocation without
+addressing the underlying parser bug, and the analyzer would still
+see the same wrong signal on the next run.
+
+**Related:** Closed damien-robotsix/robotsix-cai#23,
+damien-robotsix/robotsix-cai#141. Spin-loop audit
+damien-robotsix/robotsix-cai#254 (3 PRs rejected in 25 minutes
+trying to act on the phantom finding). Tracking
+damien-robotsix/robotsix-cai#260.
+
+**Exit condition:** Revisit only if `parse.py`'s token counting is
+fixed (specifically: it correctly accumulates input from system
+prompts and assistant messages, not just user messages) AND the
+same "low input tokens / high output tokens" pattern still appears
+in the parsed signals. Until both conditions hold, this entry
+applies.


### PR DESCRIPTION
Refs #260. Closes the analyzer spin-loop class triggered by #254.

## Problem

The analyzer rediscovers issues that have already been closed by reasoned design choice and re-raises them under fresh fingerprints. Concrete chain:

- **#23** (closed 2026-04-09) — supervisor closed it as "downstream of a `parse.py` token-counting bug, the proposed remediation would bloat prompts without addressing root cause"
- **#141** (just closed) — same observation, fingerprint `sparse-prompt-context` instead of `low-input-token-context`. The analyzer never saw #23's rationale because `cmd_analyze` fetches only OPEN issues.
- **#242, #245, #250** — three rejected fix PRs in 25 minutes
- **#254** — `loop_stuck` audit raising the alarm

Root cause at cai.py:295-303: closed-issue rationales evaporate the moment an issue is closed.

## Two layers

### Layer 1 — closed-issue rationales fed to the analyzer

- New helpers \`_fetch_closed_auto_improve_issues()\` and \`_closed_issues_block()\`
- \`cmd_analyze\` fetches up to 50 recently closed auto-improve issues, extracts the last non-bot comment as the closing rationale, and includes them in a \`## Previously closed auto-improve issues\` block
- \`prompts/backend-auto-improve.md\` filter section rewritten to instruct the analyzer to consult the closed-issues block and refuse to re-raise overlapping findings unless concrete new evidence proves the prior reasoning wrong (in which case it must explicitly cite the prior issue number)

### Layer 2 — durable design decisions

- New \`prompts/design-decisions.md\` (curated, supervisor-edited). Format: Decision / Why / Related / Exit condition.
- New helper \`_design_decisions_block()\` reads the file and wraps it as a prompt section.
- Block prepended to all three subagents that decide what to raise/skip/fix:
  - \`cmd_analyze\` — primary filter
  - \`cmd_audit\` — audit shouldn't flag patterns the supervisor accepts
  - \`_build_fix_prompt\` — refuses to act on a finding that overlaps a decision, even if the finding slipped past analyze (defense in depth)
- \`prompts/backend-fix.md\` gains a "Check the design decisions first" section: exit with zero diff and surface the conflict rather than make the change.
- \`prompts/backend-audit.md\` lists design decisions as input #1.

### Seeded decision entry

The seed \`design-decisions.md\` documents the parse.py-token-counting decision in detail, references closed #23 / #141 / spin-loop audit #254, and includes the explicit exit condition (parse.py token counting is fixed AND the same signal still appears).

## Why both layers

| Layer | Source | Lifetime | Maintenance |
|---|---|---|---|
| 1 — closed-issue rationales | derived from \`gh issue list\` | until issue ages out of the lookback window | none — fully automatic |
| 2 — design decisions file | supervisor-curated | indefinite | edit the markdown file |

The two reinforce each other. A closure rationale that keeps re-firing is the signal to promote it to a Layer-2 entry; the implementation could later surface that suggestion automatically.

## Test plan
- [ ] Run \`cai analyze\` against signals that previously produced #141-style findings — expect \`No findings.\` (or a finding that explicitly cites #23/#141 and the design-decisions entry)
- [ ] Verify the closed-issues block in the analyzer's actual prompt input by adding a temporary stdout dump
- [ ] Verify \`cmd_audit\`'s prompt also contains the design-decisions block
- [ ] Verify \`_build_fix_prompt\` for any open issue contains the block
- [ ] Hand the fix subagent a fake issue that violates the seeded design decision (e.g. "Add file paths to fix prompts to reduce exploration"); expect zero diff + a stdout paragraph naming the decision entry
- [ ] Confirm an unrelated open issue still gets raised normally — the filter is closed-only, open-issue dedup is unchanged

## Notes
- Independent of the rebase-improvement PR damien-robotsix/robotsix-cai#257; either can land first
- The Dockerfile already does \`COPY prompts /app/prompts\` so the new file ships automatically
- No new dependencies, no schema changes, no migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)