### PR TITLE
auto-improve: `cmd_confirm` PR search query differs from PR body format

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -3425,7 +3425,7 @@ def cmd_confirm(args) -> int:
         try:
             prs = _gh_json([
                 "pr", "list", "--repo", REPO,
-                "--search", f"Refs #{num}",
+                "--search", f'"Refs {REPO}#{num}" in:body',
                 "--state", "merged",
                 "--json", "number",
                 "--limit", "1",


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#325

**Issue:** #325 — `cmd_confirm` PR search query differs from PR body format

## PR Summary

### What this fixes
`cmd_confirm` searched for linked PRs using `Refs #<num>` which omits the repository prefix and `in:body` qualifier, making it inconsistent with the actual PR body format (`Refs {REPO}#<num>`) and the query used by `_find_linked_pr`. This could cause false matches or missed matches.

### What was changed
- **`cai.py`** line 3428: Changed the PR search query in `cmd_confirm` from `f"Refs #{num}"` to `f'"Refs {REPO}#{num}" in:body'` to match the format used by `_find_linked_pr` and the actual text written into PR bodies.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
