### PR TITLE
auto-improve: Pre-specify deferred tools in prompts to eliminate ToolSearch overhead

### DIFF
--- a/prompts/backend-fix.md
+++ b/prompts/backend-fix.md
@@ -82,6 +82,10 @@ Grep, and Glob instead.
    with `subagent_type: Explore` instead of issuing many sequential
    Grep or Read calls. A single Explore subagent can parallelize
    the search internally, saving tokens and tool-call rounds.
+9. **Pre-fetch deferred tools.** Before starting work, run a single
+   `ToolSearch` call to fetch the tools you will need (e.g.,
+   `"select:TodoWrite"`). This avoids repeated discovery calls
+   scattered throughout the session.
 
 ## Check the design decisions first
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#200

**Issue:** #200 — Pre-specify deferred tools in prompts to eliminate ToolSearch overhead

## PR Summary

### What this fixes
The fix subagent was making repeated ToolSearch calls (12 calls, 8% of total) scattered throughout sessions to discover deferred tools on-demand, inflating output tokens with redundant JSON schema fetches.

### What was changed
- `prompts/backend-fix.md`: Added efficiency guidance item 9 ("Pre-fetch deferred tools") instructing the fix subagent to run a single upfront `ToolSearch` call for needed deferred tools (e.g., `TodoWrite`) instead of discovering them repeatedly throughout the session.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
