### PR TITLE
auto-improve: Multiple PRs stuck in persistent `revise result=rebase_failed exit=0` loop

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -1371,6 +1371,11 @@ def _select_revise_targets() -> list[dict]:
         label_names = {lbl["name"] for lbl in issue.get("labels", [])}
         if LABEL_PR_OPEN not in label_names:
             continue
+        # Circuit breaker: skip PRs whose issues already carry the
+        # merge-blocked label — a prior rebase failure has flagged
+        # them for recovery, not another rebase attempt.  See #225.
+        if LABEL_MERGE_BLOCKED in label_names:
+            continue
 
         # Find the most recent commit timestamp on the branch.
         try:
@@ -1683,17 +1688,28 @@ def cmd_revise(args) -> int:
                                 "\n\n<details><summary>Resolver notes</summary>"
                                 f"\n\n{resolver_summary}\n\n</details>"
                             )
-                        _run(
+                        comment_res = _run(
                             ["gh", "pr", "comment", str(pr_number),
                              "--repo", REPO, "--body", comment_body],
                             capture_output=True,
                         )
+                        if comment_res.returncode != 0:
+                            print(
+                                f"[cai revise] PR #{pr_number}: failed to "
+                                f"post rebase-failure comment:\n"
+                                f"{comment_res.stderr}",
+                                file=sys.stderr, flush=True,
+                            )
                         print(
                             f"[cai revise] rebase failed for PR #{pr_number}; "
                             "posted comment",
                             flush=True,
                         )
-                        _set_labels(issue_number, remove=[LABEL_REVISING])
+                        _set_labels(
+                            issue_number,
+                            add=[LABEL_MERGE_BLOCKED],
+                            remove=[LABEL_REVISING],
+                        )
                         log_run("revise", repo=REPO, pr=pr_number,
                                 result="rebase_failed", exit=0)
                         continue


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#225

**Issue:** #225 — Multiple PRs stuck in persistent `revise result=rebase_failed exit=0` loop

## PR Summary

### What this fixes
PRs stuck in a persistent `revise result=rebase_failed exit=0` loop because the existing comment-based loop guard depends on `gh pr comment` succeeding — if the comment post fails silently, the guard never fires and the same rebase is reattempted every tick indefinitely.

### What was changed
- **cai.py `_select_revise_targets()`** (~line 1374): Added a label-based circuit breaker that skips PRs whose linked issue already carries the `merge-blocked` label, preventing re-selection of PRs with known rebase failures regardless of whether the failure comment was successfully posted.
- **cai.py rebase-failure path** (~line 1708): Changed `_set_labels` call to also add `LABEL_MERGE_BLOCKED` when rebase fails (previously only removed `LABEL_REVISING`), providing a durable, label-based signal that doesn't depend on comment posting.
- **cai.py `gh pr comment` call** (~line 1691): Captured the return value of the `gh pr comment` call and added a stderr warning if the comment fails to post, making silent failures visible in logs.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
