### PR TITLE
auto-improve: review-pr should identify reccurrent patterns and propose improvement of fix accordingly

### DIFF
--- a/.claude/agents/cai-analyze.md
+++ b/.claude/agents/cai-analyze.md
@@ -33,6 +33,12 @@ sessions from outside the container.
 4. **Container or installer bugs** — issues visible from the JSONL
    that suggest a `Dockerfile`, `install.sh`, `cai.py`, or
    `docker-compose.yml` change
+5. **Recurring review-pr patterns** — if the same category of
+   review-pr finding (e.g., `missing_co_change`, `stale_docs`)
+   appears across 3+ different PRs, consider raising a
+   `prompt_quality` or `workflow_efficiency` finding that proposes
+   a systemic fix (e.g., adding a checklist step to the fix agent,
+   updating a prompt to remind about the pattern)
 
 ## Categories
 
@@ -61,6 +67,13 @@ You receive the following sections in the user message, in order:
 2. **Currently open auto-improve issues** — number, state label, title
 3. **Previously closed auto-improve issues** (if any) — number,
    closing timestamp, labels, closing rationale
+4. **Review-PR patterns** (optional) — JSONL entries from
+   `cai review-pr` findings. Each line is a JSON object with
+   `timestamp`, `pr_number`, `category`, and `description`.
+   Look for recurring categories or descriptions across multiple
+   PRs — repeated patterns suggest a systemic issue in the codebase
+   or in the agents' prompts that could be addressed with an
+   improvement issue.
 
 ## What to output
 
@@ -140,8 +153,8 @@ output `No findings.` and stop.
 ## Guardrails
 
 - Every finding must be grounded in actual signal from the parsed
-  transcript data — no speculation about issues you can't see in the
-  signals.
+  transcript data or from the review-pr patterns — no speculation
+  about issues you can't see in the signals.
 - Stick to one of the 4 categories above; do not invent new ones.
 - Keep titles short and imperative ("Reduce X", "Fix Y", "Remove Z").
 - Do not include code blocks longer than 10 lines in remediations.

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,8 +88,8 @@ RUN wget -nv -O /usr/local/bin/supercronic \
 #                                    cloned-worktree agents have it
 #                                    copied in/out by the wrapper
 #                                    around each invocation)
-#   - /var/log/cai/               → cai_logs          (run log — one
-#                                    key=value line per cai invocation;
+#   - /var/log/cai/               → cai_logs          (run log, cost log,
+#                                    and review-pr finding patterns;
 #                                    named volume avoids host permission
 #                                    issues that a bind-mount causes)
 #

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ subprocess with no shared state.
 
 | Subcommand | Default schedule | What it does |
 |---|---|---|
-| `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
+| `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts and recent review-pr finding patterns, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
 | `cai.py refine` | `10 * * * *` (hourly :10) | Picks the oldest `:needs-refinement` issue, invokes the cai-refine subagent (read-only) to produce a structured plan, updates the issue body, and transitions the label to `:raised` |
 | `cai.py fix` | `15 * * * *` (hourly :15) | Picks the oldest eligible issue, runs 3 parallel plan agents then a select agent to choose the best plan, lets a fix subagent implement it with full tool permissions, opens a PR — see lifecycle below |
 | `cai.py revise` | `30 * * * *` (hourly :30) | Watches `:pr-open` PRs for new comments and iterates on the same branch via force-push; also auto-rebases unmergeable PRs onto current main |

--- a/README.md
+++ b/README.md
@@ -452,9 +452,11 @@ The container uses three Docker named volumes:
   memory directly from `/app/.claude/agent-memory/<agent-name>/`
   via the mounted `cai_agent_memory` volume — no copy in/out by
   the wrapper.
-- **`cai_logs`** (mounted at `/var/log/cai`) — run log. One
-  key=value line per `cai` invocation. Using a named volume avoids
-  the host permission issues that a bind-mount causes.
+- **`cai_logs`** (mounted at `/var/log/cai`) — run log (`cai.log`),
+  cost log (`cai-cost.jsonl`), and review-pr finding patterns
+  (`review-pr-patterns.jsonl`). One key=value line per `cai`
+  invocation in the run log. Using a named volume avoids the host
+  permission issues that a bind-mount causes.
 
 The container runs as the non-root `cai` user (uid 1000). This is
 required by `claude-code` because the fix and revise subagents use

--- a/cai.py
+++ b/cai.py
@@ -775,7 +775,8 @@ def cmd_analyze(args) -> int:
     # in `.claude/agents/cai-analyze.md`. Durable per-agent learnings
     # live in its `memory: project` pool. The wrapper only passes
     # dynamic per-run context (parsed signals, open issues,
-    # closed-issue rationales) via stdin as the user message.
+    # closed-issue rationales, review-pr patterns) via stdin as the
+    # user message.
     user_message = (
         "## Parsed signals\n\n"
         "```json\n"

--- a/cai.py
+++ b/cai.py
@@ -144,6 +144,10 @@ CODE_AUDIT_MEMORY = Path("/var/log/cai/code-audit-memory.md")
 PROPOSE_MEMORY = Path("/var/log/cai/propose-memory.md")
 # Persistent memory file for the update-check agent.
 UPDATE_CHECK_MEMORY = Path("/var/log/cai/update-check-memory.md")
+# Persistent log of review-pr finding patterns. Each line is a JSON
+# object with {timestamp, pr_number, category, description}. The
+# analyze agent reads this to spot recurring review patterns.
+REVIEW_PR_PATTERNS = Path("/var/log/cai/review-pr-patterns.jsonl")
 
 # Persistent per-agent memory directory. Each declarative subagent
 # has `memory: project` in its frontmatter, which Claude Code stores
@@ -749,6 +753,24 @@ def cmd_analyze(args) -> int:
     closed_issues = _fetch_closed_auto_improve_issues(limit=50)
     closed_block = _closed_issues_block(closed_issues)
 
+    # Review-PR patterns — recurring findings from pre-merge reviews
+    # that may indicate systemic issues worth raising as improvements.
+    review_patterns = _read_review_pr_patterns()
+    review_patterns_block = ""
+    if review_patterns:
+        review_patterns_block = (
+            "\n\n## Review-PR patterns\n\n"
+            "The following are recent findings from `cai review-pr` pre-merge "
+            "reviews. Look for recurring categories or descriptions that suggest "
+            "a systemic issue in the codebase or in the auto-improve agents' "
+            "output. If you see the same kind of finding repeated across multiple "
+            "PRs, consider raising an improvement issue to address the root "
+            "cause.\n\n"
+            "```jsonl\n"
+            f"{review_patterns}\n"
+            "```\n"
+        )
+
     # The system prompt, tool allowlist, and model choice all live
     # in `.claude/agents/cai-analyze.md`. Durable per-agent learnings
     # live in its `memory: project` pool. The wrapper only passes
@@ -761,6 +783,7 @@ def cmd_analyze(args) -> int:
         "```\n"
         f"{issues_block}"
         f"{closed_block}"
+        f"{review_patterns_block}"
     )
 
     analyzer = _run_claude_p(
@@ -4587,6 +4610,47 @@ _REVIEW_COMMENT_HEADING_FINDINGS = "## cai pre-merge review"
 _REVIEW_COMMENT_HEADING_CLEAN = "## cai pre-merge review (clean)"
 
 
+def _append_review_pr_patterns(pr_number: int, agent_output: str) -> None:
+    """Append review-pr finding patterns to the JSONL log for trend analysis."""
+    findings = re.findall(
+        r"^### Finding:\s*(\S+)\s*\n(.*?)(?=^### Finding:|\Z)",
+        agent_output,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not findings:
+        return
+    ts = datetime.now(timezone.utc).isoformat()
+    try:
+        REVIEW_PR_PATTERNS.parent.mkdir(parents=True, exist_ok=True)
+        with REVIEW_PR_PATTERNS.open("a") as f:
+            for category, body in findings:
+                desc_match = re.search(r"\*\*Description:\*\*\s*(.+)", body)
+                desc = desc_match.group(1).strip() if desc_match else body.strip()[:160]
+                record = json.dumps({
+                    "timestamp": ts,
+                    "pr_number": pr_number,
+                    "category": category,
+                    "description": desc,
+                })
+                f.write(record + "\n")
+    except OSError as exc:
+        print(f"[cai review-pr] could not write pattern log: {exc}", flush=True)
+
+
+def _read_review_pr_patterns() -> str:
+    """Read the review-pr patterns log and return recent entries for the analyzer."""
+    if not REVIEW_PR_PATTERNS.exists():
+        return ""
+    try:
+        lines = REVIEW_PR_PATTERNS.read_text().strip().splitlines()
+    except OSError:
+        return ""
+    if not lines:
+        return ""
+    # Return the last 100 entries (most recent patterns).
+    return "\n".join(lines[-100:])
+
+
 def cmd_review_pr(args) -> int:
     """Review open PRs for ripple effects and post findings as PR comments."""
     print("[cai review-pr] checking open PRs against main", flush=True)
@@ -4729,6 +4793,7 @@ def cmd_review_pr(args) -> int:
             )
 
             if has_findings:
+                _append_review_pr_patterns(pr_number, agent_output)
                 # Findings comments use the actionable heading form
                 # so the revise subagent picks them up on its next
                 # tick (`_BOT_COMMENT_MARKERS` does NOT match this).

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,9 +136,11 @@ The container uses three Docker named volumes:
   all user state.
 - **`cai_agent_memory`** (mounted at `/app/.claude/agent-memory`) —
   per-agent durable memory accumulated by the declarative subagents.
-- **`cai_logs`** (mounted at `/var/log/cai`) — run log. One
-  key=value line per `cai` invocation. Using a named volume avoids
-  the host permission issues that a bind-mount causes.
+- **`cai_logs`** (mounted at `/var/log/cai`) — run log (`cai.log`),
+  cost log (`cai-cost.jsonl`), and review-pr finding patterns
+  (`review-pr-patterns.jsonl`). One key=value line per `cai`
+  invocation in the run log. Using a named volume avoids the host
+  permission issues that a bind-mount causes.
 
 The container runs as the non-root `cai` user (uid 1000) — see
 Dockerfile for the rationale.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#385

**Issue:** #385 — review-pr should identify reccurrent patterns and propose improvement of fix accordingly

## PR Summary

### What this fixes
Issue #385 requested that `cai review-pr` accumulate recurring finding patterns and feed them into the analyzer so it can raise systemic improvement issues targeting root causes of repeated PR problems.

### What was changed
- **`cai.py`** — Added `REVIEW_PR_PATTERNS` constant (`/var/log/cai/review-pr-patterns.jsonl`); added `_append_review_pr_patterns()` helper that parses `### Finding:` blocks from review-pr output and appends them as JSONL lines; added `_read_review_pr_patterns()` helper that reads the last 100 entries; called `_append_review_pr_patterns()` in `cmd_review_pr` after findings are detected; added a `## Review-PR patterns` section to the `cmd_analyze` user message when pattern data is available
- **`.cai-staging/agents/cai-analyze.md`** — Added item 4 to "Input format" documenting the new `## Review-PR patterns` section; added item 5 to "What to look for" instructing the analyzer to raise systemic improvement issues when the same finding category recurs across 3+ PRs; updated the guardrails to allow review-pr patterns as a grounding signal

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
