### PR TITLE
entrypoint: only run issue-solving cycle at container startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ subprocess with no shared state.
 | `cai.py propose` | `0 4 * * 0` (weekly Sunday 04:00 UTC) | Creative improvement proposals — clones the repo read-only, runs a creative agent to propose an ambitious improvement, then a review agent to evaluate feasibility; approved proposals are filed as `auto-improve:raised` issues so they flow through the refine → fix pipeline |
 | `cai.py update-check` | `0 4 * * 1` (weekly Monday 04:00 UTC) | Claude Code release check — clones the repo, fetches the latest Claude Code releases from GitHub, and runs a Sonnet agent that compares the current pinned version against the latest releases; findings (new versions, deprecated flags, best practices) are published as `update-check` namespace issues |
 | `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → left as `:merged` (Sonnet) |
-| `cai.py cycle` | _(manual/on-demand)_ | Runs verify → fix → revise → review-pr → merge → confirm in sequence. Convenience wrapper for a full pipeline pass; not included in scheduled or startup runs |
+| `cai.py cycle` | _(startup + manual/on-demand)_ | Runs verify → fix → revise → review-pr → merge → confirm in sequence. The entrypoint runs this once synchronously at `docker compose up -d` so the issue-solving pipeline produces immediate logs; not scheduled via cron (the individual steps have their own cron lines) |
 | `cai.py test` | _(manual/on-demand)_ | Runs the project test suite (`python -m unittest discover` under `tests/`) |
 
 On `docker compose up -d` the entrypoint templates the crontab from
@@ -70,9 +70,12 @@ the env vars (`CAI_ANALYZER_SCHEDULE`, `CAI_FIX_SCHEDULE`,
 `CAI_REFINE_SCHEDULE`, `CAI_REVIEW_PR_SCHEDULE`, `CAI_MERGE_SCHEDULE`,
 `CAI_REVISE_SCHEDULE`, `CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`,
 `CAI_AUDIT_TRIAGE_SCHEDULE`, `CAI_CODE_AUDIT_SCHEDULE`,
-`CAI_PROPOSE_SCHEDULE`, `CAI_UPDATE_CHECK_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`), runs each
-scheduled subcommand once synchronously so logs show immediate results, then execs
-supercronic. (`cycle` is on-demand only and is not part of scheduled or startup runs.)
+`CAI_PROPOSE_SCHEDULE`, `CAI_UPDATE_CHECK_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`),
+runs `cai.py cycle` once synchronously so the issue-solving pipeline
+produces immediate logs, then execs supercronic. Analysis, audit,
+proposal, refine, and update-check agents are **not** run at startup
+— they wait for their own cron ticks so container restarts don't
+re-trigger token-heavy analysis passes.
 
 ### Issue lifecycle
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,9 +19,12 @@
 #    Each is its own crontab line so supercronic runs them as
 #    independent processes — natural concurrency, easy to add more.
 #
-# 2. Do one synchronous pass of init / analyze / refine / fix / review-pr / revise / merge / verify / audit so
-#    `docker compose up -d` produces useful logs immediately rather
-#    than waiting for the first cron tick.
+# 2. Do one synchronous `cai.py cycle` pass (verify → fix → revise →
+#    review-pr → merge → confirm) so `docker compose up -d` produces
+#    useful logs immediately rather than waiting for the first cron
+#    tick. Only the issue-solving cycle runs at startup; analysis,
+#    audit, proposal, and update-check agents wait for their cron
+#    ticks so container restarts don't burn tokens re-running them.
 #
 # 3. Exec supercronic as PID 1. supercronic handles SIGTERM gracefully
 #    (lets in-flight tasks finish) and streams child stdout/stderr to
@@ -78,47 +81,8 @@ else
   echo "[entrypoint] gh not yet authenticated; skipping git credential setup"
 fi
 
-echo "[entrypoint] running initial cai.py init"
-python /app/cai.py init || echo "[entrypoint] init exited non-zero; continuing"
-
-echo "[entrypoint] running initial cai.py analyze"
-python /app/cai.py analyze || echo "[entrypoint] analyze exited non-zero; continuing"
-
-echo "[entrypoint] running initial cai.py verify"
-python /app/cai.py verify || echo "[entrypoint] verify exited non-zero; continuing"
-
-echo "[entrypoint] running initial cai.py refine"
-python /app/cai.py refine || echo "[entrypoint] refine exited non-zero; continuing"
-
-echo "[entrypoint] running initial cai.py fix"
-python /app/cai.py fix || echo "[entrypoint] fix exited non-zero; continuing"
-
-echo "[entrypoint] running initial cai.py review-pr"
-python /app/cai.py review-pr || echo "[entrypoint] review-pr exited non-zero; continuing"
-
-echo "[entrypoint] running initial cai.py revise"
-python /app/cai.py revise || echo "[entrypoint] revise exited non-zero; continuing"
-
-echo "[entrypoint] running initial cai.py merge"
-python /app/cai.py merge || echo "[entrypoint] merge exited non-zero; continuing"
-
-echo "[entrypoint] running initial cai.py audit"
-python /app/cai.py audit || echo "[entrypoint] audit exited non-zero; continuing"
-
-echo "[entrypoint] running initial cai.py audit-triage"
-python /app/cai.py audit-triage || echo "[entrypoint] audit-triage exited non-zero; continuing"
-
-echo "[entrypoint] running initial cai.py code-audit"
-python /app/cai.py code-audit || echo "[entrypoint] code-audit exited non-zero; continuing"
-
-echo "[entrypoint] running initial cai.py propose"
-python /app/cai.py propose || echo "[entrypoint] propose exited non-zero; continuing"
-
-echo "[entrypoint] running initial cai.py update-check"
-python /app/cai.py update-check || echo "[entrypoint] update-check exited non-zero; continuing"
-
-echo "[entrypoint] running initial cai.py confirm"
-python /app/cai.py confirm || echo "[entrypoint] confirm exited non-zero; continuing"
+echo "[entrypoint] running initial cai.py cycle"
+python /app/cai.py cycle || echo "[entrypoint] cycle exited non-zero; continuing"
 
 echo "[entrypoint] handing off to supercronic"
 exec supercronic "$CRONTAB_PATH"


### PR DESCRIPTION
## Summary
- Replaces 14 individual synchronous agent invocations in `entrypoint.sh` with a single `cai.py cycle` call, so container boot only fires the issue-solving pipeline (verify → fix → revise → review-pr → merge → confirm).
- `analyze`, `refine`, `audit`, `audit-triage`, `code-audit`, `propose`, `update-check`, `init`, and `confirm` no longer run at container start — they wait for their own cron ticks. Container restarts no longer burn tokens re-triggering token-heavy analysis passes.
- Delegating to `cai.py cycle` means the startup pass automatically tracks the canonical `cmd_cycle` definition in `cai.py`, eliminating drift between two parallel lists.
- README updated: the `cycle` row and the `docker compose up -d` paragraph now accurately describe the new startup behavior (previously both claimed `cycle` was on-demand only).

## Test plan
- [ ] `bash -n entrypoint.sh` passes (verified locally).
- [ ] `docker compose up -d` on a fresh container logs `[entrypoint] running initial cai.py cycle` followed by the six cycle steps, then hands off to supercronic.
- [ ] Confirm `analyze` / `propose` / `audit` / `update-check` do **not** appear in startup logs on a `docker compose restart`.
- [ ] Confirm cron-scheduled runs of the excluded agents still fire on their normal intervals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)