### PR TITLE
fix/revise: switch to `--permission-mode auto` so self-modifying agents can edit `.claude/agents/*.md`

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -800,13 +800,29 @@ def cmd_fix(args) -> int:
         #    body) as the user message via stdin.
         user_message = _build_fix_user_message(issue)
         print(f"[cai fix] running cai-fix subagent in {work_dir}", flush=True)
-        # `acceptEdits` auto-accepts file edits (Read/Edit/Write/Grep/Glob)
-        # without prompting. We don't use `bypassPermissions` because
-        # claude-code refuses it when running as root inside the container,
-        # and `acceptEdits` is sufficient for code-editing fixes.
+        # `--permission-mode auto` uses Claude Code's background
+        # safety classifier to auto-approve low-risk actions (like
+        # editing `.claude/agents/*.md` files when auto-improve is
+        # self-modifying its own prompts) while still blocking
+        # genuinely dangerous operations. We need this because
+        # `acceptEdits` denies writes to `.claude/` even though the
+        # agent has Edit/Write tools — the fix agent kept exiting
+        # with "I need write permission to .claude/agents/cai-fix.md"
+        # (see issues #288, #298).
+        #
+        # Defense in depth on top of `auto`:
+        #   - the agent runs in a throwaway clone
+        #     (`/tmp/cai-fix-N/`), so any unwanted edit only damages
+        #     the clone, never the main worktree
+        #   - `.claude/settings.json`'s deny rules still block
+        #     `git push`, `git remote`, and `gh` regardless of mode
+        #   - cai-fix's tool allowlist excludes Bash entirely, so
+        #     the agent can't invoke shell commands at all
+        #   - the wrapper trust-but-verifies the working tree before
+        #     committing/pushing
         agent = _run(
             ["claude", "-p", "--agent", "cai-fix",
-             "--permission-mode", "acceptEdits"],
+             "--permission-mode", "auto"],
             input=user_message,
             cwd=str(work_dir),
             capture_output=True,
@@ -1572,13 +1588,25 @@ def cmd_revise(args) -> int:
             )
 
             # 6. Invoke the declared cai-revise subagent.
+            #    `--permission-mode auto` uses the background safety
+            #    classifier to auto-approve low-risk actions (like
+            #    editing `.claude/agents/*.md` for self-modifying
+            #    revise comments) while still blocking dangerous
+            #    operations. We can't use `acceptEdits` because it
+            #    denies `.claude/` writes; we don't want
+            #    `dangerously-skip-permissions` because cai-revise has
+            #    Bash and the classifier-based gating is the better
+            #    safety layer for that combination. Same blast-radius
+            #    reasoning as cmd_fix above: throwaway clone, deny
+            #    rules in `.claude/settings.json` still block
+            #    push/remote/gh, trust-but-verify in step 7.
             print(
                 f"[cai revise] running cai-revise subagent in {work_dir}",
                 flush=True,
             )
             agent = _run(
                 ["claude", "-p", "--agent", "cai-revise",
-                 "--permission-mode", "acceptEdits"],
+                 "--permission-mode", "auto"],
                 input=user_message,
                 cwd=str(work_dir),
                 capture_output=True,


### PR DESCRIPTION
Resolves the recurring **"I need write permission to .claude/agents/cai-fix.md"** exit pattern that issues #288 and #298 (and several others) keep flagging.

## The bug

Both \`cai-fix\` and \`cai-revise\` legitimately need to edit \`.claude/agents/*.md\` files when auto-improve self-modifies its own prompts. With \`--permission-mode acceptEdits\`, Claude Code denies writes to \`.claude/\` even though both agents have \`Edit\` and \`Write\` in their tool allowlists. The fix agent kept exiting with explicit "I need write permission" notes (visible in the \`:no-action\` comment of #288 and several other issues), and the \`:no-action\` label suppressed retries until a human stepped in.

This is the **"agent keeps complaining about missing the rights"** pattern flagged in this conversation.

## The fix

Switch \`cmd_fix\` and \`cmd_revise\` to \`--permission-mode auto\`. Auto Mode uses Claude Code's background safety classifier to auto-approve low-risk actions (like editing a \`.claude/agents/*.md\` file inside a throwaway clone) while still blocking genuinely dangerous operations.

This is more nuanced than \`--dangerously-skip-permissions\` (which would skip all gating unconditionally) and gives a real safety layer for cai-revise in particular, which has Bash in its tool allowlist for git rebase operations.

The two read-only agents (\`cmd_code_audit\`, \`cmd_review_pr\`) keep \`acceptEdits\` because they don't have Edit/Write tools — there's nothing for the auto classifier to approve there.

## Defense in depth still applies

Auto mode is an addition to the existing safety layers, not a replacement:

- Both agents run in throwaway clones (\`/tmp/cai-fix-N/\`, \`/tmp/cai-revise-N-uid/\`), so any unwanted edit only damages the clone, never the main worktree.
- \`.claude/settings.json\`'s deny rules still block \`Bash(git push:*)\`, \`Bash(git remote:*)\`, and \`Bash(gh:*)\` regardless of permission mode.
- \`cai-fix\` has no Bash at all in its tool allowlist.
- \`cai-revise\` has Bash but the deny rules above scope it to git operations on the local clone only.
- The wrapper trust-but-verifies the working tree before committing/pushing (rebase state clean, no unmerged paths, HEAD ancestor of \`origin/main\`).

## Test plan
- [ ] Re-label #288 as \`auto-improve:requested\` after this lands and let the next \`cai fix\` tick attempt the read-before-edit rule rewrite that was previously blocked. Expected: the agent successfully edits \`cai-fix.md\` and \`cai-revise.md\` without the "I need write permission" exit.
- [ ] Same for #298 (Read errors investigation).
- [ ] Verify cai-revise can still resolve a rebase conflict (no regression on the existing Bash + git path).
- [ ] Verify the auto classifier doesn't auto-approve a \`git push\` attempt — the settings.json deny rules should still fire (those are independent of permission mode).

## Notes

If \`--permission-mode auto\` isn't supported in the pinned Claude Code 2.1.96 (the docs I could find said it's the modern recommendation as of 2026, but I couldn't verify the specific version), the agent invocation will exit with an unrecognized-flag error and we'll know immediately. Fallback would be \`--dangerously-skip-permissions\`, which is the bigger hammer but bulletproof against denial.

Closes the underlying root cause for #288 and #298 (the analyzer-raised issues that kept flagging Edit and Read errors — both of which were partly the agent failing to land prompt changes because of the permission denial, not the actual quality of the prompts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)