### PR TITLE
cost: run cai-review-pr on haiku

### DIFF
--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -2,7 +2,7 @@
 name: cai-review-pr
 description: Pre-merge ripple-effect review for an open PR. Walks the diff, searches the broader codebase for inconsistencies the PR introduced but didn't update, and emits `### Finding:` blocks the wrapper posts as a PR comment. Read-only.
 tools: Read, Grep, Glob, Agent
-model: claude-sonnet-4-6
+model: claude-haiku-4-5
 memory: project
 ---
 


### PR DESCRIPTION
## Summary

- Switches `cai-review-pr`'s model from `claude-sonnet-4-6` to `claude-haiku-4-5` (`.claude/agents/cai-review-pr.md:5`).
- Addresses #381: review was costing more than fix.

## Why Haiku

The pre-merge ripple-effect review is mostly mechanical work: extract identifiers from the diff, grep the tree for references, flag mismatches. That pattern is well within Haiku's range — it's the same shape as `cai-git` (which already runs on Haiku) or a targeted Explore sub-run.

Manager-on-Sonnet was paying Sonnet rates on a task that doesn't need Sonnet reasoning. The review also re-runs on every new head SHA during the revise loop, so per-issue amortised cost scaled badly with rebase churn — exactly why this category showed up as more expensive than `cai-fix` despite fixes being the "harder" job.

## Scope kept narrow

- Tools list unchanged (`Read, Grep, Glob, Agent`).
- Prompt body unchanged — delegation guidance at lines 61–64 still points at built-in `Explore`, which transcript-isolates broad searches away from the parent. Haiku-on-Haiku delegation still helps there because each sub-run has its own context window.
- Not softening the "exhaustive in a single pass" language yet — keep that as a follow-up if false-negative findings start climbing.
- Not adding docs-only short-circuiting in `cmd_review_pr` — separate optimization, separate PR.

## Risks

- Haiku may miss subtler ripple effects that Sonnet would catch. If the next couple of days of runs show missed cross-file inconsistencies the reviewer should have flagged, revert this and explore the delegation-only approach instead (keep Sonnet manager, move just the grep work to Haiku via `Agent(subagent_type="Explore", model="haiku", ...)` — that path was probed and confirmed working during the spike).
- This PR will itself be reviewed by the new Haiku reviewer — that's actually a useful first data point.

## Test plan

- [ ] CI passes.
- [ ] `cai review-pr` runs successfully against this PR and posts a review comment (with or without findings — either outcome is informative).
- [ ] Watch `cai-cost.jsonl` for the `review-pr` category over the next 24-48h to confirm cost drop.
- [ ] Spot-check one or two findings to make sure Haiku is still catching real ripple effects, not just rubber-stamping.

Closes #381