### PR TITLE
fix agent: forbid inline `--system-prompt` for new subagent roles

### DIFF
--- a/.claude/agents/cai-fix.md
+++ b/.claude/agents/cai-fix.md
@@ -51,6 +51,22 @@ Edit, Write, Grep, and Glob — Bash is not in your tool allowlist.
    directory. Don't modify `.github/workflows/` files unless the
    issue is specifically about them — if in doubt, exit without
    changes.
+7. **Declarative subagents only.** When introducing a new subagent
+   role — for any reason, including a multi-phase pipeline,
+   specialised reviewer, or experimental agent — declare it as a
+   `.claude/agents/cai-<name>.md` file with YAML frontmatter
+   (`name`, `description`, `tools`, optional `model`, optional
+   `memory: project`) and invoke it via `claude -p --agent cai-<name>`
+   from the wrapper. **Never** introduce a new subagent as a
+   Python string constant in cai.py invoked via `claude -p
+   --system-prompt <string> --tools <list>`. Inline system prompts
+   are exactly the pattern the Path A migration retired (#270);
+   reintroducing them — even for "just one new agent" — is a
+   regression. The Python wrapper-side scaffolding (helpers, loops,
+   parallelism) is fine to add; only the prompt-delivery shape
+   has to be declarative. If you find yourself reaching for
+   `--system-prompt` or `--tools` on the command line, stop and
+   write the agent file instead.
 
 ## Efficiency guidance
 


### PR DESCRIPTION
Add a hard rule (#7) to \`.claude/agents/cai-fix.md\` requiring any **new** subagent role to be declared as a \`.claude/agents/cai-<name>.md\` file with YAML frontmatter and invoked via \`claude -p --agent cai-<name>\`. Forbid the inline \`claude -p --system-prompt <string> --tools <list>\` pattern.

## Why

PR #318 (now closed) introduced a 3-phase fix pipeline (plan → select → implement) for issue #269 but added the new "plan" and "select" agents as Python string constants in cai.py (\`_PLAN_SYSTEM_PROMPT\`, \`_SELECT_SYSTEM_PROMPT\`) invoked via:

\`\`\`
claude -p --model claude-opus-4-6 --system-prompt _PLAN_SYSTEM_PROMPT --tools Read,Grep,Glob
\`\`\`

That is exactly the pre-Path-A pattern that phases 1-7 of the architectural migration (#270, closed) spent eight PRs retiring:
- prompt lives in code instead of a declarative agent file
- tool allowlist is a CLI flag instead of frontmatter
- model pin is scattered across call sites instead of declared in one place
- new agents have no per-agent memory pool
- new agents are invisible to \`.claude/agents/\` discoverability and code-audit

The fix agent took the path of least resistance because it had no rule telling it the declarative shape is the only acceptable shape. This rule prevents the same regression on the next new-subagent PR.

## What's allowed and what's not

**Allowed (wrapper-side scaffolding stays in cai.py):**
- Helpers like \`_run_single_plan_agent()\`, \`_run_plan_phase()\`, \`_run_select_phase()\`
- Parallelism (\`concurrent.futures\`)
- Orchestration loops, retry logic, output parsing
- Anything that's "Python around the agent invocation"

**Not allowed:**
- \`--system-prompt <string>\` in any \`claude -p\` invocation
- \`--tools <list>\` in any \`claude -p\` invocation (use the agent file's frontmatter \`tools:\` field instead)
- New \`_FOO_SYSTEM_PROMPT\` Python string constants for agent prompts

The Python wrapper is still the orchestrator. Only the prompt-delivery shape has to be declarative.

## Test plan
- [ ] After this lands, re-label #269 as \`auto-improve:requested\` and let \`cai fix\` take another pass. Expected: the next PR for #269 produces \`.claude/agents/cai-plan.md\` and \`.claude/agents/cai-select.md\` (with frontmatter declaring \`tools: Read, Grep, Glob\`, \`model: claude-opus-4-6\`) and the wrapper invokes them via \`claude -p --agent cai-plan\` / \`--agent cai-select\` instead of inline \`--system-prompt\` strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)