### PR TITLE
docker: pre-create named-volume mount points with `cai` ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,10 +65,19 @@ RUN wget -nv -O /usr/local/bin/supercronic \
 # prompts). UID 1000 matches the typical first-host-user UID so the
 # bind-mounted `./logs:/var/log/cai` directory works without extra
 # host-side chowning.
+#
+# We pre-create the named-volume mount points (`/home/cai/.config/gh`
+# for `cai_gh_config` and `/home/cai/.claude/projects` for
+# `cai_transcripts`) with cai:cai ownership. Docker copies the
+# image's contents (including ownership and permissions) into a
+# new empty named volume on first mount — without these pre-created
+# directories, the volume mount points are created at runtime as
+# root:root and the cai user gets "permission denied" trying to
+# write `gh` credentials or claude-code transcripts there.
 RUN groupadd --system --gid 1000 cai \
     && useradd --system --gid cai --uid 1000 --create-home --shell /bin/bash cai \
-    && mkdir -p /var/log/cai \
-    && chown -R cai:cai /var/log/cai
+    && mkdir -p /var/log/cai /home/cai/.config/gh /home/cai/.claude/projects \
+    && chown -R cai:cai /var/log/cai /home/cai
 
 WORKDIR /app
 COPY --chown=cai:cai cai.py /app/cai.py


### PR DESCRIPTION
Follow-up to #331 (non-root container). On a fresh install with empty named volumes, \`gh auth login\` fails with:

\`\`\`
open /home/cai/.config/gh/hosts.yml: permission denied
\`\`\`

## Root cause

When Docker creates a new empty named volume and mounts it at a path that **doesn't exist in the image**, the mount point is created at runtime as \`root:root\`. The non-root \`cai\` user (uid 1000) then can't write to it.

The standard fix is to pre-create the directory in the image with the correct ownership before the volume gets mounted. Docker copies the image's directory contents (including ownership and permissions) into a new empty volume on first mount, so a pre-created \`cai:cai\`-owned directory becomes a \`cai:cai\`-owned volume.

## What changed

The Dockerfile's user-creation \`RUN\` block now also \`mkdir -p\`s both volume mount points alongside the existing \`/var/log/cai\`:

- \`/home/cai/.config/gh\` (mount point for \`cai_gh_config\`)
- \`/home/cai/.claude/projects\` (mount point for \`cai_transcripts\`)

…and \`chown -R cai:cai\` covers both via \`/home/cai\`. The \`useradd --create-home\` step already creates \`/home/cai\` itself, so the chown also fixes any stray \`/etc/skel\` files copied during useradd.

**Diff: 1 file changed, 11 insertions, 2 deletions.**

## Migration note for the existing broken deployment

This fix only takes effect on volumes created **after** the new image is built/pulled. For the existing volumes that were already created with root ownership (the ones giving you the permission denied error right now), the workaround is one of:

**Option A — chown the volume contents (preserves any data):**
\`\`\`
docker compose down
docker run --rm -v cai_gh_config:/data alpine chown -R 1000:1000 /data
docker compose run --rm cai gh auth login --git-protocol https
docker compose up -d
\`\`\`

**Option B — delete and recreate:**
\`\`\`
docker compose down
docker volume rm cai_gh_config
docker compose pull   # or build, after this PR lands
docker compose run --rm cai gh auth login --git-protocol https
docker compose up -d
\`\`\`

After this PR lands, both options work; before this PR lands, Option A is the only one that works because Option B would just hit the same permission-denied error on the freshly-created volume.

## Test plan
- [ ] Build the new image: \`docker compose build\`
- [ ] Wipe both volumes (clean slate test): \`docker volume rm cai_gh_config cai_transcripts\`
- [ ] Run \`gh auth login\` against the fresh volumes: \`docker compose run --rm cai gh auth login --git-protocol https\` — should complete without permission errors.
- [ ] Confirm \`hosts.yml\` is owned by \`cai:cai\`: \`docker run --rm -v cai_gh_config:/data alpine ls -la /data\`
- [ ] Start the container normally: \`docker compose up -d\` — should report gh auth as configured, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)