### PR TITLE
auto-improve: Successful PR reject (close) does not remove stale `merge-blocked` label

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -518,7 +518,7 @@ def _recover_stale_pr_open(issues: list[dict], *, log_prefix: str = "cai") -> li
         if state == "CLOSED":
             issue_labels = {lbl["name"] for lbl in issue.get("labels", [])}
             raised_label = LABEL_AUDIT_RAISED if LABEL_AUDIT_RAISED in issue_labels else LABEL_RAISED
-            if _set_labels(issue["number"], add=[raised_label], remove=[LABEL_PR_OPEN]):
+            if _set_labels(issue["number"], add=[raised_label], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED]):
                 print(
                     f"[{log_prefix}] recovered stale :pr-open on #{issue['number']} "
                     f"(PR #{pr['number']} closed unmerged)",

--- a/cai.py
+++ b/cai.py
@@ -3690,13 +3690,13 @@ def cmd_merge(args) -> int:
             )
             if close_result.returncode == 0:
                 print(f"[cai merge] PR #{pr_number}: closed successfully", flush=True)
-                if not _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN]):
+                if not _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED]):
                     print(
                         f"[cai merge] WARNING: label transition to :no-action failed for "
                         f"#{issue_number} after closing PR #{pr_number}; retrying",
                         flush=True,
                     )
-                    if not _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN]):
+                    if not _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED]):
                         print(
                             f"[cai merge] WARNING: label transition to :no-action failed twice for "
                             f"#{issue_number} — issue may be stuck without a lifecycle label",


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#202

**Issue:** #202 — Successful PR reject (close) does not remove stale `merge-blocked` label

## PR Summary

### What this fixes
When a PR is rejected and closed in `cmd_merge`, the `merge-blocked` label was not removed from the issue. If the PR had previously been held (which adds `merge-blocked`), that stale label would persist alongside `no-action`.

### What was changed
- `cai.py` (lines ~3693, ~3699): Added `LABEL_MERGE_BLOCKED` to the `remove` list in both the primary and retry `_set_labels` calls that run after a PR is successfully closed as a reject.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
