### PR TITLE
auto-improve: `_select_revise_targets` skips LABEL_REVISING check, allowing duplicate concurrent processing

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -1924,7 +1924,8 @@ def _select_revise_targets() -> list[dict]:
     """Return PRs needing revision (unaddressed comments since last commit).
 
     Eligible = branch matches auto-improve/<N>-* AND linked issue has
-    label auto-improve:pr-open. Returns a list of dicts with keys:
+    label auto-improve:pr-open AND does NOT have label
+    auto-improve:revising. Returns a list of dicts with keys:
     pr_number, issue_number, branch, comments (the unaddressed ones).
 
     Reads BOTH issue-level comments (via `gh pr list --json comments`)

--- a/cai.py
+++ b/cai.py
@@ -1965,6 +1965,8 @@ def _select_revise_targets() -> list[dict]:
         label_names = {lbl["name"] for lbl in issue.get("labels", [])}
         if LABEL_PR_OPEN not in label_names:
             continue
+        if LABEL_REVISING in label_names:
+            continue
 
         # Find the most recent commit date via `gh pr view`.
         try:


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#352

**Issue:** #352 — `_select_revise_targets` skips LABEL_REVISING check, allowing duplicate concurrent processing

## PR Summary

### What this fixes
`_select_revise_targets()` only checked that `LABEL_PR_OPEN` was present on the linked issue, but did not skip issues already carrying `LABEL_REVISING`. This allowed a second scheduler tick overlapping an in-progress `cmd_revise` to pick up the same PR again and start a duplicate concurrent revision.

### What was changed
- **`cai.py`**: Added `if LABEL_REVISING in label_names: continue` at line 1968, immediately after the existing `LABEL_PR_OPEN` guard in `_select_revise_targets()`. This mirrors the concurrency-guard pattern used in `cmd_fix` and prevents duplicate processing of PRs already under active revision.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
