### PR TITLE
auto-improve: Semantic error sampling in transcript analysis

### DIFF
--- a/.claude/agents/cai-analyze.md
+++ b/.claude/agents/cai-analyze.md
@@ -24,7 +24,10 @@ sessions from outside the container.
 ## What to look for
 
 1. **Tool-call errors** — Edit failures, permission errors, repeated
-   retries, error patterns visible in the parsed signals
+   retries, error patterns visible in the parsed signals. When
+   `error_tools` shows a pattern, consult `error_details` for
+   representative error text and preceding reasoning; quote the actual
+   error text in the Evidence field.
 2. **Prompt issues** — unclear instructions, missing guidance in the
    agent prompts cai sends to claude (this prompt itself, or the
    other agents in `.claude/agents/`)
@@ -54,6 +57,7 @@ You receive the following sections in the user message, in order:
    - `tool_counts` — full tool usage map (capped)
    - `error_tools` — tools that errored, with counts
    - `error_categories` — controllable vs network/auth errors
+   - `error_details` — up to 20 sampled errors: {tool, error_text, reasoning_context}
    - `repeated_sequences` — runs of 3+ identical consecutive calls
    - `token_usage` — input/output token totals (including `cache_creation_tokens` and `cache_read_tokens` breakdowns)
    - `tool_sequence_preview` — first 100 tool calls in sequence

--- a/parse.py
+++ b/parse.py
@@ -96,6 +96,8 @@ def extract_tool_calls(lines: list[str]) -> dict:
     tool_counter: Counter = Counter()
     error_tools: list[str] = []
     error_categories: list[str] = []
+    error_details: list[dict] = []
+    _last_assistant_text: str = ""
     tool_sequences: list[str] = []
     total_input_tokens = 0
     total_output_tokens = 0
@@ -132,6 +134,8 @@ def extract_tool_calls(lines: list[str]) -> dict:
 
         if role == "assistant":
             for block in content if isinstance(content, list) else []:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    _last_assistant_text = block.get("text", "")
                 if isinstance(block, dict) and block.get("type") == "tool_use":
                     name = block.get("name", "unknown")
                     tool_counter[name] += 1
@@ -148,6 +152,11 @@ def extract_tool_calls(lines: list[str]) -> dict:
                         error_text = _extract_error_text(block)
                         category = _categorize_error(error_text)
                         error_categories.append(category)
+                        if len(error_details) < TOP_N:
+                            detail: dict = {"tool": tool_sequences[-1], "error_text": error_text[:200]}
+                            if _last_assistant_text:
+                                detail["reasoning_context"] = _last_assistant_text[:150]
+                            error_details.append(detail)
 
     # Repeated consecutive-run detection: runs of 3+ identical calls in
     # a row are a strong signal that a loop could be replaced by a
@@ -185,6 +194,7 @@ def extract_tool_calls(lines: list[str]) -> dict:
             "controllable": controllable_errors,
             "network_auth": network_auth_errors,
         },
+        "error_details": error_details,
         "repeated_sequences": repeated[:TOP_N],
         "token_usage": {
             "input_tokens": total_input_tokens,
@@ -269,6 +279,7 @@ def main() -> None:
             "tool_counts": {},
             "error_tools": {},
             "error_categories": {"total": 0, "controllable": 0, "network_auth": 0},
+            "error_details": [],
             "repeated_sequences": [],
             "token_usage": {"input_tokens": 0, "output_tokens": 0, "cache_creation_tokens": 0, "cache_read_tokens": 0},
             "tool_sequence_preview": "",


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#400

**Issue:** #400 — Semantic error sampling in transcript analysis

## PR Summary

### What this fixes
`parse.py` was extracting error text from tool_result blocks but discarding it — only error counts were passed to the `cai-analyze` agent, forcing findings to be vague ("Edit errored 12 times") with no root-cause detail. Surfacing error message snippets and the preceding assistant reasoning text enables grounded, evidence-backed findings.

### What was changed
- **`parse.py`**: Added `error_details: list[dict]` and `_last_assistant_text: str` variables to `extract_tool_calls()`. On each assistant message, text blocks now update `_last_assistant_text`. On each tool error, an entry `{tool, error_text[:200], reasoning_context[:150]}` is appended to `error_details` (capped at `TOP_N=20`). The `error_details` list is emitted as a top-level key in both the normal return dict and the empty-transcript fallback in `main()`.
- **`.claude/agents/cai-analyze.md`** (via staging): Added `error_details` to the `## Input format` field list; added one instruction sentence to item 1 of `## What to look for` directing the agent to consult `error_details` and quote actual error text in the Evidence field.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
