### PR TITLE
auto-improve: cai-fix.md does not document the `## Selected Implementation Plan` user-message section

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,22 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#412
+
+## Files touched
+- .claude/agents/cai-fix.md:206 — changed "by reading only the issue body" → "without opening any code files"
+- .claude/agents/cai-fix.md:407-410 — inserted new paragraph documenting the `## Selected Implementation Plan` user-message section
+
+## Files read (not touched) that matter
+- .claude/agents/cai-fix.md — the agent definition being updated
+
+## Key symbols
+- `## Selected Implementation Plan` (cai.py:1641) — user-message section injected by `cmd_fix` when `selected_plan` is truthy; now documented in the agent prompt
+
+## Design decisions
+- Inserted the Selected Implementation Plan paragraph between the intro sentence and the `## Previous Fix Attempts` paragraph — keeps related "user-message sections" documentation together
+- Rejected: placing the new paragraph after `## Previous Fix Attempts` — the plan precedes the issue block in the message, so documenting it first is more natural
+
+## Out of scope / known gaps
+- Did not change cai.py or any other file — this is purely a documentation/prompt update
+
+## Invariants this change relies on
+- The wrapper always injects `## Selected Implementation Plan` before `## Issue` when a plan exists (cai.py:1641–1652)

--- a/.claude/agents/cai-fix.md
+++ b/.claude/agents/cai-fix.md
@@ -203,7 +203,7 @@ defense-in-depth that breaks the spin loop.
 ## Triage the issue before exploring
 
 **Before opening any file or running any search**, answer these
-three questions by reading only the issue body:
+three questions without opening any code files:
 
 1. Does the issue name a **specific file or code path** to change?
 2. Does the remediation describe a **concrete edit** (add/remove/
@@ -403,6 +403,16 @@ The full body of the issue you are working on (including its
 fingerprint, category, evidence, and remediation) is appended to
 the user message as `## Issue` below. Read it carefully before doing
 anything else.
+
+A `## Selected Implementation Plan` section may also precede the
+`## Issue` block when the plan-select pipeline ran successfully.
+If present, it contains a detailed implementation plan selected
+from multiple independently generated candidates. **Read and
+follow this plan** — it has already identified the files, functions,
+and specific edits needed. You should still triage the issue (the
+plan does not exempt you from the triage gate), but once past
+triage, use the plan as your primary guide rather than exploring
+from scratch.
 
 A `## Previous Fix Attempts` section may also follow the issue
 block when earlier closed PRs exist for this issue. If present,


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#412

**Issue:** #412 — cai-fix.md does not document the `## Selected Implementation Plan` user-message section

## PR Summary

### What this fixes
`cai-fix.md` did not mention the `## Selected Implementation Plan` section that `cmd_fix` injects into the fix agent's user message when the plan-select pipeline runs, so the fix agent could silently ignore it. The triage section also said "by reading only the issue body," which could be misread as "skip everything before `## Issue`," including the plan.

### What was changed
- `.claude/agents/cai-fix.md` (via staging at `.cai-staging/agents/cai-fix.md`):
  - **Line 206**: Changed "three questions by reading only the issue body" → "three questions without opening any code files" to clarify that triage should not skip other user-message sections.
  - **Lines 407–414** (new paragraph): Added documentation of the `## Selected Implementation Plan` section in "The issue" block, instructing the agent to read and follow the plan while still passing the triage gate.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
