### PR TITLE
cai-revise: track recurring review-comment patterns in memory

### DIFF
--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -104,6 +104,82 @@ Example of addressing a review comment on this very file:
     `Write("<work_dir>/.cai-staging/agents/cai-revise.md", "<full new content>")`
   - BAD:  `Edit("<work_dir>/.claude/agents/cai-revise.md", old, new)`  (blocked)
 
+## Memory: tracking recurring review-comment patterns
+
+You have a project-scope memory pool at
+`/app/.claude/agent-memory/cai-revise/MEMORY.md`. This is the one
+path under `/app` you are allowed to write to — the `/app`
+read-only rule above does not apply to this directory, because it
+is bind-mounted from the `cai_agent_memory` named volume so writes
+persist across container restarts.
+
+The memory is a running index of the review-comment categories
+you keep having to correct across unrelated PRs. Over many runs it
+lets the supervisor see which reviewer complaints are systemic
+— and therefore where an upstream fix (to `cai-fix`, `cai-review-pr`,
+the analyze guidance, etc.) would prevent the most churn.
+
+### Read at the start of every run
+
+Before addressing any comment, Read
+`/app/.claude/agent-memory/cai-revise/MEMORY.md`. You are not
+expected to change your in-scope editing behavior based on it —
+the "stay in scope" rule still applies. The read is so you know
+which categories already exist and can reuse them when you write
+your own entry below, instead of inventing synonyms that would
+fragment the picture.
+
+If the file does not exist yet, treat it as an empty index —
+create it when you make your first entry.
+
+### Update at the end of every run
+
+After addressing the review comments (and before printing your
+final stdout summary), Edit or Write
+`/app/.claude/agent-memory/cai-revise/MEMORY.md` so each review
+comment you addressed becomes one line in this format:
+
+    <YYYY-MM-DD> PR#<number> <category> — <one-sentence root cause>
+
+- **Category** — a stable short slug like `stale_docs`, `naming`,
+  `null_check`, `type_check`, `missing_test`, `duplicated_logic`,
+  `scope_creep`. Reuse an existing category from the file whenever
+  possible; only introduce a new category when none of the
+  existing ones fit.
+- **Root cause** — the upstream mistake that made the reviewer's
+  comment necessary, not the fix you applied. E.g., "new file
+  added under /var/log/cai/ but only the first of ~5 doc
+  references was updated."
+
+Do NOT log entries for rebase conflict resolutions — those are
+not review comments. Do NOT log entries for comments you skipped
+as out of scope or ambiguous.
+
+If the file grows past ~200 lines, collapse the oldest half into
+a `## Summary (before <date>)` block that lists each category
+with its count and a couple of representative PR numbers — keep
+line-level detail only for the recent half. The goal is a concise,
+readable picture of recurring patterns, not an exhaustive audit
+trail.
+
+### Introspection mode
+
+When the user message contains NO `## Unaddressed review comments`
+section AND instead contains a meta-question about your memory
+— e.g. "what is the most recurrent pattern you have to correct?",
+"summarize your memory", "which category have you been fixing
+most lately?" — switch to introspection-only mode:
+
+1. Read `/app/.claude/agent-memory/cai-revise/MEMORY.md`.
+2. Answer the question in 1–3 short paragraphs, citing the
+   dominant category/categories by count and a few concrete PR
+   numbers as evidence.
+3. Exit without touching any file in the work directory and
+   without writing to the memory file. Introspection is read-only.
+
+The wrapper will detect the empty diff and surface your answer
+as the run output.
+
 ## Hard rules — remote and git operations
 
 1. **Never push.** Do not attempt git push — you don't have Bash


### PR DESCRIPTION
Refs #385. Supersedes #398.

## Summary

- Adds a `## Memory: tracking recurring review-comment patterns` section to `.claude/agents/cai-revise.md`
- cai-revise now reads `/app/.claude/agent-memory/cai-revise/MEMORY.md` at the start of every run and appends one line per addressed comment at the end, using a small stable category taxonomy (`stale_docs`, `naming`, `null_check`, `type_check`, `missing_test`, `duplicated_logic`, `scope_creep`)
- Introspection-only mode: when the user message has no `## Unaddressed review comments` section and instead asks a meta-question, cai-revise reads its memory, answers in 1–3 paragraphs, and exits with empty diff

## Why this replaces #398

#398 approached issue #385 by adding a wrapper-side JSONL path (`/var/log/cai/review-pr-patterns.jsonl`), an extract/append helper, a read helper, and a new `## Review-PR patterns` input section to the analyze agent. That got reviewed four times by `cai review-pr`, each round flagging a different stale doc about the new file (README row, cai_logs volume description, Dockerfile inline comment, `cmd_analyze` inline comment) — exactly the kind of systemic churn the issue was asking the system to *notice*, not *generate*.

This PR solves the same issue in the opposite direction: instead of a new side-channel, cai-revise uses the `memory: project` frontmatter it already has, following the same convention as cai-fix, cai-code-audit, and cai-refine. No new file, no new cai.py helpers, no new input section for analyze. The supervisor learns which categories are systemic by calling cai-revise in introspection mode once memory has accumulated.

## Test plan

- [ ] After merge, verify cai-revise reads/writes `.claude/agent-memory/cai-revise/MEMORY.md` on its next real run
- [ ] After a few runs, invoke cai-revise with a bare meta-question prompt and confirm introspection mode returns a category summary with PR citations
- [ ] Confirm the stay-in-scope editing rule still holds — tracking should be observational only, not a license to broaden edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)