### PR TITLE
auto-improve: Single fix-agent invocation costs 3.57× the category mean

### DIFF
--- a/.claude/agents/cai-fix.md
+++ b/.claude/agents/cai-fix.md
@@ -197,6 +197,24 @@ This is the fix step's safety net: a finding may have slipped past
 the analyze step's filters, and refusing to act on it here is the
 defense-in-depth that breaks the spin loop.
 
+## Triage the issue before exploring
+
+**Before opening any file or running any search**, answer these
+three questions by reading only the issue body:
+
+1. Does the issue name a **specific file or code path** to change?
+2. Does the remediation describe a **concrete edit** (add/remove/
+   modify specific code)?
+3. Can you state in one sentence **what the diff will look like**?
+
+If any answer is "no", the issue is likely a research task, a
+feature request, or an ambiguous finding. **Do not explore the
+codebase.** Instead, emit a `## Needs Spike` block (see below)
+and exit immediately with zero diff. Over-exploring ambiguous
+issues is the single largest source of wasted cost in the fix
+pipeline — a 30-second bail saves more than a 50-turn
+investigation that produces a speculative change.
+
 ## When to make NO changes (and exit cleanly)
 
 Producing **zero diff** is a valid outcome — the wrapper detects an

--- a/.claude/agents/cai-fix.md
+++ b/.claude/agents/cai-fix.md
@@ -207,13 +207,26 @@ three questions by reading only the issue body:
    modify specific code)?
 3. Can you state in one sentence **what the diff will look like**?
 
-If any answer is "no", the issue is likely a research task, a
-feature request, or an ambiguous finding. **Do not explore the
-codebase.** Instead, emit a `## Needs Spike` block (see below)
-and exit immediately with zero diff. Over-exploring ambiguous
-issues is the single largest source of wasted cost in the fix
-pipeline — a 30-second bail saves more than a 50-turn
-investigation that produces a speculative change.
+If any answer is "no", **do not explore the codebase.** Exit
+immediately with zero diff and a short stdout explanation.
+Over-exploring ambiguous issues is the single largest source of
+wasted cost in the fix pipeline — a 30-second bail saves more
+than a 50-turn investigation that produces a speculative change.
+
+Choose your exit path based on *why* you answered "no":
+
+- **Spike-shaped** (the acceptance criteria are "documented
+  findings", "a decision", or "a survey of what's possible" —
+  i.e., question 3 is answerable but describes an evaluation
+  outcome rather than a diff): emit a `## Needs Spike` block
+  (see the `## When to make NO changes` section below) so the
+  wrapper routes the issue to `auto-improve:needs-spike`.
+- **Ambiguous or feature-request-shaped** (the issue is vague,
+  unclear, or describes a desired capability without specifying
+  what code to change): exit with **zero diff and no `## Needs
+  Spike` marker** — the wrapper will roll the label back to
+  `auto-improve:no-action`, which is the correct queue for
+  issues that need human clarification before they can be fixed.
 
 ## When to make NO changes (and exit cleanly)
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#388

**Issue:** #388 — Single fix-agent invocation costs 3.57× the category mean

## PR Summary

### What this fixes
A single fix-agent invocation cost 3.57× the category mean ($1.09 vs $0.31 mean) because the agent over-explored a broad, ambiguous issue (#349) instead of bailing early. The fix adds an explicit pre-flight triage gate to `cai-fix.md` so the agent answers three concrete questions from the issue body alone before touching any file.

### What was changed
- `.claude/agents/cai-fix.md` (via staging at `.cai-staging/agents/cai-fix.md`): Inserted a new "Triage the issue before exploring" section between "Consult your memory first" and "When to make NO changes". The section gives a three-question checklist (specific file named? concrete edit described? diff stateable in one sentence?) and instructs the agent to emit `## Needs Spike` and exit immediately with zero diff if any answer is "no".

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
