### PR TITLE
auto-improve: `cmd_fix` rollback always restores `:raised`, losing `:requested` designation

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -1124,7 +1124,7 @@ def cmd_fix(args) -> int:
     issue_number = issue["number"]
     title = issue["title"]
     label_names = {lbl["name"] for lbl in issue.get("labels", [])}
-    origin_raised_label = LABEL_RAISED
+    origin_raised_label = LABEL_REQUESTED if LABEL_REQUESTED in label_names else LABEL_RAISED
     print(f"[cai fix] picked #{issue_number}: {title}", flush=True)
 
     # 1. Lock — set :in-progress, drop :raised and :requested.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#316

**Issue:** #316 — `cmd_fix` rollback always restores `:raised`, losing `:requested` designation

## PR Summary

### What this fixes
`cmd_fix` rollback always restored `auto-improve:raised` regardless of the issue's original label. Issues that entered the fix pipeline via `auto-improve:requested` (human-requested) were silently downgraded to `auto-improve:raised` on rollback, losing the human-requested designation.

### What was changed
- **`cai.py`** (line 1127): Changed `origin_raised_label = LABEL_RAISED` to `origin_raised_label = LABEL_REQUESTED if LABEL_REQUESTED in label_names else LABEL_RAISED`, so rollback restores the issue to whichever label it originally carried.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
