### PR TITLE
auto-improve: Audit user message omits PR body and headRefName needed for linked-issue checks

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,26 @@
+# PR Context Dossier
+Refs: robotsix-cai#425
+
+## Files touched
+- `cai.py:3399-3409` — added `headRefName` (as `branch:`) and truncated body snippet (as `body:`) to `prs_section` PR line
+
+## Files read (not touched) that matter
+- `cai.py:3222-3228` — `recent_prs` fetch already requests `headRefName` and `body` fields; no query change needed
+
+## Key symbols
+- `prs_section` (`cai.py:3396`) — markdown section passed to the audit agent user message; the loop now surfaces `headRefName` and body
+- `head_ref` (`cai.py:3400`) — local var holding `pr.get("headRefName", "")`
+- `body_snippet` (`cai.py:3401`) — first 200 chars of PR body with newlines collapsed
+
+## Design decisions
+- Truncate body to 200 chars — enough to capture `Refs REPO#N` and summary without bloating the audit message
+- Collapse `\n` to space — keeps each PR on a single markdown list line
+- Omit fields when empty — cleaner output when `headRefName` or body is absent
+- Rejected: updating `cai-audit.md` to remove documented fields — the data was already fetched, so surfacing it is the right fix
+
+## Out of scope / known gaps
+- No changes to `cai-audit.md` — the agent definition already documents linked issue references
+
+## Invariants this change relies on
+- `recent_prs` gh query already includes `headRefName` and `body` in `--json` fields (cai.py:3222-3228)
+- Each PR occupies exactly one line in `prs_section` — newline collapsing preserves this

--- a/cai.py
+++ b/cai.py
@@ -3397,12 +3397,16 @@ def cmd_audit(args) -> int:
     if recent_prs:
         for pr in recent_prs:
             label_names = [lbl["name"] for lbl in pr.get("labels", [])]
+            head_ref = pr.get("headRefName", "")
+            body_snippet = (pr.get("body") or "")[:200].replace("\n", " ").strip()
             prs_section += (
                 f"- PR #{pr['number']}: {pr['title']} "
                 f"[{pr.get('state', 'unknown')}] "
                 f"(created {pr['createdAt']}"
                 f"{', merged ' + pr['mergedAt'] if pr.get('mergedAt') else ''})"
-                f"{' labels: ' + ', '.join(label_names) if label_names else ''}\n"
+                f"{' labels: ' + ', '.join(label_names) if label_names else ''}"
+                f"{' branch: ' + head_ref if head_ref else ''}"
+                f"{' body: ' + body_snippet if body_snippet else ''}\n"
             )
     else:
         prs_section += "(none)\n"


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#425

**Issue:** #425 — Audit user message omits PR body and headRefName needed for linked-issue checks

## PR Summary

### What this fixes
The `prs_section` string built for the audit agent's user message fetched `headRefName` and `body` from the GitHub API but never included them in the output, so the audit agent lacked the linked-issue reference data it needs to check whether merged PRs have their associated issues closed.

### What was changed
- **`cai.py` (lines 3399–3409)**: Added two local variables (`head_ref`, `body_snippet`) and two new f-string fragments to the `prs_section` loop — `branch: <headRefName>` (omitted if empty) and `body: <first 200 chars of body with newlines collapsed>` (omitted if empty).

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
