### PR TITLE
auto-improve: `needs-human-review` label never created by `ensure_labels`

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -76,6 +76,7 @@ LABELS = [
     ("auto-improve:revising", "d4c5f9", "Revise subagent is actively iterating on a PR"),
     ("auto-improve:solved", "0e8a16", "Pattern verified absent from recent transcripts"),
     ("merge-blocked", "e11d48", "Merge subcommand reviewed and decided not to auto-merge; awaiting human"),
+    ("needs-human-review", "e11d48", "PR needs a human decision before merge"),
     ("category:reliability", "d73a4a", "Errors, failures, flaky behavior"),
     ("category:cost_reduction", "fbca04", "Token waste, unnecessary tool calls"),
     ("category:prompt_quality", "0075ca", "Unclear or missing prompt guidance"),


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#302

**Issue:** #302 — `needs-human-review` label never created by `ensure_labels`

## PR Summary

### What this fixes
The `needs-human-review` label (used by `_pr_set_needs_human` and `_pr_label_sweep` in `cai.py`) was never created by `ensure_labels` because it was missing from all label lists in `publish.py`. A fresh deployment would fail when trying to apply this label.

### What was changed
- `publish.py`: Added `("needs-human-review", "e11d48", "PR needs a human decision before merge")` to the `LABELS` list (after `merge-blocked`), so `ensure_labels` creates it on first run.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
