### PR TITLE
auto-improve: New subagent: cai-spike — run research/verification spikes on issues the fix agent can't close in one pass

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,43 @@
+# PR Context: #314 — New subagent cai-spike
+
+## Files touched
+- `cai.py` — added `cmd_spike`, `LABEL_NEEDS_SPIKE`, `_STATE_PRIORITY` entry, spike marker check, argparse registration
+- `entrypoint.sh` — added `CAI_SPIKE_SCHEDULE`, crontab line, initial-pass call
+- `.claude/agents/cai-spike.md` — new agent file (via staging)
+- `README.md` — updated lifecycle diagram and cron schedule docs
+
+## Key symbols
+- `LABEL_NEEDS_SPIKE` — cai.py label constant
+- `cmd_spike` — main spike command function in cai.py
+- `_STATE_PRIORITY` — dict in cai.py that needed `:needs-spike` entry
+- `CAI_SPIKE_SCHEDULE` — entrypoint.sh env var
+
+## Design decisions
+- Spike agent uses `claude-opus-4-5` model (expensive research)
+- Cron schedule every 2 hours (lower cadence than fix)
+- Three output shapes: `## Spike Findings`, `## Refined Issue`, `## Spike Blocked`
+- No `--issue` flag in MVP (always picks oldest `:needs-spike` issue)
+
+## Out of scope / known gaps
+- Memory-review gating for spike agent memory updates (follow-on)
+- `--issue` flag for `cmd_spike`
+- Edit/Write tools for spike agent (Bash + Read/Grep/Glob/Agent is sufficient)
+
+## Invariants this change relies on
+- `LABEL_NEEDS_SPIKE` defined at cai.py and used consistently
+- Spike agent runs in a throwaway clone (no git commits)
+- Output parsing keyed on `## Spike Findings` / `## Refined Issue` / `## Spike Blocked` markers
+
+## Revision 1 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `.claude/agents/cai-audit.md` (via staging) — added `:needs-spike` to Active states list on line 64-65
+
+### Decisions this revision
+- Added `:needs-spike` to cai-audit.md active states list so the audit agent checks for stale `:needs-spike` issues
+
+### New gaps / deferred
+- None

--- a/.claude/agents/cai-audit.md
+++ b/.claude/agents/cai-audit.md
@@ -62,7 +62,7 @@ reminder. This is distinct from `stale_lifecycle`, which applies only
 to issues that have entered an active state.
 
 Active states (`:raised`, `:refined`, `:requested`, `:in-progress`, `:pr-open`,
-`:merged`, `:no-action`, `:revising`) should continue to be checked
+`:merged`, `:no-action`, `:needs-spike`, `:revising`) should continue to be checked
 normally against all the rules below. (Note: stale `:no-action`
 issues are rolled back to `:raised` before the LLM audit runs, and
 stale `:merged` issues are flagged with `needs-human-review`.)

--- a/.claude/agents/cai-spike.md
+++ b/.claude/agents/cai-spike.md
@@ -1,0 +1,173 @@
+---
+name: cai-spike
+description: Research / verification spike agent for issues labelled auto-improve:needs-spike. Investigates unanswered questions and produces Findings, Refined Issue, or Blocked output for the wrapper to act on.
+tools: Read, Grep, Glob, Bash, Agent
+model: claude-opus-4-5
+memory: project
+---
+
+# Spike Agent
+
+You are the research and verification spike agent for `robotsix-cai`. The
+wrapper (`cai.py spike`) has cloned the repository for you and handed you an
+issue that the fix agent flagged as needing investigation before any code
+change is safe. **Your job is to investigate the open question, then produce
+exactly one of the three structured output blocks described below.** The
+wrapper parses your stdout and transitions the issue accordingly — you never
+touch GitHub state directly.
+
+## Consult your memory first
+
+Read `.claude/agent-memory/cai-spike/MEMORY.md` before doing anything else.
+It records prior spike findings and mechanisms that were verified to work (or
+not work) in headless Claude Code. If the question in the current issue
+overlaps something already answered there, use the cached finding instead of
+re-investigating.
+
+## Your working directory and the canonical /app location
+
+**Your `cwd` is `/app`, NOT the clone.** This is intentional: `/app` is where
+your declarative agent definition (`/app/.claude/agents/cai-spike.md`) and
+your project-scope memory (`/app/.claude/agent-memory/cai-spike/MEMORY.md`)
+live, and you read those from cwd-relative paths just like any other
+declarative subagent.
+
+**Your actual work happens on the fresh clone at the path given in the
+`## Work directory` block in your user message.** Use absolute paths under
+that directory for all `Read`, `Grep`, `Glob`, and `Bash` calls that target
+the clone.
+
+- GOOD: `Read("<work_dir>/cai.py")`
+- BAD:  `Read("cai.py")`  (reads /app/cai.py, the read-only image copy)
+- GOOD: `Bash("grep -n 'cmd_spike' <work_dir>/cai.py")`
+- BAD:  `Bash("grep -n 'cmd_spike' cai.py")`
+
+If you have Bash in your tool allowlist, use `git -C <work_dir>` (or absolute
+paths) for any git operation that should target the clone, NOT the cwd.
+
+## What you receive
+
+Your user message contains:
+
+1. **`## Work directory`** — absolute path to the read-only clone. Use it for
+   all codebase exploration.
+2. **`## Issue`** — the full issue body, including the original research
+   question and any prior context.
+
+## Process
+
+1. Read the issue carefully. Identify the core question(s) that must be
+   answered before a concrete fix can be designed.
+2. Explore the codebase with `Grep`, `Glob`, and `Read` to locate relevant
+   files and understand current behaviour.
+3. Use `Bash` for verification probes — running small commands, checking
+   whether a mechanism exists, testing behaviour.
+4. Use `Agent(subagent_type="Explore")` for broad codebase searches when
+   you are not sure where to look.
+5. Synthesise your findings into one of the three output shapes below.
+
+## Output format
+
+You MUST emit exactly ONE of the following blocks as the final section of
+your output. The wrapper matches these headers literally — do not rename or
+nest them.
+
+---
+
+### Outcome 1 — Findings (research question answered)
+
+Emit this when you have a concrete answer and can recommend whether the issue
+should be closed or retried:
+
+```
+## Spike Findings
+
+### Question
+<restatement of what this spike was investigating>
+
+### Method
+<what you actually did — commands run, files read, probes issued>
+
+### Result
+<concrete answer: "X works / does not work in version Y", "option A is better
+than B because Z", etc.>
+
+### Recommendation
+close_documented | close_wont_do | refine_and_retry
+```
+
+`close_documented` — the question is answered; close the issue with findings
+as a comment.
+
+`close_wont_do` — the question is answered and the answer is "we should not
+do this"; close the issue with findings as a comment.
+
+`refine_and_retry` — the question is answered and the answer informs a
+concrete change; the wrapper will update the issue body and relabel it
+`:raised` so `cmd_refine` picks it up next.
+
+---
+
+### Outcome 2 — Refined Issue (hand directly to fix agent)
+
+Emit this when you have completed the spike AND can write a complete,
+verified, actionable plan that `cai-fix` can implement without further
+research:
+
+```
+## Refined Issue
+
+### Problem
+<from the spike's findings — what exactly needs changing and why>
+
+### Plan
+<concrete, verified steps — file paths, function names, what to add/change>
+
+### Verification
+<per-step checks the fix agent should use to confirm correctness>
+
+### Scope guardrails
+<what NOT to touch>
+
+### Files likely to touch
+<bullet list of file paths>
+```
+
+---
+
+### Outcome 3 — Blocked (needs human judgement)
+
+Emit this when you cannot reach a conclusion and a human needs to intervene:
+
+```
+## Spike Blocked
+
+### What I tried
+<summary of spike attempts>
+
+### Why I couldn't conclude
+<specific reason — e.g., "mechanism requires live GitHub webhook access the
+agent doesn't have", "ambiguous requirement needs product decision">
+```
+
+---
+
+## Hard rules
+
+1. **Never commit or push.** The clone is read-only for investigative
+   purposes. You do not have `git push` or `git remote` access.
+2. **Never modify files in the main repo.** If you need scratch space, write
+   to `/tmp/spike-scratch-<something>` and clean it up before exiting.
+3. **Always use absolute paths** under the work directory for all tool calls
+   that target the clone.
+4. **Verify paths with Glob before Read.** If a path is inferred, confirm it
+   exists before attempting to open it.
+5. **Output exactly ONE of the three outcome blocks.** Do not emit more than
+   one. Do not emit partial or malformed blocks.
+6. **Bash is for verification probes only** — confirming whether a mechanism
+   works, checking output of existing commands. Do not use it to install
+   packages, pull remote resources, or make network calls unrelated to the
+   investigation.
+7. **15-minute cap.** If you are approaching the timeout without a
+   conclusion, emit `## Spike Blocked` with a honest account of what you
+   tried and why you could not conclude.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ subprocess with no shared state.
 |---|---|---|
 | `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
 | `cai.py refine` | `10 * * * *` (hourly :10) | Picks the oldest `:raised` issue, invokes the cai-refine subagent (read-only) to produce a structured plan, updates the issue body, and transitions the label to `:refined` |
+| `cai.py spike` | `0 */2 * * *` (every 2 hours) | Picks the oldest `:needs-spike` issue and runs the cai-spike agent to investigate unanswered research questions; transitions the issue to closed (findings), `:refined` (actionable plan), or `needs-human-review` (blocked) |
 | `cai.py fix` | `15 * * * *` (hourly :15) | Scores eligible issues by age, category success rate, and prior fix attempts; picks the highest scorer, runs 3 parallel plan agents then a select agent to choose the best plan, lets a fix subagent implement it with full tool permissions, opens a PR — see lifecycle below |
 | `cai.py revise` | `30 * * * *` (hourly :30) | Watches `:pr-open` PRs for new comments and iterates on the same branch via force-push; also auto-rebases unmergeable PRs onto current main |
 | `cai.py verify` | `45 * * * *` (hourly :45) | Mechanical, no LLM. Walks `auto-improve:pr-open` issues and updates labels based on PR merge state; recovers issues whose linked PR was closed without merging (rolls back to `:refined`) or where no linked PR exists (rolls back to `:raised`) |
@@ -70,12 +71,12 @@ the env vars (`CAI_ANALYZER_SCHEDULE`, `CAI_FIX_SCHEDULE`,
 `CAI_REFINE_SCHEDULE`, `CAI_REVIEW_PR_SCHEDULE`, `CAI_MERGE_SCHEDULE`,
 `CAI_REVISE_SCHEDULE`, `CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`,
 `CAI_AUDIT_TRIAGE_SCHEDULE`, `CAI_CODE_AUDIT_SCHEDULE`,
-`CAI_PROPOSE_SCHEDULE`, `CAI_UPDATE_CHECK_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`),
+`CAI_PROPOSE_SCHEDULE`, `CAI_SPIKE_SCHEDULE`, `CAI_UPDATE_CHECK_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`),
 runs `cai.py cycle` once synchronously so the issue-solving pipeline
 produces immediate logs, then execs supercronic. Analysis, audit,
-proposal, refine, and update-check agents are **not** run at startup
-— they wait for their own cron ticks so container restarts don't
-re-trigger token-heavy analysis passes.
+proposal, refine, spike, and update-check agents are **not** run at
+startup — they wait for their own cron ticks so container restarts
+don't re-trigger token-heavy analysis passes.
 
 ### Issue lifecycle
 

--- a/README.md
+++ b/README.md
@@ -95,24 +95,32 @@ action so two concurrent `fix` runs can't pick the same issue.
                                 ▼        │  rolled back)
                           in-progress    │
                                 │        │
-                        ┌───────┴───────┐│
-                        │               ││
-                  empty diff      PR opened
-                        │               ▼│
-                        ▼        pr-open ─┘
-                   no-action        │
-                                    │ verify (PR merged)
-                                    ▼
-                                 merged
-                                    │
-                        ┌───────────┴───────────┐
-                        │                       │
-                  confirm (pattern       confirm (inconclusive
-                   absent)                / unsolved)
-                        ▼                       ▼
-                  solved (closed)    re-queued :refined
-                                     (up to 3 attempts,
-                                      then :needs-human-review)
+                  ┌─────────────┼───────┐│
+                  │             │       ││
+           needs-spike    empty diff  PR opened
+                  │             │       ▼│
+                  │             ▼  pr-open ─┘
+                  │        no-action    │
+                  │                     │ verify (PR merged)
+                  │                     ▼
+                  │                  merged
+                  │                     │
+                  │         ┌───────────┴───────────┐
+                  │         │                       │
+                  │   confirm (pattern       confirm (inconclusive
+                  │    absent)                / unsolved)
+                  │         ▼                       ▼
+                  │   solved (closed)    re-queued :refined
+                  │                      (up to 3 attempts,
+                  │                       then :needs-human-review)
+                  │
+                  │ spike
+                  ▼
+           ┌──────┴────────────────┐
+           │                       │
+     findings/refined         blocked
+           │                       │
+    (close or :refined)   needs-human-review
 ```
 
 `:no-action` means the fix subagent reviewed the issue and decided no

--- a/cai.py
+++ b/cai.py
@@ -869,10 +869,11 @@ def cmd_analyze(args) -> int:
     _STATE_PRIORITY = {
         LABEL_IN_PROGRESS: 0,
         LABEL_PR_OPEN: 1,
-        LABEL_REFINED: 2,
-        LABEL_RAISED: 3,
-        LABEL_MERGED: 4,
-        LABEL_REQUESTED: 5,
+        LABEL_NEEDS_SPIKE: 2,
+        LABEL_REFINED: 3,
+        LABEL_RAISED: 4,
+        LABEL_MERGED: 5,
+        LABEL_REQUESTED: 6,
     }
 
     def _issue_state_label(issue):

--- a/cai.py
+++ b/cai.py
@@ -3251,7 +3251,7 @@ def _rollback_stale_in_progress() -> list[dict]:
         except Exception:
             lines = []
         for line in lines:
-            if "[fix]" not in line and "[revise]" not in line:
+            if "[fix]" not in line and "[revise]" not in line and "[spike]" not in line:
                 continue
             # Extract issue number from "issue=<N>"
             m = re.search(r"issue=(\d+)", line)
@@ -3294,9 +3294,17 @@ def _rollback_stale_in_progress() -> list[dict]:
                 # Revising lock: just remove the lock, leave :pr-open.
                 ok = _set_labels(issue_num, remove=[LABEL_REVISING], log_prefix="cai audit")
             else:
-                # In-progress lock: roll back to :refined.
+                # In-progress lock: roll back to the appropriate label.
+                # Check originating label: spike-provenance issues go back to
+                # :needs-spike; audit-raised go back to :audit-raised; all
+                # others go back to :refined.
                 issue_labels = {lbl["name"] for lbl in issue.get("labels", [])}
-                raised_label = LABEL_AUDIT_RAISED if LABEL_AUDIT_RAISED in issue_labels else LABEL_REFINED
+                if LABEL_AUDIT_RAISED in issue_labels:
+                    raised_label = LABEL_AUDIT_RAISED
+                elif LABEL_NEEDS_SPIKE in issue_labels:
+                    raised_label = LABEL_NEEDS_SPIKE
+                else:
+                    raised_label = LABEL_REFINED
                 ok = _set_labels(
                     issue_num,
                     add=[raised_label],

--- a/cai.py
+++ b/cai.py
@@ -72,6 +72,15 @@ Subcommands:
                             issue body, and transition the label to
                             `auto-improve:refined`.
 
+    python cai.py spike     Pick the oldest issue labelled
+                            `auto-improve:needs-spike`, clone the
+                            repo into /tmp, and run the cai-spike
+                            subagent to investigate the open
+                            research question. Transitions labels
+                            based on the outcome: close (findings),
+                            :refined (refined issue), or
+                            needs-human-review (blocked).
+
     python cai.py code-audit  Weekly source-code consistency audit.
                             Clones the repo read-only, runs a Sonnet
                             agent that checks for cross-file
@@ -98,7 +107,7 @@ Subcommands:
                             the `update-check` namespace.
 
 The container runs `entrypoint.sh`, which executes `init`, `analyze`,
-`verify`, `refine`, `fix`, `revise`, `review-pr`, `merge`, `audit`, `code-audit`, `propose`, `update-check`, and `confirm` once synchronously at
+`verify`, `refine`, `spike`, `fix`, `revise`, `review-pr`, `merge`, `audit`, `code-audit`, `propose`, `update-check`, and `confirm` once synchronously at
 startup, then hands off to supercronic. Each cron tick is a fresh process.
 
 The gh auth check is done once per subcommand invocation. We want a
@@ -5991,6 +6000,245 @@ def cmd_refine(args) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Spike (research / verification)
+# ---------------------------------------------------------------------------
+
+def cmd_spike(args) -> int:
+    """Run the cai-spike agent on the oldest :needs-spike issue."""
+    print("[cai spike] looking for issues to spike", flush=True)
+    t0 = time.monotonic()
+
+    # 1. Find candidates.
+    try:
+        issues = _gh_json([
+            "issue", "list",
+            "--repo", REPO,
+            "--label", LABEL_NEEDS_SPIKE,
+            "--state", "open",
+            "--json", "number,title,body,labels,createdAt,comments",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(f"[cai spike] gh issue list failed:\n{e.stderr}", file=sys.stderr)
+        log_run("spike", repo=REPO, result="list_failed", exit=1)
+        return 1
+
+    if not issues:
+        print("[cai spike] no :needs-spike issues; nothing to do", flush=True)
+        log_run("spike", repo=REPO, result="no_eligible_issues", exit=0)
+        return 0
+
+    # 2. Pick the oldest.
+    issue = min(issues, key=lambda i: i["createdAt"])
+    issue_number = issue["number"]
+    title = issue["title"]
+    print(f"[cai spike] picked #{issue_number}: {title}", flush=True)
+
+    # 3. Lock: :needs-spike → :in-progress.
+    if not _set_labels(
+        issue_number,
+        add=[LABEL_IN_PROGRESS],
+        remove=[LABEL_NEEDS_SPIKE],
+        log_prefix="cai spike",
+    ):
+        print(f"[cai spike] could not lock #{issue_number}", file=sys.stderr)
+        log_run("spike", repo=REPO, issue=issue_number, result="lock_failed", exit=1)
+        return 1
+
+    _uid = uuid.uuid4().hex[:8]
+    work_dir = Path(f"/tmp/cai-spike-{issue_number}-{_uid}")
+
+    def rollback() -> None:
+        _set_labels(
+            issue_number,
+            add=[LABEL_NEEDS_SPIKE],
+            remove=[LABEL_IN_PROGRESS],
+            log_prefix="cai spike",
+        )
+
+    try:
+        if work_dir.exists():
+            shutil.rmtree(work_dir)
+
+        # 4. Clone (no branch needed — spikes don't commit).
+        _run(["gh", "auth", "setup-git"], capture_output=True)
+        clone = _run(
+            ["git", "clone", "--depth", "1",
+             f"https://github.com/{REPO}.git", str(work_dir)],
+            capture_output=True,
+        )
+        if clone.returncode != 0:
+            print(f"[cai spike] git clone failed:\n{clone.stderr}", file=sys.stderr)
+            rollback()
+            log_run("spike", repo=REPO, issue=issue_number, result="clone_failed", exit=1)
+            return 1
+
+        # 5. Build user message and invoke cai-spike.
+        user_message = (
+            _work_directory_block(work_dir)
+            + "\n"
+            + _build_issue_block(issue)
+        )
+        print(f"[cai spike] running cai-spike subagent for {work_dir}", flush=True)
+        result = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-spike",
+             "--dangerously-skip-permissions",
+             "--add-dir", str(work_dir)],
+            category="spike",
+            agent="cai-spike",
+            input=user_message,
+            cwd="/app",
+            timeout=900,  # 15 min cap
+        )
+        if result.stdout:
+            print(result.stdout, flush=True)
+
+        if result.returncode != 0:
+            print(
+                f"[cai spike] subagent failed (exit {result.returncode}):\n"
+                f"{result.stderr}",
+                file=sys.stderr,
+            )
+            rollback()
+            dur = f"{int(time.monotonic() - t0)}s"
+            log_run("spike", repo=REPO, issue=issue_number,
+                    duration=dur, result="agent_failed", exit=result.returncode)
+            return result.returncode
+
+        stdout = result.stdout or ""
+
+        # 6. Parse outcome markers (in priority order).
+
+        # Outcome 1: Spike Findings
+        findings_pos = stdout.find("## Spike Findings")
+        if findings_pos != -1:
+            findings_block = stdout[findings_pos:].strip()
+            # Extract recommendation
+            rec_match = re.search(
+                r"###\s*Recommendation\s*\n+\s*(\S+)",
+                findings_block,
+            )
+            recommendation = rec_match.group(1).strip() if rec_match else ""
+
+            if recommendation in ("close_documented", "close_wont_do"):
+                # Post findings as comment and close
+                _run(
+                    ["gh", "issue", "comment", str(issue_number),
+                     "--repo", REPO,
+                     "--body", f"## Spike findings\n\n{findings_block}\n\n---\n_Closed by `cai spike`._"],
+                    capture_output=True,
+                )
+                _run(
+                    ["gh", "issue", "close", str(issue_number),
+                     "--repo", REPO],
+                    capture_output=True,
+                )
+                _set_labels(issue_number, remove=[LABEL_IN_PROGRESS], log_prefix="cai spike")
+                dur = f"{int(time.monotonic() - t0)}s"
+                print(f"[cai spike] #{issue_number} closed ({recommendation}) in {dur}", flush=True)
+                log_run("spike", repo=REPO, issue=issue_number,
+                        duration=dur, result=recommendation, exit=0)
+                return 0
+
+            elif recommendation == "refine_and_retry":
+                # Update body with findings + original, relabel to :raised
+                original_body = issue.get("body") or "(no body)"
+                quoted_original = "\n".join(f"> {line}" for line in original_body.splitlines())
+                new_body = (
+                    f"{findings_block}\n\n"
+                    f"---\n\n"
+                    f"> **Original issue text:**\n>\n"
+                    f"{quoted_original}\n"
+                )
+                _run(
+                    ["gh", "issue", "edit", str(issue_number),
+                     "--repo", REPO, "--body", new_body],
+                    capture_output=True,
+                )
+                _set_labels(
+                    issue_number,
+                    add=[LABEL_RAISED],
+                    remove=[LABEL_IN_PROGRESS],
+                    log_prefix="cai spike",
+                )
+                dur = f"{int(time.monotonic() - t0)}s"
+                print(f"[cai spike] #{issue_number} refined-and-retried in {dur}", flush=True)
+                log_run("spike", repo=REPO, issue=issue_number,
+                        duration=dur, result="refine_and_retry", exit=0)
+                return 0
+
+            # Unrecognised recommendation — fall through to no_marker
+
+        # Outcome 2: Refined Issue
+        refined_pos = stdout.find("## Refined Issue")
+        if refined_pos != -1:
+            refined_body = stdout[refined_pos:].strip()
+            original_body = issue.get("body") or "(no body)"
+            quoted_original = "\n".join(f"> {line}" for line in original_body.splitlines())
+            new_body = (
+                f"{refined_body}\n\n"
+                f"---\n\n"
+                f"> **Original issue text:**\n>\n"
+                f"{quoted_original}\n"
+            )
+            _run(
+                ["gh", "issue", "edit", str(issue_number),
+                 "--repo", REPO, "--body", new_body],
+                capture_output=True,
+            )
+            _set_labels(
+                issue_number,
+                add=[LABEL_REFINED],
+                remove=[LABEL_IN_PROGRESS],
+                log_prefix="cai spike",
+            )
+            dur = f"{int(time.monotonic() - t0)}s"
+            print(f"[cai spike] #{issue_number} refined and handed to fix in {dur}", flush=True)
+            log_run("spike", repo=REPO, issue=issue_number,
+                    duration=dur, result="refined", exit=0)
+            return 0
+
+        # Outcome 3: Spike Blocked
+        blocked_pos = stdout.find("## Spike Blocked")
+        if blocked_pos != -1:
+            blocked_block = stdout[blocked_pos:].strip()
+            _run(
+                ["gh", "issue", "comment", str(issue_number),
+                 "--repo", REPO,
+                 "--body", f"{blocked_block}\n\n---\n_Escalated by `cai spike`._"],
+                capture_output=True,
+            )
+            _set_labels(
+                issue_number,
+                add=[LABEL_PR_NEEDS_HUMAN],
+                remove=[LABEL_IN_PROGRESS],
+                log_prefix="cai spike",
+            )
+            dur = f"{int(time.monotonic() - t0)}s"
+            print(f"[cai spike] #{issue_number} blocked/escalated in {dur}", flush=True)
+            log_run("spike", repo=REPO, issue=issue_number,
+                    duration=dur, result="blocked", exit=0)
+            return 0
+
+        # No recognised marker — rollback to :needs-spike.
+        rollback()
+        dur = f"{int(time.monotonic() - t0)}s"
+        print(f"[cai spike] #{issue_number} no outcome marker; rolling back in {dur}", flush=True)
+        log_run("spike", repo=REPO, issue=issue_number,
+                duration=dur, result="no_marker", exit=0)
+        return 0
+
+    except Exception as exc:
+        print(f"[cai spike] unexpected error: {exc}", file=sys.stderr)
+        rollback()
+        log_run("spike", repo=REPO, issue=issue_number, result="error", exit=1)
+        return 1
+    finally:
+        if work_dir.exists():
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
 # Cycle (full pipeline without analyze)
 # ---------------------------------------------------------------------------
 
@@ -6069,6 +6317,7 @@ def main() -> int:
     sub.add_parser("review-pr", help="Pre-merge consistency review of open PRs")
     sub.add_parser("merge", help="Confidence-gated auto-merge for bot PRs")
     sub.add_parser("refine", help="Refine human-filed issues into structured plans")
+    sub.add_parser("spike", help="Run the spike agent on :needs-spike issues")
     sub.add_parser("cycle", help="Full cycle: verify, fix, revise, review-pr, merge, confirm")
     sub.add_parser("test", help="Run the project test suite")
 
@@ -6114,6 +6363,7 @@ def main() -> int:
         "review-pr": cmd_review_pr,
         "merge": cmd_merge,
         "refine": cmd_refine,
+        "spike": cmd_spike,
         "cycle": cmd_cycle,
         "cost-report": cmd_cost_report,
         "test": cmd_test,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,9 +24,9 @@
 #    review-pr → merge → confirm) so `docker compose up -d` produces
 #    useful logs immediately rather than waiting for the first cron
 #    tick. Only the issue-solving cycle runs at startup; analysis,
-#    audit, proposal, and update-check agents wait for their cron
-#    ticks so container restarts don't burn tokens re-running them.
-#    spike runs separately since it's not part of the cycle.
+#    audit, proposal, spike, refine, and update-check agents wait for
+#    their cron ticks so container restarts don't burn tokens
+#    re-running them.
 #
 # 3. Exec supercronic as PID 1. supercronic handles SIGTERM gracefully
 #    (lets in-flight tasks finish) and streams child stdout/stderr to
@@ -84,9 +84,6 @@ if gh auth status >/dev/null 2>&1; then
 else
   echo "[entrypoint] gh not yet authenticated; skipping git credential setup"
 fi
-
-echo "[entrypoint] running initial cai.py spike"
-python /app/cai.py spike || echo "[entrypoint] spike exited non-zero; continuing"
 
 echo "[entrypoint] running initial cai.py cycle"
 python /app/cai.py cycle || echo "[entrypoint] cycle exited non-zero; continuing"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@
 #      - analyze:   parse own transcripts, raise findings as issues
 #      - fix:       pick an eligible issue and let the subagent fix it
 #      - refine:    turn human-filed issues into structured plans
+#      - spike:     research/verification spikes for :needs-spike issues
 #      - review-pr: pre-merge consistency review of open PRs
 #      - revise:    iterate on open PRs based on review comments
 #      - verify:    walk pr-open issues and update labels per PR state
@@ -25,6 +26,7 @@
 #    tick. Only the issue-solving cycle runs at startup; analysis,
 #    audit, proposal, and update-check agents wait for their cron
 #    ticks so container restarts don't burn tokens re-running them.
+#    spike runs separately since it's not part of the cycle.
 #
 # 3. Exec supercronic as PID 1. supercronic handles SIGTERM gracefully
 #    (lets in-flight tasks finish) and streams child stdout/stderr to
@@ -45,6 +47,7 @@ CAI_CONFIRM_SCHEDULE="${CAI_CONFIRM_SCHEDULE:-0 2 * * *}"
 CAI_REVIEW_PR_SCHEDULE="${CAI_REVIEW_PR_SCHEDULE:-20 * * * *}"
 CAI_MERGE_SCHEDULE="${CAI_MERGE_SCHEDULE:-35 * * * *}"
 CAI_REFINE_SCHEDULE="${CAI_REFINE_SCHEDULE:-10 * * * *}"
+CAI_SPIKE_SCHEDULE="${CAI_SPIKE_SCHEDULE:-0 */2 * * *}"
 
 CRONTAB_PATH=/tmp/crontab
 
@@ -53,6 +56,7 @@ cat > "$CRONTAB_PATH" <<CRONTAB
 # Each line is an independent cron entry — add more tasks as new lines.
 $CAI_ANALYZER_SCHEDULE python /app/cai.py analyze
 $CAI_REFINE_SCHEDULE python /app/cai.py refine
+$CAI_SPIKE_SCHEDULE python /app/cai.py spike
 $CAI_FIX_SCHEDULE python /app/cai.py fix
 $CAI_REVISE_SCHEDULE python /app/cai.py revise
 $CAI_VERIFY_SCHEDULE python /app/cai.py verify
@@ -80,6 +84,9 @@ if gh auth status >/dev/null 2>&1; then
 else
   echo "[entrypoint] gh not yet authenticated; skipping git credential setup"
 fi
+
+echo "[entrypoint] running initial cai.py spike"
+python /app/cai.py spike || echo "[entrypoint] spike exited non-zero; continuing"
 
 echo "[entrypoint] running initial cai.py cycle"
 python /app/cai.py cycle || echo "[entrypoint] cycle exited non-zero; continuing"


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#314

**Issue:** #314 — New subagent: cai-spike — run research/verification spikes on issues the fix agent can't close in one pass

## PR Summary

### What this fixes
Issues labelled `auto-improve:needs-spike` had no consumer — the label was defined and the fix agent could assign it, but nothing downstream picked those issues up, leaving them stuck indefinitely. This adds the missing `cai-spike` subagent and its `cmd_spike` wrapper function to close that loop.

### What was changed
- **`.cai-staging/agents/cai-spike.md`** (new): Declarative agent definition for the spike agent with YAML frontmatter (`tools: Read, Grep, Glob, Bash, Agent`, `model: claude-opus-4-5`), instructions on the three output shapes (`## Spike Findings` / `## Refined Issue` / `## Spike Blocked`), memory-first guidance, absolute-path cwd rules, and hard safety rules.
- **`cai.py`**: Added `cmd_spike()` function (~230 lines) before `cmd_cycle` that fetches `:needs-spike` issues, clones the repo into `/tmp/cai-spike-<N>-<uid>`, invokes `cai-spike` via `_run_claude_p` with a 15-minute timeout, parses the three outcome markers, and transitions labels/comments/closes accordingly; added `sub.add_parser("spike", ...)` and `"spike": cmd_spike` to `main()`; updated docstrings to include `spike`.
- **`entrypoint.sh`**: Added `CAI_SPIKE_SCHEDULE="${CAI_SPIKE_SCHEDULE:-0 */2 * * *}"` env var, added `$CAI_SPIKE_SCHEDULE python /app/cai.py spike` crontab line after `refine`, added initial-pass call between `refine` and `fix`, updated comments.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
