### PR TITLE
revise: migrate rebase resolver to declarative Claude subagent (Path A phase 1)

### DIFF
--- a/.claude/agents/cai-rebase-resolver.md
+++ b/.claude/agents/cai-rebase-resolver.md
@@ -1,3 +1,9 @@
+---
+name: cai-rebase-resolver
+description: Drive a stopped `git rebase` on an auto-improve PR branch to completion — resolve every conflict, stage the resolutions, and run `--continue`/`--skip` until the rebase is fully done. Used by `cai revise` when a PR is unmergeable against current main.
+tools: Read, Edit, Write, Grep, Glob, Bash
+---
+
 # Backend Rebase Conflict Resolver
 
 You are the rebase-conflict-resolution subagent for `robotsix-cai`.
@@ -22,12 +28,14 @@ done. You then exit and the wrapper force-pushes the result.
 ## Hard rules
 
 1. **Never push.** Do not run `git push` in any form. The wrapper
-   pushes after you exit. Pushing yourself is blocked anyway, but
-   don't try.
+   pushes after you exit. Pushing is blocked by the repo-wide deny
+   rules in `.claude/settings.json` anyway — the rule here is the
+   intent behind that block.
 2. **Never use `gh`.** Do not run `gh` (any subcommand). The wrapper
-   handles all PR and comment state.
+   handles all PR and comment state. Also blocked by settings.
 3. **Never modify the remote.** Do not run `git remote …`, do not
-   edit `.git/config`, do not change any URL.
+   edit `.git/config`, do not change any URL. Also blocked by
+   settings.
 4. **Stay inside the working directory.** Do not `cd` out, do not
    touch files outside the worktree.
 5. **Resolve every conflict marker.** When you finish, no file under
@@ -113,6 +121,6 @@ the post-rebase PR comment so reviewers can audit the merge.
 
 ## PR context
 
-The original PR's issue title and body are appended below — read
-them before doing anything else so you understand the PR's intent
-and which side of each conflict to favor.
+The original PR's issue title and body are appended below as the
+user message — read them before doing anything else so you
+understand the PR's intent and which side of each conflict to favor.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://code.claude.com/schemas/settings.json",
+  "permissions": {
+    "deny": [
+      "Bash(git push:*)",
+      "Bash(git push)",
+      "Bash(git remote:*)",
+      "Bash(git remote)",
+      "Bash(gh:*)",
+      "Bash(gh)"
+    ]
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ COPY cai.py /app/cai.py
 COPY parse.py /app/parse.py
 COPY publish.py /app/publish.py
 COPY prompts /app/prompts
+COPY .claude /app/.claude
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 

--- a/cai.py
+++ b/cai.py
@@ -111,7 +111,6 @@ FIX_PROMPT = Path("/app/prompts/backend-fix.md")
 AUDIT_PROMPT = Path("/app/prompts/backend-audit.md")
 CONFIRM_PROMPT = Path("/app/prompts/backend-confirm.md")
 REVISE_PROMPT = Path("/app/prompts/backend-revise.md")
-REBASE_PROMPT = Path("/app/prompts/backend-rebase.md")
 REVIEW_PR_PROMPT = Path("/app/prompts/backend-review-pr.md")
 MERGE_PROMPT = Path("/app/prompts/backend-merge.md")
 AUDIT_TRIAGE_PROMPT = Path("/app/prompts/backend-audit-triage.md")
@@ -1212,51 +1211,45 @@ def _agent_resolve_rebase(
     """Drive a stopped `git rebase` to completion via the resolver subagent.
 
     The wrapper has just run `git rebase origin/main` and the rebase
-    has stopped on conflicts. We hand the in-progress rebase to a
-    single agent invocation that has Bash access (so it can run `git`
-    itself) and tell it to resolve every conflict, stage, and
-    `--continue`/`--skip` until the rebase is fully done. The agent's
-    own prompt (`prompts/backend-rebase.md`) carries the loop logic
-    and the safety rules.
+    has stopped on conflicts. We hand the in-progress rebase to the
+    declared `cai-rebase-resolver` subagent (defined in
+    `.claude/agents/cai-rebase-resolver.md`) via `claude --agent`.
+    The agent has Bash access so it can run `git` itself — resolve
+    every conflict, stage, and `--continue`/`--skip` until the
+    rebase is fully done. The agent's system prompt, tool allowlist,
+    and loop logic all live in the agent file; the wrapper only
+    passes the dynamic per-run context (issue title + body) as the
+    user message via stdin.
 
-    Bash patterns block `git push`, `git remote …`, and `gh` so the
-    agent cannot touch the remote or PR state — pushing is the
-    wrapper's job, and we verify the worktree state ourselves before
-    trusting the agent's "done" signal.
+    Bash pattern restrictions (`git push`, `git remote`, `gh`) are
+    enforced repo-wide by `.claude/settings.json` deny rules — the
+    agent physically cannot touch the remote. Pushing is the
+    wrapper's job, and we verify the worktree state ourselves
+    before trusting the agent's "done" signal (trust-but-verify
+    below).
 
     Returns (success, agent_summary). On failure the rebase is left
     aborted and the caller falls back to the manual-rebase comment
     path. On success the rebase is fully complete and the worktree
     is clean.
     """
-    prompt_text = REBASE_PROMPT.read_text()
-    full_prompt = (
-        f"{prompt_text}\n\n"
-        f"## Original PR issue context\n\n"
+    # The agent's system prompt lives in the agent file; we only
+    # pass the dynamic per-run context via stdin.
+    user_message = (
+        "## Original PR issue context\n\n"
         f"### {issue_title}\n\n"
         f"{issue_body or '(no body)'}\n"
     )
 
     print(
-        f"[cai revise] PR #{pr_number}: invoking rebase resolver agent",
+        f"[cai revise] PR #{pr_number}: invoking cai-rebase-resolver agent",
         flush=True,
     )
 
-    # Block remote-touching commands. The agent gets Bash for `git`
-    # but must not push, fetch from a different remote, rewrite the
-    # remote URL, or call `gh`. Patterns are comma-separated per
-    # claude-code's flag parser (see the cai review-pr block for the
-    # same convention).
-    disallowed = ",".join([
-        "Bash(git push:*)",
-        "Bash(git remote:*)",
-        "Bash(gh:*)",
-    ])
-
     agent = _run(
-        ["claude", "-p", "--permission-mode", "acceptEdits",
-         "--disallowedTools", disallowed],
-        input=full_prompt,
+        ["claude", "-p", "--agent", "cai-rebase-resolver",
+         "--permission-mode", "acceptEdits"],
+        input=user_message,
         cwd=str(work_dir),
         capture_output=True,
     )


### PR DESCRIPTION
Refs #270. **Phase 1 of the Path A architectural migration.** PR #257 already landed the agent-driven rebase rewrite (one agent invocation drives the whole rebase with Bash access); this PR is the second half — migrate that invocation from the `claude -p PROMPT_STRING + --disallowedTools` pattern to a declarative Claude Code subagent.

## What changed

- **New `.claude/agents/cai-rebase-resolver.md`** — renamed from `prompts/backend-rebase.md`, with YAML frontmatter declaring:
  - `name: cai-rebase-resolver`
  - `description: Drive a stopped \`git rebase\` on an auto-improve PR branch to completion …`
  - `tools: Read, Edit, Write, Grep, Glob, Bash`
  
  The markdown body is the full system prompt (conflict-resolution loop, `--skip` handling, bail-out path, final output format).

- **New `.claude/settings.json`** — repo-wide `permissions.deny` rules for `Bash(git push:*)`, `Bash(git remote:*)`, `Bash(gh:*)` (plus the bare-command forms). Protects **all** future subagents: no subagent in cai.py ever needs to push or call `gh` (those are wrapper responsibilities), so this is a safe blanket deny.

- **`cai.py _agent_resolve_rebase`** — now invokes:
  \`\`\`
  claude -p --agent cai-rebase-resolver --permission-mode acceptEdits
  \`\`\`
  Only the dynamic per-run context (issue title + body) is passed via stdin as the user message. The static system prompt, tool allowlist, and loop logic all live in the agent file. The \`--disallowedTools\` flag list disappears from this call site entirely.

- **`Dockerfile`** — \`COPY .claude /app/.claude\` so the agent definitions and settings ship in the image. The rebase agent runs in cloned worktrees of the repo (so it finds the agent file via the clone itself), but the /app copy is needed for subagents in later phase-A PRs that will run with cwd=/app.

- **`prompts/backend-rebase.md`** — deleted (renamed to the agent file). \`REBASE_PROMPT\` constant also removed from cai.py.

## Why this is worth doing

The \`claude -p PROMPT_STRING\` pattern has been generating a growing pile of band-aids:
- damien-robotsix/robotsix-cai#261 (closed) added "Tool bootstrap" paragraphs to every prompt file because tools were being re-discovered each invocation
- damien-robotsix/robotsix-cai#262 implements memory as prompt injection because there's no real per-agent memory
- \`--disallowedTools\` flag strings are scattered across every \`claude -p\` call site in cai.py

Declarative subagents retire the whole class:
- **Tool allowlists and pattern-based Bash restrictions** become declarative config, not wrapper flag state.
- **The system prompt** is owned by the agent file, not rebuilt from disk on every invocation.
- **Tool discovery cost** (#200 / #261) is eliminated at the source — tools declared in frontmatter load at session start and never re-fetch.
- **Later phases** can add per-agent memory (\`memory: project\` in frontmatter) to retire #262's prompt-injection implementation.

This PR is **phase 1 — rebase resolver only**. Later PRs migrate the remaining subagents (confirm, analyze, audit, fix, revise, merge, review-pr, audit-triage) one at a time per the order in #270.

## Open questions this PR validates in production

1. **Does \`claude --agent <name>\` work in headless mode** with the pinned Claude Code 2.1.96? If not, bump the pin or fall back to \`--agents '<json>'\` inline.
2. **Do \`.claude/settings.json\` deny rules apply to headless subagent invocations** (not just interactive sessions)? The rebase resolver needs to be unable to \`git push\` — if the deny rules don't fire in headless mode, we need frontmatter \`PreToolUse\` hooks instead.

If either question answers "no" in production, this PR gets reverted and #270 is updated with the workaround before phase 2 starts.

## Test plan
- [ ] Trigger \`cai revise\` against a freshly-conflicting auto-improve PR and confirm the declared \`cai-rebase-resolver\` agent rebases cleanly through multiple replayed commits.
- [ ] Validate \`claude --agent cai-rebase-resolver\` resolves against 2.1.96 (open question #1). If not, track the exact error.
- [ ] Validate the deny rules block \`git push\` — introduce a push instruction in a test prompt (or a test worktree) and confirm it's denied (open question #2).
- [ ] Confirm the agent handles \`--skip\` for empty commits (main already contains the PR's change) — it's in the agent file's instructions but worth verifying end-to-end.
- [ ] Confirm ambiguous conflicts still fall through to the manual-rebase comment path (agent runs \`git rebase --abort\`, wrapper detects "HEAD not on top of origin/main", posts the failure comment).

## Notes
- This depends on #257 being merged (it is — the agent-driven rewrite is in main already).
- The \`## Revise subagent: rebase resolution failed\` marker string is unchanged, so the loop guard at cai.py:1316 and the auto-recovery in \`_recover_stuck_rebase_prs\` still trigger correctly.
- \`_rebase_conflict_files\` is kept (used by the post-agent verification).
- Closes the rebase resolver's contribution to #200's tool-discovery cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)