### PR TITLE
auto-improve: Outcome-Driven Fix Prioritization with Confirm-Loop Re-queuing

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,41 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#413
+
+## Files touched
+- `cai.py:192` — Added `OUTCOME_LOG_PATH = Path("/var/log/cai/cai-outcomes.jsonl")`
+- `cai.py:228-244` — Added `_log_outcome()` helper (appends JSON record to outcome log, never raises)
+- `cai.py:246-301` — Added `_load_outcome_counts()` (reads outcome log, returns per-category totals) and `_load_outcome_stats()` (computes success rates, 0.60 prior for <3 obs)
+- `cai.py:1086-1111` — Replaced FIFO `min(createdAt)` in `_select_fix_target()` with scored `max()` using age × success_rate × (1/prior_attempts)
+- `cai.py:4833-4960` — Rewrote verdict loop in `cmd_confirm()`: added `merged_by_num` lookup dict, `_extract_category()` helper, outcome logging for all three verdicts, and re-queue logic (up to 3 attempts → `:refined`, then `needs-human-review`)
+- `cai.py:4142-4159` — Appended Category Success Rates table to `cmd_cost_report()`
+
+## Files read (not touched) that matter
+- `cai.py` (log_cost pattern, ~line 210) — followed the same "never raises" pattern for `_log_outcome`
+- `cai.py` (LABEL constants, ~line 169-182) — used `LABEL_REFINED` and `LABEL_PR_NEEDS_HUMAN` for re-queue/escalation
+- `cai.py` (_fetch_previous_fix_attempts, ~line 1085) — used as-is for prior attempt count; NOT modified
+
+## Key symbols
+- `_log_outcome` (cai.py:228) — writes one outcome record per confirm verdict
+- `_load_outcome_counts` (cai.py:246) — raw per-category {total, solved} counts (90-day window)
+- `_load_outcome_stats` (cai.py:286) — success rates; <3 obs → 0.60 prior
+- `_score` (cai.py:1090) — nested function in `_select_fix_target`; scores each candidate
+- `_extract_category` (cai.py:4863) — nested function in `cmd_confirm` verdict loop; pulls `category:X` label value
+- `requeue_matches` (cai.py:4895) — `re.findall` (not `re.search`) to handle multiple appended re-queue blocks
+
+## Design decisions
+- Used `re.findall` + `[-1]` for re-queue count parsing — multiple appended blocks exist after repeated re-queues; `re.search` would return the first (lowest) count
+- Used `LABEL_PR_NEEDS_HUMAN = "needs-human-review"` for escalation — already used for human-attention scenarios, consistent with existing conventions
+- Kept `_fetch_previous_fix_attempts` unmodified — scope guardrail
+- `_load_outcome_counts` is the canonical file reader; `_load_outcome_stats` delegates to it (DRY)
+- Rejected: separate `outcomes.py` module — issue says prefer inline matching `log_cost()` pattern
+
+## Out of scope / known gaps
+- `_fetch_previous_fix_attempts` is called once per candidate in `_select_fix_target()` — adds latency for large candidate sets but acceptable per scope guardrails
+- `cai-confirm.md` agent definition not modified — confidence field addition deferred
+- `publish.py` not modified — category labels already set correctly
+
+## Invariants this change relies on
+- `category:{value}` labels are already applied to issues by `publish.py`
+- `_fetch_previous_fix_attempts` returns empty list on API failure (safe default for scoring)
+- `OUTCOME_LOG_PATH.parent` (`/var/log/cai/`) is writable at runtime (same assumption as `COST_LOG_PATH`)
+- The `%Y-%m-%dT%H:%M:%SZ` strptime format matches GitHub API `createdAt` field format

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -52,6 +52,23 @@ Refs: robotsix-cai/robotsix-cai#413
 ### New gaps / deferred
 - None
 
+## Revision 2 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:230` — added module-level `_get_issue_category(issue) -> str` helper before `_log_outcome()`
+- `cai.py:1105-1111` — replaced 5-line inline category extraction inside `_score()` with `_get_issue_category(issue)`
+- `cai.py:4872-4876` — removed nested `_extract_category()` from `cmd_confirm()`; replaced its 3 call sites with `_get_issue_category(mi)`
+
+### Decisions this revision
+- `_get_issue_category` placed immediately before `_log_outcome` (outcome-related helpers cluster)
+- No behavioral change — pure deduplication; both original implementations were identical
+
+### New gaps / deferred
+- None
+
 ## Invariants this change relies on
 - `category:{value}` labels are already applied to issues by `publish.py`
 - `_fetch_previous_fix_attempts` returns empty list on API failure (safe default for scoring)

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -34,6 +34,24 @@ Refs: robotsix-cai/robotsix-cai#413
 - `cai-confirm.md` agent definition not modified — confidence field addition deferred
 - `publish.py` not modified — category labels already set correctly
 
+## Revision 1 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:15` — updated module docstring "Pick the oldest issue" → describe scoring logic
+- `cai.py:1032` — updated `_select_fix_target` docstring to describe outcome-driven scoring (replaces "oldest open issue")
+- `cai.py:6042` — updated `--issue` help text to "instead of using automatic scoring-based selection"
+- `README.md:55` — updated `cai.py fix` table row to describe scoring strategy instead of "oldest eligible"
+- `README.md:270` — updated inline comment `# oldest eligible` → `# automatic scoring-based selection`
+
+### Decisions this revision
+- Expanded `_select_fix_target` docstring to include the scoring formula for developer clarity
+
+### New gaps / deferred
+- None
+
 ## Invariants this change relies on
 - `category:{value}` labels are already applied to issues by `publish.py`
 - `_fetch_previous_fix_attempts` returns empty list on API failure (safe default for scoring)

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -74,3 +74,21 @@ Refs: robotsix-cai/robotsix-cai#413
 - `_fetch_previous_fix_attempts` returns empty list on API failure (safe default for scoring)
 - `OUTCOME_LOG_PATH.parent` (`/var/log/cai/`) is writable at runtime (same assumption as `COST_LOG_PATH`)
 - The `%Y-%m-%dT%H:%M:%SZ` strptime format matches GitHub API `createdAt` field format
+
+## Revision 3 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:51-56` — updated module docstring for `confirm` to describe re-queue behavior (was "stay as :merged")
+- `cai.py:4735-4740` — expanded `cmd_confirm()` docstring to include re-queue and escalation logic
+- `README.md:64` — updated confirm table row to reflect re-queue flow instead of terminal `:merged`
+- `README.md:109-113` — updated ASCII lifecycle diagram: "stays :merged" → "re-queued :refined / :needs-human-review"
+
+### Decisions this revision
+- Kept ASCII diagram compact (same column width) by using two lines for the re-queue annotation
+- No behavioral changes — documentation only
+
+### New gaps / deferred
+- None

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ subprocess with no shared state.
 | `cai.py code-audit` | `0 3 * * 0` (weekly Sunday 03:00 UTC) | Source-code consistency audit — clones the repo read-only, runs a Sonnet agent to flag cross-file inconsistencies, dead code, missing references, duplicated logic, hardcoded drift, config mismatches, and registration mismatches; publishes findings as `code-audit` namespace issues |
 | `cai.py propose` | `0 4 * * 0` (weekly Sunday 04:00 UTC) | Creative improvement proposals — clones the repo read-only, runs a creative agent to propose an ambitious improvement, then a review agent to evaluate feasibility; approved proposals are filed as `auto-improve:raised` issues so they flow through the refine → fix pipeline |
 | `cai.py update-check` | `0 4 * * 1` (weekly Monday 04:00 UTC) | Claude Code release check — clones the repo, fetches the latest Claude Code releases from GitHub, and runs a Sonnet agent that compares the current pinned version against the latest releases; findings (new versions, deprecated flags, best practices) are published as `update-check` namespace issues |
-| `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → left as `:merged` (Sonnet) |
+| `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → re-queued to `:refined` (up to 3 attempts), then escalated to `:needs-human-review` (Sonnet) |
 | `cai.py cycle` | _(startup + manual/on-demand)_ | Runs verify → fix → revise → review-pr → merge → confirm in sequence. The entrypoint runs this once synchronously at `docker compose up -d` so the issue-solving pipeline produces immediate logs; not scheduled via cron (the individual steps have their own cron lines) |
 | `cai.py test` | _(manual/on-demand)_ | Runs the project test suite (`python -m unittest discover` under `tests/`) |
 
@@ -109,8 +109,9 @@ action so two concurrent `fix` runs can't pick the same issue.
                   confirm (pattern       confirm (inconclusive
                    absent)                / unsolved)
                         ▼                       ▼
-                  solved (closed)       stays :merged
-                                     (reasoning posted)
+                  solved (closed)    re-queued :refined
+                                     (up to 3 attempts,
+                                      then :needs-human-review)
 ```
 
 `:no-action` means the fix subagent reviewed the issue and decided no

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ subprocess with no shared state.
 |---|---|---|
 | `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
 | `cai.py refine` | `10 * * * *` (hourly :10) | Picks the oldest `:raised` issue, invokes the cai-refine subagent (read-only) to produce a structured plan, updates the issue body, and transitions the label to `:refined` |
-| `cai.py fix` | `15 * * * *` (hourly :15) | Picks the oldest eligible issue, runs 3 parallel plan agents then a select agent to choose the best plan, lets a fix subagent implement it with full tool permissions, opens a PR — see lifecycle below |
+| `cai.py fix` | `15 * * * *` (hourly :15) | Scores eligible issues by age, category success rate, and prior fix attempts; picks the highest scorer, runs 3 parallel plan agents then a select agent to choose the best plan, lets a fix subagent implement it with full tool permissions, opens a PR — see lifecycle below |
 | `cai.py revise` | `30 * * * *` (hourly :30) | Watches `:pr-open` PRs for new comments and iterates on the same branch via force-push; also auto-rebases unmergeable PRs onto current main |
 | `cai.py verify` | `45 * * * *` (hourly :45) | Mechanical, no LLM. Walks `auto-improve:pr-open` issues and updates labels based on PR merge state; recovers issues whose linked PR was closed without merging (rolls back to `:refined`) or where no linked PR exists (rolls back to `:raised`) |
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` and `:no-action` issues, flags stale `:merged` issues for human review, deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |
@@ -267,7 +267,7 @@ just-trying-things-out from the terminal would use:
 
 ```bash
 docker compose exec cai python /app/cai.py analyze
-docker compose exec cai python /app/cai.py fix              # oldest eligible
+docker compose exec cai python /app/cai.py fix              # automatic scoring-based selection
 docker compose exec cai python /app/cai.py fix --issue 12   # specific issue
 docker compose exec cai python /app/cai.py review-pr
 docker compose exec cai python /app/cai.py revise

--- a/cai.py
+++ b/cai.py
@@ -227,6 +227,14 @@ def log_cost(row: dict) -> None:
         pass
 
 
+def _get_issue_category(issue: dict) -> str:
+    """Return the category label value for *issue*, or ``'(unknown)'`` if absent."""
+    for ln in (lbl["name"] for lbl in issue.get("labels", [])):
+        if ln.startswith("category:"):
+            return ln.split(":", 1)[1]
+    return "(unknown)"
+
+
 def _log_outcome(issue_number: int, category: str, outcome: str, fix_attempt_count: int) -> None:
     """Append one JSON record to the outcome log. Never raises."""
     try:
@@ -1103,12 +1111,7 @@ def _select_fix_target():
         except (ValueError, KeyError):
             age_days = 1.0
         # Category success rate.
-        label_names = {lbl["name"] for lbl in issue.get("labels", [])}
-        cat = "(unknown)"
-        for ln in label_names:
-            if ln.startswith("category:"):
-                cat = ln.split(":", 1)[1]
-                break
+        cat = _get_issue_category(issue)
         rate = outcome_stats.get(cat, default_rate)
         # Prior fix attempts (from closed unmerged PRs).
         prior = len(_fetch_previous_fix_attempts(issue["number"]))
@@ -4870,18 +4873,12 @@ def cmd_confirm(args) -> int:
     unsolved = 0
     inconclusive = 0
 
-    def _extract_category(issue: dict) -> str:
-        for ln in (lbl["name"] for lbl in issue.get("labels", [])):
-            if ln.startswith("category:"):
-                return ln.split(":", 1)[1]
-        return "(unknown)"
-
     for issue_num, status, reasoning in verdicts:
         if issue_num not in merged_nums:
             continue
         mi = merged_by_num[issue_num]
         if status == "solved":
-            cat = _extract_category(mi)
+            cat = _get_issue_category(mi)
             prior_attempts = len(_fetch_previous_fix_attempts(issue_num))
             _log_outcome(issue_num, cat, "solved", prior_attempts)
             _set_labels(issue_num, add=[LABEL_SOLVED], remove=[LABEL_MERGED], log_prefix="cai confirm")
@@ -4895,7 +4892,7 @@ def cmd_confirm(args) -> int:
             print(f"[cai confirm] #{issue_num}: solved — closed", flush=True)
             solved += 1
         elif status == "unsolved":
-            cat = _extract_category(mi)
+            cat = _get_issue_category(mi)
             prior_attempts = len(_fetch_previous_fix_attempts(issue_num))
             _log_outcome(issue_num, cat, "unsolved", prior_attempts)
 
@@ -4953,7 +4950,7 @@ def cmd_confirm(args) -> int:
                 print(f"[cai confirm] #{issue_num}: unsolved — max re-queues reached, needs-human", flush=True)
             unsolved += 1
         elif status == "inconclusive":
-            cat = _extract_category(mi)
+            cat = _get_issue_category(mi)
             prior_attempts = len(_fetch_previous_fix_attempts(issue_num))
             _log_outcome(issue_num, cat, "inconclusive", prior_attempts)
             # Post reasoning to the issue so humans can see why, but

--- a/cai.py
+++ b/cai.py
@@ -51,8 +51,9 @@ Subcommands:
     python cai.py confirm   Re-analyze the recent transcript window and
                             verify whether `:merged` issues are actually
                             solved. Patterns that disappeared get closed
-                            with `:solved`; patterns that persist stay
-                            as `:merged`.
+                            with `:solved`; patterns that persist are
+                            re-queued to `:refined` (up to 3 attempts),
+                            then escalated to `:needs-human-review`.
 
     python cai.py review-pr Walk open PRs against main, run a
                             consistency review for ripple effects, and
@@ -4732,7 +4733,12 @@ def _parse_verdicts(text: str) -> list[tuple[int, str, str]]:
 
 
 def cmd_confirm(args) -> int:
-    """Re-analyze the recent window to verify :merged issues are solved."""
+    """Re-analyze the recent window to verify :merged issues are solved.
+
+    For unsolved issues, logs the outcome and either re-queues to
+    :refined (up to 3 attempts) or escalates to :needs-human-review
+    after max attempts.
+    """
     print("[cai confirm] checking merged issues against recent signals", flush=True)
     t0 = time.monotonic()
 

--- a/cai.py
+++ b/cai.py
@@ -12,8 +12,10 @@ Subcommands:
                             claude -p, and publish findings via
                             publish.py.
 
-    python cai.py fix       Pick the oldest issue labelled
-                            `auto-improve:refined` or `auto-improve:
+    python cai.py fix       Score eligible issues by age, category
+                            success rate, and prior fix attempts; pick
+                            the highest scorer labelled `auto-improve:
+                            refined` or `auto-improve:
                             requested` (audit issues reach fix via
                             triage relabelling), lock it via the `:in-progress`
                             label, clone the repo into /tmp, run 3
@@ -1029,7 +1031,11 @@ def _recover_stale_pr_open(issues: list[dict], *, log_prefix: str = "cai") -> li
 
 
 def _select_fix_target():
-    """Return the oldest open issue eligible for the fix subagent.
+    """Return the highest-scored open issue eligible for the fix subagent.
+
+    Scoring: age_days × category_success_rate × (1 / max(1, prior_attempts)).
+    Categories with fewer than 3 observations get a neutral prior of 0.60.
+    This replaces the previous FIFO (oldest-first) selection.
 
     Eligible = labelled `:refined` or `:requested`, NOT labelled
     `:in-progress` or `:pr-open`.  `audit:raised` issues are handled
@@ -6043,7 +6049,7 @@ def main() -> int:
     fix_parser = sub.add_parser("fix", help="Run the fix subagent")
     fix_parser.add_argument(
         "--issue", type=int, default=None,
-        help="Target a specific issue number instead of picking the oldest",
+        help="Target a specific issue number instead of using automatic scoring-based selection",
     )
 
     sub.add_parser("revise", help="Iterate on open PRs based on review comments")

--- a/cai.py
+++ b/cai.py
@@ -189,6 +189,7 @@ LABEL_PR_NEEDS_HUMAN = "needs-human-review"
 LOG_PATH = Path("/var/log/cai/cai.log")
 COST_LOG_PATH = Path("/var/log/cai/cai-cost.jsonl")
 REVIEW_PR_PATTERN_LOG = Path("/var/log/cai/review-pr-patterns.jsonl")
+OUTCOME_LOG_PATH = Path("/var/log/cai/cai-outcomes.jsonl")
 
 
 def log_run(category: str, **fields) -> None:
@@ -222,6 +223,80 @@ def log_cost(row: dict) -> None:
             f.flush()
     except Exception:
         pass
+
+
+def _log_outcome(issue_number: int, category: str, outcome: str, fix_attempt_count: int) -> None:
+    """Append one JSON record to the outcome log. Never raises."""
+    try:
+        OUTCOME_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        row = {
+            "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "issue_number": issue_number,
+            "category": category,
+            "outcome": outcome,
+            "fix_attempt_count": fix_attempt_count,
+        }
+        with OUTCOME_LOG_PATH.open("a") as f:
+            f.write(json.dumps(row, separators=(",", ":")) + "\n")
+            f.flush()
+    except Exception:
+        pass
+
+
+def _load_outcome_counts(days: int = 90) -> dict:
+    """Read OUTCOME_LOG_PATH and return per-category {total, solved} counts.
+
+    Filters to trailing `days` days. Malformed lines are skipped silently.
+    Returns an empty dict if the file is missing or unreadable.
+    """
+    if not OUTCOME_LOG_PATH.exists():
+        return {}
+    cutoff_ts = datetime.now(timezone.utc).timestamp() - days * 86400
+    counts: dict = {}  # category -> {"total": N, "solved": N}
+    try:
+        with OUTCOME_LOG_PATH.open("r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                ts = row.get("ts", "")
+                try:
+                    row_ts = datetime.strptime(
+                        ts, "%Y-%m-%dT%H:%M:%SZ"
+                    ).replace(tzinfo=timezone.utc).timestamp()
+                except ValueError:
+                    continue
+                if row_ts < cutoff_ts:
+                    continue
+                cat = row.get("category") or "(unknown)"
+                outcome = row.get("outcome", "")
+                bucket = counts.setdefault(cat, {"total": 0, "solved": 0})
+                bucket["total"] += 1
+                if outcome == "solved":
+                    bucket["solved"] += 1
+    except OSError:
+        return {}
+    return counts
+
+
+def _load_outcome_stats(days: int = 90) -> dict:
+    """Load per-category success rates from the trailing `days` days of outcome data.
+
+    Returns a dict mapping category name to success rate (0.0–1.0).
+    Categories with fewer than 3 observations get a neutral prior of 0.60.
+    """
+    counts = _load_outcome_counts(days)
+    rates: dict = {}
+    for cat, c in counts.items():
+        if c["total"] < 3:
+            rates[cat] = 0.60
+        else:
+            rates[cat] = c["solved"] / c["total"]
+    return rates
 
 
 def _load_cost_log(days: int = 7) -> list[dict]:
@@ -1008,7 +1083,32 @@ def _select_fix_target():
     if not candidates:
         return None
 
-    return min(candidates.values(), key=lambda i: i["createdAt"])
+    # Score candidates by age, category success rate, and prior fix attempts.
+    outcome_stats = _load_outcome_stats()
+    default_rate = 0.60
+
+    def _score(issue: dict) -> float:
+        # Age in days (older = higher base score).
+        try:
+            created = datetime.strptime(
+                issue["createdAt"], "%Y-%m-%dT%H:%M:%SZ"
+            ).replace(tzinfo=timezone.utc)
+            age_days = max(1.0, (datetime.now(timezone.utc) - created).total_seconds() / 86400)
+        except (ValueError, KeyError):
+            age_days = 1.0
+        # Category success rate.
+        label_names = {lbl["name"] for lbl in issue.get("labels", [])}
+        cat = "(unknown)"
+        for ln in label_names:
+            if ln.startswith("category:"):
+                cat = ln.split(":", 1)[1]
+                break
+        rate = outcome_stats.get(cat, default_rate)
+        # Prior fix attempts (from closed unmerged PRs).
+        prior = len(_fetch_previous_fix_attempts(issue["number"]))
+        return age_days * rate * (1.0 / max(1, prior))
+
+    return max(candidates.values(), key=_score)
 
 
 def _set_labels(issue_number: int, *, add: list[str] = (), remove: list[str] = (), log_prefix: str = "cai fix") -> bool:
@@ -4041,6 +4141,28 @@ def cmd_cost_report(args) -> int:
                 f"${mean:>9.4f}  {b['in']:>10}  {b['out']:>10}"
             )
     print()
+
+    # Category success rates from outcome log.
+    print("--- Category Success Rates (trailing 90 days) ---\n")
+    cat_counts = _load_outcome_counts(days=90)
+    if cat_counts:
+        cat_width = max(12, max(len(k) for k in cat_counts))
+        cat_header = (
+            f"{'category':<{cat_width}}  {'attempts':>8}  "
+            f"{'solved':>6}  {'rate':>7}  {'flag':>6}"
+        )
+        print(cat_header)
+        print("-" * len(cat_header))
+        for cat, c in sorted(cat_counts.items(), key=lambda kv: kv[1]["total"], reverse=True):
+            rate = c["solved"] / c["total"] if c["total"] else 0.0
+            flag = "⚠ LOW" if rate < 0.40 else ""
+            print(
+                f"{cat:<{cat_width}}  {c['total']:>8}  "
+                f"{c['solved']:>6}  {rate:>6.0%}  {flag:>6}"
+            )
+    else:
+        print("(no outcome data yet)")
+    print()
     return 0
 
 
@@ -4736,15 +4858,26 @@ def cmd_confirm(args) -> int:
     # 5. Parse verdicts.
     verdicts = _parse_verdicts(confirm.stdout)
     merged_nums = {mi["number"] for mi in merged_issues}
+    merged_by_num = {mi["number"]: mi for mi in merged_issues}
 
     solved = 0
     unsolved = 0
     inconclusive = 0
 
+    def _extract_category(issue: dict) -> str:
+        for ln in (lbl["name"] for lbl in issue.get("labels", [])):
+            if ln.startswith("category:"):
+                return ln.split(":", 1)[1]
+        return "(unknown)"
+
     for issue_num, status, reasoning in verdicts:
         if issue_num not in merged_nums:
             continue
+        mi = merged_by_num[issue_num]
         if status == "solved":
+            cat = _extract_category(mi)
+            prior_attempts = len(_fetch_previous_fix_attempts(issue_num))
+            _log_outcome(issue_num, cat, "solved", prior_attempts)
             _set_labels(issue_num, add=[LABEL_SOLVED], remove=[LABEL_MERGED], log_prefix="cai confirm")
             _run(
                 ["gh", "issue", "close", str(issue_num),
@@ -4756,16 +4889,67 @@ def cmd_confirm(args) -> int:
             print(f"[cai confirm] #{issue_num}: solved — closed", flush=True)
             solved += 1
         elif status == "unsolved":
-            _run(
-                ["gh", "issue", "comment", str(issue_num),
-                 "--repo", REPO,
-                 "--body",
-                 "Confirm check: fix did not eliminate the pattern in the recent window."],
-                capture_output=True,
+            cat = _extract_category(mi)
+            prior_attempts = len(_fetch_previous_fix_attempts(issue_num))
+            _log_outcome(issue_num, cat, "unsolved", prior_attempts)
+
+            # Parse re-queue count from issue body (use findall to handle
+            # multiple appended blocks; take the last match's count).
+            issue_body = mi.get("body") or ""
+            requeue_matches = re.findall(
+                r"## Confirm re-queue \(attempt (\d+)\)", issue_body
             )
-            print(f"[cai confirm] #{issue_num}: unsolved — left as :merged", flush=True)
+            requeue_count = int(requeue_matches[-1]) if requeue_matches else 0
+
+            if requeue_count < 3:
+                new_count = requeue_count + 1
+                requeue_block = (
+                    f"\n\n## Confirm re-queue (attempt {new_count})\n\n"
+                    f"Fix confirmed unsolved. Re-queued for another attempt."
+                )
+                _run(
+                    ["gh", "issue", "edit", str(issue_num),
+                     "--repo", REPO,
+                     "--body", issue_body + requeue_block],
+                    capture_output=True,
+                )
+                _set_labels(
+                    issue_num,
+                    add=[LABEL_REFINED],
+                    remove=[LABEL_MERGED],
+                    log_prefix="cai confirm",
+                )
+                _run(
+                    ["gh", "issue", "comment", str(issue_num),
+                     "--repo", REPO,
+                     "--body",
+                     f"Confirm check: fix did not resolve the issue. "
+                     f"Re-queued as `auto-improve:refined` (attempt {new_count}/3)."],
+                    capture_output=True,
+                )
+                print(f"[cai confirm] #{issue_num}: unsolved — re-queued (attempt {new_count}/3)", flush=True)
+            else:
+                # Cap reached — escalate to human.
+                _set_labels(
+                    issue_num,
+                    add=[LABEL_PR_NEEDS_HUMAN],
+                    remove=[LABEL_MERGED],
+                    log_prefix="cai confirm",
+                )
+                _run(
+                    ["gh", "issue", "comment", str(issue_num),
+                     "--repo", REPO,
+                     "--body",
+                     "Confirm check: fix did not resolve the issue after 3 re-queue attempts. "
+                     "Escalating to `needs-human-review`."],
+                    capture_output=True,
+                )
+                print(f"[cai confirm] #{issue_num}: unsolved — max re-queues reached, needs-human", flush=True)
             unsolved += 1
         elif status == "inconclusive":
+            cat = _extract_category(mi)
+            prior_attempts = len(_fetch_previous_fix_attempts(issue_num))
+            _log_outcome(issue_num, cat, "inconclusive", prior_attempts)
             # Post reasoning to the issue so humans can see why, but
             # avoid duplicate comments if the same reasoning was already
             # posted in the most recent comment.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#413

**Issue:** #413 — Outcome-Driven Fix Prioritization with Confirm-Loop Re-queuing

## PR Summary

### What this fixes
`_select_fix_target()` used pure FIFO (oldest issue first), spending equal effort on easy and hard issue categories. When `cmd_confirm()` found an issue `unsolved` post-merge, it left the issue stuck at `:merged` with no re-attempt and no escalation path.

### What was changed
- **`cai.py:192`** — Added `OUTCOME_LOG_PATH = Path("/var/log/cai/cai-outcomes.jsonl")` constant
- **`cai.py:228–301`** — Added `_log_outcome()` (append one JSON record per confirm verdict), `_load_outcome_counts()` (read outcome log, return per-category totals), and `_load_outcome_stats()` (compute success rates with a 0.60 neutral prior for categories with fewer than 3 observations)
- **`cai.py:1086–1111`** — Replaced FIFO `min(createdAt)` in `_select_fix_target()` with a scored `max()` selector: `score = age_days × category_success_rate × (1 / max(1, prior_attempts))`
- **`cai.py:4833–4960`** — Rewrote the verdict loop in `cmd_confirm()`: added `merged_by_num` dict for O(1) issue lookup, `_extract_category()` helper, outcome logging for all three verdicts (`solved`/`unsolved`/`inconclusive`), and re-queue logic for `unsolved` (re-labels to `:refined` up to 3 times using `re.findall` to correctly handle multiple appended blocks, then escalates to `needs-human-review`)
- **`cai.py:4142–4159`** — Appended a "Category Success Rates (trailing 90 days)" table to `cmd_cost_report()` output, including a `⚠ LOW` flag for categories with solve rate < 40%

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
