### PR TITLE
auto-improve: Revise step loops on PR #127 with four consecutive no-op runs

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -1319,6 +1319,21 @@ def _select_revise_targets() -> list[dict]:
             )
             needs_rebase = False
 
+        # Loop guard: if there are no unaddressed human comments and the
+        # bot has already posted a comment after the current commit (e.g.
+        # a "Revision summary" from a rebase-only run, or a "no
+        # additional changes" acknowledgement), skip the PR.  Without
+        # this, a needs_rebase-only PR can be re-selected every tick —
+        # each successful rebase advances commit_ts, but if main keeps
+        # moving the merge state stays DIRTY and the cycle repeats.
+        # See issue #149.
+        if not unaddressed and any(
+            _is_bot_comment(c)
+            and (_parse_iso_ts(c.get("createdAt")) or commit_ts) > commit_ts
+            for c in comments
+        ):
+            needs_rebase = False
+
         if not unaddressed and not needs_rebase:
             continue
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#149

**Issue:** #149 — Revise step loops on PR #127 with four consecutive no-op runs

## PR Summary

### What this fixes
The revise step's PR-selection logic (`_select_revise_targets`) could re-select a PR on consecutive ticks even when it had already been processed and found no actionable comments. This happened when `needs_rebase` was True (e.g., `mergeStateStatus == "DIRTY"`) but there were no unaddressed human comments — the existing loop guard only covered the rebase-failed case, not the rebase-succeeded-but-nothing-to-do case.

### What was changed
- **cai.py** (`_select_revise_targets`, ~line 1322): Added a new loop guard that clears `needs_rebase` when there are no unaddressed comments AND a bot comment (e.g. "## Revision summary" or "## Revise subagent: no additional changes") already exists after the latest commit timestamp. This prevents the PR from being re-queued on the next tick when it was already visited with nothing to do. New human comments arriving after the bot's reply will still correctly re-trigger selection.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
