### PR TITLE
auto-improve: Extend batching and parallel tool-call guidance to non-fix agents

### DIFF
--- a/.claude/agents/cai-analyze.md
+++ b/.claude/agents/cai-analyze.md
@@ -153,8 +153,24 @@ output `No findings.` and stop.
   read the file directly.
 - Do not output anything other than the markdown finding blocks (or
   the exact `No findings.` sentinel).
-- **Verify paths with Glob before Read.** When a file path is
-  constructed or inferred (not hard-coded), confirm the file exists
-  using Glob before attempting to Read it. If a Read fails, do not
-  retry the same path — use Glob to find the correct filename
-  first.
+
+## Efficiency guidance
+
+1. **Grep before Read.** Use Grep to locate the relevant file(s)
+   and line numbers before opening them with Read. Do not
+   sequentially Read files to search for content — reserve Read for
+   files whose paths and relevance are already known.
+2. **Verify paths with Glob before Read.** When a file path is
+   constructed or inferred (not hard-coded), confirm the file exists
+   using Glob before attempting to Read it. If a Read fails, do not
+   retry the same path — use Glob to find the correct filename
+   first.
+3. **Batch independent Read calls.** When you need to read multiple
+   files and the reads are independent, issue all Read calls in a
+   single turn rather than one at a time.
+4. **Batch Grep calls.** When searching for multiple patterns or
+   across multiple paths, combine them into a single Grep call using
+   regex alternation (`pat1|pat2`) or issue independent Grep calls
+   in parallel rather than sequentially. Use Glob first to narrow
+   the file set, then Grep the results, instead of running
+   exploratory Grep calls one at a time.

--- a/.claude/agents/cai-audit.md
+++ b/.claude/agents/cai-audit.md
@@ -165,6 +165,27 @@ If no anomalies are found, output exactly:
 No findings.
 ```
 
+## Efficiency guidance
+
+1. **Grep before Read.** Use Grep to locate the relevant file(s)
+   and line numbers before opening them with Read. Do not
+   sequentially Read files to search for content — reserve Read for
+   files whose paths and relevance are already known.
+2. **Verify paths with Glob before Read.** When a file path is
+   constructed or inferred (not hard-coded), confirm the file exists
+   using Glob before attempting to Read it. If a Read fails, do not
+   retry the same path — use Glob to find the correct filename
+   first.
+3. **Batch independent Read calls.** When you need to read multiple
+   files and the reads are independent, issue all Read calls in a
+   single turn rather than one at a time.
+4. **Batch Grep calls.** When searching for multiple patterns or
+   across multiple paths, combine them into a single Grep call using
+   regex alternation (`pat1|pat2`) or issue independent Grep calls
+   in parallel rather than sequentially. Use Glob first to narrow
+   the file set, then Grep the results, instead of running
+   exploratory Grep calls one at a time.
+
 ## Guardrails
 
 - Every finding must be grounded in the data you received — no
@@ -176,8 +197,3 @@ No findings.
   rollback, branch cleanup, and stale issue handling already handle.
 - Do not output anything other than the markdown finding blocks (or
   the exact `No findings.` sentinel).
-- **Verify paths with Glob before Read.** When a file path is
-  constructed or inferred (not hard-coded), confirm the file exists
-  using Glob before attempting to Read it. If a Read fails, do not
-  retry the same path — use Glob to find the correct filename
-  first.

--- a/.claude/agents/cai-code-audit.md
+++ b/.claude/agents/cai-code-audit.md
@@ -124,6 +124,27 @@ so the next run knows what you covered:
 - **Notes:** <anything the next run should know>
 ```
 
+## Efficiency guidance
+
+1. **Grep before Read.** Use Grep to locate the relevant file(s)
+   and line numbers before opening them with Read. Do not
+   sequentially Read files to search for content — reserve Read for
+   files whose paths and relevance are already known.
+2. **Verify paths with Glob before Read.** When a file path is
+   constructed or inferred (not hard-coded), confirm the file exists
+   using Glob before attempting to Read it. If a Read fails, do not
+   retry the same path — use Glob to find the correct filename
+   first.
+3. **Batch independent Read calls.** When you need to read multiple
+   files and the reads are independent, issue all Read calls in a
+   single turn rather than one at a time.
+4. **Batch Grep calls.** When searching for multiple patterns or
+   across multiple paths, combine them into a single Grep call using
+   regex alternation (`pat1|pat2`) or issue independent Grep calls
+   in parallel rather than sequentially. Use Glob first to narrow
+   the file set, then Grep the results, instead of running
+   exploratory Grep calls one at a time.
+
 ## Guardrails
 
 - Every finding must cite a specific file and line (or line range).
@@ -135,8 +156,3 @@ so the next run knows what you covered:
   inconsistencies or bugs.
 - Do not output anything other than the finding blocks, `No
   findings.`, and the memory update block.
-- **Verify paths with Glob before Read.** When a file path is
-  constructed or inferred (not hard-coded), confirm the file exists
-  using Glob before attempting to Read it. If a Read fails, do not
-  retry the same path — use Glob to find the correct filename
-  first.

--- a/.claude/agents/cai-confirm.md
+++ b/.claude/agents/cai-confirm.md
@@ -64,8 +64,24 @@ verdict. The diff is concrete evidence of what was changed.
 - Do NOT wrap the Status value in backticks. Write it as plain text.
 - Output nothing before the first `### Verdict:` block and nothing
   after the last one.
-- **Verify paths with Glob before Read.** When a file path is
-  constructed or inferred (not hard-coded), confirm the file exists
-  using Glob before attempting to Read it. If a Read fails, do not
-  retry the same path — use Glob to find the correct filename
-  first.
+
+## Efficiency guidance
+
+1. **Grep before Read.** Use Grep to locate the relevant file(s)
+   and line numbers before opening them with Read. Do not
+   sequentially Read files to search for content — reserve Read for
+   files whose paths and relevance are already known.
+2. **Verify paths with Glob before Read.** When a file path is
+   constructed or inferred (not hard-coded), confirm the file exists
+   using Glob before attempting to Read it. If a Read fails, do not
+   retry the same path — use Glob to find the correct filename
+   first.
+3. **Batch independent Read calls.** When you need to read multiple
+   files and the reads are independent, issue all Read calls in a
+   single turn rather than one at a time.
+4. **Batch Grep calls.** When searching for multiple patterns or
+   across multiple paths, combine them into a single Grep call using
+   regex alternation (`pat1|pat2`) or issue independent Grep calls
+   in parallel rather than sequentially. Use Glob first to narrow
+   the file set, then Grep the results, instead of running
+   exploratory Grep calls one at a time.

--- a/.claude/agents/cai-plan.md
+++ b/.claude/agents/cai-plan.md
@@ -57,11 +57,33 @@ The user message contains:
 
 ## Hard rules
 
-1. **Verify paths with Glob before Read.** When a file path is
+1. **Read-only.** Do not modify any files — only read and plan.
+
+## Efficiency guidance
+
+1. **Grep before Read.** Use Grep to locate the relevant file(s)
+   and line numbers before opening them with Read. Do not
+   sequentially Read files to search for content — reserve Read for
+   files whose paths and relevance are already known.
+2. **Verify paths with Glob before Read.** When a file path is
    constructed or inferred (not hard-coded), confirm the file exists
    using Glob before attempting to Read it. If a Read fails, do not
    retry the same path — use Glob to find the correct filename
    first.
+3. **Batch independent Read calls.** When you need to read multiple
+   files and the reads are independent, issue all Read calls in a
+   single turn rather than one at a time.
+4. **Batch Grep calls.** When searching for multiple patterns or
+   across multiple paths, combine them into a single Grep call using
+   regex alternation (`pat1|pat2`) or issue independent Grep calls
+   in parallel rather than sequentially. Use Glob first to narrow
+   the file set, then Grep the results, instead of running
+   exploratory Grep calls one at a time.
+5. **Use Agent for broad exploration.** When you need to search
+   broadly across multiple files or directories, use the Agent tool
+   with `subagent_type: Explore` instead of issuing many sequential
+   Grep or Read calls. A single Explore subagent can parallelize
+   the search internally, saving tokens and tool-call rounds.
 
 ## Output format
 

--- a/.claude/agents/cai-propose-review.md
+++ b/.claude/agents/cai-propose-review.md
@@ -100,3 +100,24 @@ Only reject proposals that are truly infeasible or already addressed.
 Do NOT reject proposals just because they are ambitious, large, or
 would require significant effort. The issue explicitly asks for bold
 proposals.
+
+## Efficiency guidance
+
+1. **Grep before Read.** Use Grep to locate the relevant file(s)
+   and line numbers before opening them with Read. Do not
+   sequentially Read files to search for content — reserve Read for
+   files whose paths and relevance are already known.
+2. **Verify paths with Glob before Read.** When a file path is
+   constructed or inferred (not hard-coded), confirm the file exists
+   using Glob before attempting to Read it. If a Read fails, do not
+   retry the same path — use Glob to find the correct filename
+   first.
+3. **Batch independent Read calls.** When you need to read multiple
+   files and the reads are independent, issue all Read calls in a
+   single turn rather than one at a time.
+4. **Batch Grep calls.** When searching for multiple patterns or
+   across multiple paths, combine them into a single Grep call using
+   regex alternation (`pat1|pat2`) or issue independent Grep calls
+   in parallel rather than sequentially. Use Glob first to narrow
+   the file set, then Grep the results, instead of running
+   exploratory Grep calls one at a time.

--- a/.claude/agents/cai-propose.md
+++ b/.claude/agents/cai-propose.md
@@ -83,6 +83,27 @@ something to improve), output exactly:
 No proposal.
 ```
 
+## Efficiency guidance
+
+1. **Grep before Read.** Use Grep to locate the relevant file(s)
+   and line numbers before opening them with Read. Do not
+   sequentially Read files to search for content — reserve Read for
+   files whose paths and relevance are already known.
+2. **Verify paths with Glob before Read.** When a file path is
+   constructed or inferred (not hard-coded), confirm the file exists
+   using Glob before attempting to Read it. If a Read fails, do not
+   retry the same path — use Glob to find the correct filename
+   first.
+3. **Batch independent Read calls.** When you need to read multiple
+   files and the reads are independent, issue all Read calls in a
+   single turn rather than one at a time.
+4. **Batch Grep calls.** When searching for multiple patterns or
+   across multiple paths, combine them into a single Grep call using
+   regex alternation (`pat1|pat2`) or issue independent Grep calls
+   in parallel rather than sequentially. Use Glob first to narrow
+   the file set, then Grep the results, instead of running
+   exploratory Grep calls one at a time.
+
 ## Memory update
 
 At the end of your output, always include a `## Memory Update` block

--- a/.claude/agents/cai-refine.md
+++ b/.claude/agents/cai-refine.md
@@ -90,8 +90,24 @@ file Z looks like ...">
   Problem section.
 - **Keep it short.** The fix agent reads this plan as context. A
   wall of text is counterproductive.
-- **Verify paths with Glob before Read.** When a file path is
-  constructed or inferred (not hard-coded), confirm the file exists
-  using Glob before attempting to Read it. If a Read fails, do not
-  retry the same path — use Glob to find the correct filename
-  first.
+
+## Efficiency guidance
+
+1. **Grep before Read.** Use Grep to locate the relevant file(s)
+   and line numbers before opening them with Read. Do not
+   sequentially Read files to search for content — reserve Read for
+   files whose paths and relevance are already known.
+2. **Verify paths with Glob before Read.** When a file path is
+   constructed or inferred (not hard-coded), confirm the file exists
+   using Glob before attempting to Read it. If a Read fails, do not
+   retry the same path — use Glob to find the correct filename
+   first.
+3. **Batch independent Read calls.** When you need to read multiple
+   files and the reads are independent, issue all Read calls in a
+   single turn rather than one at a time.
+4. **Batch Grep calls.** When searching for multiple patterns or
+   across multiple paths, combine them into a single Grep call using
+   regex alternation (`pat1|pat2`) or issue independent Grep calls
+   in parallel rather than sequentially. Use Glob first to narrow
+   the file set, then Grep the results, instead of running
+   exploratory Grep calls one at a time.

--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -104,8 +104,29 @@ No ripple effects found.
 4. **Do not comment on the quality of the PR itself.** Only flag
    ripple effects on the rest of the codebase.
 5. **Keep it short.** Each finding should be 3–5 sentences max.
-6. **Verify paths with Glob before Read.** When a file path is
+
+## Efficiency guidance
+
+1. **Grep before Read.** Use Grep to locate the relevant file(s)
+   and line numbers before opening them with Read. Do not
+   sequentially Read files to search for content — reserve Read for
+   files whose paths and relevance are already known.
+2. **Verify paths with Glob before Read.** When a file path is
    constructed or inferred (not hard-coded), confirm the file exists
    using Glob before attempting to Read it. If a Read fails, do not
    retry the same path — use Glob to find the correct filename
    first.
+3. **Batch independent Read calls.** When you need to read multiple
+   files and the reads are independent, issue all Read calls in a
+   single turn rather than one at a time.
+4. **Batch Grep calls.** When searching for multiple patterns or
+   across multiple paths, combine them into a single Grep call using
+   regex alternation (`pat1|pat2`) or issue independent Grep calls
+   in parallel rather than sequentially. Use Glob first to narrow
+   the file set, then Grep the results, instead of running
+   exploratory Grep calls one at a time.
+5. **Use Agent for broad exploration.** When you need to search
+   broadly across multiple files or directories, use the Agent tool
+   with `subagent_type: Explore` instead of issuing many sequential
+   Grep or Read calls. A single Explore subagent can parallelize
+   the search internally, saving tokens and tool-call rounds.

--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -159,11 +159,54 @@ Example of addressing a review comment on this very file:
    review comment specifically asks for them.
 7. **Stay inside the worktree.** Do not touch files outside the
    working directory.
-8. **Verify paths with Glob before Read.** When a file path is
+
+## Efficiency guidance
+
+1. **Fail fast on repeated errors.** If a tool call fails twice with
+   the same or similar error, stop retrying and diagnose the root
+   cause instead of looping. After 2 consecutive Edit failures on
+   the same file, re-read it to refresh your view before retrying —
+   your cached view may be stale. Do not fall back from Edit to
+   Write on the same file without first diagnosing why Edit failed —
+   Write overwrites the entire file and is rarely the correct
+   recovery.
+2. **Verify `old_string` uniqueness before calling Edit.** Before
+   submitting an Edit call, mentally confirm that your `old_string`
+   appears exactly once in the file. If you're unsure — especially
+   in files with repetitive structure (repeated function signatures,
+   similar config blocks, duplicated patterns) — expand the context
+   to 5–7 lines and include at least one highly distinctive anchor
+   line: a unique function/method name, a unique string literal, or
+   a unique comment. Never use an `old_string` composed entirely of
+   generic lines (blank lines, closing braces, common keywords) that
+   could match multiple locations.
+3. **Grep before Read.** Use Grep to locate the relevant file(s)
+   and line numbers before opening them with Read. Do not
+   sequentially Read files to search for content — reserve Read for
+   files whose paths and relevance are already known.
+4. **Verify paths with Glob before Read.** When a file path is
    constructed or inferred (not hard-coded), confirm the file exists
    using Glob before attempting to Read it. If a Read fails, do not
    retry the same path — use Glob to find the correct filename
    first.
+5. **Batch independent Read calls.** When you need to read multiple
+   files and the reads are independent, issue all Read calls in a
+   single turn rather than one at a time.
+6. **Batch edits to the same file.** Combine multiple changes into
+   as few Edit calls as possible by using larger `old_string` spans.
+   Avoid single-line edits when a multi-line replacement achieves
+   the same result in one call.
+7. **Minimize Write calls.** Before creating multiple new files,
+   consider whether the content could fit in a single file or fewer
+   files. When several files are genuinely needed, plan the full set
+   first, then issue all independent Write calls in one turn rather
+   than creating them one at a time.
+8. **Batch Grep calls.** When searching for multiple patterns or
+   across multiple paths, combine them into a single Grep call using
+   regex alternation (`pat1|pat2`) or issue independent Grep calls
+   in parallel rather than sequentially. Use Glob first to narrow
+   the file set, then Grep the results, instead of running
+   exploratory Grep calls one at a time.
 
 ## Handling an in-progress rebase
 

--- a/.claude/agents/cai-update-check.md
+++ b/.claude/agents/cai-update-check.md
@@ -120,3 +120,24 @@ run knows what you covered:
   raised or intentionally accepted.
 - Do not output anything other than the finding blocks, `No findings.`, and
   the memory update block.
+
+## Efficiency guidance
+
+1. **Grep before Read.** Use Grep to locate the relevant file(s)
+   and line numbers before opening them with Read. Do not
+   sequentially Read files to search for content — reserve Read for
+   files whose paths and relevance are already known.
+2. **Verify paths with Glob before Read.** When a file path is
+   constructed or inferred (not hard-coded), confirm the file exists
+   using Glob before attempting to Read it. If a Read fails, do not
+   retry the same path — use Glob to find the correct filename
+   first.
+3. **Batch independent Read calls.** When you need to read multiple
+   files and the reads are independent, issue all Read calls in a
+   single turn rather than one at a time.
+4. **Batch Grep calls.** When searching for multiple patterns or
+   across multiple paths, combine them into a single Grep call using
+   regex alternation (`pat1|pat2`) or issue independent Grep calls
+   in parallel rather than sequentially. Use Glob first to narrow
+   the file set, then Grep the results, instead of running
+   exploratory Grep calls one at a time.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#346

**Issue:** #346 — Extend batching and parallel tool-call guidance to non-fix agents

## PR Summary

### What this fixes
Six agent definition files (`cai-revise`, `cai-plan`, `cai-code-audit`, `cai-review-pr`, `cai-confirm`, `cai-audit`) lacked the batching and parallel tool-call efficiency guidance that `cai-fix.md` already had, causing agents to issue sequential tool calls that waste tokens and cost more than necessary.

### What was changed
- **`.cai-staging/agents/cai-revise.md`**: Added `## Efficiency guidance` section with 8 rules (all cai-fix rules except "Use Agent for broad exploration", since cai-revise has no Agent tool); removed the duplicate rule #7 "Verify paths with Glob" from "Hard rules — editing" (it was duplicating rule #7 "Stay inside the worktree", and is now consolidated into the efficiency section).
- **`.cai-staging/agents/cai-plan.md`**: Added `## Efficiency guidance` section with 5 rules (Grep before Read, Verify paths with Glob, Batch Read, Batch Grep, Use Agent for broad exploration); removed the existing standalone "Verify paths with Glob" from "Hard rules" and replaced the single hard rule with a simpler "Read-only" rule.
- **`.cai-staging/agents/cai-code-audit.md`**: Added `## Efficiency guidance` section with 4 rules (no Agent/Edit/Write rules since the agent is read-only with no Agent tool); removed the existing standalone "Verify paths with Glob" bullet from "Guardrails".
- **`.cai-staging/agents/cai-review-pr.md`**: Added `## Efficiency guidance` section with 5 rules (including "Use Agent for broad exploration" since the agent has the Agent tool); removed the existing standalone "Verify paths with Glob" rule from "Hard rules".
- **`.cai-staging/agents/cai-confirm.md`**: Added `## Efficiency guidance` section with 4 rules; removed the existing standalone "Verify paths with Glob" rule from "Hard rules".
- **`.cai-staging/agents/cai-audit.md`**: Added `## Efficiency guidance` section with 4 rules; removed the existing standalone "Verify paths with Glob" bullet from "Guardrails".

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
