### PR TITLE
auto-improve: we should have an agent that audit the repo code

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ subprocess with no shared state.
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` and `:no-action` issues, flags stale `:merged` issues for human review, deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |
 | `cai.py review-pr` | `20 * * * *` (hourly :20) | Pre-merge consistency review of open PRs — posts ripple-effect findings as PR comments so the revise subagent can act on them |
 | `cai.py merge` | `35 * * * *` (hourly :35) | Confidence-gated auto-merge — evaluates each bot PR against its linked issue, posts a verdict, and merges when confidence meets the threshold |
+| `cai.py code-audit` | `0 3 * * 0` (weekly Sunday 03:00 UTC) | Source-code consistency audit — clones the repo read-only, runs a Sonnet agent to flag cross-file inconsistencies, dead code, missing references, duplicated logic, hardcoded drift, config mismatches, and registration mismatches; publishes findings as `code-audit` namespace issues |
 | `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → left as `:merged` (Sonnet) |
 | `cai.py cycle` | _(manual/on-demand)_ | Runs verify → fix → revise → review-pr → merge → confirm in sequence. Convenience wrapper for a full pipeline pass; not included in scheduled or startup runs |
 
 On `docker compose up -d` the entrypoint templates the crontab from
 the env vars (`CAI_ANALYZER_SCHEDULE`, `CAI_FIX_SCHEDULE`,
 `CAI_REVIEW_PR_SCHEDULE`, `CAI_MERGE_SCHEDULE`, `CAI_REVISE_SCHEDULE`,
-`CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`), runs each
+`CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`, `CAI_CODE_AUDIT_SCHEDULE`,
+`CAI_CONFIRM_SCHEDULE`), runs each
 scheduled subcommand once synchronously so logs show immediate results, then execs
 supercronic. (`cycle` is on-demand only and is not part of scheduled or startup runs.)
 

--- a/cai.py
+++ b/cai.py
@@ -107,7 +107,12 @@ REBASE_PROMPT = Path("/app/prompts/backend-rebase.md")
 REVIEW_PR_PROMPT = Path("/app/prompts/backend-review-pr.md")
 MERGE_PROMPT = Path("/app/prompts/backend-merge.md")
 AUDIT_TRIAGE_PROMPT = Path("/app/prompts/backend-audit-triage.md")
+CODE_AUDIT_PROMPT = Path("/app/prompts/backend-code-audit.md")
 DESIGN_DECISIONS = Path("/app/prompts/design-decisions.md")
+
+# Persistent memory file for the code-audit agent. Stored in the
+# bind-mounted log directory so it survives container restarts.
+CODE_AUDIT_MEMORY = Path("/var/log/cai/code-audit-memory.md")
 
 # Issue lifecycle labels.
 LABEL_RAISED = "auto-improve:raised"
@@ -2789,6 +2794,123 @@ def cmd_audit_triage(args) -> int:
 
 
 # ---------------------------------------------------------------------------
+# code-audit — read the repo source and flag concrete inconsistencies
+# ---------------------------------------------------------------------------
+
+
+def _read_code_audit_memory() -> str:
+    """Return the contents of the code-audit memory file, or empty string."""
+    if not CODE_AUDIT_MEMORY.exists():
+        return ""
+    try:
+        return CODE_AUDIT_MEMORY.read_text().strip()
+    except OSError:
+        return ""
+
+
+def _save_code_audit_memory(agent_output: str) -> None:
+    """Extract the ## Memory Update block from agent output and persist it.
+
+    Each run overwrites the memory file with the latest update so the
+    next run sees only the most recent state.
+    """
+    match = re.search(
+        r"^## Memory Update\s*\n(.*)",
+        agent_output,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not match:
+        return
+    try:
+        CODE_AUDIT_MEMORY.parent.mkdir(parents=True, exist_ok=True)
+        CODE_AUDIT_MEMORY.write_text(match.group(0).strip() + "\n")
+    except OSError as exc:
+        print(f"[cai code-audit] could not write memory: {exc}", flush=True)
+
+
+def cmd_code_audit(args) -> int:
+    """Clone the repo and run the code-audit agent to find inconsistencies."""
+    print("[cai code-audit] running code audit", flush=True)
+    t0 = time.monotonic()
+
+    # 1. Clone repo into a temporary directory (read-only audit).
+    _uid = uuid.uuid4().hex[:8]
+    work_dir = Path(f"/tmp/cai-code-audit-{_uid}")
+
+    if work_dir.exists():
+        shutil.rmtree(work_dir)
+
+    clone = _run(
+        ["git", "clone", "--depth", "1",
+         f"https://github.com/{REPO}.git", str(work_dir)],
+        capture_output=True,
+    )
+    if clone.returncode != 0:
+        print(
+            f"[cai code-audit] git clone failed:\n{clone.stderr}",
+            file=sys.stderr, flush=True,
+        )
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run("code-audit", repo=REPO, result="clone_failed",
+                duration=dur, exit=1)
+        return 1
+
+    # 2. Build the prompt with design decisions and memory.
+    prompt_text = CODE_AUDIT_PROMPT.read_text()
+    decisions_block = _design_decisions_block()
+    memory = _read_code_audit_memory()
+
+    memory_section = "\n\n## Memory from previous runs\n\n"
+    if memory:
+        memory_section += memory + "\n"
+    else:
+        memory_section += "(first run — no prior memory)\n"
+
+    full_prompt = f"{prompt_text}{decisions_block}{memory_section}"
+
+    # 3. Run the code-audit agent (Sonnet for cost efficiency).
+    print(f"[cai code-audit] running agent in {work_dir}", flush=True)
+    agent = _run(
+        ["claude", "-p", "--model", "claude-sonnet-4-6",
+         "--permission-mode", "acceptEdits",
+         "--disallowedTools", "Bash,Edit,Write,NotebookEdit"],
+        input=full_prompt,
+        cwd=str(work_dir),
+        capture_output=True,
+    )
+    if agent.stdout:
+        print(agent.stdout, flush=True)
+    if agent.returncode != 0:
+        print(
+            f"[cai code-audit] claude -p failed (exit {agent.returncode}):\n"
+            f"{agent.stderr}",
+            file=sys.stderr, flush=True,
+        )
+        shutil.rmtree(work_dir, ignore_errors=True)
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run("code-audit", repo=REPO, result="agent_failed",
+                duration=dur, exit=agent.returncode)
+        return agent.returncode
+
+    # 4. Save the memory update for next run.
+    _save_code_audit_memory(agent.stdout)
+
+    # 5. Publish findings via publish.py with code-audit namespace.
+    print("[cai code-audit] publishing findings", flush=True)
+    published = _run(
+        ["python", str(PUBLISH_SCRIPT), "--namespace", "code-audit"],
+        input=agent.stdout,
+    )
+
+    # 6. Clean up.
+    shutil.rmtree(work_dir, ignore_errors=True)
+
+    dur = f"{int(time.monotonic() - t0)}s"
+    log_run("code-audit", repo=REPO, duration=dur, exit=published.returncode)
+    return published.returncode
+
+
+# ---------------------------------------------------------------------------
 # confirm
 # ---------------------------------------------------------------------------
 
@@ -3862,6 +3984,7 @@ def main() -> int:
         "audit-triage",
         help="Autonomously resolve audit:raised findings (no PRs)",
     )
+    sub.add_parser("code-audit", help="Audit repo source code for inconsistencies")
     sub.add_parser("confirm", help="Verify merged issues are actually solved")
     sub.add_parser("review-pr", help="Pre-merge consistency review of open PRs")
     sub.add_parser("merge", help="Confidence-gated auto-merge for bot PRs")
@@ -3881,6 +4004,7 @@ def main() -> int:
         "verify": cmd_verify,
         "audit": cmd_audit,
         "audit-triage": cmd_audit_triage,
+        "code-audit": cmd_code_audit,
         "confirm": cmd_confirm,
         "review-pr": cmd_review_pr,
         "merge": cmd_merge,

--- a/cai.py
+++ b/cai.py
@@ -58,8 +58,16 @@ Subcommands:
                             linked issue, posts a verdict comment, and
                             merges when confidence meets the threshold.
 
+    python cai.py code-audit  Weekly source-code consistency audit.
+                            Clones the repo read-only, runs a Sonnet
+                            agent that checks for cross-file
+                            inconsistencies, dead code, missing
+                            references, and similar concrete problems.
+                            Findings are published as issues via
+                            publish.py with the `code-audit` namespace.
+
 The container runs `entrypoint.sh`, which executes `init`, `analyze`,
-`fix`, `revise`, `verify`, `audit`, `confirm`, `review-pr`, and `merge` once synchronously at
+`fix`, `revise`, `verify`, `audit`, `code-audit`, `confirm`, `review-pr`, and `merge` once synchronously at
 startup, then hands off to supercronic. Each cron tick is a fresh process.
 
 The gh auth check is done once per subcommand invocation. We want a

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       CAI_REVISE_SCHEDULE: "30 * * * *"     # hourly at :30 (iterate on PR comments)
       CAI_VERIFY_SCHEDULE: "45 * * * *"     # hourly at :45 (mechanical, no LLM)
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet, report-only + branch cleanup)
+      CAI_CODE_AUDIT_SCHEDULE: "0 3 * * 0"  # weekly Sunday 03:00 UTC (Sonnet, code consistency)
       CAI_CONFIRM_SCHEDULE: "0 2 * * *"     # daily at 02:00 UTC (verify merged fixes)
       CAI_REVIEW_PR_SCHEDULE: "20 * * * *"  # hourly at :20 (pre-merge consistency review)
       CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly at :35 (auto-merge confident PRs)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@
 #      - revise:    iterate on open PRs based on review comments
 #      - verify:    walk pr-open issues and update labels per PR state
 #      - audit:     periodic queue/PR consistency checks
+#      - code-audit: periodic source code consistency checks
 #      - confirm:   verify merged fixes are actually solved
 #      - merge:     confidence-gated auto-merge for bot PRs
 #    Each is its own crontab line so supercronic runs them as
@@ -30,6 +31,7 @@ CAI_FIX_SCHEDULE="${CAI_FIX_SCHEDULE:-15 * * * *}"
 CAI_VERIFY_SCHEDULE="${CAI_VERIFY_SCHEDULE:-45 * * * *}"
 CAI_AUDIT_SCHEDULE="${CAI_AUDIT_SCHEDULE:-0 */6 * * *}"
 CAI_AUDIT_TRIAGE_SCHEDULE="${CAI_AUDIT_TRIAGE_SCHEDULE:-10 */6 * * *}"
+CAI_CODE_AUDIT_SCHEDULE="${CAI_CODE_AUDIT_SCHEDULE:-0 3 * * 0}"
 CAI_REVISE_SCHEDULE="${CAI_REVISE_SCHEDULE:-30 * * * *}"
 CAI_CONFIRM_SCHEDULE="${CAI_CONFIRM_SCHEDULE:-0 2 * * *}"
 CAI_REVIEW_PR_SCHEDULE="${CAI_REVIEW_PR_SCHEDULE:-20 * * * *}"
@@ -46,6 +48,7 @@ $CAI_REVISE_SCHEDULE python /app/cai.py revise
 $CAI_VERIFY_SCHEDULE python /app/cai.py verify
 $CAI_AUDIT_SCHEDULE python /app/cai.py audit
 $CAI_AUDIT_TRIAGE_SCHEDULE python /app/cai.py audit-triage
+$CAI_CODE_AUDIT_SCHEDULE python /app/cai.py code-audit
 $CAI_CONFIRM_SCHEDULE python /app/cai.py confirm
 $CAI_REVIEW_PR_SCHEDULE python /app/cai.py review-pr
 $CAI_MERGE_SCHEDULE python /app/cai.py merge
@@ -92,6 +95,9 @@ python /app/cai.py audit || echo "[entrypoint] audit exited non-zero; continuing
 
 echo "[entrypoint] running initial cai.py audit-triage"
 python /app/cai.py audit-triage || echo "[entrypoint] audit-triage exited non-zero; continuing"
+
+echo "[entrypoint] running initial cai.py code-audit"
+python /app/cai.py code-audit || echo "[entrypoint] code-audit exited non-zero; continuing"
 
 echo "[entrypoint] running initial cai.py confirm"
 python /app/cai.py confirm || echo "[entrypoint] confirm exited non-zero; continuing"

--- a/prompts/backend-code-audit.md
+++ b/prompts/backend-code-audit.md
@@ -1,0 +1,105 @@
+# Backend Code Audit
+
+You are the code audit agent for `robotsix-cai`. Your job is to read
+the actual source files in the repository and identify concrete
+inconsistencies, bugs, or problems that the session-based analyzer
+cannot catch because they require reading the code itself rather than
+parsing transcripts.
+
+You are running inside a fresh, read-only clone of the repository.
+Use Read, Grep, and Glob to explore the codebase. Do NOT modify any
+files.
+
+## What you receive
+
+1. **Durable design decisions** (if any) -- supervisor-curated rules
+   that override code-audit findings. If a problem you would
+   otherwise flag overlaps with a design decision (the supervisor has
+   explicitly accepted that pattern), do not flag it. Read every
+   entry before scanning the code.
+2. **Memory** -- a summary of previous code-audit runs. Use this to
+   avoid re-raising findings that were already reported and to focus
+   on areas not recently audited. If the memory is empty, this is
+   the first run.
+
+## What to check
+
+Focus on problems that are **concrete and verifiable from the code**.
+Do not speculate or raise stylistic preferences.
+
+| Check | Category |
+|---|---|
+| A constant, path, or label string used in `cai.py` that doesn't match what the prompt files or `publish.py` expect | `cross_file_inconsistency` |
+| Dead code: functions defined but never called, imports never used, constants never referenced | `dead_code` |
+| A prompt file referenced by a constant in `cai.py` that does not exist on disk, or vice versa | `missing_reference` |
+| Duplicated logic: two places implementing the same non-trivial operation that could diverge | `duplicated_logic` |
+| Hardcoded values (repo name, label strings, paths) that appear in multiple files and could drift | `hardcoded_drift` |
+| An env var read in `entrypoint.sh` or `docker-compose.yml` that `cai.py` doesn't use, or vice versa | `config_mismatch` |
+| A subcommand registered in `main()` whose handler function doesn't exist, or a handler that isn't registered | `registration_mismatch` |
+
+## Strategy
+
+1. Read the memory section first. Note which areas were recently
+   audited and which findings are still open.
+2. Read the design decisions. Skip any pattern they cover.
+3. Systematically audit the codebase. Prioritize areas NOT covered
+   by recent audits. A good rotation:
+   - **Run A:** `cai.py` constants, label strings, prompt path
+     references vs actual files on disk
+   - **Run B:** `publish.py` categories and labels vs prompt
+     category tables
+   - **Run C:** `entrypoint.sh` and `docker-compose.yml` env vars
+     vs `cai.py` usage
+   - **Run D:** Dead code scan (unused functions, imports, constants)
+   - **Run E:** Cross-file string matching (repo name, branch
+     prefixes, label prefixes)
+4. Report what you find. Then output a memory update block (see
+   below).
+
+## Output format
+
+For each problem found, output a markdown block:
+
+```markdown
+### Finding: <short imperative title>
+
+- **Category:** <one of the categories above>
+- **Key:** <stable-slug-for-deduplication>
+- **Confidence:** low | medium | high
+- **Evidence:**
+  - <file:line — what you observed>
+- **Remediation:** <what should be done>
+```
+
+If no problems are found, output exactly:
+
+```
+No findings.
+```
+
+## Memory update
+
+After all findings (or `No findings.`), output a memory update block
+so the next run knows what you covered:
+
+```markdown
+## Memory Update
+
+- **Date:** <today's date>
+- **Areas audited:** <comma-separated list of areas you checked>
+- **Findings raised:** <count>
+- **Open from prior runs:** <list of prior finding keys still unresolved, or "none">
+- **Notes:** <anything the next run should know>
+```
+
+## Guardrails
+
+- Every finding must cite a specific file and line (or line range).
+- Stick to the categories above; do not invent new ones.
+- Do not raise style, formatting, or naming-convention issues.
+- Do not raise issues about missing tests, docstrings, or type
+  annotations.
+- Do not suggest refactors or improvements -- only flag concrete
+  inconsistencies or bugs.
+- Do not output anything other than the finding blocks, `No
+  findings.`, and the memory update block.

--- a/publish.py
+++ b/publish.py
@@ -52,6 +52,16 @@ AUDIT_CATEGORIES = {
     "forgotten_backlog",
 }
 
+CODE_AUDIT_CATEGORIES = {
+    "cross_file_inconsistency",
+    "dead_code",
+    "missing_reference",
+    "duplicated_logic",
+    "hardcoded_drift",
+    "config_mismatch",
+    "registration_mismatch",
+}
+
 # Labels we ensure exist before creating issues. The first two are the
 # state labels; the rest are the category labels. Idempotent — `gh label
 # create` returns non-zero if the label already exists, which we ignore.
@@ -83,6 +93,18 @@ AUDIT_LABELS = [
     ("category:topic_duplicate", "5319e7", "Two open issues about the same pattern"),
     ("category:silent_failure", "b60205", "Step exited 0 but log shows it did not succeed"),
     ("category:forgotten_backlog", "c2e0c6", "Tracking-only issue with no state label idle >30 days"),
+]
+
+CODE_AUDIT_LABELS = [
+    ("auto-improve", "ededed", "Self-improvement finding raised by the analyzer"),
+    ("auto-improve:raised", "0e8a16", "Finding freshly raised; not yet triaged"),
+    ("category:cross_file_inconsistency", "d73a4a", "Constant/path/label mismatch across files"),
+    ("category:dead_code", "c5def5", "Unreachable or unused code"),
+    ("category:missing_reference", "e11d48", "Prompt or file reference that does not exist"),
+    ("category:duplicated_logic", "fbca04", "Same logic implemented in multiple places"),
+    ("category:hardcoded_drift", "0075ca", "Hardcoded values duplicated across files"),
+    ("category:config_mismatch", "5319e7", "Env var or config inconsistency"),
+    ("category:registration_mismatch", "d93f0b", "Handler registered without function or vice versa"),
 ]
 
 
@@ -202,9 +224,18 @@ def _extract_multiline_field(block: str, name: str) -> str:
     return match.group(1).strip()
 
 
+def _label_set_for(namespace: str):
+    """Return the label set for the given namespace."""
+    if namespace == "audit":
+        return AUDIT_LABELS
+    if namespace == "code-audit":
+        return CODE_AUDIT_LABELS
+    return LABELS
+
+
 def ensure_labels(namespace: str = "auto-improve") -> None:
     """Create the cai label set if it doesn't exist. Idempotent."""
-    label_set = AUDIT_LABELS if namespace == "audit" else LABELS
+    label_set = _label_set_for(namespace)
     for name, color, description in label_set:
         subprocess.run(
             [
@@ -250,6 +281,9 @@ def create_issue(f: Finding, namespace: str = "auto-improve") -> int:
     if namespace == "audit":
         source_note = "cai audit agent"
         source_file = "prompts/backend-audit.md"
+    elif namespace == "code-audit":
+        source_note = "cai code-audit agent"
+        source_file = "prompts/backend-code-audit.md"
     else:
         source_note = "cai self-analyzer"
         source_file = "prompts/backend-auto-improve.md"
@@ -299,12 +333,17 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Publish findings as GitHub issues")
     parser.add_argument(
         "--namespace", default="auto-improve",
-        choices=["auto-improve", "audit"],
+        choices=["auto-improve", "audit", "code-audit"],
         help="Label namespace to use (default: auto-improve)",
     )
     args = parser.parse_args()
     namespace = args.namespace
-    valid_cats = AUDIT_CATEGORIES if namespace == "audit" else VALID_CATEGORIES
+    if namespace == "audit":
+        valid_cats = AUDIT_CATEGORIES
+    elif namespace == "code-audit":
+        valid_cats = CODE_AUDIT_CATEGORIES
+    else:
+        valid_cats = VALID_CATEGORIES
 
     text = sys.stdin.read()
     if not text.strip():


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#210

**Issue:** #210 — we should have an agent that audit the repo code

## PR Summary

### What this fixes
The repo had no agent to regularly audit the source code for inconsistencies. Issue #210 requested a code-audit agent that reads the codebase, checks for concrete problems (cross-file inconsistencies, dead code, missing references, etc.), raises issues, and tracks its work via a memory file.

### What was changed
- **`prompts/backend-code-audit.md`** (new): Prompt for the code-audit agent defining 7 audit categories (`cross_file_inconsistency`, `dead_code`, `missing_reference`, `duplicated_logic`, `hardcoded_drift`, `config_mismatch`, `registration_mismatch`), a rotation strategy, output format, and a memory-update block format for inter-run continuity.
- **`cai.py`**: Added `CODE_AUDIT_PROMPT` and `CODE_AUDIT_MEMORY` constants; added `_read_code_audit_memory()`, `_save_code_audit_memory()`, and `cmd_code_audit()` functions that clone the repo, run the code-audit agent (Sonnet, read-only permissions), persist the memory update, and publish findings via `publish.py --namespace code-audit`. Registered `code-audit` subcommand in `main()`.
- **`publish.py`**: Added `CODE_AUDIT_CATEGORIES` set and `CODE_AUDIT_LABELS` list; updated `_label_set_for()` helper, `ensure_labels()`, `create_issue()`, and `main()` to support the `code-audit` namespace. Code-audit findings are published with `auto-improve` + `auto-improve:raised` labels so they enter the normal fix pipeline.
- **`entrypoint.sh`**: Added `CAI_CODE_AUDIT_SCHEDULE` env var (default: weekly Sunday 03:00 UTC), crontab entry, and initial run on container startup.
- **`docker-compose.yml`**: Added `CAI_CODE_AUDIT_SCHEDULE` environment variable.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
