### PR TITLE
fix: gate cmd_merge on review-pr having reviewed the current SHA

### DIFF
--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -64,6 +64,16 @@ ripple effects in these six categories:
 3. Check if the PR's changes are consistent with those references
 4. Only report findings where you are confident there is a real
    inconsistency — not hypothetical or stylistic concerns
+5. **Be exhaustive in a single pass.** Before returning, walk
+   through the diff one more time and, for each of the six
+   categories in the table above, ask "did I actually search the
+   codebase for this kind of ripple effect?". Do not stop at the
+   first category where you found something. Each extra round-trip
+   through the review/revise loop costs a full re-review, a revise
+   commit, and a merge verdict — so missing a finding here forces
+   the fix agent to burn another whole cycle for each category you
+   skipped. Report **all** ripple effects you can confidently
+   identify, not just one per run.
 
 ## Output format
 

--- a/cai.py
+++ b/cai.py
@@ -4420,6 +4420,45 @@ def cmd_merge(args) -> int:
         # SHA), the bot naturally re-evaluates without requiring a
         # human to manually clear the label.
 
+        # Safety filter 7: require `cai review-pr` to have reviewed
+        # the current head SHA before we run a merge verdict on it.
+        #
+        # Without this gate, `cmd_merge` runs on every new commit — in
+        # particular, every commit that `cmd_revise` pushes in response
+        # to a prior review's findings — BEFORE the reviewer has had a
+        # chance to walk the new diff. That produces a verdict on an
+        # un-reviewed SHA (uninformed by the ripple-effect scan) and,
+        # via `_pr_label_sweep`, flips the PR to `needs-human-review`
+        # while the fix/review/revise loop is still actively making
+        # progress. The PR then flaps through the label on every cycle
+        # until the reviewer finally reports clean. Refs #351
+        # post-mortem: 5+ premature verdicts, each one flagging the PR
+        # for human triage even though revise was still addressing
+        # ripple findings one round at a time.
+        #
+        # Matches either heading variant (findings or clean) because
+        # both start with `_REVIEW_COMMENT_HEADING_FINDINGS` and both
+        # include the head SHA on the heading line. Mirrors the
+        # already-reviewed check in `cmd_review_pr`.
+        has_review_at_sha = False
+        for comment in pr.get("comments", []):
+            body = (comment.get("body") or "")
+            first_line = body.split("\n", 1)[0]
+            if (
+                first_line.startswith(_REVIEW_COMMENT_HEADING_FINDINGS)
+                and head_sha in first_line
+            ):
+                has_review_at_sha = True
+                break
+
+        if not has_review_at_sha:
+            print(
+                f"[cai merge] PR #{pr_number}: review-pr has not reviewed "
+                f"{head_sha[:8]} yet; waiting",
+                flush=True,
+            )
+            continue
+
         # Safety filter 3: unaddressed review comments → let revise handle.
         # Mirror the revise subcommand's filter logic via the shared helper
         # so a "no additional changes" reply correctly suppresses the loop.


### PR DESCRIPTION
## Summary

Analysis of PR #351 / issue #313 surfaced three problems in the auto-improve lifecycle. This PR addresses the deterministic pieces of all three with a single, tight gating filter plus a prompt tweak.

## The three problems observed on PR #351

### 1. Merge agent runs while review still has pending findings
`cmd_merge`'s existing "unaddressed review comments" filter is scoped to comments newer than the current `commit_ts`. After `cmd_revise` pushes a fresh commit, any review findings from the *previous* SHA fall below `commit_ts` and no new review has run yet — so `cmd_merge` happily evaluates the new SHA without any ripple-effect scan, producing a verdict that is structurally uninformed. On PR #351 this fired five times, each time with the same "hold" reasoning.

### 2. `needs-human-review` is toggled while fix/review are still looping
`_pr_label_sweep` (called at the bottom of `cmd_merge`) treats the latest merge verdict (when newer than `commit_ts`) as a signal that the bot is stuck. Because problem #1 posts a verdict on every fresh revise commit, the sweep correctly *applies* the label — but the fix/review/revise loop is in fact still actively making progress, so the label flaps up and down on every cycle.

### 3. Fix ↔ review back-and-forth finds one category at a time
In PR #351 the reviewer returned, in order:
1. `cross_cutting_ref` (hardcoded `"verify"` in `log_run`/comments)
2. `stale_docs` (README lifecycle diagram)
3. `missing_co_change` (`LABEL_REVISING` in `cmd_verify`'s MERGED transition)
4. `missing_co_change` (`LABEL_REVISING` in four `_set_labels` sites in `cmd_merge`)

All four findings were present in the very first diff. The reviewer walked the diff once per run and stopped at the first category it found, forcing the fix agent through four round-trips (each one: new commit → re-review → re-revise → re-merge verdict → re-flag) instead of one exhaustive pass.

## Changes

- **`cai.py` — `cmd_merge` safety filter 7**: before running the merge verdict on a PR, require that a `## cai pre-merge review` comment exists for the current head SHA (either the findings variant or the clean variant — both start with the same heading and include the SHA on the first line, mirroring `cmd_review_pr`'s existing "already reviewed" check). If no review yet, log `review-pr has not reviewed <sha> yet; waiting` and skip. This also naturally fixes problem #2: `_pr_label_sweep` only flips the label when `latest_verdict_ts > commit_ts`, so once `cmd_merge` stops posting verdicts against un-reviewed SHAs, the sweep stops flapping the label.

- **`.claude/agents/cai-review-pr.md`**: add an explicit "be exhaustive in a single pass" step to the "How to work" section, with a concrete explanation of the cost of missing a finding (a whole review/revise/merge cycle per missed category). This targets problem #3.

## What this does NOT change
- The merge agent's reasoning (confidence threshold, verdict format, etc.) is untouched.
- `_pr_label_sweep` is not modified directly — the cmd_merge gate is sufficient to keep the label stable during an active loop.
- Issue #313 / PR #351 itself is not touched; if it is still open when this lands, its next cycle will simply wait for review before re-evaluating.

## Test plan
- [ ] Run `cai cycle` against a test repo with a freshly-opened auto-improve PR; confirm `cmd_merge` logs `review-pr has not reviewed <sha> yet; waiting` for the first tick when review happens to run *after* merge in the ordering, and proceeds normally on the second tick once `## cai pre-merge review` is posted.
- [ ] Push a fresh revise commit on an already-merged-approved PR; confirm `cmd_merge` re-gates on review instead of producing a premature verdict on the new SHA.
- [ ] Verify on PR #351 (or a similar re-opened issue) that `needs-human-review` no longer flaps during the fix/review loop.
- [ ] Confirm `python -m py_compile cai.py` passes (done locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)