### PR TITLE
auto-improve: log should be hold as an internal volume as others

### DIFF
--- a/.claude/agents/cai-audit.md
+++ b/.claude/agents/cai-audit.md
@@ -29,7 +29,7 @@ The user message contains:
    date, last update date, body
 2. **Recent PRs** — last 30 or last 7 days (whichever is larger),
    with state, merge status, labels, linked issue references
-3. **Log tail** — last ~200 lines of `logs/cai.log`
+3. **Log tail** — last ~200 lines of `/var/log/cai/cai.log`
 4. **Cost summary** — per-category aggregates and the top 10 most
    expensive `claude -p` invocations from the last 7 days, sourced
    from `/var/log/cai/cai-cost.jsonl`. Costs come from

--- a/.claude/agents/cai-code-audit.md
+++ b/.claude/agents/cai-code-audit.md
@@ -47,7 +47,7 @@ intentionally not raised.
 The user message contains one section:
 
 1. **Runtime memory** — a summary of previous code-audit runs
-   from the bind-mounted runtime log. Use this to avoid re-raising
+   from the named-volume runtime log. Use this to avoid re-raising
    findings that were already reported and to focus on areas not
    recently audited. If it's empty, this is the first run against
    a fresh container.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# cai run logs (host-side bind mount)
-logs/
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,8 @@ RUN wget -nv -O /usr/local/bin/supercronic \
 # which we need so the fix and revise subagents can edit
 # `.claude/agents/*.md` files (auto-improve self-modifies its own
 # prompts). UID 1000 matches the typical first-host-user UID so the
-# bind-mounted `./logs:/var/log/cai` directory works without extra
-# host-side chowning.
+# named `cai_logs` volume mounted at `/var/log/cai` works without
+# extra host-side chowning.
 #
 # We pre-create the named-volume mount points with cai:cai ownership
 # so Docker's "copy image contents into a new empty named volume on
@@ -88,6 +88,10 @@ RUN wget -nv -O /usr/local/bin/supercronic \
 #                                    cloned-worktree agents have it
 #                                    copied in/out by the wrapper
 #                                    around each invocation)
+#   - /var/log/cai/               → cai_logs          (run log — one
+#                                    key=value line per cai invocation;
+#                                    named volume avoids host permission
+#                                    issues that a bind-mount causes)
 #
 # We pre-create a few subdirs under /home/cai (.config/gh and
 # .claude/projects) so they exist with cai ownership in the image,

--- a/README.md
+++ b/README.md
@@ -493,13 +493,13 @@ docker volume inspect cai_home
 docker run --rm -v cai_home:/data alpine ls -R /data
 ```
 
-A **run log** is written to `./logs/cai.log` (bind-mounted from
-`/var/log/cai/cai.log` inside the container). Each `init`, `analyze`,
+A **run log** is written to `/var/log/cai/cai.log` inside the container
+(persisted in the `cai_logs` named volume). Each `init`, `analyze`,
 `fix`, `review-pr`, `revise`, `verify`, `audit`, `code-audit`, `propose`, `confirm`, and `merge` invocation appends one key=value line so you can
-watch cycle activity from the host without `docker exec`:
+watch cycle activity:
 
 ```bash
-tail -f ~/robotsix-cai/logs/cai.log
+docker exec -it $(docker compose ps -q cai) tail -f /var/log/cai/cai.log
 ```
 
 Wipe everything (deletes claude credentials, transcripts, gh
@@ -508,7 +508,7 @@ afterwards):
 
 ```bash
 docker compose down --volumes        # if you used compose
-docker volume rm cai_home cai_agent_memory   # standalone
+docker volume rm cai_home cai_agent_memory cai_logs   # standalone
 ```
 
 The installer also wipes these volumes automatically when re-run, so

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ the `volumes:` block.
 
 ## Persistent data
 
-The container uses two Docker named volumes:
+The container uses three Docker named volumes:
 
 - **`cai_home`** (mounted at `/home/cai`) — the cai user's entire
   home directory. Holds Claude OAuth credentials
@@ -449,6 +449,9 @@ The container uses two Docker named volumes:
   memory directly from `/app/.claude/agent-memory/<agent-name>/`
   via the mounted `cai_agent_memory` volume — no copy in/out by
   the wrapper.
+- **`cai_logs`** (mounted at `/var/log/cai`) — run log. One
+  key=value line per `cai` invocation. Using a named volume avoids
+  the host permission issues that a bind-mount causes.
 
 The container runs as the non-root `cai` user (uid 1000). This is
 required by `claude-code` because the fix and revise subagents use

--- a/cai.py
+++ b/cai.py
@@ -129,7 +129,7 @@ TRANSCRIPT_DIR = Path("/home/cai/.claude/projects")
 PARSE_SCRIPT = Path("/app/parse.py")
 PUBLISH_SCRIPT = Path("/app/publish.py")
 # Persistent memory file for the code-audit agent. Stored in the
-# bind-mounted log directory so it survives container restarts.
+# named-volume log directory so it survives container restarts.
 CODE_AUDIT_MEMORY = Path("/var/log/cai/code-audit-memory.md")
 # Persistent memory file for the propose agent (same pattern).
 PROPOSE_MEMORY = Path("/var/log/cai/propose-memory.md")
@@ -3926,7 +3926,7 @@ def cmd_code_audit(args) -> int:
         return 1
 
     # 2. Build the user message with the runtime memory from the
-    #    bind-mounted log directory. System prompt, tool allowlist
+    #    named-volume log directory (cai_logs). System prompt, tool allowlist
     #    (Read/Grep/Glob), and model (sonnet) all live in
     #    `.claude/agents/cai-code-audit.md`. Durable per-agent
     #    learnings live in its `memory: project` pool, which the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       # of their per-issue clones by the wrapper around each
       # invocation.
       - cai_agent_memory:/app/.claude/agent-memory
-      - ./logs:/var/log/cai
+      - cai_logs:/var/log/cai
     # Required if Watchtower is enabled (uncommented below):
     # labels:
     #   - "com.centurylinklabs.watchtower.enable=true"
@@ -106,3 +106,5 @@ volumes:
     name: cai_home
   cai_agent_memory:
     name: cai_agent_memory
+  cai_logs:
+    name: cai_logs

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,7 +124,7 @@ docker compose up
 
 ## Persistent data
 
-The container uses two Docker named volumes:
+The container uses three Docker named volumes:
 
 - **`cai_home`** (mounted at `/home/cai`) — the cai user's entire
   home directory. Holds Claude OAuth credentials
@@ -136,6 +136,9 @@ The container uses two Docker named volumes:
   all user state.
 - **`cai_agent_memory`** (mounted at `/app/.claude/agent-memory`) —
   per-agent durable memory accumulated by the declarative subagents.
+- **`cai_logs`** (mounted at `/var/log/cai`) — run log. One
+  key=value line per `cai` invocation. Using a named volume avoids
+  the host permission issues that a bind-mount causes.
 
 The container runs as the non-root `cai` user (uid 1000) — see
 Dockerfile for the rationale.

--- a/docs/index.md
+++ b/docs/index.md
@@ -152,7 +152,7 @@ per-agent memory — re-running `install.sh` is the easiest way):
 
 ```bash
 docker compose down --volumes        # if you used compose
-docker volume rm cai_home cai_agent_memory   # standalone
+docker volume rm cai_home cai_agent_memory cai_logs   # standalone
 ```
 
 ## License

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,6 @@ echo "Install directory: $INSTALL_DIR"
 echo "Image:             robotsix/cai:$IMAGE_TAG"
 echo
 
-mkdir -p "$INSTALL_DIR/logs"
 cd "$INSTALL_DIR"
 
 if [[ -e docker-compose.yml ]]; then

--- a/install.sh
+++ b/install.sh
@@ -167,7 +167,7 @@ services:
       # so the durable notes each subagent accumulates across runs
       # survive container restarts.
       - cai_agent_memory:/app/.claude/agent-memory
-      - ./logs:/var/log/cai
+      - cai_logs:/var/log/cai
 ${CAI_LABEL_BLOCK}${WATCHTOWER_SERVICE}
 
 volumes:
@@ -175,6 +175,8 @@ volumes:
     name: cai_home
   cai_agent_memory:
     name: cai_agent_memory
+  cai_logs:
+    name: cai_logs
 YAML
     echo
     echo "[OK] Wrote $INSTALL_DIR/docker-compose.yml (in-container OAuth mode)"
@@ -224,7 +226,7 @@ services:
       # so the durable notes each subagent accumulates across runs
       # survive container restarts.
       - cai_agent_memory:/app/.claude/agent-memory
-      - ./logs:/var/log/cai
+      - cai_logs:/var/log/cai
 ${CAI_LABEL_BLOCK}${WATCHTOWER_SERVICE}
 
 volumes:
@@ -232,6 +234,8 @@ volumes:
     name: cai_home
   cai_agent_memory:
     name: cai_agent_memory
+  cai_logs:
+    name: cai_logs
 YAML
     cat > .env <<ENV
 ANTHROPIC_API_KEY=${API_KEY}

--- a/install.sh
+++ b/install.sh
@@ -269,7 +269,7 @@ fi
 # root. Easier to wipe and start fresh than to migrate.
 echo
 echo "Wiping any existing cai volumes for a clean install..."
-for vol in cai_home cai_agent_memory cai_claude cai_gh_config cai_transcripts; do
+for vol in cai_home cai_agent_memory cai_logs cai_claude cai_gh_config cai_transcripts; do
   if docker volume inspect "$vol" >/dev/null 2>&1; then
     if docker volume rm "$vol" >/dev/null 2>&1; then
       echo "  removed: $vol"


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#374

**Issue:** #374 — log should be hold as an internal volume as others

## PR Summary

### What this fixes
The `./logs:/var/log/cai` bind-mount caused permission issues on some hosts because the host directory was created as root and the `cai` user inside the container couldn't write to it. Switching to a named Docker volume (`cai_logs`) avoids this problem — Docker's volume initialization copies the image's pre-created `cai:cai`-owned `/var/log/cai` directory into the new volume, preserving ownership without any host-side `chown`.

### What was changed
- **`docker-compose.yml`**: Changed `./logs:/var/log/cai` bind-mount to `cai_logs:/var/log/cai` named volume; added `cai_logs` to the top-level `volumes:` block.
- **`install.sh`**: Same bind-mount → named volume change in both generated `docker-compose.yml` templates (OAuth mode and API-key mode); added `cai_logs` to both `volumes:` sections.
- **`Dockerfile`**: Updated the UID-1000 comment to reference the `cai_logs` named volume instead of the old bind-mount; added `cai_logs` entry to the mount-point list comment.
- **`README.md`**: Updated the run log description to explain logs are in the `cai_logs` named volume and changed the `tail -f` example to use `docker exec`; added `cai_logs` to the standalone volume removal command.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
