### PR TITLE
fix: migrate to declarative Claude subagent (Path A phase 4)

### DIFF
--- a/.claude/agents/cai-fix.md
+++ b/.claude/agents/cai-fix.md
@@ -1,3 +1,9 @@
+---
+name: cai-fix
+description: Autonomous code-editing subagent for `robotsix-cai`. Makes the smallest targeted change that addresses an auto-improve issue handed by the wrapper. Cannot run git or gh — the wrapper handles all remote state and PR opening.
+tools: Read, Edit, Write, Grep, Glob
+---
+
 # Backend Fix Subagent
 
 You are the autonomous fix subagent for `robotsix-cai`. The wrapper
@@ -12,10 +18,10 @@ and label transitions — so you only need to focus on the code.
 
 You are running inside a fresh clone of `damien-robotsix/robotsix-cai`.
 The full source tree is here, including `cai.py`, `parse.py`,
-`publish.py`, `prompts/`, the `Dockerfile`, `install.sh`,
-`docker-compose.yml`, the README, and the GitHub workflows under
-`.github/workflows/`. Bash is not available — use Read, Edit, Write,
-Grep, and Glob instead.
+`publish.py`, `prompts/`, `.claude/agents/`, the `Dockerfile`,
+`install.sh`, `docker-compose.yml`, the README, and the GitHub
+workflows under `.github/workflows/`. You have Read, Edit, Write,
+Grep, and Glob — Bash is not in your tool allowlist.
 
 ## Hard rules
 
@@ -31,9 +37,11 @@ Grep, and Glob instead.
    actually requires. Do not refactor surrounding code, rename
    variables, reformat, add comments, or "improve" things outside
    the scope of the issue.
-3. **Do not run `git`, `gh`, or anything that touches the remote.**
-   The wrapper will commit, push, and open the PR after you exit.
-   Just leave your changes uncommitted in the working tree.
+3. **Do not touch git, gh, or the remote.** Bash is not available
+   anyway, and the repo-wide `.claude/settings.json` denies
+   `git push`, `git remote`, and `gh` even if it were. The wrapper
+   will commit, push, and open the PR after you exit. Just leave
+   your changes uncommitted in the working tree.
 4. **Do not add tests, docstrings, or type annotations** unless the
    issue specifically asks for them.
 5. **Do not delete or substantially rewrite existing files** unless
@@ -85,13 +93,13 @@ Grep, and Glob instead.
 
 ## Check the design decisions first
 
-If a `## Durable design decisions` section is appended to this
-prompt, **read every entry before doing anything else**. Those
-entries are supervisor-curated rules that override the issue you've
-been handed. If the issue you're working on overlaps with a design
-decision (the issue is asking you to do something the decision
-explicitly forbids), do not make the change. Instead, exit with
-**zero diff** and print a short paragraph to stdout that:
+Your user message may begin with a `## Durable design decisions`
+section — supervisor-curated rules that override the issue you've
+been handed. **Read every entry before doing anything else.** If the
+issue you're working on overlaps with a design decision (the issue
+is asking you to do something the decision explicitly forbids), do
+not make the change. Instead, exit with **zero diff** and print a
+short paragraph to stdout that:
 
 1. Names the design-decision entry by title
 2. Quotes the relevant rule
@@ -185,5 +193,5 @@ explanation.
 
 The full body of the issue you are working on (including its
 fingerprint, category, evidence, and remediation) is appended to
-this prompt as `## Issue` below. Read it carefully before doing
+the user message as `## Issue` below. Read it carefully before doing
 anything else.

--- a/cai.py
+++ b/cai.py
@@ -106,7 +106,6 @@ TRANSCRIPT_DIR = Path("/root/.claude/projects")
 # Files baked into the image alongside cai.py.
 PARSE_SCRIPT = Path("/app/parse.py")
 PUBLISH_SCRIPT = Path("/app/publish.py")
-FIX_PROMPT = Path("/app/prompts/backend-fix.md")
 REVISE_PROMPT = Path("/app/prompts/backend-revise.md")
 REVIEW_PR_PROMPT = Path("/app/prompts/backend-review-pr.md")
 MERGE_PROMPT = Path("/app/prompts/backend-merge.md")
@@ -638,12 +637,18 @@ def _issue_has_label(issue_number: int, label: str) -> bool:
     return label in [l["name"] for l in (issue or {}).get("labels", [])]
 
 
-def _build_fix_prompt(issue: dict) -> str:
-    prompt = FIX_PROMPT.read_text()
-    # Durable design decisions — defense in depth. If a finding slips
-    # past `analyze` but overlaps a design-decision entry, the fix
-    # subagent should refuse to act and surface the conflict instead.
-    # See #260.
+def _build_fix_user_message(issue: dict) -> str:
+    """Build the dynamic per-run user message for the cai-fix agent.
+
+    The system prompt, tool allowlist, and hard rules all live in
+    `.claude/agents/cai-fix.md`. The wrapper only passes the
+    dynamic context:
+
+      1. Durable design decisions (defense in depth — if a finding
+         slips past analyze but overlaps a decision entry, the fix
+         subagent refuses to act and surfaces the conflict).
+      2. The issue body + any comments the reviewer left on it.
+    """
     decisions_block = _design_decisions_block()
     issue_block = (
         f"## Issue\n\n"
@@ -657,7 +662,7 @@ def _build_fix_prompt(issue: dict) -> str:
             author = c.get("author", {}).get("login", "unknown")
             body = c.get("body", "")
             issue_block += f"**{author}:**\n{body}\n\n"
-    return f"{prompt}{decisions_block}\n\n{issue_block}"
+    return f"{decisions_block}\n\n{issue_block}"
 
 
 def _parse_suggested_issues(agent_output: str) -> list[dict]:
@@ -833,17 +838,21 @@ def cmd_fix(args) -> int:
         branch = f"auto-improve/{issue_number}-{_slugify(title)}"
         _git(work_dir, "checkout", "-b", branch)
 
-        # 5. Run the fix subagent in the work dir with full permissions.
-        prompt = _build_fix_prompt(issue)
-        print(f"[cai fix] running fix subagent in {work_dir}", flush=True)
+        # 5. Run the cai-fix declarative subagent in the work dir.
+        #    System prompt, tool allowlist, and hard rules live in
+        #    `.claude/agents/cai-fix.md`. The wrapper only passes
+        #    dynamic per-run context (design decisions + the issue
+        #    body) as the user message via stdin.
+        user_message = _build_fix_user_message(issue)
+        print(f"[cai fix] running cai-fix subagent in {work_dir}", flush=True)
         # `acceptEdits` auto-accepts file edits (Read/Edit/Write/Grep/Glob)
         # without prompting. We don't use `bypassPermissions` because
         # claude-code refuses it when running as root inside the container,
         # and `acceptEdits` is sufficient for code-editing fixes.
         agent = _run(
-            ["claude", "-p", "--permission-mode", "acceptEdits",
-             "--disallowedTools", "Bash"],
-            input=prompt,
+            ["claude", "-p", "--agent", "cai-fix",
+             "--permission-mode", "acceptEdits"],
+            input=user_message,
             cwd=str(work_dir),
             capture_output=True,
         )


### PR DESCRIPTION
Refs #270. **Phase 4 of the Path A architectural migration.** After phases 1-3 (rebase resolver, confirm, analyze + audit), migrate the fix subagent — the one that owns the whole edit-commit-push-PR loop for every auto-improve issue.

## What changed

### New declarative agent
- **`.claude/agents/cai-fix.md`** (renamed from `prompts/backend-fix.md`)
  - `tools: Read, Edit, Write, Grep, Glob` — no Bash, no `gh`, no git. The wrapper handles all remote state and PR creation after the agent exits.
  - No explicit model pin (inherits default)
- The markdown body preserves every section of the old prompt verbatim: hard rules, efficiency guidance, the design-decision safety net, zero-diff exit path, `## Suggested Issue` emission format, and `## PR Summary` contract — so `_parse_suggested_issues` and the PR-summary extraction continue to work without changes.

### cai.py
- **`_build_fix_prompt` → `_build_fix_user_message`**: renamed and shrunk. No longer reads `FIX_PROMPT` from disk or concatenates a system prompt. Only builds the dynamic per-run user message (design-decisions block + issue body + reviewer comments), which is passed as stdin.
- **`cmd_fix`**: invokes `claude -p --agent cai-fix --permission-mode acceptEdits`. The `--disallowedTools Bash` flag disappears (tool allowlist is declarative). `acceptEdits` is preserved because claude-code refuses `bypassPermissions` when running as root inside the container.
- **`FIX_PROMPT`** path constant removed.
- **`prompts/backend-fix.md`** deleted.

## Why phase 4 matters

- **Largest system prompt retired.** `backend-fix.md` was 190 lines — the heaviest prompt in the repo. Moving it out of per-run concatenation is a measurable cost reduction on every `cai fix` cron tick.
- **Defense-in-depth for design decisions preserved.** The decisions block still travels with every fix invocation (via `_build_fix_user_message`), but now as the user message instead of the system prompt. The fix agent's "Check the design decisions first" section was rewritten to reference the user message rather than "appended to this prompt".
- **Four subagents down, three to go.** After this lands: `cai-rebase-resolver`, `cai-confirm`, `cai-analyze`, `cai-audit`, `cai-fix` are all declarative. Remaining subagents: `cai-revise`, `cai-merge`, `cai-review-pr`, and `cai-audit-triage`.

## What phase 4 does NOT do yet

- **No per-agent memory migration.** Design decisions still come via stdin. The memory migration is a dedicated later PR once memory-loading in headless mode is verified end-to-end.
- **No skill extraction.** `_parse_suggested_issues`, branch lifecycle management, clone management, PR creation — all stay as wrapper-owned Python.
- **No thin-dispatcher work.** `cmd_fix` is still ~300 lines of orchestration (branching, rollback, commit loop, push, PR create, label transitions). Shrinkdown is phase 7.

## Test plan
- [ ] Run `cai fix` against a simple fixture issue and confirm the declarative `cai-fix` agent makes edits and emits the `## PR Summary` block in the expected format.
- [ ] Verify `_parse_suggested_issues` still extracts `## Suggested Issue` blocks from the agent output — the format is unchanged.
- [ ] Verify the fix agent cannot invoke Bash (the tool allowlist blocks it at the session level, even if the prompt didn't forbid it).
- [ ] Verify the design-decisions defense-in-depth still triggers: hand the fix agent a fake issue that violates the seeded parse.py-token-bug decision, expect zero diff + a stdout paragraph naming the decision entry.
- [ ] Confirm the suggested-issues path still creates issues with `auto-improve:raised` (no change to `_create_suggested_issues`, but worth a smoke test).

## Dependency order

Independent of any other open Path A PR. `.claude/settings.json` and the `Dockerfile COPY .claude` hunks are already in main (from phase 1), so this PR has no shared infra overlap — it only touches the fix-specific files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)