### PR TITLE
auto-improve: the verification of claude auth in install does not work and is not necessary

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -335,21 +335,10 @@ if [[ "$TTY" == "/dev/tty" ]]; then
     read -r _ < /dev/tty || true
     if ! docker compose run --rm -it cai claude < /dev/tty; then
       # The REPL may exit non-zero (Ctrl-C, Ctrl-D, etc.); don't
-      # treat that as an error path on its own — verify auth state
-      # afterwards instead.
+      # treat that as an error — it auto-prompts on next start.
       :
     fi
     echo
-    echo "Verifying claude auth state..."
-    if docker compose run --rm cai claude auth status --text 2>&1 | grep -q "Login method:"; then
-      echo "[OK] claude is authenticated. Credentials persisted in cai_home."
-    else
-      echo "[!] claude auth could not be verified. Try again:"
-      echo "      cd $INSTALL_DIR && docker compose run --rm -it cai claude"
-      echo "      (the REPL will auto-prompt for login on first start;"
-      echo "       exit gracefully with /exit or Ctrl-D when done)"
-      exit 1
-    fi
   fi
 
   echo


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#343

**Issue:** #343 — the verification of claude auth in install does not work and is not necessary

## PR Summary

### What this fixes
The `claude auth status` verification block in `install.sh` was producing false negatives — reporting auth failure even when login had succeeded — causing the install script to exit with an error unnecessarily. The check is also redundant since the REPL's own login flow already confirms success to the user.

### What was changed
- **`install.sh`**: Removed the `echo "Verifying claude auth state..."` block (lines 342–352) including the `docker compose run --rm cai claude auth status` check, success/failure echo messages, and `exit 1`. Also updated the comment on the REPL invocation to reflect that errors are non-fatal and login auto-prompts on next start. Kept the blank `echo` for visual spacing before the "Next steps:" section.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
