### PR TITLE
fix: remove obsolete git/gh deny restrictions from settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,3 @@
 {
-  "$schema": "https://code.claude.com/schemas/settings.json",
-  "permissions": {
-    "deny": [
-      "Bash(git push:*)",
-      "Bash(git push)",
-      "Bash(git remote:*)",
-      "Bash(git remote)",
-      "Bash(gh:*)",
-      "Bash(gh)"
-    ]
-  }
+  "$schema": "https://code.claude.com/schemas/settings.json"
 }


### PR DESCRIPTION
## Summary
- Remove the `permissions.deny` entries for `git push`, `git remote`, and `gh` from `.claude/settings.json` — these restrictions are no longer needed.

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)