### PR TITLE
audit-triage + code-audit: final subagent migrations (Path A phase 7)

### DIFF
--- a/.claude/agents/cai-audit-triage.md
+++ b/.claude/agents/cai-audit-triage.md
@@ -1,3 +1,10 @@
+---
+name: cai-audit-triage
+description: Triage `audit:raised` findings and emit structured verdicts (close_duplicate / close_resolved / passthrough / escalate). Inline-only — all the state (raised issues, other open issues, recent PRs) is provided in the user message. No tool use needed.
+tools: Read
+model: claude-sonnet-4-6
+---
+
 # Backend Audit Triage
 
 You are the audit triage agent for `robotsix-cai`. Your job is to
@@ -8,13 +15,15 @@ duplicates and findings about issues that have already been resolved
 — can be closed directly. Others describe code changes the bot
 should make: pass those through to the regular fix subagent.
 
-You have **no tools**. The full state you need is provided inline
-below: every `audit:raised` issue's full body, the list of all other
-open `auto-improve*` issues for duplicate detection, and the recent
-PRs (so you can see what's already been merged). Decide based on
-that context alone.
+The full state you need is provided inline in the user message:
+every `audit:raised` issue's full body, the list of all other open
+`auto-improve*` issues for duplicate detection, and the recent PRs
+(so you can see what's already been merged). Decide based on that
+context alone.
 
 ## What you receive
+
+In the user message, in order:
 
 1. **`audit:raised` issues** — full title, body, labels, age. These
    are the issues you must triage.

--- a/.claude/agents/cai-code-audit.md
+++ b/.claude/agents/cai-code-audit.md
@@ -1,3 +1,10 @@
+---
+name: cai-code-audit
+description: Read-only audit of the `robotsix-cai` source tree for concrete inconsistencies, dead code, and missing cross-file references the session-based analyzer cannot catch. Runs in a fresh clone and emits `### Finding:` blocks plus a memory update for the next run.
+tools: Read, Grep, Glob
+model: claude-sonnet-4-6
+---
+
 # Backend Code Audit
 
 You are the code audit agent for `robotsix-cai`. Your job is to read
@@ -7,17 +14,19 @@ cannot catch because they require reading the code itself rather than
 parsing transcripts.
 
 You are running inside a fresh, read-only clone of the repository.
-Use Read, Grep, and Glob to explore the codebase. Do NOT modify any
-files.
+Use Read, Grep, and Glob to explore the codebase. You have no write
+tools — do not try to modify any files.
 
 ## What you receive
 
-1. **Durable design decisions** (if any) -- supervisor-curated rules
+In the user message, in order:
+
+1. **Durable design decisions** (if any) — supervisor-curated rules
    that override code-audit findings. If a problem you would
    otherwise flag overlaps with a design decision (the supervisor has
    explicitly accepted that pattern), do not flag it. Read every
    entry before scanning the code.
-2. **Memory** -- a summary of previous code-audit runs. Use this to
+2. **Memory** — a summary of previous code-audit runs. Use this to
    avoid re-raising findings that were already reported and to focus
    on areas not recently audited. If the memory is empty, this is
    the first run.
@@ -45,7 +54,8 @@ Do not speculate or raise stylistic preferences.
 3. Systematically audit the codebase. Prioritize areas NOT covered
    by recent audits. A good rotation:
    - **Run A:** `cai.py` constants, label strings, prompt path
-     references vs actual files on disk
+     references vs actual files on disk (and `.claude/agents/`
+     references — many agents are declared there now)
    - **Run B:** `publish.py` categories and labels vs prompt
      category tables
    - **Run C:** `entrypoint.sh` and `docker-compose.yml` env vars

--- a/cai.py
+++ b/cai.py
@@ -106,8 +106,6 @@ TRANSCRIPT_DIR = Path("/root/.claude/projects")
 # Files baked into the image alongside cai.py.
 PARSE_SCRIPT = Path("/app/parse.py")
 PUBLISH_SCRIPT = Path("/app/publish.py")
-AUDIT_TRIAGE_PROMPT = Path("/app/prompts/backend-audit-triage.md")
-CODE_AUDIT_PROMPT = Path("/app/prompts/backend-code-audit.md")
 DESIGN_DECISIONS = Path("/app/prompts/design-decisions.md")
 
 # Persistent memory file for the code-audit agent. Stored in the
@@ -2490,9 +2488,8 @@ def cmd_audit_triage(args) -> int:
     except subprocess.CalledProcessError:
         recent_prs = []
 
-    # 3. Build the prompt.
-    prompt_text = AUDIT_TRIAGE_PROMPT.read_text()
-
+    # 3. Build the user message. System prompt, tool allowlist, and
+    #    model (sonnet) all live in `.claude/agents/cai-audit-triage.md`.
     raised_section = "## audit:raised issues to triage\n\n"
     for oi in raised_issues:
         labels = ", ".join(lbl["name"] for lbl in oi.get("labels", []))
@@ -2532,17 +2529,16 @@ def cmd_audit_triage(args) -> int:
     else:
         pr_section += "(none)\n"
 
-    full_prompt = (
-        f"{prompt_text}\n\n"
+    user_message = (
         f"{raised_section}\n"
         f"{other_section}\n"
         f"{pr_section}\n"
     )
 
-    # 4. Run claude with the triage prompt (Sonnet — same tier as audit).
+    # 4. Invoke the declared cai-audit-triage subagent.
     triage = _run(
-        ["claude", "-p", "--model", "claude-sonnet-4-6"],
-        input=full_prompt,
+        ["claude", "-p", "--agent", "cai-audit-triage"],
+        input=user_message,
         capture_output=True,
     )
     print(triage.stdout, flush=True)
@@ -2777,8 +2773,9 @@ def cmd_code_audit(args) -> int:
                 duration=dur, exit=1)
         return 1
 
-    # 2. Build the prompt with design decisions and memory.
-    prompt_text = CODE_AUDIT_PROMPT.read_text()
+    # 2. Build the user message with design decisions and memory.
+    #    System prompt, tool allowlist (Read/Grep/Glob), and model
+    #    (sonnet) all live in `.claude/agents/cai-code-audit.md`.
     decisions_block = _design_decisions_block()
     memory = _read_code_audit_memory()
 
@@ -2788,15 +2785,14 @@ def cmd_code_audit(args) -> int:
     else:
         memory_section += "(first run — no prior memory)\n"
 
-    full_prompt = f"{prompt_text}{decisions_block}{memory_section}"
+    user_message = f"{decisions_block}{memory_section}"
 
-    # 3. Run the code-audit agent (Sonnet for cost efficiency).
+    # 3. Invoke the declared cai-code-audit subagent.
     print(f"[cai code-audit] running agent in {work_dir}", flush=True)
     agent = _run(
-        ["claude", "-p", "--model", "claude-sonnet-4-6",
-         "--permission-mode", "acceptEdits",
-         "--disallowedTools", "Bash,Edit,Write,NotebookEdit"],
-        input=full_prompt,
+        ["claude", "-p", "--agent", "cai-code-audit",
+         "--permission-mode", "acceptEdits"],
+        input=user_message,
         cwd=str(work_dir),
         capture_output=True,
     )


### PR DESCRIPTION
Refs #270. **Phase 7 of the Path A architectural migration — the final cleanup batch.** After phases 1-6 migrated the core subagents, this PR migrates the remaining two small read-only agents (audit-triage and code-audit) and **completes the declarative-subagent migration**.

## What changed

### Two new declarative agents
- **`.claude/agents/cai-audit-triage.md`** (renamed from `prompts/backend-audit-triage.md`)
  - `tools: Read` — minimal placeholder, agent is inline-only and doesn't actually use tools (the old code didn't pass `--disallowedTools` either — the agent just reads its input and emits verdicts)
  - `model: claude-sonnet-4-6`
- **`.claude/agents/cai-code-audit.md`** (renamed from `prompts/backend-code-audit.md`)
  - `tools: Read, Grep, Glob`
  - `model: claude-sonnet-4-6`
  - Body gets one minor update: the "Run A" rotation guidance now mentions `.claude/agents/` references alongside `prompts/` (many agents are declared there now)

### cai.py
- **`cmd_audit_triage`** — invokes `claude -p --agent cai-audit-triage`. Only dynamic per-run context (raised issues, other open issues, recent PRs) via stdin. `--model` flag disappears.
- **`cmd_code_audit`** — invokes `claude -p --agent cai-code-audit --permission-mode acceptEdits`. Both `--model` and `--disallowedTools Bash,Edit,Write,NotebookEdit` flags disappear — both live in the agent file's frontmatter. Only the dynamic per-run context (design decisions + memory from prior runs) via stdin.
- **`AUDIT_TRIAGE_PROMPT`** and **`CODE_AUDIT_PROMPT`** path constants removed.
- **`prompts/backend-audit-triage.md`** and **`prompts/backend-code-audit.md`** deleted.

## Declarative migration complete

After this PR, **all nine subagents are declarative**:

| Agent | Migrated in | Model | Tools |
|---|---|---|---|
| `cai-confirm` | #276 | sonnet | Read, Grep, Glob |
| `cai-analyze` | #278 | default | Read, Grep, Glob |
| `cai-audit` | #278 | sonnet | Read, Grep, Glob |
| `cai-fix` | #285 | default | Read, Edit, Write, Grep, Glob |
| `cai-review-pr` | #287 | default | Read, Grep, Glob, Agent |
| `cai-merge` | #287 | opus | Read |
| `cai-revise` | #294 | default | Read, Edit, Write, Grep, Glob, Bash |
| `cai-audit-triage` | this PR | sonnet | Read |
| `cai-code-audit` | this PR | sonnet | Read, Grep, Glob |

The `prompts/backend-*.md` files are all gone. The only thing still in `prompts/` is `design-decisions.md`, which is intentionally curated data, not a system prompt.

## What phase 7 does NOT do yet

- **No per-agent memory migration.** `cai-code-audit` still reads its memory from `/var/log/cai/code-audit-memory.md` (the wrapper reads it + passes via stdin). Migrating to `.claude/agent-memory/cai-code-audit/` is a future phase once headless memory loading is verified.
- **No skill extraction.** `publish.py`, label transitions, and clone management all stay wrapper-owned.
- **No dispatcher shrinkdown.** cai.py still owns all the deterministic orchestration around each `cmd_*`.

## Next phases (already scoped in #270)

- **Phase 8 — per-agent memory migration.** Move design-decisions and closed-issue rationales from stdin injection to real `.claude/agent-memory/<agent>/` pools. Also migrate `code-audit-memory.md` to the same system. This retires the band-aid from #262.
- **Phase 9 — skill extraction.** Turn deterministic helpers (label transitions, PR creation, publish-findings, closed-issue fetching) into `.claude/skills/` that agents invoke directly. The user's original direction: "deterministic scripts shall become skills for the agents if possible."
- **Phase 10 — dispatcher shrinkdown.** Collapse cai.py from ~3700 lines to a thin cron dispatcher. Entry points become ~10 lines each: look up the agent, compute the minimal user message, invoke, verify, record.

## Test plan
- [ ] Run `cai audit-triage` against a fixture with an `audit:raised` issue and confirm the declarative agent produces parseable `### Verdict: #N` blocks.
- [ ] Run `cai code-audit` and confirm the declarative agent produces `### Finding:` blocks plus the `## Memory Update` block `_save_code_audit_memory` expects.
- [ ] Verify both agents use Sonnet (log / token accounting).
- [ ] Verify `cai-code-audit` cannot Edit files — the tool allowlist blocks it.

## Dependency order

Independent of #287 and #294. The two agent files are unique to this PR; shared infra is already in main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)