### PR TITLE
auto-improve: Rewrite revise prompt exit-code-as-signal commands to avoid false error inflation

### DIFF
--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -190,10 +190,10 @@ shell's cwd is `/app`, not the clone.**
    `git -C <work_dir> diff --name-only --diff-filter=U` — it must
    be empty.
 5. **Decide continue vs skip:**
-   - Run: `git -C <work_dir> diff --cached --quiet`
-   - If exit code is `0` (no staged changes → empty commit), run:
+   - Run: `git -C <work_dir> diff --cached --stat`
+   - If the output is **empty** (no staged changes → empty commit), run:
      `git -C <work_dir> rebase --skip`
-   - Otherwise run:
+   - If the output is **non-empty** (staged changes exist), run:
      `GIT_EDITOR=true git -C <work_dir> -c core.editor=true rebase --continue`
      (the editor override prevents git from opening an interactive
      prompt for the commit message).
@@ -205,7 +205,7 @@ The rebase is fully done when neither
 exists. Confirm with:
 
 ```
-test ! -d <work_dir>/.git/rebase-merge && test ! -d <work_dir>/.git/rebase-apply && echo done
+if [ -d <work_dir>/.git/rebase-merge ] || [ -d <work_dir>/.git/rebase-apply ]; then echo REBASE_IN_PROGRESS; else echo REBASE_DONE; fi
 ```
 
 ### When you cannot resolve a conflict


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#323

**Issue:** #323 — Rewrite revise prompt exit-code-as-signal commands to avoid false error inflation

## PR Summary

### What this fixes
The cai-revise agent prompt contained two Bash commands that intentionally used non-zero exit codes as control signals (`git diff --cached --quiet` and a `test` chain), which parse.py counted as Bash errors — inflating the error rate by ~2 false positives per rebased commit (contributing to a 48% Bash error rate).

### What was changed
- **`.claude/agents/cai-revise.md`** (via staging directory): 
  - Step 5: replaced `git diff --cached --quiet` (exits 1 when staged changes exist) with `git diff --cached --stat` (always exits 0, prints summary or nothing), and updated the surrounding instructions to check stdout emptiness instead of exit code.
  - Rebase-done confirmation: replaced `test ! -d … && test ! -d … && echo done` (exits 1 when rebase dirs exist) with an `if/else` that always exits 0 and prints `REBASE_IN_PROGRESS` or `REBASE_DONE`.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
