### PR TITLE
confirm: migrate to declarative Claude subagent (Path A phase 2)

### DIFF
--- a/.claude/agents/cai-confirm.md
+++ b/.claude/agents/cai-confirm.md
@@ -1,3 +1,10 @@
+---
+name: cai-confirm
+description: Verify whether each `auto-improve:merged` issue has actually been resolved by checking the merged PR's diff against the issue's remediation and the recent parsed transcript signals against the issue's evidence. Produces exactly one verdict per issue — no new findings, no remediations.
+tools: Read, Grep, Glob
+model: claude-sonnet-4-6
+---
+
 # Backend Confirm
 
 You are the confirm agent for `robotsix-cai`'s self-improvement loop.
@@ -14,6 +21,9 @@ resolved. You produce exactly one verdict per issue — nothing else.
 3. **PR diffs** — when available, the unified diff of the merged pull
    request associated with each issue. This shows exactly what code
    was changed to address the issue.
+
+All three come in as the user message. You do not need to fetch
+them yourself.
 
 ## What to produce
 

--- a/cai.py
+++ b/cai.py
@@ -107,7 +107,6 @@ TRANSCRIPT_DIR = Path("/root/.claude/projects")
 PARSE_SCRIPT = Path("/app/parse.py")
 PUBLISH_SCRIPT = Path("/app/publish.py")
 FIX_PROMPT = Path("/app/prompts/backend-fix.md")
-CONFIRM_PROMPT = Path("/app/prompts/backend-confirm.md")
 REVISE_PROMPT = Path("/app/prompts/backend-revise.md")
 REVIEW_PR_PROMPT = Path("/app/prompts/backend-review-pr.md")
 MERGE_PROMPT = Path("/app/prompts/backend-merge.md")
@@ -3037,9 +3036,10 @@ def cmd_confirm(args) -> int:
                 mi["_pr_diff"] = diff_text
                 mi["_pr_number"] = pr_num
 
-    # 3. Build the confirm prompt.
-    prompt_text = CONFIRM_PROMPT.read_text()
-
+    # 3. Build the user message (parsed signals + merged issues +
+    #    PR diffs). The system prompt, tool allowlist, and model
+    #    choice all live in `.claude/agents/cai-confirm.md` — the
+    #    wrapper only passes dynamic per-run context via stdin.
     issues_section = "## Merged issues to verify\n\n"
     for mi in merged_issues:
         issues_section += (
@@ -3052,8 +3052,7 @@ def cmd_confirm(args) -> int:
                 f"```diff\n{mi['_pr_diff']}\n```\n\n"
             )
 
-    full_prompt = (
-        f"{prompt_text}\n\n"
+    user_message = (
         "## Parsed signals\n\n"
         "```json\n"
         f"{parsed_signals}\n"
@@ -3061,11 +3060,10 @@ def cmd_confirm(args) -> int:
         f"{issues_section}"
     )
 
-    # 4. Run claude with Sonnet.
+    # 4. Invoke the declared cai-confirm subagent.
     confirm = _run(
-        ["claude", "-p", "--model", "claude-sonnet-4-6",
-         "--disallowedTools", "Bash"],
-        input=full_prompt,
+        ["claude", "-p", "--agent", "cai-confirm"],
+        input=user_message,
         capture_output=True,
     )
     if confirm.returncode != 0:


### PR DESCRIPTION
Refs #270. **Phase 2 of the Path A architectural migration.** After phase 1 (#274, rebase resolver), migrate the confirm subagent to the declarative form.

## What changed

- **New `.claude/agents/cai-confirm.md`** (renamed from `prompts/backend-confirm.md`) — declarative agent file with frontmatter:
  - `tools: Read, Grep, Glob` — read-only, no Bash, no Edit
  - `model: claude-sonnet-4-6` — explicit model pin (previously a `--model` flag in cai.py)
- **`cai.py cmd_confirm`** — invokes `claude --agent cai-confirm`. Both `--model claude-sonnet-4-6` and `--disallowedTools Bash` flags disappear — they live in the agent file. Only the dynamic per-run context (parsed signals + merged issues with their PR diffs) is passed via stdin.
- **`Dockerfile`** — `COPY .claude /app/.claude` (shared infrastructure with phase 1; if #274 merges first this hunk is a no-op).
- **`.claude/settings.json`** — repo-wide deny rules for `Bash(git push:*)`, `Bash(git remote:*)`, `Bash(gh:*)` (shared with #274). cai-confirm is read-only and doesn't need these, but phase 2 establishes the settings file if phase 1 hasn't.
- **`CONFIRM_PROMPT` constant** — removed from cai.py.

## Why cai-confirm was chosen as phase 2

- **Simple**: read-only, no Bash, no worktree, no branch lifecycle.
- **Single call site**: one `claude -p` invocation in `cmd_confirm`, no orchestration loop.
- **Low risk**: if it breaks, the worst outcome is that `:merged` issues don't get their verdict on the next cron tick — not corrupted code or lost work.
- **Validates the pattern for non-Bash subagents.** Phase 1 (#274) validated it for a Bash-enabled agent; phase 2 validates it for a read-only Sonnet agent. Together they cover the two flavors the remaining subagents will need.

## Independent of #274

This PR is **self-contained** and does not depend on #274 merging first. Whichever lands first ships the shared `.claude/` infrastructure (Dockerfile COPY + settings.json); the second PR's hunks on those files become no-ops on merge.

## What phase 2 does NOT do (yet)

- **No per-agent memory migration.** Design decisions and closed-issue rationales still come via prompt injection (#262). Memory migration lands in phase 3 (analyze + audit) where the payoff is largest.
- **No skill extraction.** `parse.py`, label management, etc. stay as wrapper-invoked deterministic scripts. Skills get introduced later once we have multiple subagents that benefit.
- **No dispatcher shrinkdown.** cai.py's non-agent housekeeping (`_recover_stuck_rebase_prs`, `_filter_unaddressed_comments`, `_select_revise_targets`, lifecycle helpers) stays put. That's phase 7+.

## Test plan
- [ ] Run `cai confirm` against a fixture with a `:merged` issue and confirm the declarative agent produces a verdict matching the existing behavior.
- [ ] Verify the agent runs as Sonnet (check the log line / token accounting — the model pin should come from frontmatter, not the command line).
- [ ] Verify the agent has no Bash access — introduce a Bash call in a test prompt and confirm it's blocked by the frontmatter tool allowlist.
- [ ] Confirm the verdict-parsing in `_parse_verdicts` still works unchanged (stdout format is identical because the system prompt's "## What to produce" section is preserved verbatim).

## Notes
- This PR is deliberately narrow. Per #270, phases 3–6 migrate the remaining subagents; phase 7 shrinks the dispatcher once the pattern is uniform.
- If `claude --agent` turns out to have issues in headless mode against 2.1.96 (the open question phase 1 is also validating), this PR would need the same workaround — either version bump or `--agents '<json>'` inline. Flagged on #270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)