### PR TITLE
auto-improve: `CAI_REFINE_SCHEDULE` absent from docker-compose.yml and install.sh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       # Defaults are staggered so the three jobs never overlap.
       CAI_ANALYZER_SCHEDULE: "0 0 * * *"   # daily at 00:00 UTC (LLM call)
       CAI_FIX_SCHEDULE: "15 * * * *"        # hourly at :15 (cheap if no work)
+      CAI_REFINE_SCHEDULE: "10 * * * *"     # hourly at :10 (structure human-filed issues)
       CAI_REVISE_SCHEDULE: "30 * * * *"     # hourly at :30 (iterate on PR comments)
       CAI_VERIFY_SCHEDULE: "45 * * * *"     # hourly at :45 (mechanical, no LLM)
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet, report-only + branch cleanup)

--- a/install.sh
+++ b/install.sh
@@ -136,6 +136,7 @@ services:
       # stagger them so they never overlap.
       CAI_ANALYZER_SCHEDULE: "0 0 * * *"   # daily 00:00 UTC (LLM call)
       CAI_FIX_SCHEDULE: "15 * * * *"        # hourly :15 (cheap if no work)
+      CAI_REFINE_SCHEDULE: "10 * * * *"     # hourly :10 (structure human-filed issues)
       CAI_REVISE_SCHEDULE: "30 * * * *"     # hourly :30 (iterate on PR comments)
       CAI_VERIFY_SCHEDULE: "45 * * * *"     # hourly :45 (no LLM)
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet, report-only + branch cleanup)
@@ -197,6 +198,7 @@ services:
       # stagger them so they never overlap.
       CAI_ANALYZER_SCHEDULE: "0 0 * * *"   # daily 00:00 UTC (LLM call)
       CAI_FIX_SCHEDULE: "15 * * * *"        # hourly :15 (cheap if no work)
+      CAI_REFINE_SCHEDULE: "10 * * * *"     # hourly :10 (structure human-filed issues)
       CAI_REVISE_SCHEDULE: "30 * * * *"     # hourly :30 (iterate on PR comments)
       CAI_VERIFY_SCHEDULE: "45 * * * *"     # hourly :45 (no LLM)
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet, report-only + branch cleanup)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#353

**Issue:** #353 — `CAI_REFINE_SCHEDULE` absent from docker-compose.yml and install.sh

## PR Summary

### What this fixes
`CAI_REFINE_SCHEDULE` was defined and used in `entrypoint.sh` but was absent from the `environment:` blocks in `docker-compose.yml` and both generated docker-compose stanzas in `install.sh`, making the schedule non-overridable without manually editing those files.

### What was changed
- **`docker-compose.yml`**: Added `CAI_REFINE_SCHEDULE: "10 * * * *"` after `CAI_FIX_SCHEDULE` in the `environment:` block
- **`install.sh`**: Added `CAI_REFINE_SCHEDULE: "10 * * * *"` after `CAI_FIX_SCHEDULE` in both generated docker-compose stanzas (OAuth mode and API-key mode), using `replace_all: true` since the two stanzas are identical

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
