### PR TITLE
add `:needs-spike` label + wire fix agent to apply it on spike-shaped bails

### DIFF
--- a/.claude/agents/cai-fix.md
+++ b/.claude/agents/cai-fix.md
@@ -130,10 +130,23 @@ another run can try later. You should exit without changes when:
 - **The issue asks for a spike, research, or evaluation** rather
   than a specific code change. If the acceptance criteria are
   "documented findings" or "a decision" or "a survey of what's
-  possible" — not a concrete file edit — exit cleanly and note
-  that this issue needs a spike (which may be driven by a
-  different agent, a later cycle, or a human) rather than a
-  routine fix attempt.
+  possible" — not a concrete file edit — exit cleanly. To signal
+  to the wrapper that this is a spike (not just a vague issue),
+  **emit a `## Needs Spike` block** somewhere in your stdout
+  before exiting, like this:
+
+  ~~~
+  ## Needs Spike
+
+  <one-paragraph description of what the spike needs to figure out>
+  ~~~
+
+  When the wrapper sees this marker, it transitions the issue to
+  the `auto-improve:needs-spike` label (instead of the default
+  `auto-improve:no-action`) so the spike-handling agent
+  (cai-spike, see #314) picks it up later. The spike may be
+  driven by a different agent, a later cycle, or a human —
+  emitting the marker is the handoff.
 - You'd be guessing
 
 In all of these cases, **print a short paragraph to stdout

--- a/cai.py
+++ b/cai.py
@@ -118,6 +118,7 @@ LABEL_PR_OPEN = "auto-improve:pr-open"
 LABEL_MERGED = "auto-improve:merged"
 LABEL_SOLVED = "auto-improve:solved"
 LABEL_NO_ACTION = "auto-improve:no-action"
+LABEL_NEEDS_SPIKE = "auto-improve:needs-spike"
 LABEL_REVISING = "auto-improve:revising"
 LABEL_MERGE_BLOCKED = "merge-blocked"
 LABEL_AUDIT_RAISED = "audit:raised"
@@ -847,23 +848,61 @@ def cmd_fix(args) -> int:
             n = _create_suggested_issues(suggested, issue_number)
             print(f"[cai fix] created {n}/{len(suggested)} suggested issue(s)", flush=True)
 
-        # 6. Inspect the working tree. Empty diff = deliberate no-action.
+        # 6. Inspect the working tree. Empty diff = deliberate
+        #    no-action OR a spike-shaped bail-out (the agent
+        #    recognised the issue needs a spike, not a code change,
+        #    per the bullet in cai-fix.md).
         status = _git(work_dir, "status", "--porcelain", check=False)
         if not status.stdout.strip():
-            reasoning = (agent.stdout or "").strip()[:2000]
+            agent_text = agent.stdout or ""
+            reasoning = agent_text.strip()[:2000]
+
+            # Detect the spike marker. The cai-fix agent emits a
+            # `## Needs Spike` block when bailing on a spike-shaped
+            # issue so the wrapper can route to :needs-spike instead
+            # of the default :no-action.
+            is_spike = re.search(
+                r"^##\s*Needs Spike\b",
+                agent_text,
+                flags=re.MULTILINE,
+            ) is not None
+
+            if is_spike:
+                target_label = LABEL_NEEDS_SPIKE
+                comment_heading = "## Fix subagent: needs a spike"
+                comment_footer = (
+                    "_Set by `cai fix` after the subagent recognised "
+                    "this issue as spike-shaped (research / verification "
+                    "/ evaluation). The cai-spike subagent (#314) will "
+                    "pick this up once it ships. Re-label to "
+                    f"`{origin_raised_label}` to retry as a routine "
+                    "fix instead._"
+                )
+                log_result = "needs_spike"
+                log_label = "auto-improve:needs-spike"
+            else:
+                target_label = LABEL_NO_ACTION
+                comment_heading = "## Fix subagent: no action needed"
+                comment_footer = (
+                    "_Set by `cai fix` after the subagent reviewed and "
+                    "decided no code change was needed. Re-label to "
+                    f"`{origin_raised_label}` to retry, or close if "
+                    "you agree._"
+                )
+                log_result = "no_action_needed"
+                log_label = "auto-improve:no-action"
+
             print(
                 f"[cai fix] subagent produced no changes for #{issue_number}; "
-                "marking auto-improve:no-action",
+                f"marking {log_label}",
                 flush=True,
             )
             # Post the agent's reasoning as a comment on the issue
             comment_body = (
-                f"## Fix subagent: no action needed\n\n"
+                f"{comment_heading}\n\n"
                 f"{reasoning}\n\n"
                 f"---\n"
-                f"_Set by `cai fix` after the subagent reviewed and decided "
-                f"no code change was needed. Re-label to "
-                f"`{origin_raised_label}` to retry, or close if you agree._"
+                f"{comment_footer}"
             )
             _run(
                 ["gh", "issue", "comment", str(issue_number),
@@ -871,25 +910,26 @@ def cmd_fix(args) -> int:
                  "--body", comment_body],
                 capture_output=True,
             )
-            # Transition: in-progress -> no-action (NOT back to :raised)
+            # Transition: in-progress -> target_label (NOT back to :raised)
             if not _set_labels(
                 issue_number,
-                add=[LABEL_NO_ACTION],
+                add=[target_label],
                 remove=[LABEL_IN_PROGRESS],
             ):
                 print(
-                    f"[cai fix] WARNING: label transition to :no-action failed for "
-                    f"#{issue_number}; retrying",
+                    f"[cai fix] WARNING: label transition to {log_label} "
+                    f"failed for #{issue_number}; retrying",
                     flush=True,
                 )
                 if not _set_labels(
                     issue_number,
-                    add=[LABEL_NO_ACTION],
+                    add=[target_label],
                     remove=[LABEL_IN_PROGRESS],
                 ):
                     print(
-                        f"[cai fix] WARNING: label transition to :no-action failed twice for "
-                        f"#{issue_number} — issue may be stuck without a lifecycle label",
+                        f"[cai fix] WARNING: label transition to "
+                        f"{log_label} failed twice for #{issue_number} "
+                        "— issue may be stuck without a lifecycle label",
                         file=sys.stderr, flush=True,
                     )
                     rollback()
@@ -898,7 +938,7 @@ def cmd_fix(args) -> int:
                     return 1
             locked = False
             log_run("fix", repo=REPO, issue=issue_number,
-                    result="no_action_needed", exit=0)
+                    result=log_result, exit=0)
             return 0
 
         # Count changed files for the log line.

--- a/publish.py
+++ b/publish.py
@@ -73,6 +73,7 @@ LABELS = [
     ("auto-improve:pr-open", "5319e7", "fix subagent opened a PR"),
     ("auto-improve:merged", "0e8a16", "PR was merged; awaiting verify"),
     ("auto-improve:no-action", "c5def5", "Fix subagent reviewed and decided no code change is needed; awaiting human triage"),
+    ("auto-improve:needs-spike", "e99695", "Issue needs a research spike before code changes (handled by cai-spike, see #314)"),
     ("auto-improve:revising", "d4c5f9", "Revise subagent is actively iterating on a PR"),
     ("auto-improve:solved", "0e8a16", "Pattern verified absent from recent transcripts"),
     ("merge-blocked", "e11d48", "Merge subcommand reviewed and decided not to auto-merge; awaiting human"),


### PR DESCRIPTION
The fix subagent already recognises spike-shaped issues (research / verification / evaluation work that doesn't map to a code change) and exits cleanly with a stdout note, per the bullet added in #310. But the wrapper has historically transitioned every empty-diff bail to \`auto-improve:no-action\`, which conflates "the agent reviewed and decided no code change is needed" with "this issue needs a spike before any code change can even be designed." Two very different states with very different next-action requirements.

This PR adds a dedicated label and wires the fix agent to use it.

## Three changes

### 1. New \`auto-improve:needs-spike\` label
Added to \`publish.py\`'s \`LABELS\` list so it's idempotently re-created on every container startup. Color: \`e99695\` (light salmon, distinct from the other state labels). Description points at #314 (the cai-spike subagent that will eventually pick these up).

### 2. \`cai-fix.md\` spike bullet updated
The spike-recognition bullet in the "exit cleanly" section is updated to instruct the agent to emit a structured marker:

\`\`\`
## Needs Spike

<one-paragraph description of what the spike needs to figure out>
\`\`\`

When the agent emits this block, the wrapper detects it and routes to the new label.

### 3. \`cmd_fix\` no-action handler restructured
Detects the \`## Needs Spike\` marker in agent stdout (regex \`^##\\s*Needs Spike\\b\`). If present:
- target label = \`auto-improve:needs-spike\` (instead of \`:no-action\`)
- comment heading = "Fix subagent: needs a spike"
- log result = \`needs_spike\`

Otherwise the existing \`:no-action\` flow is preserved unchanged for non-spike empty diffs. The new \`LABEL_NEEDS_SPIKE\` constant is added near \`LABEL_NO_ACTION\`.

## Why this matters

Without the distinction:
- The audit agent can't tell which issues are stuck because they legitimately need a spike vs which were just bad findings
- \`_unstuck_stale_no_action\` rolls everything back to \`:raised\` after 7 days, **including spike-shaped issues that should stay parked** until cai-spike (#314) lands
- The spike-handling agent (#314) has no eligibility filter to query for once it ships
- Humans browsing the issue tracker can't distinguish "agent decided not to act" from "agent decided this is research, not coding"

## Existing issues already re-labelled

The two existing spike-shaped issues #308 (skills evaluation) and #309 (CLAUDE.md factoring) have been manually re-labelled as \`:needs-spike\` (removing \`:no-action\`) ahead of this PR. Once it lands, future spike-shaped bails will get the right label automatically.

## Test plan
- [ ] Hand the fix agent a synthetic spike-shaped issue (e.g., copy of #308 or #309 in a test repo). Expected: agent emits \`## Needs Spike\` block, wrapper applies \`:needs-spike\` instead of \`:no-action\`, comment heading reads "Fix subagent: needs a spike."
- [ ] Hand the fix agent a normal "agent reviewed and decided no change" issue (e.g., a label-state-reconciliation task like #304). Expected: agent doesn't emit the marker, wrapper applies \`:no-action\` as today, no regression.
- [ ] Verify the new label survives a container restart (publish.py's \`ensure_labels\` runs on startup and idempotently re-creates it).
- [ ] Verify \`_unstuck_stale_no_action\` does NOT touch \`:needs-spike\` issues — its query is \`--label auto-improve:no-action\` so it should naturally exclude them, but worth confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)