### PR TITLE
activate per-agent memory on all nine subagents (Path A phase 8)

### DIFF
--- a/.claude/agents/cai-analyze.md
+++ b/.claude/agents/cai-analyze.md
@@ -2,6 +2,7 @@
 name: cai-analyze
 description: Analyze parsed signals from the cai container's own Claude Code session transcripts and raise auto-improve findings for code, prompt, or workflow issues. Read-only — the wrapper publishes findings as GitHub issues after the agent exits.
 tools: Read, Grep, Glob
+memory: project
 ---
 
 # Backend Auto-Improve

--- a/.claude/agents/cai-audit-triage.md
+++ b/.claude/agents/cai-audit-triage.md
@@ -3,6 +3,7 @@ name: cai-audit-triage
 description: Triage `audit:raised` findings and emit structured verdicts (close_duplicate / close_resolved / passthrough / escalate). Inline-only — all the state (raised issues, other open issues, recent PRs) is provided in the user message. No tool use needed.
 tools: Read
 model: claude-sonnet-4-6
+memory: project
 ---
 
 # Backend Audit Triage

--- a/.claude/agents/cai-audit.md
+++ b/.claude/agents/cai-audit.md
@@ -3,6 +3,7 @@ name: cai-audit
 description: Audit the current GitHub issue queue, recent PRs, and log tail to find inconsistencies in the auto-improve lifecycle state machine. Report-only — findings go to humans for triage, not to the fix subagent.
 tools: Read, Grep, Glob
 model: claude-sonnet-4-6
+memory: project
 ---
 
 # Backend Audit

--- a/.claude/agents/cai-code-audit.md
+++ b/.claude/agents/cai-code-audit.md
@@ -3,6 +3,7 @@ name: cai-code-audit
 description: Read-only audit of the `robotsix-cai` source tree for concrete inconsistencies, dead code, and missing cross-file references the session-based analyzer cannot catch. Runs in a fresh clone and emits `### Finding:` blocks plus a memory update for the next run.
 tools: Read, Grep, Glob
 model: claude-sonnet-4-6
+memory: project
 ---
 
 # Backend Code Audit

--- a/.claude/agents/cai-confirm.md
+++ b/.claude/agents/cai-confirm.md
@@ -3,6 +3,7 @@ name: cai-confirm
 description: Verify whether each `auto-improve:merged` issue has actually been resolved by checking the merged PR's diff against the issue's remediation and the recent parsed transcript signals against the issue's evidence. Produces exactly one verdict per issue — no new findings, no remediations.
 tools: Read, Grep, Glob
 model: claude-sonnet-4-6
+memory: project
 ---
 
 # Backend Confirm

--- a/.claude/agents/cai-fix.md
+++ b/.claude/agents/cai-fix.md
@@ -2,6 +2,7 @@
 name: cai-fix
 description: Autonomous code-editing subagent for `robotsix-cai`. Makes the smallest targeted change that addresses an auto-improve issue handed by the wrapper. Cannot run git or gh — the wrapper handles all remote state and PR opening.
 tools: Read, Edit, Write, Grep, Glob
+memory: project
 ---
 
 # Backend Fix Subagent

--- a/.claude/agents/cai-merge.md
+++ b/.claude/agents/cai-merge.md
@@ -3,6 +3,7 @@ name: cai-merge
 description: Assess whether a pull request correctly implements its linked issue and emit a structured merge verdict (confidence + action). Inline-only — the issue body, PR diff, and PR comments all arrive as the user message. No tool use needed.
 tools: Read
 model: claude-opus-4-6
+memory: project
 ---
 
 # Backend Merge Review

--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -2,6 +2,7 @@
 name: cai-review-pr
 description: Pre-merge ripple-effect review for an open PR. Walks the diff, searches the broader codebase for inconsistencies the PR introduced but didn't update, and emits `### Finding:` blocks the wrapper posts as a PR comment. Read-only.
 tools: Read, Grep, Glob, Agent
+memory: project
 ---
 
 # Backend Pre-Merge Review

--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -2,6 +2,7 @@
 name: cai-revise
 description: Handle an auto-improve PR that needs attention — resolve any in-progress rebase against main AND address unaddressed reviewer comments, in one session. Used by `cai revise` after the wrapper has cloned, checked out, and attempted `git rebase origin/main`.
 tools: Read, Edit, Write, Grep, Glob, Bash
+memory: project
 ---
 
 # Backend Revise Subagent


### PR DESCRIPTION
Refs #270. **Phase 8 of the Path A architectural migration.** Turn on per-agent memory for every declarative subagent so they can accumulate durable notes across runs.

## What changed

- **`memory: project`** added to every agent's frontmatter (`cai-analyze`, `cai-audit`, `cai-audit-triage`, `cai-code-audit`, `cai-confirm`, `cai-fix`, `cai-merge`, `cai-review-pr`, `cai-revise`). Claude Code scopes each agent's memory to `.claude/agent-memory/<agent-name>/MEMORY.md`, shared via git.

- **Nine `MEMORY.md` seed files** created under `.claude/agent-memory/<agent-name>/`. Each is a one-paragraph stub describing what that agent should accumulate across runs (patterns it has considered, approaches that kept getting rejected, noise signals to ignore). No curated content yet — the agents start empty and accumulate over time.

- **No cai.py changes.** The declarative `memory: project` frontmatter field is the whole mechanism.

## What this unlocks

Each agent now has a durable place to remember what it has done. Examples of what future runs might accumulate:

- `cai-fix`: "approach X was rejected by cai merge for reason Y — don't try again"
- `cai-analyze`: "signal S turned out to be noise from the parse.py token-counting bug"
- `cai-audit`: "dysfunction pattern D already flagged this week as #NNN"
- `cai-code-audit`: "rotation state — last run audited area A; next run should audit area B"
- `cai-revise`: "recurring review-comment theme R; address preemptively"

This retires the need for the wrapper to re-derive this kind of state from GitHub on every run.

## What phase 8 does NOT do yet

- **No memory-writing mechanism.** Agents can read their memory but most can't write it (they lack the `Write` tool). `cai-fix` and `cai-revise` technically can (they have Edit/Write) but there's no structured instruction in their prompts telling them to update memory. A follow-up PR will add a "## Memory Update" block convention the wrapper parses and writes on the agent's behalf — same mechanism `cmd_code_audit` already uses for its runtime memory at `/var/log/cai/code-audit-memory.md`.
- **No migration of code-audit runtime memory** to the new project-scope location. Keeping both: runtime memory needs to persist across container rebuilds and the git-backed location would be reset on every image rebuild.
- **No seeded content.** All nine `MEMORY.md` files are empty stubs. Real content gets added as the agents learn from their own runs.

## Test plan
- [ ] Run any subagent (e.g. `cai analyze`) and confirm it does not error on the new `memory: project` frontmatter field.
- [ ] Optional: populate one memory file with a single test entry (e.g. `cai-analyze` with "skip signal S — known noise") and check the session transcript for that content appearing in the agent's reasoning.
- [ ] Verify the `.claude/agent-memory/` directory ships in the Docker image (the existing `COPY .claude /app/.claude` already covers it — no Dockerfile change needed).

## Dependency order

Independent of all other open Path A PRs. Only adds files and modifies agent frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)