### PR TITLE
auto-improve: PR #355 revise loop on merge-blocked cai-spike PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ identity as the operator.
 If the bot can't address a comment (unclear or out of scope), it
 posts a reply explaining why and exits without changes.
 
-**Skip conditions:** `cai revise` silently skips a PR when its linked
+**Skip conditions:** `cai revise` skips (logging a `[cai revise] … skipping` message) a PR when its linked
 issue carries the `merge-blocked` label **or** the PR itself carries
 the `needs-human-review` label. Revising code cannot unblock a PR
 that is waiting on a human decision, so the bot leaves it alone to

--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ identity as the operator.
 If the bot can't address a comment (unclear or out of scope), it
 posts a reply explaining why and exits without changes.
 
+**Skip conditions:** `cai revise` silently skips a PR when its linked
+issue carries the `merge-blocked` label **or** the PR itself carries
+the `needs-human-review` label. Revising code cannot unblock a PR
+that is waiting on a human decision, so the bot leaves it alone to
+avoid infinite revision loops. A human must clear those labels
+(and, for `merge-blocked` issues, resolve the underlying blocker)
+to re-enable automatic comment-driven iteration.
+
 ### Pre-merge consistency review
 
 The `review-pr` subcommand (default: hourly at `:20`) walks all open

--- a/cai.py
+++ b/cai.py
@@ -5039,9 +5039,14 @@ def cmd_merge(args) -> int:
         # decided not to merge". Re-evaluation gating is purely
         # SHA-based (see safety filter 6 below): if the PR's HEAD SHA
         # has a prior merge-verdict comment, we skip; otherwise we
-        # re-evaluate. That way, when revise pushes a new commit (new
-        # SHA), the bot naturally re-evaluates without requiring a
-        # human to manually clear the label.
+        # re-evaluate.
+        #
+        # NOTE (issue #399): `cai revise` no longer runs on PRs that
+        # carry the `merge-blocked` or `needs-human-review` label, so
+        # the automatic SHA-based re-evaluation loop no longer applies
+        # to blocked PRs. A human must manually clear the
+        # `merge-blocked` label (and any `needs-human-review` label)
+        # to restart the merge-evaluation cycle for those PRs.
 
         # Safety filter 7: require `cai review-pr` to have reviewed
         # the current head SHA before we run a merge verdict on it.

--- a/cai.py
+++ b/cai.py
@@ -2088,7 +2088,7 @@ def _select_revise_targets() -> list[dict]:
             "pr", "list",
             "--repo", REPO,
             "--state", "open",
-            "--json", "number,headRefName,comments",
+            "--json", "number,headRefName,comments,labels",
             "--limit", "50",
         ]) or []
     except subprocess.CalledProcessError as e:
@@ -2118,6 +2118,23 @@ def _select_revise_targets() -> list[dict]:
         if LABEL_PR_OPEN not in label_names:
             continue
         if LABEL_REVISING in label_names:
+            continue
+
+        # Skip PRs that are blocked on a human decision — revising
+        # code won't unblock them and causes an infinite loop.
+        # Issue #399.
+        pr_label_names = {lbl["name"] for lbl in pr.get("labels", [])}
+        if LABEL_MERGE_BLOCKED in label_names or LABEL_PR_NEEDS_HUMAN in pr_label_names:
+            skip_reason = []
+            if LABEL_MERGE_BLOCKED in label_names:
+                skip_reason.append(f"issue has :{LABEL_MERGE_BLOCKED}")
+            if LABEL_PR_NEEDS_HUMAN in pr_label_names:
+                skip_reason.append(f"PR has :{LABEL_PR_NEEDS_HUMAN}")
+            print(
+                f"[cai revise] PR #{pr['number']}: skipping — "
+                f"{', '.join(skip_reason)} (needs human decision)",
+                flush=True,
+            )
             continue
 
         # Find the most recent commit date via `gh pr view`.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#399

**Issue:** #399 — PR #355 revise loop on merge-blocked cai-spike PR

## PR Summary

### What this fixes
PR #355 (and any similar PR) was caught in an infinite revise loop: the revise agent kept processing it every cycle reporting `comments_addressed=1`, but since the PR carries `merge-blocked` and `needs-human-review` labels, no code change can unblock it — only a human decision can.

### What was changed
- **`cai.py` line 1994**: Added `labels` to the `--json` fields in the `pr list` call inside `_select_revise_targets()` so PR-level labels are available without an extra API call.
- **`cai.py` after line 2024**: Added a guard block that skips any PR whose linked issue carries `LABEL_MERGE_BLOCKED` or whose PR carries `LABEL_PR_NEEDS_HUMAN`, printing a descriptive skip message and continuing to the next PR.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
