### PR TITLE
review-pr + merge: migrate to declarative Claude subagents (Path A phase 5)

### DIFF
--- a/.claude/agents/cai-merge.md
+++ b/.claude/agents/cai-merge.md
@@ -1,12 +1,21 @@
+---
+name: cai-merge
+description: Assess whether a pull request correctly implements its linked issue and emit a structured merge verdict (confidence + action). Inline-only — the issue body, PR diff, and PR comments all arrive as the user message. No tool use needed.
+tools: Read
+model: claude-opus-4-6
+---
+
 # Backend Merge Review
 
 You are the merge review agent for `robotsix-cai`. Your job is to
 assess whether a pull request correctly implements its linked issue
-and decide whether the PR is safe to auto-merge. You have **no
-tools** — the issue body, PR diff, and PR comments are provided
-inline below.
+and decide whether the PR is safe to auto-merge. The issue body, PR
+diff, and PR comments are provided inline in the user message —
+you do not need to fetch anything.
 
 ## What you receive
+
+In the user message, in order:
 
 1. **Issue body** — the full original spec the PR is meant to implement
 2. **PR diff** — the complete unified diff

--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -1,3 +1,9 @@
+---
+name: cai-review-pr
+description: Pre-merge ripple-effect review for an open PR. Walks the diff, searches the broader codebase for inconsistencies the PR introduced but didn't update, and emits `### Finding:` blocks the wrapper posts as a PR comment. Read-only.
+tools: Read, Grep, Glob, Agent
+---
+
 # Backend Pre-Merge Review
 
 You are the pre-merge review agent for `robotsix-cai`. Your job is to
@@ -8,7 +14,9 @@ codebase. You have read-only access to the repository via
 
 ## What you receive
 
-1. **PR metadata** — number, title, author, base branch
+In the user message, in order:
+
+1. **PR metadata** — number, title, author, base branch, head SHA
 2. **PR diff** — the full unified diff of the PR
 
 ## What to look for

--- a/cai.py
+++ b/cai.py
@@ -107,8 +107,6 @@ TRANSCRIPT_DIR = Path("/root/.claude/projects")
 PARSE_SCRIPT = Path("/app/parse.py")
 PUBLISH_SCRIPT = Path("/app/publish.py")
 REVISE_PROMPT = Path("/app/prompts/backend-revise.md")
-REVIEW_PR_PROMPT = Path("/app/prompts/backend-review-pr.md")
-MERGE_PROMPT = Path("/app/prompts/backend-merge.md")
 AUDIT_TRIAGE_PROMPT = Path("/app/prompts/backend-audit-triage.md")
 CODE_AUDIT_PROMPT = Path("/app/prompts/backend-code-audit.md")
 DESIGN_DECISIONS = Path("/app/prompts/design-decisions.md")
@@ -3272,11 +3270,12 @@ def cmd_review_pr(args) -> int:
                 )
                 continue
 
-            # Build the prompt.
-            prompt_text = REVIEW_PR_PROMPT.read_text()
+            # Build the user message. The system prompt, tool
+            # allowlist (Read/Grep/Glob/Agent), and hard rules all
+            # live in `.claude/agents/cai-review-pr.md`. The wrapper
+            # only passes dynamic per-run context via stdin.
             author_login = pr.get("author", {}).get("login", "unknown")
-            full_prompt = (
-                f"{prompt_text}\n\n"
+            user_message = (
                 f"## PR metadata\n\n"
                 f"- **Number:** #{pr_number}\n"
                 f"- **Title:** {title}\n"
@@ -3287,16 +3286,11 @@ def cmd_review_pr(args) -> int:
                 f"```diff\n{pr_diff}\n```\n"
             )
 
-            # Run the review agent (read-only tools only). The
-            # `--allowedTools` flag must receive a single comma- (or
-            # space-) separated string. Passing the tools as separate
-            # positional args would cause claude-code's parser to set
-            # only `Read` as the allowed tool and treat `Grep`/`Glob`
-            # as positional arguments to the prompt.
+            # Invoke the declared cai-review-pr subagent.
             agent = _run(
-                ["claude", "-p", "--permission-mode", "acceptEdits",
-                 "--allowedTools", "Read,Grep,Glob"],
-                input=full_prompt,
+                ["claude", "-p", "--agent", "cai-review-pr",
+                 "--permission-mode", "acceptEdits"],
+                input=user_message,
                 cwd=str(work_dir),
                 capture_output=True,
             )
@@ -3752,10 +3746,10 @@ def cmd_merge(args) -> int:
                 comment_texts.append(body)
         comments_section = "\n\n---\n\n".join(comment_texts) if comment_texts else "(no comments)"
 
-        # Build the prompt.
-        prompt_text = MERGE_PROMPT.read_text()
-        full_prompt = (
-            f"{prompt_text}\n\n"
+        # Build the user message. The system prompt, tool allowlist,
+        # and model (opus-4-6) all live in `.claude/agents/cai-merge.md`.
+        # The wrapper only passes dynamic per-run context via stdin.
+        user_message = (
             f"## Linked issue\n\n"
             f"### #{issue_full.get('number', issue_number)} \u2014 {issue_full.get('title', '')}\n\n"
             f"{issue_full.get('body') or '(no body)'}\n\n"
@@ -3765,11 +3759,10 @@ def cmd_merge(args) -> int:
             f"{comments_section}\n"
         )
 
-        # Run the model (read-only, no tools).
+        # Invoke the declared cai-merge subagent.
         agent = _run(
-            ["claude", "-p", "--model", "claude-opus-4-6",
-             "--disallowedTools", "Bash"],
-            input=full_prompt,
+            ["claude", "-p", "--agent", "cai-merge"],
+            input=user_message,
             capture_output=True,
         )
         if agent.returncode != 0:


### PR DESCRIPTION
Refs #270. **Phase 5 of the Path A architectural migration.** After phases 1-4 (rebase resolver, confirm, analyze + audit, fix), migrate the two remaining PR-facing read-only agents — review-pr and merge — in one batched PR. Both are small single-call invocations with similar shape, so batching them saves review overhead.

## What changed

### Two new declarative agents
- **`.claude/agents/cai-review-pr.md`** (renamed from `prompts/backend-review-pr.md`)
  - `tools: Read, Grep, Glob, Agent` — read-only plus the Explore subagent for broad codebase searches (the prompt already recommends it)
  - No explicit model pin (inherits default)
- **`.claude/agents/cai-merge.md`** (renamed from `prompts/backend-merge.md`)
  - `tools: Read` — minimal. The prompt body says "you have no tools — the issue body, PR diff, and PR comments are provided inline." The declarative form matches that intent: an allowlist the agent won't actually use.
  - `model: claude-opus-4-6` — explicit Opus pin (previously a `--model` flag)

### cai.py
- **`cmd_review_pr`** — invokes `claude --agent cai-review-pr --permission-mode acceptEdits`. The `--allowedTools Read,Grep,Glob` flag disappears. Only the dynamic per-run context (PR metadata + diff) is passed via stdin. The lengthy comment explaining the `--allowedTools` parser quirk also goes away — no such flag in the new invocation.
- **`cmd_merge`** — invokes `claude --agent cai-merge`. Both `--model claude-opus-4-6` and `--disallowedTools Bash` flags disappear. Only the user message (linked issue + PR diff + PR comments) comes via stdin.
- **`REVIEW_PR_PROMPT`** and **`MERGE_PROMPT`** path constants removed.
- **`prompts/backend-review-pr.md`** and **`prompts/backend-merge.md`** deleted (renamed to agent files).

## Why batch these two

- **Shape identity.** Both are single-call, read-only agents with no orchestration loop. Neither writes files, commits, or pushes.
- **PR-facing pair.** Both consume PR state and emit structured output the wrapper parses (`### Finding:` / `### Merge Verdict:`). Migrating them together keeps the "PR-evaluation surface" of cai.py consistent.

## What phase 5 does NOT do yet

- **No per-agent memory migration.** Neither agent has meaningful memory — they're stateless evaluators.
- **No skill extraction.** PR diff fetching, comment fetching, verdict parsing, and state transitions all stay in the wrapper.
- **No dispatcher shrinkdown.** `cmd_review_pr` and `cmd_merge` still own SHA idempotency, threshold logic, close/merge actions, etc.

## Test plan
- [ ] Run `cai review-pr` against an open PR with a known ripple-effect pattern (e.g., a constant rename) and confirm the declarative agent produces `### Finding:` blocks.
- [ ] Run `cai merge` against a PR with a `:merged`-style linked issue and confirm the declarative agent emits a parseable `### Merge Verdict: PR #N` block that `_parse_merge_verdict` extracts cleanly.
- [ ] Verify the Opus model pin on cai-merge is respected (check log / token accounting).
- [ ] Verify cai-review-pr's `Agent` tool still lets it spawn the Explore subagent for broad searches.

## Migration status after this lands

Six subagents declarative: **cai-rebase-resolver** (#274), **cai-confirm** (#276), **cai-analyze** + **cai-audit** (#278), **cai-fix** (#285), **cai-review-pr** + **cai-merge** (this PR). Remaining: `cai-revise` (phase 6, largest remaining), `cai-audit-triage` + `cai-code-audit` (phase 7 cleanup batch).

## Dependency order

Independent of all other open Path A PRs. `.claude/settings.json` and the `Dockerfile COPY .claude` hunks are already in main (from phase 1), so no shared infra overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)