### PR TITLE
analyze + audit: migrate to declarative Claude subagents (Path A phase 3)

### DIFF
--- a/.claude/agents/cai-analyze.md
+++ b/.claude/agents/cai-analyze.md
@@ -1,3 +1,9 @@
+---
+name: cai-analyze
+description: Analyze parsed signals from the cai container's own Claude Code session transcripts and raise auto-improve findings for code, prompt, or workflow issues. Read-only — the wrapper publishes findings as GitHub issues after the agent exits.
+tools: Read, Grep, Glob
+---
+
 # Backend Auto-Improve
 
 You are the analyzer for `robotsix-cai`'s self-improvement loop. Your
@@ -37,18 +43,24 @@ sessions from outside the container.
 
 ## Input format
 
-You will receive a parsed signal summary as part of the prompt context.
-The structure is what `parse.py` outputs:
+You receive the following sections in the user message, in order:
 
-- `tool_call_count` — total tool calls across all sessions analyzed
-- `top_tools` — top 5 most-used tools
-- `tool_counts` — full tool usage map (capped)
-- `error_tools` — tools that errored, with counts
-- `error_categories` — controllable vs network/auth errors
-- `repeated_sequences` — runs of 3+ identical consecutive calls
-- `token_usage` — input/output token totals
-- `tool_sequence_preview` — first 100 tool calls in sequence
-- `note` (optional) — `"empty transcript"` if there's no data yet
+1. **Durable design decisions** (if any) — supervisor-curated rules
+   that override signal-derived findings (see Filter section below).
+2. **Parsed signals** — JSON output of `parse.py` against the recent
+   transcript window. Structure:
+   - `tool_call_count` — total tool calls across all sessions analyzed
+   - `top_tools` — top 5 most-used tools
+   - `tool_counts` — full tool usage map (capped)
+   - `error_tools` — tools that errored, with counts
+   - `error_categories` — controllable vs network/auth errors
+   - `repeated_sequences` — runs of 3+ identical consecutive calls
+   - `token_usage` — input/output token totals
+   - `tool_sequence_preview` — first 100 tool calls in sequence
+   - `note` (optional) — `"empty transcript"` if there's no data yet
+3. **Currently open auto-improve issues** — number, state label, title
+4. **Previously closed auto-improve issues** (if any) — number,
+   closing timestamp, labels, closing rationale
 
 ## What to output
 
@@ -83,7 +95,7 @@ No findings.
 ## Filter
 
 Before raising any new finding, check **all three** of the following
-sections at the end of the prompt:
+sections from the user message:
 
 1. **Durable design decisions** — supervisor-curated rules. If your
    proposed finding overlaps with an entry, do NOT output it. The

--- a/.claude/agents/cai-audit.md
+++ b/.claude/agents/cai-audit.md
@@ -1,3 +1,10 @@
+---
+name: cai-audit
+description: Audit the current GitHub issue queue, recent PRs, and log tail to find inconsistencies in the auto-improve lifecycle state machine. Report-only — findings go to humans for triage, not to the fix subagent.
+tools: Read, Grep, Glob
+model: claude-sonnet-4-6
+---
+
 # Backend Audit
 
 You are the audit agent for `robotsix-cai`'s self-improvement loop.
@@ -119,7 +126,7 @@ For each anomaly, output a markdown block:
 ```markdown
 ### Finding: <short imperative title>
 
-- **Category:** <one of the 6 categories above>
+- **Category:** <one of the 7 categories above>
 - **Key:** <stable-slug-for-deduplication>
 - **Confidence:** low | medium | high
 - **Evidence:**

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://code.claude.com/schemas/settings.json",
+  "permissions": {
+    "deny": [
+      "Bash(git push:*)",
+      "Bash(git push)",
+      "Bash(git remote:*)",
+      "Bash(git remote)",
+      "Bash(gh:*)",
+      "Bash(gh)"
+    ]
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ COPY cai.py /app/cai.py
 COPY parse.py /app/parse.py
 COPY publish.py /app/publish.py
 COPY prompts /app/prompts
+COPY .claude /app/.claude
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 

--- a/cai.py
+++ b/cai.py
@@ -106,9 +106,7 @@ TRANSCRIPT_DIR = Path("/root/.claude/projects")
 # Files baked into the image alongside cai.py.
 PARSE_SCRIPT = Path("/app/parse.py")
 PUBLISH_SCRIPT = Path("/app/publish.py")
-ANALYZER_PROMPT = Path("/app/prompts/backend-auto-improve.md")
 FIX_PROMPT = Path("/app/prompts/backend-fix.md")
-AUDIT_PROMPT = Path("/app/prompts/backend-audit.md")
 CONFIRM_PROMPT = Path("/app/prompts/backend-confirm.md")
 REVISE_PROMPT = Path("/app/prompts/backend-revise.md")
 REBASE_PROMPT = Path("/app/prompts/backend-rebase.md")
@@ -393,8 +391,6 @@ def cmd_analyze(args) -> int:
             flush=True,
         )
 
-    prompt_text = ANALYZER_PROMPT.read_text()
-
     # Fetch currently open auto-improve issues so the analyzer can
     # avoid raising duplicates (semantic dedup, not just fingerprint).
     _STATE_PRIORITY = {
@@ -451,8 +447,12 @@ def cmd_analyze(args) -> int:
     # any signal from parsed transcripts. See #260.
     decisions_block = _design_decisions_block()
 
-    full_prompt = (
-        f"{prompt_text}"
+    # The system prompt, tool allowlist, and model choice all live
+    # in `.claude/agents/cai-analyze.md`. The wrapper only passes
+    # dynamic per-run context (design decisions, parsed signals,
+    # open issues, closed-issue rationales) via stdin as the user
+    # message.
+    user_message = (
         f"{decisions_block}\n\n"
         "## Parsed signals\n\n"
         "```json\n"
@@ -463,8 +463,8 @@ def cmd_analyze(args) -> int:
     )
 
     analyzer = _run(
-        ["claude", "-p", "--disallowedTools", "Bash"],
-        input=full_prompt,
+        ["claude", "-p", "--agent", "cai-analyze"],
+        input=user_message,
         capture_output=True,
     )
     print(analyzer.stdout, flush=True)
@@ -2349,9 +2349,9 @@ def cmd_audit(args) -> int:
         except Exception:
             log_tail = "(could not read log)"
 
-    # Build the prompt.
-    prompt_text = AUDIT_PROMPT.read_text()
-
+    # Build the user message. The system prompt, tool allowlist,
+    # and model choice all live in `.claude/agents/cai-audit.md` —
+    # the wrapper only passes dynamic per-run context via stdin.
     issues_section = "## Open auto-improve issues\n\n"
     if open_issues:
         for oi in open_issues:
@@ -2402,8 +2402,7 @@ def cmd_audit(args) -> int:
     # accepted. See #260.
     decisions_block = _design_decisions_block()
 
-    full_prompt = (
-        f"{prompt_text}"
+    user_message = (
         f"{decisions_block}\n\n"
         f"{issues_section}\n"
         f"{prs_section}\n"
@@ -2411,11 +2410,10 @@ def cmd_audit(args) -> int:
         f"{deterministic_section}"
     )
 
-    # Step 3: Run claude with the audit prompt (Sonnet).
+    # Step 3: Invoke the declared cai-audit subagent.
     audit = _run(
-        ["claude", "-p", "--model", "claude-sonnet-4-6",
-         "--disallowedTools", "Bash"],
-        input=full_prompt,
+        ["claude", "-p", "--agent", "cai-audit"],
+        input=user_message,
         capture_output=True,
     )
     print(audit.stdout, flush=True)


### PR DESCRIPTION
Refs #270. **Phase 3 of the Path A architectural migration.** After #274 (rebase resolver) and #276 (confirm), migrate the two finding-raising subagents — analyze and audit — together in one PR.

## What changed

### Two new declarative agents
- **`.claude/agents/cai-analyze.md`** (renamed from `prompts/backend-auto-improve.md`)
  - `tools: Read, Grep, Glob` — read-only
  - No explicit model pin (inherits default)
- **`.claude/agents/cai-audit.md`** (renamed from `prompts/backend-audit.md`)
  - `tools: Read, Grep, Glob` — read-only
  - `model: claude-sonnet-4-6` — explicit Sonnet pin (previously a `--model` flag)

Both markdown bodies are the same system prompts as before — filter instructions, guardrails, and output format are preserved verbatim so the existing `publish.py` finding-parser continues to work.

### cai.py changes
- **`cmd_analyze`** — invokes `claude --agent cai-analyze`. `--disallowedTools Bash` flag disappears. The prompt concatenation is gone; the wrapper builds a `user_message` with only the dynamic per-run context (design decisions, parsed signals, open issues, closed-issue rationales) and pipes it via stdin. `ANALYZER_PROMPT` constant removed.
- **`cmd_audit`** — invokes `claude --agent cai-audit`. Both `--model claude-sonnet-4-6` and `--disallowedTools Bash` flags disappear — both in frontmatter now. Same stdin-only pattern. `AUDIT_PROMPT` constant removed.

### Shared infra (self-contained off main)
- **`Dockerfile`** — `COPY .claude /app/.claude`
- **`.claude/settings.json`** — repo-wide deny rules for `Bash(git push:*)`, `Bash(git remote:*)`, `Bash(gh:*)`

These hunks overlap with #274 and #276. Whichever PR merges first establishes them; the others become no-ops on merge.

## Why these two together

- **Shape similarity.** Both are read-only finding-raisers with the same stdout contract (`### Finding: ...` blocks parsed by `publish.py`). Migrating them together means one review pass covering the common pattern.
- **Prompt size.** Together they retire two of the heaviest prompt injections in cai.py (analyze prompt ~137 lines, audit prompt ~147 lines). Moving them out of per-run concatenation is a measurable prompt-size reduction.
- **Memory is next.** A follow-up PR (phase 3b) will migrate the design-decisions block from stdin to real per-agent memory. Doing both agents together now is a prerequisite — the memory migration will touch both.

## What phase 3 does NOT do yet

- **No per-agent memory migration.** The `_design_decisions_block()` and `_fetch_closed_auto_improve_issues()` helpers from #262 still run in cai.py and their output is prepended to the user message. Phase 3 moves them from being part of the **system prompt** to being part of the **user message** — a separation of static-agent-definition from dynamic-run-context that sets up the memory migration, but doesn't yet move the durable parts into the agent's memory pool. That's phase 3b.
- **No skill extraction.** `parse.py`, closed-issue fetching, label management, etc. all stay as wrapper-invoked Python. Skills come later once there's a real procedural-knowledge case (e.g. the fix agent needing to invoke label transitions directly).
- **No cmd_analyze/cmd_audit shrinkdown.** The deterministic parts (fetching open issues, running parse.py, rolling back stale in-progress, etc.) stay in the wrapper. That's the "thin dispatcher" work in phase 7.

## Test plan
- [ ] Run `cai analyze` against a fixture transcript and confirm the declarative agent produces findings in the same `### Finding: ...` format the existing `publish.py` expects.
- [ ] Run `cai audit` and confirm the Sonnet model pin is respected (check the log line / token accounting).
- [ ] Verify neither agent can invoke Bash (introduce a Bash call in the user message and confirm it's blocked by the frontmatter tool allowlist).
- [ ] Confirm the closed-issue rationale still suppresses re-raises of #23/#141-style findings (the filter logic is preserved verbatim in the agent file body).

## Dependency order

Independent of #274, #276. The three PRs can land in any order — git will auto-merge the shared `.claude/` infrastructure hunks since they're identical across all three. If #274 and #276 both land before this one, the auto-merge is trivial (no-op on Dockerfile + settings.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)