### PR TITLE
auto-improve: Upgrade pinned Claude Code version from 2.1.96 to 2.1.101

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV BROWSER=echo
 
 # Pin the claude-code version so the self-improvement loop is reproducible.
 # Bumping this should be a deliberate, reviewed change.
-ARG CLAUDE_CODE_VERSION=2.1.96
+ARG CLAUDE_CODE_VERSION=2.1.101
 
 # Pin supercronic (the in-container cron supervisor; Phase D onward).
 # SHA256 is computed once against v0.2.44's linux-amd64 binary; bumping


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#403

**Issue:** #403 — Upgrade pinned Claude Code version from 2.1.96 to 2.1.101

## PR Summary

### What this fixes
The pinned Claude Code version (2.1.96) had several critical bugs affecting this project: sub-agents in isolated worktrees were denied Read/Edit access to their own worktree files (directly breaking cai-fix and cai-revise), `--dangerously-skip-permissions` was silently downgraded after protected-path writes, `RemoteTrigger` sent empty bodies and was rejected by the server, and a Bash tool permission bypass allowed arbitrary code execution in headless mode.

### What was changed
- **`Dockerfile` line 18**: Bumped `ARG CLAUDE_CODE_VERSION` from `2.1.96` to `2.1.101` to pick up all fixes from v2.1.97 through v2.1.101.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
