### PR TITLE
docker: run as non-root `cai` user so `--dangerously-skip-permissions` works

### DIFF
--- a/.claude/agents/cai-analyze.md
+++ b/.claude/agents/cai-analyze.md
@@ -16,7 +16,7 @@ prompts, Dockerfile, installer, or docs should change.
 
 You analyze ONLY the cai container's own runtime sessions. The signal
 data you receive comes from JSONL files under
-`/root/.claude/projects/-app/` inside the container — sessions where
+`/home/cai/.claude/projects/-app/` inside the container — sessions where
 the cai container itself invoked `claude -p`. You do NOT look at
 sessions from outside the container.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,12 +57,27 @@ RUN wget -nv -O /usr/local/bin/supercronic \
     && chmod +x /usr/local/bin/supercronic \
     && supercronic -version
 
+# Create a non-root user. claude-code refuses
+# `--dangerously-skip-permissions` when running as root
+# ("cannot be used with root/sudo privileges for security reasons"),
+# which we need so the fix and revise subagents can edit
+# `.claude/agents/*.md` files (auto-improve self-modifies its own
+# prompts). UID 1000 matches the typical first-host-user UID so the
+# bind-mounted `./logs:/var/log/cai` directory works without extra
+# host-side chowning.
+RUN groupadd --system --gid 1000 cai \
+    && useradd --system --gid cai --uid 1000 --create-home --shell /bin/bash cai \
+    && mkdir -p /var/log/cai \
+    && chown -R cai:cai /var/log/cai
+
 WORKDIR /app
-COPY cai.py /app/cai.py
-COPY parse.py /app/parse.py
-COPY publish.py /app/publish.py
-COPY .claude /app/.claude
-COPY entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+COPY --chown=cai:cai cai.py /app/cai.py
+COPY --chown=cai:cai parse.py /app/parse.py
+COPY --chown=cai:cai publish.py /app/publish.py
+COPY --chown=cai:cai .claude /app/.claude
+COPY --chown=cai:cai entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh && chown cai:cai /app
+
+USER cai
 
 CMD ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ any files at all, one `docker run` is enough.
 
 ```bash
 docker run --rm \
-  -v ~/.claude/.credentials.json:/root/.claude/.credentials.json \
+  -v ~/.claude/.credentials.json:/home/cai/.claude/.credentials.json \
   robotsix/cai:latest
 ```
 
@@ -420,14 +420,20 @@ the `volumes:` block.
 
 The container uses two Docker named volumes:
 
-- **`cai_transcripts`** (mounted at `/root/.claude/projects`) —
+- **`cai_transcripts`** (mounted at `/home/cai/.claude/projects`) —
   claude-code writes one JSONL file per session under
-  `/root/.claude/projects/<sanitized-cwd>/<session-id>.jsonl`; the
+  `/home/cai/.claude/projects/<sanitized-cwd>/<session-id>.jsonl`; the
   volume keeps that data across restarts so future analyzer runs can
   read it.
-- **`cai_gh_config`** (mounted at `/root/.config/gh`) — the `gh` CLI's
+- **`cai_gh_config`** (mounted at `/home/cai/.config/gh`) — the `gh` CLI's
   credential store. Populated once by the installer's
   `gh auth login` step and reused on every subsequent run.
+
+The container runs as the non-root `cai` user (uid 1000). This is
+required by `claude-code` because the fix and revise subagents use
+`--dangerously-skip-permissions` to allow self-modifying edits to
+`.claude/agents/*.md`, and `claude-code` refuses that flag when
+invoked as root.
 
 The transcript parser (`parse.py`) only considers sessions whose JSONL
 file was modified within a configurable window. This prevents stale

--- a/cai.py
+++ b/cai.py
@@ -94,14 +94,17 @@ REPO = "damien-robotsix/robotsix-cai"
 SMOKE_PROMPT = "Say hello in one short sentence."
 
 # Root of claude-code's per-cwd transcript dirs. claude-code writes
-# `/root/.claude/projects/<sanitized-cwd>/<session-id>.jsonl` for every
+# `~/.claude/projects/<sanitized-cwd>/<session-id>.jsonl` for every
 # session, so this directory contains one subdir per cwd:
 #   * `-app/`            — sessions started by cai.py inside /app
 #   * `-tmp-cai-fix-<N>/` — sessions started by the fix subagent in
 #                          its per-issue clone under /tmp
 # The analyzer parses *all* of them so the fix subagent's tool-rich
 # sessions feed back into the next analyzer cycle.
-TRANSCRIPT_DIR = Path("/root/.claude/projects")
+#
+# Path is /home/cai/... because the container runs as the non-root
+# `cai` user (uid 1000) — see Dockerfile.
+TRANSCRIPT_DIR = Path("/home/cai/.claude/projects")
 
 # Files baked into the image alongside cai.py.
 PARSE_SCRIPT = Path("/app/parse.py")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,12 +47,15 @@ services:
       # session JSONL into ~/.claude/projects/<sanitized-cwd>/<sid>.jsonl
       # inside the container; this named volume keeps that data across
       # container restarts so future analyzer runs can read it.
-      - cai_transcripts:/root/.claude/projects
+      #
+      # Mount path is /home/cai/... because the container now runs as
+      # the non-root `cai` user (uid 1000) — see Dockerfile.
+      - cai_transcripts:/home/cai/.claude/projects
       # Persistent gh CLI configuration. The installer runs
       # `docker compose run --rm cai gh auth login` once and the
       # resulting credentials land here, so subsequent `docker compose
       # up` runs don't need to re-authenticate.
-      - cai_gh_config:/root/.config/gh
+      - cai_gh_config:/home/cai/.config/gh
       - ./logs:/var/log/cai
       # Uncomment to use OAuth credentials from the host instead of an
       # API key. Requires `claude login` to have been run on the host so
@@ -61,7 +64,7 @@ services:
       # so claude-code can refresh the OAuth access token in place; a
       # :ro mount would block refresh and 401 after the token expires.
       #
-      # - ${HOME}/.claude/.credentials.json:/root/.claude/.credentials.json
+      # - ${HOME}/.claude/.credentials.json:/home/cai/.claude/.credentials.json
     # Required if Watchtower is enabled (uncommented below):
     # labels:
     #   - "com.centurylinklabs.watchtower.enable=true"

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,7 @@ any files at all, one `docker run` is enough.
 
 ```bash
 docker run --rm \
-  -v ~/.claude/.credentials.json:/root/.claude/.credentials.json \
+  -v ~/.claude/.credentials.json:/home/cai/.claude/.credentials.json \
   robotsix/cai:latest
 ```
 
@@ -122,11 +122,12 @@ docker compose up
 
 The container persists Claude Code's session transcripts in a Docker
 named volume called **`cai_transcripts`**, mounted at
-`/root/.claude/projects` inside the container. claude-code writes one
+`/home/cai/.claude/projects` inside the container. claude-code writes one
 JSONL file per session under
-`/root/.claude/projects/<sanitized-cwd>/<session-id>.jsonl`, and the
+`/home/cai/.claude/projects/<sanitized-cwd>/<session-id>.jsonl`, and the
 volume keeps that data across container restarts so future analyzer
-runs can read it.
+runs can read it. (The container runs as the non-root `cai` user, uid
+1000 — see Dockerfile for the rationale.)
 
 Inspect the volume from outside the container:
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,7 +60,7 @@ echo
 
 # Wire `gh` in as the git credential helper so the fix subagent can
 # `git push` over HTTPS using the same token that's in the
-# cai_gh_config volume. /root/.gitconfig isn't persisted across
+# cai_gh_config volume. ~/.gitconfig isn't persisted across
 # container restarts, so we re-run this every startup.
 if gh auth status >/dev/null 2>&1; then
   echo "[entrypoint] configuring gh as the git credential helper"

--- a/install.sh
+++ b/install.sh
@@ -158,9 +158,9 @@ services:
       # access token when it expires. claude-code writes the refreshed
       # token back to this file; without :rw, subsequent API calls
       # would 401 once the token lifetime is up.
-      - \${HOME}/.claude/.credentials.json:/root/.claude/.credentials.json
-      - cai_transcripts:/root/.claude/projects
-      - cai_gh_config:/root/.config/gh
+      - \${HOME}/.claude/.credentials.json:/home/cai/.claude/.credentials.json
+      - cai_transcripts:/home/cai/.claude/projects
+      - cai_gh_config:/home/cai/.config/gh
       - ./logs:/var/log/cai
 ${CAI_LABEL_BLOCK}${WATCHTOWER_SERVICE}
 
@@ -205,8 +205,8 @@ services:
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "50"        # read at most N recent transcript files (0 = no limit)
     volumes:
-      - cai_transcripts:/root/.claude/projects
-      - cai_gh_config:/root/.config/gh
+      - cai_transcripts:/home/cai/.claude/projects
+      - cai_gh_config:/home/cai/.config/gh
       - ./logs:/var/log/cai
 ${CAI_LABEL_BLOCK}${WATCHTOWER_SERVICE}
 

--- a/parse.py
+++ b/parse.py
@@ -21,7 +21,7 @@ calls this script (see .claude/agents/cai-analyze.md).
 
 Usage::
 
-    python parse.py /root/.claude/projects/-app/
+    python parse.py /home/cai/.claude/projects/-app/
     python parse.py <transcript-file.jsonl>
     cat *.jsonl | python parse.py
 """


### PR DESCRIPTION
**Urgent fix.** PR #329 switched the fix and revise subagents to \`--dangerously-skip-permissions\` (the only flag that lets them write to \`.claude/agents/*.md\` for self-modifying edits), but claude-code refuses that flag when invoked as root inside the container:

\`\`\`
--dangerously-skip-permissions cannot be used with
root/sudo privileges for security reasons
\`\`\`

The container has been running as root since day one. Every \`cai fix\` and \`cai revise\` cron tick is currently exit-1-ing.

The proper fix is to switch to a non-root user — cai doesn't need root for anything (supercronic, gh, git, npm-installed claude-code, and the wrapper all work fine as a regular user).

## What changes

### Dockerfile
- Create a system user \`cai\` with **uid 1000** (matches the typical first-host-user uid so the bind-mounted \`./logs:/var/log/cai\` works without extra host-side chowning)
- Pre-create \`/var/log/cai\` and chown it to \`cai\` so the bind-mount target exists and is writable
- Use \`COPY --chown=cai:cai\` for the application files
- Switch to \`USER cai\` before the entrypoint

### docker-compose.yml — volume mount paths
- \`cai_transcripts: /root/.claude/projects\` → \`cai_transcripts: /home/cai/.claude/projects\`
- \`cai_gh_config: /root/.config/gh\` → \`cai_gh_config: /home/cai/.config/gh\`
- Optional OAuth credentials mount path also moves to \`/home/cai/.claude/.credentials.json\`

### cai.py
- \`TRANSCRIPT_DIR\` constant moves from \`/root/.claude/projects\` to \`/home/cai/.claude/projects\`
- **No agent invocation flag changes** — \`--dangerously-skip-permissions\` stays. It works now because the container is non-root.

### Other files for consistency
- \`parse.py\` module docstring example
- \`.claude/agents/cai-analyze.md\` mention of the transcript path
- \`README.md\` persistent-data section + standalone docker-run example (also documents the new non-root behavior)
- \`docs/index.md\` same
- \`install.sh\` both docker-compose templates (credentials-mount mode and api-key mode)
- \`entrypoint.sh\` comment about \`~/.gitconfig\` (was \`/root/...\`)

## Migration note for the existing deployment

The \`cai_transcripts\` and \`cai_gh_config\` named volumes will appear empty to the container after this lands because the mount points have moved. The data inside the volumes is unchanged on disk — docker just mounts them at the new paths.

For most users this means **re-authenticating gh once** on the next \`docker compose up\`:

\`\`\`
docker compose run --rm cai gh auth login
\`\`\`

…and losing the historical transcript window for one analyze cycle.

If preserving the historical transcripts matters, a manual migration is possible: \`docker compose run --rm --entrypoint /bin/bash cai\` and copy \`/root/.claude/projects/\` to \`/home/cai/.claude/projects/\` before starting normal operation. For this single-user deployment we probably don't need to bother.

## Test plan
- [ ] Build the image: \`docker compose build\`
- [ ] Confirm the image runs as the \`cai\` user: \`docker compose run --rm cai whoami\` should output \`cai\`
- [ ] Re-authenticate gh: \`docker compose run --rm cai gh auth login\`
- [ ] Run a fix tick on a non-spike issue (e.g. label one of the \`:raised\` issues as \`:requested\`): expect the agent to actually edit files and open a PR
- [ ] Run a fix tick on #288 or #298 (already \`:requested\`): expect the agent to successfully edit \`.claude/agents/cai-fix.md\` / \`cai-revise.md\` and open a PR — the previous "I need write permission" exit pattern should be gone
- [ ] Confirm \`./logs/cai.log\` on the host is being written to (no permission denied errors)

## Alternative if this breaks anything

If running as non-root surfaces unexpected issues (volume permissions, claude-code config dir, gh auth), the fallback is to revert to \`--permission-mode acceptEdits\` in cai.py for both \`cmd_fix\` and \`cmd_revise\`. That gets the cron working again at the cost of losing self-modification capability for \`.claude/agents/*.md\` (which is what we had before #329). I'd rather try the non-root path first because it's the proper fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)