### PR TITLE
Pin execution/analysis agents to claude-sonnet-4-6

### DIFF
--- a/.claude/agents/cai-analyze.md
+++ b/.claude/agents/cai-analyze.md
@@ -2,6 +2,7 @@
 name: cai-analyze
 description: Analyze parsed signals from the cai container's own Claude Code session transcripts and raise auto-improve findings for code, prompt, or workflow issues. Read-only — the wrapper publishes findings as GitHub issues after the agent exits.
 tools: Read, Grep, Glob
+model: claude-sonnet-4-6
 memory: project
 ---
 

--- a/.claude/agents/cai-fix.md
+++ b/.claude/agents/cai-fix.md
@@ -2,6 +2,7 @@
 name: cai-fix
 description: Autonomous code-editing subagent for `robotsix-cai`. Makes the smallest targeted change that addresses an auto-improve issue handed by the wrapper. Cannot run git or gh — the wrapper handles all remote state and PR opening.
 tools: Read, Edit, Write, Grep, Glob
+model: claude-sonnet-4-6
 memory: project
 ---
 

--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -2,6 +2,7 @@
 name: cai-review-pr
 description: Pre-merge ripple-effect review for an open PR. Walks the diff, searches the broader codebase for inconsistencies the PR introduced but didn't update, and emits `### Finding:` blocks the wrapper posts as a PR comment. Read-only.
 tools: Read, Grep, Glob, Agent
+model: claude-sonnet-4-6
 memory: project
 ---
 

--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -2,6 +2,7 @@
 name: cai-revise
 description: Handle an auto-improve PR that needs attention — resolve any in-progress rebase against main AND address unaddressed reviewer comments, in one session. Used by `cai revise` after the wrapper has cloned, checked out, and attempted `git rebase origin/main`.
 tools: Read, Edit, Write, Grep, Glob, Bash
+model: claude-sonnet-4-6
 memory: project
 ---
 


### PR DESCRIPTION
## Summary

- Reserve Opus for planning/judgment agents only: `cai-plan`, `cai-select`, `cai-merge` stay on `claude-opus-4-6`.
- Pin code-editing execution subagents (`cai-fix`, `cai-revise`) and read-only analysis agents (`cai-analyze`, `cai-review-pr`) to `claude-sonnet-4-6` — previously they inherited from the caller, which made the model choice implicit.

## Rationale

Planning, plan selection, and the final auto-merge gate benefit from Opus's stronger judgment. Mechanical execution (applying a plan, rebasing, addressing review comments) and read-only analysis passes (transcript analysis, ripple-effect review) are well within Sonnet 4.6's capabilities, and making the model explicit in frontmatter removes dependency on the invoker's default.

No behavioral code changes — only `model:` frontmatter added in four agent definitions.

## Test plan

- [ ] Verify `cai fix`, `cai revise`, `cai analyze`, and `cai review-pr` still function end-to-end on a real issue/PR
- [ ] Confirm Opus usage is limited to `cai-plan`, `cai-select`, `cai-merge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)