### PR TITLE
cai-fix/revise: PR context dossier + cut revise diff dump

### DIFF
--- a/.claude/agents/cai-fix.md
+++ b/.claude/agents/cai-fix.md
@@ -310,6 +310,71 @@ fix subagent in a subsequent cycle.
 Only suggest issues that are concrete and actionable — do not
 suggest vague improvements or things you are unsure about.
 
+## Before you exit: write the PR context dossier
+
+If (and only if) you are making code changes, write a short dossier
+to `<work_dir>/.cai/pr-context.md` **before** emitting your
+`## PR Summary` block. The wrapper's `git add -A` step picks it up
+automatically and it lands in the PR alongside your code changes.
+
+The dossier exists for one reason: the `cai-revise` agent reads it
+at the start of every revise cycle so it does not have to Grep/Glob
+its way to the same understanding of the PR you already have. A
+`.github/workflows/cleanup-pr-context.yml` workflow deletes the
+file from `main` automatically after the PR is merged, so it never
+lands on `main` — you do not need to worry about cleanup.
+
+**Skip the dossier entirely when you are exiting with zero diff**
+(ambiguous issue, `## Needs Spike` bail, memory-overlap bail, etc.).
+A dossier with no accompanying code change is noise, not signal.
+
+Write the file with a single `Write` call using this exact template:
+
+~~~
+# PR Context Dossier
+Refs: <ORG>/<REPO>#<issue_number>
+
+## Files touched
+- <relative/path>:<line> — <what changed, one line>
+
+## Files read (not touched) that matter
+- <relative/path> — <why it's relevant to understanding the change>
+
+## Key symbols
+- `<symbol_name>` (<relative/path>:<line>) — <role in the change>
+
+## Design decisions
+- <decision> — <reason>
+- Rejected: <alternative> — <why not>
+
+## Out of scope / known gaps
+- <what you deliberately did not touch and why>
+
+## Invariants this change relies on
+- <assumption the edit depends on>
+~~~
+
+Rules:
+
+  - Use paths **relative to the clone root** — e.g. `cai.py:1493`,
+    NOT `<work_dir>/cai.py:1493`. The revise agent resolves them
+    against its own work directory.
+  - Keep each bullet to one line when possible. The dossier is a
+    cost-saver, not a design document — a bloated dossier defeats
+    the purpose.
+  - Do not duplicate the `## PR Summary` block. The summary is for
+    humans reading the PR; the dossier is for downstream agents.
+  - Do not paste code excerpts longer than one or two lines. Point
+    to `file:line` instead.
+  - Do not list every file you Read — only the ones that materially
+    shaped the fix.
+  - Be truthful about **out-of-scope gaps**: the revise agent uses
+    that section to decide what NOT to touch when addressing review
+    comments.
+  - Be truthful about **invariants**: if a reviewer later asks for
+    something that would break an invariant you listed here, the
+    revise agent will know to flag it instead of silently obeying.
+
 ## Final output
 
 When you are done — whether you made changes or not — **end your

--- a/.claude/agents/cai-merge.md
+++ b/.claude/agents/cai-merge.md
@@ -73,6 +73,28 @@ When in doubt, output **medium** or **low**. The default merge
 threshold is `high`, so a `high` verdict should reflect genuine
 certainty — not optimism or best-effort guessing.
 
+### Exemption: `.cai/pr-context.md`
+
+The file `.cai/pr-context.md` is an auto-generated dossier that the
+`cai-fix` and `cai-revise` agents use to share PR context across
+runs. It is expected in every auto-improve PR, and a
+`.github/workflows/cleanup-pr-context.yml` workflow deletes it from
+`main` right after the PR is merged, so it never ends up in the
+main branch tree.
+
+When walking the diff, **evaluate the PR as if this file were not
+present**:
+
+- Do not count its addition as "new files not mentioned in the
+  issue" or as scope creep.
+- Do not count it against the "PR adds tests or docstrings unless
+  the issue asked for them" rule.
+- Do not trace its contents back to the issue remediation — it is
+  not part of the fix, it is metadata about the fix.
+
+All other files in the diff must still meet the usual completeness,
+scope, and correctness criteria.
+
 ## Output format
 
 Emit exactly this structured block — nothing else:

--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -104,6 +104,14 @@ No ripple effects found.
 4. **Do not comment on the quality of the PR itself.** Only flag
    ripple effects on the rest of the codebase.
 5. **Keep it short.** Each finding should be 3–5 sentences max.
+6. **Ignore `.cai/pr-context.md`.** This file is an auto-generated
+   dossier that the `cai-fix` and `cai-revise` agents use to share
+   PR context across runs. It is metadata, not code, and a
+   `.github/workflows/cleanup-pr-context.yml` workflow auto-deletes
+   it from `main` after merge. If a hunk in the diff adds or
+   modifies `.cai/pr-context.md`, skip it entirely — do not flag
+   it under `stale_docs`, `dead_config`, `missing_co_change`, or
+   any other category.
 
 ## Efficiency guidance
 

--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -356,6 +356,60 @@ judgement about how to merge the two sides:
 Bailing is a valid outcome — it is much better than merging wrong
 code.
 
+## Read the PR context dossier first
+
+Before looking at any review comment, Read
+`<work_dir>/.cai/pr-context.md` if it exists. The `cai-fix` agent
+writes this dossier when it opens the PR (and earlier revise cycles
+append to it), and it is the single most valuable context you have
+for this PR. It lists:
+
+- **Files touched** — the exact files already edited, with line
+  anchors, so you do not have to re-discover them via Grep/Glob.
+- **Files read (not touched) that matter** — adjacent context the
+  fix agent considered.
+- **Key symbols** — the functions/constants/labels the change
+  hinges on, with file:line anchors.
+- **Design decisions** — what was chosen and what was explicitly
+  rejected, so you do not revisit dead-ends.
+- **Out of scope / known gaps** — things the fix agent deliberately
+  did not touch. Use this to judge whether a review comment is
+  asking you to cross a gap boundary (usually out of scope for
+  revise; flag in your stdout summary if you choose to).
+- **Invariants this change relies on** — assumptions a review
+  comment's suggested edit must not break.
+
+**Treat the dossier as ground truth for the PR's intent**, NOT for
+its current state. It is a hint, not an assertion:
+
+  - If the dossier lists a `<path>:<line>` that does not match the
+    current file (because of a rebase, or because an earlier revise
+    round already touched that file), re-verify with Read before
+    editing.
+  - If the dossier file does not exist, the user message's
+    **`## Current PR state`** block will contain only a `git diff
+    origin/main..HEAD --stat` summary (no unified diff — the
+    wrapper no longer includes one). Use the stat as your entry
+    point: Read the listed files in the clone directly, use
+    Grep/Glob or the Explore subagent for broader context, and
+    treat the clone itself as ground truth. Legacy PRs opened
+    before the dossier was introduced, or PRs where `cai-fix`
+    exited with zero diff, will have no dossier file — this is
+    expected, and you must create a minimal dossier yourself
+    before exiting if you make any code changes (see the "Update
+    the PR context dossier before you exit" section below).
+  - If the dossier contradicts the actual files in the clone in a
+    non-trivial way (for example, a file the dossier says was
+    touched has none of the described changes), trust what you
+    Read from the clone — it is the authoritative ground truth —
+    and note the discrepancy in your stdout summary so the
+    supervisor can investigate.
+
+The goal is to eliminate exploratory Grep/Glob/Read rounds when the
+dossier already answers the question. Reading the dossier first is
+the cheapest way to do this — do it before anything else in the
+review-comment phase.
+
 ## Addressing review comments
 
 Once the rebase is complete (or was already clean), move on to the
@@ -373,6 +427,48 @@ one:
    that comment.
 4. **Use the original issue and the current PR diff as context**
    only — do not re-implement the issue from scratch.
+
+### Update the PR context dossier before you exit
+
+After you finish addressing the review comments (and before
+printing your stdout summary), append a new section to
+`<work_dir>/.cai/pr-context.md` so the next revise cycle inherits
+your work:
+
+~~~
+## Revision <N> (<YYYY-MM-DD>)
+
+### Rebase
+- <clean | resolved: <files> | aborted>
+
+### Files touched this revision
+- <relative/path>:<line> — <what changed, one line>
+
+### Decisions this revision
+- <decision> — <reason>
+
+### New gaps / deferred
+- <any review comment you deliberately did not address and why>
+~~~
+
+Rules:
+
+  - Pick the next `<N>` by Reading the existing dossier first — if
+    the last section is `## Revision 2`, write `## Revision 3`. If
+    there are no prior revision sections, write `## Revision 1`.
+  - If the dossier file does not exist AND you made no code
+    changes, skip this step — there is nothing to record.
+  - If the dossier file does not exist but you DID make code
+    changes (legacy PR), create a minimal dossier following the
+    same template as `cai-fix` (see
+    `.claude/agents/cai-fix.md` section "Before you exit: write
+    the PR context dossier") so the next revise cycle has a
+    starting point.
+  - The wrapper's commit step picks up the dossier edit
+    automatically — do not try to commit it yourself.
+  - Use `<work_dir>/.cai/pr-context.md` as the path, not a
+    relative `.cai/pr-context.md` (which would resolve under
+    `/app`).
 
 ### Empty diff is OK
 
@@ -402,7 +498,23 @@ The user message contains these sections:
    conflicted files
 2. **Original issue** — the issue the PR was opened against. This
    is for context only; do not re-implement the issue from scratch.
-3. **Current PR diff** — what has already been changed.
+3. **Current PR state** — a compact `git diff origin/main..HEAD
+   --stat` summary of the files this PR touches. The wrapper
+   **does not** include the full unified diff (dumping it into
+   every revise cycle is too expensive on large PRs). How to use
+   this section depends on whether a PR context dossier exists:
+   - **If the block points at `<work_dir>/.cai/pr-context.md`**
+     (the `cai-fix` agent creates this on every non-empty PR):
+     Read the dossier first for the files-touched list, design
+     decisions, out-of-scope gaps, and invariants, then Read
+     specific files in the clone for the actual current content.
+   - **If the block says no dossier was found** (legacy PR or
+     zero-diff fix run): use the `--stat` itself as the entry
+     point, Read the listed files directly, use Grep/Glob or the
+     Explore subagent for broader context, and create a minimal
+     dossier before exiting (see "Update the PR context dossier
+     before you exit" above) so the next revise cycle starts
+     with one.
 4. **Unaddressed review comments** — the comments you need to
    address (may be empty if the only work was a rebase).
 

--- a/.github/workflows/cleanup-pr-context.yml
+++ b/.github/workflows/cleanup-pr-context.yml
@@ -1,0 +1,52 @@
+name: Cleanup PR context dossier
+
+# Deletes `.cai/pr-context.md` from the default branch whenever an
+# auto-improve PR that carried one is merged in. The dossier is an
+# auto-generated file that `cai-fix` creates and `cai-revise` updates
+# so the revise agent does not have to re-explore the repo at the
+# start of every cycle. It is meant to live only on the PR branch —
+# once the PR is merged, the file has no purpose on `main` and is
+# removed by this workflow.
+#
+# The workflow runs on every push to `main`, but it is a no-op when
+# the file is not present, so the cost is tiny. GitHub's default
+# policy — pushes made with GITHUB_TOKEN do not re-trigger workflows
+# — prevents the cleanup commit from retriggering this job.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Delete `.cai/pr-context.md` if present
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ ! -f .cai/pr-context.md ]; then
+            echo "No .cai/pr-context.md on main; nothing to do."
+            exit 0
+          fi
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git rm .cai/pr-context.md
+          # `.cai/` is dossier-only today; remove the directory if it
+          # became empty so we don't leave a stray tracked placeholder.
+          if [ -d .cai ] && [ -z "$(ls -A .cai)" ]; then
+            rmdir .cai
+          fi
+
+          git commit -m "cleanup: remove auto-improve PR context dossier from main"
+          git push origin main

--- a/cai.py
+++ b/cai.py
@@ -2475,7 +2475,7 @@ def cmd_revise(args) -> int:
                     "to addressing review comments (if any).\n"
                 )
 
-            # 4. Fetch original issue body + current PR diff.
+            # 4. Fetch original issue body.
             try:
                 issue_data = _gh_json([
                     "issue", "view", str(issue_number),
@@ -2485,11 +2485,76 @@ def cmd_revise(args) -> int:
             except subprocess.CalledProcessError:
                 issue_data = {"number": issue_number, "title": "(unknown)", "body": ""}
 
-            diff_result = _run(
-                ["gh", "pr", "diff", str(pr_number), "--repo", REPO],
-                capture_output=True,
+            # 4b. Describe the PR's current state to the agent.
+            #
+            #     Historically this block dumped the full unified
+            #     `gh pr diff` into the user message — a large token
+            #     sink on PRs that touch many lines, especially since
+            #     cai-revise runs every cycle for the full lifetime
+            #     of a PR. The full diff is now gone entirely: the
+            #     agent gets a compact `git diff origin/main..HEAD
+            #     --stat` summary as a file-level map, and explores
+            #     the clone itself (Read, Grep, Glob, and delegation
+            #     to Explore) when it needs the actual content.
+            #
+            #     When `.cai/pr-context.md` is present (`cai-fix`
+            #     writes it on every non-empty PR), the dossier is
+            #     the richer map and the agent Reads it first. When
+            #     it is missing (legacy PRs, or PRs where cai-fix
+            #     exited with zero diff), the stat alone is enough —
+            #     the agent uses it as the entry point and explores
+            #     from there, then writes a fresh dossier before
+            #     exiting so the next revise cycle has one.
+            dossier_path = work_dir / ".cai" / "pr-context.md"
+            stat_result = _git(
+                work_dir, "diff", "origin/main..HEAD", "--stat",
+                check=False,
             )
-            pr_diff = diff_result.stdout if diff_result.returncode == 0 else "(could not fetch diff)"
+            pr_stat = (stat_result.stdout or "").strip() or (
+                "(no changes vs origin/main)"
+            )
+            if dossier_path.exists():
+                pr_state_block = (
+                    f"## Current PR state\n\n"
+                    f"A PR context dossier is present at "
+                    f"`{work_dir}/.cai/pr-context.md` — **Read it "
+                    f"first.** It lists the files touched, key "
+                    f"symbols, design decisions, out-of-scope gaps, "
+                    f"and invariants the change relies on. Use it as "
+                    f"the ground-truth map of what this PR is doing "
+                    f"and Read specific files in the clone for the "
+                    f"actual current content.\n\n"
+                    f"The full unified diff is **not** included — "
+                    f"the dossier plus on-demand Reads is cheaper "
+                    f"and more accurate. A `git diff "
+                    f"origin/main..HEAD --stat` summary follows as a "
+                    f"file-level map:\n\n"
+                    f"```\n{pr_stat}\n```\n\n"
+                )
+            else:
+                pr_state_block = (
+                    f"## Current PR state\n\n"
+                    f"_No `.cai/pr-context.md` dossier was found — "
+                    f"this is a legacy PR or one where `cai-fix` "
+                    f"exited with zero diff. The full unified diff "
+                    f"is **not** included either — it is a token "
+                    f"sink on large PRs and you can reconstruct the "
+                    f"same information more accurately by Reading "
+                    f"files in the clone directly._\n\n"
+                    f"A `git diff origin/main..HEAD --stat` summary "
+                    f"follows as a file-level map. **Use it as your "
+                    f"entry point:** Read the listed files in the "
+                    f"clone to see the actual current content, use "
+                    f"Grep/Glob or the Explore subagent for any "
+                    f"broader context you need, and — if you make "
+                    f"code changes in this revision — create a "
+                    f"minimal dossier at "
+                    f"`{work_dir}/.cai/pr-context.md` before exiting "
+                    f"(see `.claude/agents/cai-fix.md` → 'Before you "
+                    f"exit: write the PR context dossier') so the "
+                    f"next revise cycle starts with one.\n\n"
+                    f"```\n{pr_stat}\n```\n\n"
+                )
 
             # 5. Build the user message. The system prompt, tool
             #    allowlist (Agent + edit tools), and hard rules all
@@ -2516,9 +2581,8 @@ def cmd_revise(args) -> int:
                 + f"## Original issue\n\n"
                 + f"### #{issue_data['number']} — {issue_data.get('title', '')}\n\n"
                 + f"{issue_data.get('body') or '(no body)'}\n\n"
-                + f"## Current PR diff\n\n"
-                + f"```diff\n{pr_diff}\n```\n\n"
-                + f"{comments_section}"
+                + pr_state_block
+                + comments_section
             )
 
             # 5b. Pre-create the `.cai-staging/agents/` directory so


### PR DESCRIPTION
## Summary

- **New `.cai/pr-context.md` dossier carried across the fix → revise boundary.** `cai-fix` writes it on every non-empty PR with files touched, key symbols, design decisions, out-of-scope gaps, and invariants. `cai-revise` reads it first at the start of each cycle (no more Grep/Glob to re-derive what the PR is doing) and appends a `## Revision N` section before exiting so subsequent cycles inherit the accumulated context.
- **`cmd_revise` no longer dumps the full `gh pr diff` into the user message.** The full unified diff is gone entirely. Revise gets only a compact `git diff origin/main..HEAD --stat` summary as a file-level map and Reads files in the clone directly — more accurate than a potentially-stale diff and drastically cheaper on large PRs. Legacy PRs with no dossier take the same stat-only path and create a minimal dossier before exiting.
- **`cai-review-pr` and `cai-merge` get explicit exemptions** so they ignore the dossier file in the diff (don't flag it as scope creep, stale docs, or untraceable-to-issue).
- **New `.github/workflows/cleanup-pr-context.yml`** deletes `.cai/pr-context.md` from `main` on every push, so the dossier exists only on the PR branch and never lands in the mainline tree. Pushes made with `GITHUB_TOKEN` don't retrigger workflows, so the cleanup commit is a safe one-shot.

## Test plan

- [ ] Run `cai fix` on a real `:refined` issue → confirm the opened PR contains `.cai/pr-context.md` with the expected sections.
- [ ] Run `cai review-pr` on that PR → confirm the dossier file is not flagged in any `### Finding:` block.
- [ ] Leave a review comment and run `cai revise` → confirm the user message's `## Current PR state` section points at the dossier and omits the full unified diff, the agent Reads the dossier, and a `## Revision 1` section is appended on exit.
- [ ] Run `cai merge` on the PR → confirm cai-merge does not downgrade the verdict because of the dossier.
- [ ] After merge → confirm the cleanup workflow runs on `main`, deletes `.cai/pr-context.md`, and commits a `cleanup: remove auto-improve PR context dossier from main` commit.
- [ ] Open a legacy-style PR with no dossier and run `cai revise` → confirm the stat-only fallback works and the agent creates a minimal dossier before exiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)