### PR TITLE
auto-improve: Add "read before Write" guidance to fix and revise agent prompts

### DIFF
--- a/.claude/agents/cai-fix.md
+++ b/.claude/agents/cai-fix.md
@@ -100,7 +100,10 @@ Example of updating this very file:
    intervening edits may have changed line content or context. Use a
    unique, multi-line `old_string` (3+ lines of surrounding context)
    to avoid ambiguous-match failures. Do not propose edits to files
-   you have not read.
+   you have not read. This rule applies equally to Write — if you
+   are overwriting an existing file with Write, you must Read it
+   first. The Write tool will reject calls to existing files that
+   have not been Read.
 2. **Make minimal, targeted changes.** Touch only what the issue
    actually requires. Do not refactor surrounding code, rename
    variables, reformat, add comments, or "improve" things outside
@@ -125,7 +128,10 @@ Example of updating this very file:
    the same or similar error, stop retrying and diagnose the root
    cause instead of looping. After 2 consecutive Edit failures on
    the same file, re-read it to refresh your view before retrying —
-   your cached view may be stale.
+   your cached view may be stale. Do not fall back from Edit to
+   Write on the same file without first diagnosing why Edit failed —
+   Write overwrites the entire file and is rarely the correct
+   recovery.
 2. **Grep before Read.** Use Grep to locate the relevant file(s)
    and line numbers before opening them with Read. Do not
    sequentially Read files to search for content — reserve Read for

--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -138,7 +138,13 @@ Example of addressing a review comment on this very file:
    session. If more than 2 tool calls have occurred since you last
    Read a file, you **must** re-read it before editing it again.
    Use a unique, multi-line `old_string` (3+ lines of surrounding
-   context) to avoid ambiguous-match failures.
+   context) to avoid ambiguous-match failures. This rule applies
+   equally to Write — if you are overwriting an existing file with
+   Write, you must Read it first. The Write tool will reject calls
+   to existing files that have not been Read. Do not fall back from
+   Edit to Write on the same file without first diagnosing why Edit
+   failed — Write overwrites the entire file and is rarely the
+   correct recovery.
 2. **Stay in scope.** When addressing review comments, only address
    the comments listed. Do not redo the original work, reinterpret
    the issue, refactor unrelated code, or "improve" things outside


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#317

**Issue:** #317 — Add "read before Write" guidance to fix and revise agent prompts

## PR Summary

### What this fixes
The "Read before you edit" hard rule in both `cai-fix.md` and `cai-revise.md` only covered Edit, not Write. This gap caused a 50% Write error rate and Edit→Write retry loops where the agent fell back to Write without re-reading the file.

### What was changed
- **`.claude/agents/cai-fix.md`** (via staging): Extended hard rule #1 to state that Write on existing files also requires a prior Read; extended efficiency rule #1 ("Fail fast") to warn against blindly falling back from Edit to Write.
- **`.claude/agents/cai-revise.md`** (via staging): Extended hard rule #1 under "Hard rules — editing" with both the Write-requires-Read guidance and the Edit→Write fallback warning.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
