### PR TITLE
auto-improve: Fix `parse.py` to include cache tokens in `token_usage` totals

### DIFF
--- a/.claude/agents/cai-analyze.md
+++ b/.claude/agents/cai-analyze.md
@@ -55,7 +55,7 @@ You receive the following sections in the user message, in order:
    - `error_tools` — tools that errored, with counts
    - `error_categories` — controllable vs network/auth errors
    - `repeated_sequences` — runs of 3+ identical consecutive calls
-   - `token_usage` — input/output token totals
+   - `token_usage` — input/output token totals (including `cache_creation_tokens` and `cache_read_tokens` breakdowns)
    - `tool_sequence_preview` — first 100 tool calls in sequence
    - `note` (optional) — `"empty transcript"` if there's no data yet
 2. **Currently open auto-improve issues** — number, state label, title

--- a/parse.py
+++ b/parse.py
@@ -99,6 +99,8 @@ def extract_tool_calls(lines: list[str]) -> dict:
     tool_sequences: list[str] = []
     total_input_tokens = 0
     total_output_tokens = 0
+    total_cache_creation_tokens = 0
+    total_cache_read_tokens = 0
 
     for raw in lines:
         raw = raw.strip()
@@ -122,6 +124,10 @@ def extract_tool_calls(lines: list[str]) -> dict:
         usage = msg.get("usage") or entry.get("usage", {})
         if usage:
             total_input_tokens += usage.get("input_tokens", 0)
+            total_input_tokens += usage.get("cache_creation_input_tokens", 0)
+            total_input_tokens += usage.get("cache_read_input_tokens", 0)
+            total_cache_creation_tokens += usage.get("cache_creation_input_tokens", 0)
+            total_cache_read_tokens += usage.get("cache_read_input_tokens", 0)
             total_output_tokens += usage.get("output_tokens", 0)
 
         if role == "assistant":
@@ -183,6 +189,8 @@ def extract_tool_calls(lines: list[str]) -> dict:
         "token_usage": {
             "input_tokens": total_input_tokens,
             "output_tokens": total_output_tokens,
+            "cache_creation_tokens": total_cache_creation_tokens,
+            "cache_read_tokens": total_cache_read_tokens,
         },
         "tool_sequence_preview": sequence_preview,
     }
@@ -262,7 +270,7 @@ def main() -> None:
             "error_tools": {},
             "error_categories": {"total": 0, "controllable": 0, "network_auth": 0},
             "repeated_sequences": [],
-            "token_usage": {"input_tokens": 0, "output_tokens": 0},
+            "token_usage": {"input_tokens": 0, "output_tokens": 0, "cache_creation_tokens": 0, "cache_read_tokens": 0},
             "tool_sequence_preview": "",
             "note": "empty transcript",
         }))


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#370

**Issue:** #370 — Fix `parse.py` to include cache tokens in `token_usage` totals

## PR Summary

### What this fixes
`parse.py` was only reading `input_tokens` from JSONL usage blocks, silently ignoring `cache_creation_input_tokens` and `cache_read_input_tokens`. This caused wildly under-reported input token counts (e.g., 3 reported vs. 16,496 actual), making the `in_tokens < 500` warning trigger spuriously and producing useless token-usage signals.

### What was changed
- **`parse.py`**: Added two new accumulators (`total_cache_creation_tokens`, `total_cache_read_tokens`). In the `if usage:` block, both cache token fields are now summed into `total_input_tokens` (so the total is accurate) and tracked separately in their own accumulators. The returned `token_usage` dict now includes `cache_creation_tokens` and `cache_read_tokens` keys. The empty-transcript fallback dict was also updated to include these new keys with zero defaults.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
