### PR TITLE
auto-improve: `_pr_label_sweep` uses divergent default threshold rank from `cmd_merge`

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -3847,7 +3847,7 @@ def _pr_label_sweep() -> tuple[int, int]:
     except subprocess.CalledProcessError:
         return (0, 0)
 
-    threshold_rank = _CONFIDENCE_RANKS.get(_MERGE_THRESHOLD, 99)
+    threshold_rank = _CONFIDENCE_RANKS.get(_MERGE_THRESHOLD, _CONFIDENCE_RANKS["high"])
     added = 0
     removed = 0
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#319

**Issue:** #319 — `_pr_label_sweep` uses divergent default threshold rank from `cmd_merge`

## PR Summary

### What this fixes
`_pr_label_sweep` used `99` as the fallback rank when `_MERGE_THRESHOLD` held an unrecognized value, while `cmd_merge` used `_CONFIDENCE_RANKS["high"]` (= 3). This divergence caused every PR to be flagged `needs-human-review` when the threshold was unrecognized, since rank 99 is higher than any valid confidence rank.

### What was changed
- **`cai.py`** (line 3850): Changed the default value in `_CONFIDENCE_RANKS.get(_MERGE_THRESHOLD, 99)` from `99` to `_CONFIDENCE_RANKS["high"]`, matching the fallback used in `cmd_merge` at line 3950.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
