### PR TITLE
auto-improve: Roll back `:pr-open` issue to `:raised` when linked PR is closed without merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ subprocess with no shared state.
 | `cai.py refine` | `10 * * * *` (hourly :10) | Picks the oldest `:needs-refinement` issue, invokes the cai-refine subagent (read-only) to produce a structured plan, updates the issue body, and transitions the label to `:raised` |
 | `cai.py fix` | `15 * * * *` (hourly :15) | Picks the oldest eligible issue, runs 3 parallel plan agents then a select agent to choose the best plan, lets a fix subagent implement it with full tool permissions, opens a PR — see lifecycle below |
 | `cai.py revise` | `30 * * * *` (hourly :30) | Watches `:pr-open` PRs for new comments and iterates on the same branch via force-push; also auto-rebases unmergeable PRs onto current main |
-| `cai.py verify` | `45 * * * *` (hourly :45) | Mechanical, no LLM. Walks `auto-improve:pr-open` issues and updates labels based on PR merge state; also recovers issues whose `:pr-open` label was lost |
+| `cai.py verify` | `45 * * * *` (hourly :45) | Mechanical, no LLM. Walks `auto-improve:pr-open` issues and updates labels based on PR merge state; recovers issues whose linked PR was closed without merging or where no linked PR exists (rolls back to `:raised`) |
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` and `:no-action` issues, flags stale `:merged` issues for human review, deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |
 | `cai.py review-pr` | `20 * * * *` (hourly :20) | Pre-merge consistency review of open PRs — posts ripple-effect findings as PR comments so the revise subagent can act on them |
 | `cai.py merge` | `35 * * * *` (hourly :35) | Confidence-gated auto-merge — evaluates each bot PR against its linked issue, posts a verdict, and merges when confidence meets the threshold |
@@ -80,8 +80,8 @@ action so two concurrent `fix` runs can't pick the same issue.
 
 ```
                               raised  ◄──┐
-                                │       │ (PR closed
-                                │ fix    │  unmerged,
+                                │       │ (PR closed unmerged
+                                │ fix    │  or no linked PR,
                                 ▼        │  rolled back)
                           in-progress    │
                                 │        │

--- a/cai.py
+++ b/cai.py
@@ -2660,7 +2660,7 @@ def cmd_verify(args) -> int:
             continue
         state = (pr.get("state") or "").upper()
         if state == "MERGED":
-            _set_labels(num, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED], log_prefix="cai verify")
+            _set_labels(num, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED, LABEL_REVISING], log_prefix="cai verify")
             print(f"[cai verify] #{num}: PR #{pr['number']} merged → :merged", flush=True)
             transitioned += 1
         elif state == "CLOSED":

--- a/cai.py
+++ b/cai.py
@@ -871,7 +871,7 @@ def _select_fix_target():
     exclusively by the audit-triage agent — only issues that triage
     re-labels to `auto-improve:raised` enter the fix pipeline.
     If no candidates are found, attempts to recover stale `:pr-open`
-    issues whose linked PR was closed unmerged.
+    issues whose linked PR was closed unmerged or that have no linked PR.
     """
     candidates: dict[int, dict] = {}
     for label in (LABEL_RAISED, LABEL_REQUESTED):
@@ -2650,7 +2650,7 @@ def cmd_verify(args) -> int:
     transitioned = 0
     pr_open_issue_nums = {i["number"] for i in issues}
 
-    # Handle MERGED transitions inline; CLOSED recovery uses the shared helper.
+    # Handle MERGED transitions inline; CLOSED and no-linked-PR recovery uses the shared helper.
     remaining = []
     for issue in issues:
         num = issue["number"]

--- a/cai.py
+++ b/cai.py
@@ -809,6 +809,7 @@ def _gh_user_identity() -> tuple[str, str]:
 def _recover_stale_pr_open(issues: list[dict], *, log_prefix: str = "cai") -> list[dict]:
     """Transition :pr-open issues whose linked PR was closed (unmerged) back to :raised.
 
+    Also recovers issues with no linked PR at all (dangling :pr-open).
     Returns the list of issues that were successfully recovered.
     """
     recovered: list[dict] = []
@@ -816,13 +817,42 @@ def _recover_stale_pr_open(issues: list[dict], *, log_prefix: str = "cai") -> li
         if LABEL_IN_PROGRESS in {lbl["name"] for lbl in issue.get("labels", [])}:
             continue
         pr = _find_linked_pr(issue["number"])
+        issue_labels = {lbl["name"] for lbl in issue.get("labels", [])}
+        raised_label = LABEL_AUDIT_RAISED if LABEL_AUDIT_RAISED in issue_labels else LABEL_RAISED
+        remove_labels = [LABEL_PR_OPEN, LABEL_MERGE_BLOCKED, LABEL_REVISING]
         if pr is None:
+            if _set_labels(issue["number"], add=[raised_label], remove=remove_labels, log_prefix=log_prefix):
+                comment = (
+                    "## Auto-improve: rolling back to :raised\n\n"
+                    "No linked PR found for this `:pr-open` issue. "
+                    "Resetting to `:raised` so the fix subagent can attempt a fresh fix.\n\n"
+                    f"---\n_Rolled back automatically by `{log_prefix}`._"
+                )
+                _run(["gh", "issue", "comment", str(issue["number"]),
+                      "--repo", REPO, "--body", comment], capture_output=True)
+                log_run("verify", repo=REPO, issue=issue["number"],
+                        pr=0, result="rollback_no_pr", exit=0)
+                print(
+                    f"[{log_prefix}] recovered stale :pr-open on #{issue['number']} "
+                    f"(no linked PR found)",
+                    flush=True,
+                )
+                recovered.append(issue)
             continue
         state = (pr.get("state") or "").upper()
         if state == "CLOSED":
-            issue_labels = {lbl["name"] for lbl in issue.get("labels", [])}
-            raised_label = LABEL_AUDIT_RAISED if LABEL_AUDIT_RAISED in issue_labels else LABEL_RAISED
-            if _set_labels(issue["number"], add=[raised_label], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED], log_prefix=log_prefix):
+            if _set_labels(issue["number"], add=[raised_label], remove=remove_labels, log_prefix=log_prefix):
+                comment = (
+                    "## Auto-improve: rolling back to :raised\n\n"
+                    f"Linked PR #{pr['number']} was closed without merging. "
+                    "Resetting this issue to `:raised` so the fix subagent can "
+                    "re-attempt on the next tick.\n\n"
+                    f"---\n_Rolled back automatically by `{log_prefix}`._"
+                )
+                _run(["gh", "issue", "comment", str(issue["number"]),
+                      "--repo", REPO, "--body", comment], capture_output=True)
+                log_run(subcmd, repo=REPO, issue=issue["number"],
+                        pr=pr["number"], result="rollback_closed_pr", exit=0)
                 print(
                     f"[{log_prefix}] recovered stale :pr-open on #{issue['number']} "
                     f"(PR #{pr['number']} closed unmerged)",
@@ -2625,7 +2655,7 @@ def cmd_verify(args) -> int:
         num = issue["number"]
         pr = _find_linked_pr(num)
         if pr is None:
-            print(f"[cai verify] #{num}: no linked PR found, leaving as-is", flush=True)
+            remaining.append(issue)
             continue
         state = (pr.get("state") or "").upper()
         if state == "MERGED":

--- a/cai.py
+++ b/cai.py
@@ -4967,13 +4967,13 @@ def cmd_merge(args) -> int:
             )
             if close_result.returncode == 0:
                 print(f"[cai merge] PR #{pr_number}: closed successfully", flush=True)
-                if not _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED], log_prefix="cai merge"):
+                if not _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED, LABEL_REVISING], log_prefix="cai merge"):
                     print(
                         f"[cai merge] WARNING: label transition to :no-action failed for "
                         f"#{issue_number} after closing PR #{pr_number}; retrying",
                         flush=True,
                     )
-                    if not _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED], log_prefix="cai merge"):
+                    if not _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED, LABEL_REVISING], log_prefix="cai merge"):
                         print(
                             f"[cai merge] WARNING: label transition to :no-action failed twice for "
                             f"#{issue_number} — issue may be stuck without a lifecycle label",
@@ -5010,13 +5010,13 @@ def cmd_merge(args) -> int:
             )
             if merge_result.returncode == 0:
                 print(f"[cai merge] PR #{pr_number}: merged successfully", flush=True)
-                if not _set_labels(issue_number, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED], log_prefix="cai merge"):
+                if not _set_labels(issue_number, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED, LABEL_REVISING], log_prefix="cai merge"):
                     print(
                         f"[cai merge] WARNING: label transition to :merged failed for "
                         f"#{issue_number} after merging PR #{pr_number}; retrying",
                         flush=True,
                     )
-                    if not _set_labels(issue_number, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED], log_prefix="cai merge"):
+                    if not _set_labels(issue_number, add=[LABEL_MERGED], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED, LABEL_REVISING], log_prefix="cai merge"):
                         print(
                             f"[cai merge] WARNING: label transition to :merged failed twice for "
                             f"#{issue_number} — issue may be stuck without a lifecycle label",

--- a/cai.py
+++ b/cai.py
@@ -813,6 +813,7 @@ def _recover_stale_pr_open(issues: list[dict], *, log_prefix: str = "cai") -> li
     Returns the list of issues that were successfully recovered.
     """
     recovered: list[dict] = []
+    subcmd = log_prefix.split()[-1]
     for issue in issues:
         if LABEL_IN_PROGRESS in {lbl["name"] for lbl in issue.get("labels", [])}:
             continue
@@ -830,7 +831,7 @@ def _recover_stale_pr_open(issues: list[dict], *, log_prefix: str = "cai") -> li
                 )
                 _run(["gh", "issue", "comment", str(issue["number"]),
                       "--repo", REPO, "--body", comment], capture_output=True)
-                log_run("verify", repo=REPO, issue=issue["number"],
+                log_run(subcmd, repo=REPO, issue=issue["number"],
                         pr=0, result="rollback_no_pr", exit=0)
                 print(
                     f"[{log_prefix}] recovered stale :pr-open on #{issue['number']} "

--- a/cai.py
+++ b/cai.py
@@ -29,7 +29,7 @@ Subcommands:
                             `:pr-open`, find their linked PR by `Refs`
                             search, and transition the label:
                             merged → `:merged`,
-                            closed-unmerged → `:raised`.
+                            closed-unmerged or no-linked-PR → `:raised`.
 
     python cai.py audit     Periodic queue/PR consistency audit.
                             Deterministically rolls back stale
@@ -897,7 +897,7 @@ def _select_fix_target():
             candidates[issue["number"]] = issue
 
     if not candidates:
-        # Recover stale :pr-open issues whose linked PR was closed (unmerged).
+        # Recover stale :pr-open issues whose linked PR was closed (unmerged) or that have no linked PR.
         # This handles cases where the verify step failed to transition them
         # back to :raised (e.g. due to GitHub search indexing delays).
         try:


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#313

**Issue:** #313 — Roll back `:pr-open` issue to `:raised` when linked PR is closed without merging

## PR Summary

### What this fixes
Issues labelled `auto-improve:pr-open` could sit indefinitely when their linked PR was closed without merging (or when no linked PR existed at all). The existing `_recover_stale_pr_open` helper silently skipped issues with no linked PR and didn't post comments or remove the `:revising` label on recovery, leaving orphaned issues with no audit trail.

### What was changed
- **`cai.py` — `_recover_stale_pr_open`**: Added handling for the `pr is None` case (rolls back to `:raised` with an explanatory comment). Added `LABEL_REVISING` to the label removal list. Added `_run(["gh", "issue", "comment", ...])` calls to post explanatory comments on each recovered issue. Added `log_run` calls for audit trail visibility.
- **`cai.py` — `cmd_verify`**: Changed the `pr is None` branch from printing "leaving as-is" and skipping, to appending the issue to `remaining` so it flows through `_recover_stale_pr_open` for proper recovery.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
