### PR TITLE
auto-improve: Revise subcommand: other `exit=1` failure paths don't propagate to function return code

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -1566,6 +1566,7 @@ def cmd_revise(args) -> int:
 
     print(f"[cai revise] found {len(targets)} PR(s) to revise", flush=True)
 
+    had_failure = False
     for target in targets:
         pr_number = target["pr_number"]
         issue_number = target["issue_number"]
@@ -1586,6 +1587,7 @@ def cmd_revise(args) -> int:
             )
             log_run("revise", repo=REPO, pr=pr_number,
                     result="lock_failed", exit=1)
+            had_failure = True
             continue
 
         _run(["gh", "auth", "setup-git"], capture_output=True)
@@ -1610,6 +1612,7 @@ def cmd_revise(args) -> int:
                 _set_labels(issue_number, remove=[LABEL_REVISING])
                 log_run("revise", repo=REPO, pr=pr_number,
                         result="clone_failed", exit=1)
+                had_failure = True
                 continue
 
             _git(work_dir, "fetch", "origin", branch)
@@ -1701,6 +1704,7 @@ def cmd_revise(args) -> int:
                     _set_labels(issue_number, remove=[LABEL_REVISING])
                     log_run("revise", repo=REPO, pr=pr_number,
                             result="rebase_push_failed", exit=1)
+                    had_failure = True
                     continue
 
                 print(
@@ -1870,11 +1874,12 @@ def cmd_revise(args) -> int:
             _set_labels(issue_number, remove=[LABEL_REVISING])
             log_run("revise", repo=REPO, pr=pr_number,
                     result="unexpected_error", exit=1)
+            had_failure = True
         finally:
             if work_dir.exists():
                 shutil.rmtree(work_dir, ignore_errors=True)
 
-    return 0
+    return 1 if had_failure else 0
 
 
 # ---------------------------------------------------------------------------

--- a/cai.py
+++ b/cai.py
@@ -1795,6 +1795,7 @@ def cmd_revise(args) -> int:
                 _set_labels(issue_number, remove=[LABEL_REVISING])
                 log_run("revise", repo=REPO, pr=pr_number,
                         comments_addressed=0, exit=agent.returncode)
+                had_failure = True
                 continue
 
             # 7. Inspect the working tree.
@@ -1845,6 +1846,7 @@ def cmd_revise(args) -> int:
                 _set_labels(issue_number, remove=[LABEL_REVISING])
                 log_run("revise", repo=REPO, pr=pr_number,
                         result="push_failed", exit=1)
+                had_failure = True
                 continue
 
             print(f"[cai revise] force-pushed revision to {branch}", flush=True)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#208

**Issue:** #208 — Revise subcommand: other `exit=1` failure paths don't propagate to function return code

## PR Summary

### What this fixes
`cmd_revise` in `cai.py` had several failure paths (`lock_failed`, `clone_failed`, `rebase_push_failed`, `unexpected_error`) that logged `exit=1` but continued through the loop without tracking the failure, causing the function to always return 0.

### What was changed
- `cai.py`: Added `had_failure = False` before the revision loop and set `had_failure = True` after each of the four `exit=1` failure paths (`lock_failed`, `clone_failed`, `rebase_push_failed`, `unexpected_error`). Changed the final `return 0` to `return 1 if had_failure else 0` so the function's return code reflects whether any iteration failed.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
