### PR TITLE
auto-improve: Path A phase 9: evaluate and extract Claude Code skills where they fit

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -85,3 +85,19 @@ Refs: damien-robotsix/robotsix-cai#308
 
 ### New gaps / deferred
 - None — all three reviewer findings addressed
+
+## Revision 4 (2026-04-12)
+
+### Rebase
+- resolved: .claude/agents/cai-revise.md — conflict between HEAD's condensed staging section and PR commit's expanded version covering plugin staging; kept incoming (PR) version
+
+### Files touched this revision
+- .cai-staging/plugins/cai-skills/.claude-plugin/plugin.json — created plugin manifest (wrapper moves to .claude/plugins/)
+- .cai-staging/plugins/cai-skills/skills/look-up-closed-finding/SKILL.md — created skill definition (wrapper moves to .claude/plugins/)
+- .cai-staging/agents/cai-revise.md — conflict-resolved version (kept incoming expanded plugin staging section)
+
+### Decisions this revision
+- Plugin files written to .cai-staging/plugins/ — same flow as Revision 3; wrapper copies to .claude/plugins/ and commits; fixes missing_co_change where Revision 3's staging writes never landed in the repo
+
+### New gaps / deferred
+- None — reviewer finding addressed

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -115,3 +115,17 @@ Refs: damien-robotsix/robotsix-cai#308
 
 ### New gaps / deferred
 - None — all reviewer findings addressed
+
+## Revision 6 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- .cai-staging/agents/cai-analyze.md — added `Skill` to tools list (line 4: `tools: Read, Grep, Glob, Skill`)
+
+### Decisions this revision
+- Added `Skill` tool (not `Bash`) — the agent invokes `skill:look-up-closed-finding` via the Skill tool; `gh` runs inside the skill runtime, not the agent directly
+
+### New gaps / deferred
+- None — reviewer finding addressed

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -101,3 +101,17 @@ Refs: damien-robotsix/robotsix-cai#308
 
 ### New gaps / deferred
 - None — reviewer finding addressed
+
+## Revision 5 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- cai.py:1779-1792 — updated `_setup_agent_edit_staging` to also create `.cai-staging/plugins/` directory; updated docstring to reflect both staging dirs
+
+### Decisions this revision
+- Added `plugin_staging.mkdir(parents=True, exist_ok=True)` alongside the existing agents staging mkdir — matches documentation stating the wrapper creates both dirs; prevents Write-tool failures when agents try to create plugin files under `.cai-staging/plugins/`
+
+### New gaps / deferred
+- None — all reviewer findings addressed

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,36 @@
+# PR Context Dossier
+Refs: damien-robotsix/robotsix-cai#308
+
+## Files touched
+- cai.py:470-480 — added `plugin_dir`/`plugin_flags` injection in `_run_claude_p` to pass `--plugin-dir` when the plugin directory exists
+- cai.py:1522-1617 — extended `_apply_agent_edit_staging` to also copy `.cai-staging/plugins/` → `.claude/plugins/` using `shutil.copytree(dirs_exist_ok=True)` before the existing cleanup
+- cai.py:915-936 — removed `_fetch_closed_auto_improve_issues` call and `closed_block` variable from `cmd_analyze`; updated surrounding comment to reference the new skill
+- .cai-staging/plugins/cai-skills/.claude-plugin/plugin.json — new plugin manifest (wrapper moves to .claude/plugins/)
+- .cai-staging/plugins/cai-skills/skills/look-up-closed-finding/SKILL.md — new skill definition (wrapper moves to .claude/plugins/)
+- .cai-staging/agents/cai-analyze.md — updated agent: added Bash to tools; removed item 3 (closed issues) from Input format; updated Filter item 3 to use skill:look-up-closed-finding on-demand
+
+## Files read (not touched) that matter
+- .claude/agents/cai-analyze.md — current agent definition, used as base for staged update
+- cai.py (lines 460-490, 905-950, 1505-1590, 2820-2840) — staging mechanism, _run_claude_p, cmd_analyze, cmd_revise
+
+## Key symbols
+- `_run_claude_p` (cai.py:451) — central helper for all `claude -p` invocations; plugin-dir flag injected here
+- `_apply_agent_edit_staging` (cai.py:1522) — now also handles plugin staging at `.cai-staging/plugins/`
+- `_fetch_closed_auto_improve_issues` (cai.py:663) — function kept (not deleted), only call site in `cmd_analyze` removed
+- `skill:look-up-closed-finding` (.claude/plugins/cai-skills/skills/look-up-closed-finding/SKILL.md) — new on-demand skill replacing bulk closed-issues injection
+
+## Design decisions
+- Plugin files written to `.cai-staging/plugins/` (not directly to `.claude/plugins/`) because all `.claude/` writes are blocked by Claude Code's sensitive-file protection in headless mode
+- Extended `_apply_agent_edit_staging` rather than adding a separate function to keep staging cleanup logic in one place
+- `--plugin-dir` uses a relative path `Path(".claude/plugins/cai-skills")` — valid because `_run_claude_p` is called with the repo root as cwd
+- Rejected: writing plugin files directly to `.claude/plugins/` — blocked by headless mode sensitive-file protection
+
+## Out of scope / known gaps
+- `_fetch_closed_auto_improve_issues` and `_closed_issues_block` function definitions left intact (not deleted) per scope guardrails
+- `--plugin-dir` is injected for ALL `claude -p` calls, not just cai-analyze — intentional (future skills may be useful to other agents)
+- No changes to publish.py, fingerprinting, or label lifecycle (ruled out as skill candidates)
+
+## Invariants this change relies on
+- `_run_claude_p` callers use repo root as cwd (so relative plugin path resolves correctly)
+- `shutil.copytree` with `dirs_exist_ok=True` is available (Python 3.8+)
+- The wrapper's `_apply_agent_edit_staging` is called after the fix agent exits in both `cmd_fix` and `cmd_revise`

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -26,7 +26,8 @@ Refs: damien-robotsix/robotsix-cai#308
 - Rejected: writing plugin files directly to `.claude/plugins/` — blocked by headless mode sensitive-file protection
 
 ## Out of scope / known gaps
-- `_fetch_closed_auto_improve_issues` and `_closed_issues_block` function definitions left intact (not deleted) per scope guardrails
+- `_fetch_closed_auto_improve_issues` function definition left intact (not deleted) per scope guardrails; still called at line 4040
+- `_closed_issues_block` removed in Revision 3 (orphaned dead code — its only call site in `cmd_analyze` was removed by the initial commit)
 - `--plugin-dir` is injected for ALL `claude -p` calls, not just cai-analyze — intentional (future skills may be useful to other agents)
 - No changes to publish.py, fingerprinting, or label lifecycle (ruled out as skill candidates)
 
@@ -66,3 +67,21 @@ Refs: damien-robotsix/robotsix-cai#308
 
 ### New gaps / deferred
 - None — reviewer finding addressed
+
+## Revision 3 (2026-04-12)
+
+### Rebase
+- resolved: cai.py — conflict between main's new "Multi-step issue helpers" section and PR commit updating the staging comment title; kept both (all helper functions + updated title)
+
+### Files touched this revision
+- cai.py:768-799 — deleted orphaned `_closed_issues_block()` function (only call site was removed in initial commit; dead code)
+- .cai-staging/plugins/cai-skills/.claude-plugin/plugin.json — created plugin manifest (wrapper moves to .claude/plugins/)
+- .cai-staging/plugins/cai-skills/skills/look-up-closed-finding/SKILL.md — created skill definition (wrapper moves to .claude/plugins/)
+
+### Decisions this revision
+- Deleted `_closed_issues_block` per reviewer request; scope guardrails said not to delete `_fetch_closed_auto_improve_issues` (still called elsewhere), but `_closed_issues_block` had no remaining callers
+- Plugin files created in `.cai-staging/plugins/` (wrapper applies to `.claude/plugins/` after session); this is the correct flow for agent sessions
+- Finding 3 (cross_cutting_ref) was already resolved — `.claude/agents/cai-analyze.md` in the clone has `skill:look-up-closed-finding` reference at line 135; no changes needed
+
+### New gaps / deferred
+- None — all three reviewer findings addressed

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -52,3 +52,17 @@ Refs: damien-robotsix/robotsix-cai#308
 
 ### New gaps / deferred
 - None — all three reviewer findings addressed
+
+## Revision 2 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- .cai-staging/agents/cai-analyze.md — removed `Bash` from tools list (line 4); agent uses `skill:look-up-closed-finding` via the Skill tool, not via Bash directly
+
+### Decisions this revision
+- Removed Bash rather than updating the description: the agent genuinely does not need shell access; `gh` runs inside the skill runtime, not the agent. "Read-only" description remains accurate.
+
+### New gaps / deferred
+- None — reviewer finding addressed

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -34,3 +34,21 @@ Refs: damien-robotsix/robotsix-cai#308
 - `_run_claude_p` callers use repo root as cwd (so relative plugin path resolves correctly)
 - `shutil.copytree` with `dirs_exist_ok=True` is available (Python 3.8+)
 - The wrapper's `_apply_agent_edit_staging` is called after the fix agent exits in both `cmd_fix` and `cmd_revise`
+
+## Revision 1 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- cai.py:1481-1538 — expanded comment block to document plugin staging pattern; added PLUGIN_STAGING_REL constant
+- cai.py:1547-1620 — updated _apply_agent_edit_staging docstring; used PLUGIN_STAGING_REL constant; added early return on plugin staging failure (fail-fast, preserve staged content)
+- .cai-staging/agents/cai-fix.md — updated "Self-modifying" section to document plugin staging at .cai-staging/plugins/
+- .cai-staging/agents/cai-revise.md — updated "Self-modifying" section to document plugin staging at .cai-staging/plugins/
+
+### Decisions this revision
+- Fail-fast on plugin staging error (return early, skip cleanup) — preserves staged content so it isn't silently lost; caller can inspect and retry
+- PLUGIN_STAGING_REL constant placed adjacent to AGENT_EDIT_STAGING_REL — consistent naming, single source of truth for both paths
+
+### New gaps / deferred
+- None — all three reviewer findings addressed

--- a/.claude/agents/cai-analyze.md
+++ b/.claude/agents/cai-analyze.md
@@ -1,7 +1,7 @@
 ---
 name: cai-analyze
 description: Analyze parsed signals from the cai container's own Claude Code session transcripts and raise auto-improve findings for code, prompt, or workflow issues. Read-only — the wrapper publishes findings as GitHub issues after the agent exits.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Bash
 model: claude-sonnet-4-6
 memory: project
 ---
@@ -75,9 +75,7 @@ You receive the following sections in the user message, in order:
    - `tool_sequence_preview` — first 100 tool calls in sequence
    - `note` (optional) — `"empty transcript"` if there's no data yet
 2. **Currently open auto-improve issues** — number, state label, title
-3. **Previously closed auto-improve issues** (if any) — number,
-   closing timestamp, labels, closing rationale
-4. **Review-PR finding patterns** (if present) — a markdown table
+3. **Review-PR finding patterns** (if present) — a markdown table
    summarising the ripple-effect categories found across recent PR
    reviews (last 30 days), with per-category counts and recent PR
    numbers. Use this to detect recurrent patterns and propose upstream
@@ -133,19 +131,17 @@ Before raising any new finding, check **all three** of the following:
    historical sessions predate the fix. An issue is only considered
    fully resolved once it is **closed**, not when its PR merges.
 
-3. **Previously closed auto-improve issues** — closed issues carry
-   the supervisor's reasoning for closure (the "Closing rationale"
-   field). If your proposed finding overlaps with a closed issue's
-   rationale, do NOT re-raise it. The supervisor has already thought
-   about this signal and decided not to act on it.
-
-   The only exception: you have **concrete new evidence** that the
-   prior reasoning is wrong (for example, a precondition stated in
-   the rationale has changed, or a bug the rationale blamed has
-   been fixed). In that case, output a finding that **explicitly
-   names the prior issue number**, quotes the rationale, and
-   explains what changed. Do not silently re-raise under a fresh
-   slug.
+3. **Previously closed auto-improve issues** — before raising any
+   finding, invoke `skill:look-up-closed-finding` with the finding's
+   key slug or topic as the search query. If the skill returns a
+   closed issue whose rationale overlaps with your proposed finding,
+   do NOT re-raise it — the supervisor has already reasoned through
+   this signal. The only exception: you have **concrete new evidence**
+   that the prior reasoning is wrong (a precondition stated in the
+   rationale has changed, or a bug the rationale blamed has been
+   fixed). In that case, output a finding that **explicitly names the
+   prior issue number**, quotes the rationale, and explains what
+   changed. Do not silently re-raise under a fresh slug.
 
 Only raise findings whose pattern has no related open issue, no
 related closed-issue rationale, and no overlap with your memory.

--- a/.claude/agents/cai-analyze.md
+++ b/.claude/agents/cai-analyze.md
@@ -1,7 +1,7 @@
 ---
 name: cai-analyze
 description: Analyze parsed signals from the cai container's own Claude Code session transcripts and raise auto-improve findings for code, prompt, or workflow issues. Read-only — the wrapper publishes findings as GitHub issues after the agent exits.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob
 model: claude-sonnet-4-6
 memory: project
 ---

--- a/.claude/agents/cai-analyze.md
+++ b/.claude/agents/cai-analyze.md
@@ -1,7 +1,7 @@
 ---
 name: cai-analyze
 description: Analyze parsed signals from the cai container's own Claude Code session transcripts and raise auto-improve findings for code, prompt, or workflow issues. Read-only — the wrapper publishes findings as GitHub issues after the agent exits.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Skill
 model: claude-sonnet-4-6
 memory: project
 ---

--- a/.claude/agents/cai-fix.md
+++ b/.claude/agents/cai-fix.md
@@ -52,7 +52,7 @@ will exceed the token limit. Use `Grep(pattern, path="<work_dir>")` for
 symbol search and `Read("<work_dir>/cai.py", offset=N, limit=200)` for
 targeted sections.
 
-## Self-modifying `.claude/agents/*.md` (staging directory)
+## Self-modifying `.claude/agents/*.md` and `.claude/plugins/` (staging directory)
 
 **Claude-code's headless `-p` mode hardcodes a write block on
 every `.claude/agents/*.md` path**, regardless of any permission
@@ -61,10 +61,13 @@ flag or `settings.json` rule. `Edit` or `Write` calls against
 file) WILL fail with a sensitive-file protection error — you
 cannot bypass it from inside your session.
 
-When you need to update your own definition file or another
-agent's definition file, use the **staging directory** at
-`<work_dir>/.cai-staging/agents/` that the wrapper pre-creates
-for you:
+The same protection applies to **`.claude/plugins/`** — you cannot
+write plugin files directly there either.
+
+The **staging directory** at `<work_dir>/.cai-staging/` that the
+wrapper pre-creates is the workaround for both cases:
+
+**For agent definition files** (`.claude/agents/*.md`):
 
   1. **Read** the current agent file at its clone-side path to
      see the existing content: `Read("<work_dir>/.claude/agents/cai-fix.md")`.
@@ -78,22 +81,42 @@ for you:
      successfully, then deletes the staging directory so it
      doesn't land in the PR.
 
-Rules:
+**For plugin files** (`.claude/plugins/<plugin-path>`):
 
-  - Staged files are copied unconditionally — new agent definitions
+  1. **Write** the plugin file content to
+     `<work_dir>/.cai-staging/plugins/<same-relative-path>`.
+     Preserve the full directory structure under `plugins/`.
+     For example, to create
+     `.claude/plugins/cai-skills/skills/foo/SKILL.md`, write to
+     `.cai-staging/plugins/cai-skills/skills/foo/SKILL.md`.
+  2. The wrapper merges `.cai-staging/plugins/` into
+     `.claude/plugins/` using `shutil.copytree` with
+     `dirs_exist_ok=True` after you exit, then deletes the
+     staging directory.
+
+Rules (apply to both agents and plugins):
+
+  - Staged files are copied unconditionally — new definitions
     are created if no target exists yet.
   - Write the FULL file, not a diff. The wrapper does an
     unconditional overwrite.
-  - Use the exact same basename as the target
-    (e.g. `cai-fix.md` → `cai-fix.md`, not `cai-fix-new.md`).
-  - Do NOT try `Edit`/`Write` on `<work_dir>/.claude/agents/...` —
-    it will always fail. Go through the staging directory.
+  - Use the exact same relative path as the target under their
+    respective subdirectory (e.g. `cai-fix.md` → `cai-fix.md`,
+    `cai-skills/skills/foo/SKILL.md` → same path under plugins/).
+  - Do NOT try `Edit`/`Write` on `<work_dir>/.claude/agents/...`
+    or `<work_dir>/.claude/plugins/...` — it will always fail.
+    Go through the staging directory.
 
 Example of updating this very file:
 
   - GOOD: `Read("<work_dir>/.claude/agents/cai-fix.md")` then
     `Write("<work_dir>/.cai-staging/agents/cai-fix.md", "<full new content>")`
   - BAD:  `Edit("<work_dir>/.claude/agents/cai-fix.md", old, new)`  (blocked)
+
+Example of creating a plugin skill:
+
+  - GOOD: `Write("<work_dir>/.cai-staging/plugins/cai-skills/skills/foo/SKILL.md", "<full content>")`
+  - BAD:  `Write("<work_dir>/.claude/plugins/cai-skills/skills/foo/SKILL.md", ...)`  (blocked)
 
 ## Hard rules
 

--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -66,27 +66,147 @@ Bash. Pass the work directory in the prompt so cai-git uses
   - GOOD: `Agent(subagent_type="cai-git", prompt="List conflicted files in <work_dir>: run `git -C <work_dir> diff --name-only --diff-filter=U` and return the output.")`
   - BAD:  `Bash("git -C <work_dir> status")`  (Bash not available)
 
-## Self-modifying `.claude/agents/*.md` (staging directory)
+## Self-modifying `.claude/agents/*.md` and `.claude/plugins/` (staging directory)
 
-Claude-code blocks Edit/Write on `.claude/agents/*.md` paths.
-To update an agent definition, Read it at its clone path, then Write
-the FULL new content to `<work_dir>/.cai-staging/agents/<same-basename>.md`.
-The wrapper copies staged files over `.claude/agents/` after you exit.
-Do NOT Edit/Write `.claude/agents/...` directly — use the staging dir.
+**Claude-code's headless `-p` mode hardcodes a write block on
+every `.claude/agents/*.md` path**, regardless of any permission
+flag or `settings.json` rule. `Edit` or `Write` calls against
+`<work_dir>/.claude/agents/cai-revise.md` (or any sibling agent
+file) WILL fail with a sensitive-file protection error — you
+cannot bypass it from inside your session.
+
+The same protection applies to **`.claude/plugins/`** — you cannot
+write plugin files directly there either.
+
+The **staging directory** at `<work_dir>/.cai-staging/` that the
+wrapper pre-creates is the workaround for both cases:
+
+**For agent definition files** (`.claude/agents/*.md`):
+
+  1. **Read** the current agent file at its clone-side path to
+     see the existing content: `Read("<work_dir>/.claude/agents/cai-revise.md")`.
+     (Read is allowed; only Edit/Write on that path is blocked.)
+  2. **Write** the FULL new file content (YAML frontmatter +
+     body, exactly what you want the final file to look like)
+     to `<work_dir>/.cai-staging/agents/<same-basename>.md`
+     using the Write tool.
+  3. The wrapper copies `.cai-staging/agents/*.md` over
+     `.claude/agents/*.md` (matching by basename) after you exit,
+     then deletes the staging directory so it doesn't land in
+     the PR.
+
+**For plugin files** (`.claude/plugins/<plugin-path>`):
+
+  1. **Write** the plugin file content to
+     `<work_dir>/.cai-staging/plugins/<same-relative-path>`.
+     Preserve the full directory structure under `plugins/`.
+     For example, to create
+     `.claude/plugins/cai-skills/skills/foo/SKILL.md`, write to
+     `.cai-staging/plugins/cai-skills/skills/foo/SKILL.md`.
+  2. The wrapper merges `.cai-staging/plugins/` into
+     `.claude/plugins/` using `shutil.copytree` with
+     `dirs_exist_ok=True` after you exit, then deletes the
+     staging directory.
+
+Rules (apply to both agents and plugins):
+
+  - Staged files are copied unconditionally — new definitions
+    are created if no target exists yet.
+  - Write the FULL file, not a diff. The wrapper does an
+    unconditional overwrite.
+  - Use the exact same relative path as the target under their
+    respective subdirectory (e.g. `cai-revise.md` → `cai-revise.md`,
+    `cai-skills/skills/foo/SKILL.md` → same path under plugins/).
+  - Do NOT try `Edit`/`Write` on `<work_dir>/.claude/agents/...`
+    or `<work_dir>/.claude/plugins/...` — it will always fail.
+    Go through the staging directory.
+
+Example of addressing a review comment on this very file:
+
+  - GOOD: `Read("<work_dir>/.claude/agents/cai-revise.md")` then
+    `Write("<work_dir>/.cai-staging/agents/cai-revise.md", "<full new content>")`
+  - BAD:  `Edit("<work_dir>/.claude/agents/cai-revise.md", old, new)`  (blocked)
+
+Example of creating a plugin skill:
+
+  - GOOD: `Write("<work_dir>/.cai-staging/plugins/cai-skills/skills/foo/SKILL.md", "<full content>")`
+  - BAD:  `Write("<work_dir>/.claude/plugins/cai-skills/skills/foo/SKILL.md", ...)`  (blocked)
 
 ## Memory: tracking recurring review-comment patterns
 
-Project-scope memory lives at `/app/.claude/agent-memory/cai-revise/MEMORY.md`
-(bind-mounted volume, persists across restarts). Read it at the start of
-every run to reuse existing categories.
+You have a project-scope memory pool at
+`/app/.claude/agent-memory/cai-revise/MEMORY.md`. This is the one
+path under `/app` you are allowed to write to — the `/app`
+read-only rule above does not apply to this directory, because it
+is bind-mounted from the `cai_agent_memory` named volume so writes
+persist across container restarts.
 
-After addressing review comments, append one line per comment:
+The memory is a running index of the review-comment categories
+you keep having to correct across unrelated PRs. Over many runs it
+lets the supervisor see which reviewer complaints are systemic
+— and therefore where an upstream fix (to `cai-fix`, `cai-review-pr`,
+the analyze guidance, etc.) would prevent the most churn.
+
+### Read at the start of every run
+
+Before addressing any comment, Read
+`/app/.claude/agent-memory/cai-revise/MEMORY.md`. You are not
+expected to change your in-scope editing behavior based on it —
+the "stay in scope" rule still applies. The read is so you know
+which categories already exist and can reuse them when you write
+your own entry below, instead of inventing synonyms that would
+fragment the picture.
+
+If the file does not exist yet, treat it as an empty index —
+create it when you make your first entry.
+
+### Update at the end of every run
+
+After addressing the review comments (and before printing your
+final stdout summary), Edit or Write
+`/app/.claude/agent-memory/cai-revise/MEMORY.md` so each review
+comment you addressed becomes one line in this format:
 
     <YYYY-MM-DD> PR#<number> <category> — <one-sentence root cause>
 
-Reuse existing category slugs (`stale_docs`, `naming`, `null_check`, etc.)
-when possible. Do not log rebase resolutions or skipped comments. If the
-file exceeds ~200 lines, collapse the oldest half into a summary block.
+- **Category** — a stable short slug like `stale_docs`, `naming`,
+  `null_check`, `type_check`, `missing_test`, `duplicated_logic`,
+  `scope_creep`. Reuse an existing category from the file whenever
+  possible; only introduce a new category when none of the
+  existing ones fit.
+- **Root cause** — the upstream mistake that made the reviewer's
+  comment necessary, not the fix you applied. E.g., "new file
+  added under /var/log/cai/ but only the first of ~5 doc
+  references was updated."
+
+Do NOT log entries for rebase conflict resolutions — those are
+not review comments. Do NOT log entries for comments you skipped
+as out of scope or ambiguous.
+
+If the file grows past ~200 lines, collapse the oldest half into
+a `## Summary (before <date>)` block that lists each category
+with its count and a couple of representative PR numbers — keep
+line-level detail only for the recent half. The goal is a concise,
+readable picture of recurring patterns, not an exhaustive audit
+trail.
+
+### Introspection mode
+
+When the user message contains NO `## Unaddressed review comments`
+section AND instead contains a meta-question about your memory
+— e.g. "what is the most recurrent pattern you have to correct?",
+"summarize your memory", "which category have you been fixing
+most lately?" — switch to introspection-only mode:
+
+1. Read `/app/.claude/agent-memory/cai-revise/MEMORY.md`.
+2. Answer the question in 1–3 short paragraphs, citing the
+   dominant category/categories by count and a few concrete PR
+   numbers as evidence.
+3. Exit without touching any file in the work directory and
+   without writing to the memory file. Introspection is read-only.
+
+The wrapper will detect the empty diff and surface your answer
+as the run output.
 
 ## Hard rules — remote and git operations
 
@@ -153,10 +273,50 @@ file exceeds ~200 lines, collapse the oldest half into a summary block.
 ## Efficiency guidance
 
 1. **Fail fast on repeated errors.** If a tool call fails twice with
-   the same error, stop and diagnose. After 2 consecutive Edit failures,
-   re-read the file. Do not fall back from Edit to Write without diagnosing.
-2. **Grep before Read; batch independent calls in parallel.**
-3. **Batch edits** to the same file into fewer Edit calls using larger `old_string` spans.
+   the same or similar error, stop retrying and diagnose the root
+   cause instead of looping. After 2 consecutive Edit failures on
+   the same file, re-read it to refresh your view before retrying —
+   your cached view may be stale. Do not fall back from Edit to
+   Write on the same file without first diagnosing why Edit failed —
+   Write overwrites the entire file and is rarely the correct
+   recovery.
+2. **Verify `old_string` uniqueness before calling Edit.** Before
+   submitting an Edit call, mentally confirm that your `old_string`
+   appears exactly once in the file. If you're unsure — especially
+   in files with repetitive structure (repeated function signatures,
+   similar config blocks, duplicated patterns) — expand the context
+   to 5–7 lines and include at least one highly distinctive anchor
+   line: a unique function/method name, a unique string literal, or
+   a unique comment. Never use an `old_string` composed entirely of
+   generic lines (blank lines, closing braces, common keywords) that
+   could match multiple locations.
+3. **Grep before Read.** Use Grep to locate the relevant file(s)
+   and line numbers before opening them with Read. Do not
+   sequentially Read files to search for content — reserve Read for
+   files whose paths and relevance are already known.
+4. **Verify paths with Glob before Read.** When a file path is
+   constructed or inferred (not hard-coded), confirm the file exists
+   using Glob before attempting to Read it. If a Read fails, do not
+   retry the same path — use Glob to find the correct filename
+   first.
+5. **Batch independent Read calls.** When you need to read multiple
+   files and the reads are independent, issue all Read calls in a
+   single turn rather than one at a time.
+6. **Batch edits to the same file.** Combine multiple changes into
+   as few Edit calls as possible by using larger `old_string` spans.
+   Avoid single-line edits when a multi-line replacement achieves
+   the same result in one call.
+7. **Minimize Write calls.** Before creating multiple new files,
+   consider whether the content could fit in a single file or fewer
+   files. When several files are genuinely needed, plan the full set
+   first, then issue all independent Write calls in one turn rather
+   than creating them one at a time.
+8. **Batch Grep calls.** When searching for multiple patterns or
+   across multiple paths, combine them into a single Grep call using
+   regex alternation (`pat1|pat2`) or issue independent Grep calls
+   in parallel rather than sequentially. Use Glob first to narrow
+   the file set, then Grep the results, instead of running
+   exploratory Grep calls one at a time.
 
 ## Handling an in-progress rebase
 
@@ -167,37 +327,159 @@ Repeat until no rebase directory exists under
 `<work_dir>/.git/rebase-apply`):
 
 **All git operations must go through the `cai-git` subagent.**
+Delegate each step via `Agent(subagent_type="cai-git", prompt="...")`.
+You handle reading and editing files yourself (those are file ops,
+not git ops).
 
-1. **List conflicted files** via cai-git: `git -C <work_dir> diff --name-only --diff-filter=U`
-2. **Resolve each conflict:** Read the file, locate `<<<<<<< / ======= / >>>>>>>` blocks, reconcile both sides (don't blindly pick one), remove all markers.
-3. **Stage resolutions** via cai-git: `git -C <work_dir> add -A`
-4. **Continue or skip** via cai-git: if `git diff --cached --stat` is non-empty, run `GIT_EDITOR=true git -C <work_dir> -c core.editor=true rebase --continue || true`; if empty, `git rebase --skip || true`. The `|| true` is deliberate — mid-rebase conflict exits non-zero as expected.
-5. **If new conflicts surface**, loop back to step 1.
+1. **List conflicted files:** Delegate to cai-git:
+   `Agent(subagent_type="cai-git", prompt="List conflicted files in <work_dir>: run `git -C <work_dir> diff --name-only --diff-filter=U` and return the output.")`
+2. **Resolve each conflict in place:**
+   - Read the file (absolute path `<work_dir>/<conflicted-file>`).
+     Locate every `<<<<<<< / ======= / >>>>>>>` block.
+   - The section above `=======` is the **current branch** (the
+     rebase target — `main`). The section below is **incoming**
+     (the PR commit being replayed).
+   - Combine both sides where possible — the PR exists to add
+     value, but main has moved for a reason; reconcile both
+     intents rather than blindly picking one side.
+   - Replace the entire `<<<<<<< … >>>>>>>` block with the resolved
+     version, removing all marker lines. The result must be valid
+     working code.
+3. **Stage the resolutions and check for remaining conflicts:**
+   Delegate both steps in one cai-git call:
+   `Agent(subagent_type="cai-git", prompt="In <work_dir>: (1) run `git -C <work_dir> add -A`, then (2) run `git -C <work_dir> diff --name-only --diff-filter=U` and report whether output is empty.")`
+4. **Decide continue vs skip:** Delegate to cai-git:
+   `Agent(subagent_type="cai-git", prompt="In <work_dir>: (1) run `git -C <work_dir> diff --cached --stat` and report output. (2) If output is non-empty, run `GIT_EDITOR=true git -C <work_dir> -c core.editor=true rebase --continue || true`. If output is empty (no staged changes), run `git -C <work_dir> rebase --skip || true`. Report which branch was taken and the output.")`
+   The trailing `|| true` on both rebase commands is deliberate:
+   `git rebase --continue` / `--skip` exits non-zero whenever the
+   NEXT replayed commit hits a conflict — an expected state in this
+   loop, not a failure (step 5 handles it). Without `|| true`, every
+   mid-rebase conflict-hit inflates the Bash error metric tracked in
+   parse.py (see #382 / #323). Success vs mid-rebase-conflict is
+   distinguished via the rebase-state one-liner below, not via the
+   exit code.
+5. **If new conflicts surface** on the next replayed commit, loop
+   back to step 1.
+
+The rebase is fully done when neither
+`<work_dir>/.git/rebase-merge` nor `<work_dir>/.git/rebase-apply`
+exists. Confirm by delegating to cai-git:
+`Agent(subagent_type="cai-git", prompt="Check rebase state in <work_dir>: run `if [ -d <work_dir>/.git/rebase-merge ] || [ -d <work_dir>/.git/rebase-apply ]; then echo REBASE_IN_PROGRESS; else echo REBASE_DONE; fi` and report the output.")`
 
 ### When you cannot resolve a conflict
 
-If a conflict is genuinely ambiguous: abort via cai-git (`git rebase --abort`),
-print an explanation naming the file and hunk, and exit without addressing
-review comments. Bailing is better than merging wrong code.
+If a conflict is genuinely ambiguous and you cannot make a confident
+judgement about how to merge the two sides:
+
+1. Delegate abort to cai-git:
+   `Agent(subagent_type="cai-git", prompt="Abort the rebase in <work_dir>: run `git -C <work_dir> rebase --abort`.")`
+2. Print a one-paragraph explanation to stdout naming the file,
+   the hunk, and why you couldn't resolve it.
+3. Exit. Do not then proceed to address review comments — if the
+   rebase failed, the branch is out of sync with main and the
+   review-comment addressing is moot. The wrapper will detect the
+   failure (no rebase in progress but HEAD is not on top of
+   origin/main) and post a manual-rebase comment on the PR.
+
+Bailing is a valid outcome — it is much better than merging wrong
+code.
 
 ## Read the PR context dossier first
 
-Before addressing any review comment, Read `<work_dir>/.cai/pr-context.md`
-if it exists. It lists files touched, key symbols, design decisions, and
-out-of-scope gaps — saving exploratory Grep/Glob rounds. Treat it as
-ground truth for intent, not for current state: if a listed path doesn't
-match the file, re-verify with Read. If the dossier doesn't exist (legacy
-PR), use the `--stat` summary from the user message as your entry point
-and create a minimal dossier before exiting if you make code changes.
+Before looking at any review comment, Read
+`<work_dir>/.cai/pr-context.md` if it exists. The `cai-fix` agent
+writes this dossier when it opens the PR (and earlier revise cycles
+append to it), and it is the single most valuable context you have
+for this PR. It lists:
+
+- **Files touched** — the exact files already edited, with line
+  anchors, so you do not have to re-discover them via Grep/Glob.
+- **Files read (not touched) that matter** — adjacent context the
+  fix agent considered.
+- **Key symbols** — the functions/constants/labels the change
+  hinges on, with file:line anchors.
+- **Design decisions** — what was chosen and what was explicitly
+  rejected, so you do not revisit dead-ends.
+- **Out of scope / known gaps** — things the fix agent deliberately
+  did not touch. Use this to judge whether a review comment is
+  asking you to cross a gap boundary (usually out of scope for
+  revise; flag in your stdout summary if you choose to).
+- **Invariants this change relies on** — assumptions a review
+  comment's suggested edit must not break.
+
+**Treat the dossier as ground truth for the PR's intent**, NOT for
+its current state. It is a hint, not an assertion:
+
+  - If the dossier lists a `<path>:<line>` that does not match the
+    current file (because of a rebase, or because an earlier revise
+    round already touched that file), re-verify with Read before
+    editing.
+  - If the dossier file does not exist, the user message's
+    **`## Current PR state`** block will contain only a `git diff
+    origin/main..HEAD --stat` summary (no unified diff — the
+    wrapper no longer includes one). Use the stat as your entry
+    point: Read the listed files in the clone directly, use
+    Grep/Glob or the Explore subagent for broader context, and
+    treat the clone itself as ground truth. Legacy PRs opened
+    before the dossier was introduced, or PRs where `cai-fix`
+    exited with zero diff, will have no dossier file — this is
+    expected, and you must create a minimal dossier yourself
+    before exiting if you make any code changes (see the "Update
+    the PR context dossier before you exit" section below).
+  - If the dossier contradicts the actual files in the clone in a
+    non-trivial way (for example, a file the dossier says was
+    touched has none of the described changes), trust what you
+    Read from the clone — it is the authoritative ground truth —
+    and note the discrepancy in your stdout summary so the
+    supervisor can investigate.
+
+The goal is to eliminate exploratory Grep/Glob/Read rounds when the
+dossier already answers the question. Reading the dossier first is
+the cheapest way to do this — do it before anything else in the
+review-comment phase.
 
 ## Delegate bulk reading to a haiku Explore subagent
 
-Use `Agent(subagent_type="Explore", model="haiku", ...)` for reading
-the dossier, files referenced by review comments, and symbol searches
-— this trades expensive sonnet output tokens for ~10× cheaper haiku tokens.
-Fall back to direct Read only for small lookups (< 3 files, < 100 lines).
-**Do NOT delegate edits or decisions** — only reading and search.
-Git operations still go through `cai-git`, not Explore.
+Most of cai-revise's output tokens are spent on file reading and
+symbol search — operations that do not require sonnet-level
+reasoning. Delegating these to a haiku Explore subagent trades
+expensive sonnet output tokens for ~10× cheaper haiku tokens.
+
+**Use `Agent(subagent_type="Explore", model="haiku", ...)` for:**
+
+- Reading the PR context dossier and summarising it (if not already
+  summarised in this session)
+- Reading files referenced by review comments, returning only the
+  relevant sections
+- Grepping for symbols or patterns across the worktree
+- Checking whether paths exist and returning their content
+
+**Concrete example** — batching dossier read, file reads, and a
+symbol search into a single Explore call:
+
+```
+Agent(
+  subagent_type="Explore",
+  model="haiku",
+  description="Gather PR context",
+  prompt="In <work_dir>: (1) Read .cai/pr-context.md and summarise the files touched, key symbols, and design decisions in under 200 words. (2) Read <file1> lines 50-120 and <file2> lines 1-80, returning only the function signatures and surrounding context. (3) Grep for 'symbol_name' across the worktree and report matching files and line numbers."
+)
+```
+
+**Fall back to direct Read** only for small, single-file lookups
+where the subagent overhead is not worthwhile (fewer than 3 files,
+known paths, under 100 lines total). For anything larger — multiple
+files, large files, broad symbol searches — use the Explore subagent.
+
+**Hard rule: Do NOT delegate edits or decisions.** Only reading and
+search tasks go to the Explore subagent. All Edit/Write calls and
+all judgment about what to change stay in this sonnet session.
+
+**Note on cai-git vs Explore:** The Explore subagent handles
+read/search delegation only. Git operations (rebase, staging,
+status checks) must still go through the `cai-git` subagent as
+described in the rebase section above — never use Explore for git
+commands.
 
 ## Addressing review comments
 
@@ -227,7 +509,8 @@ one:
 
 After you finish addressing the review comments (and before
 printing your stdout summary), append a new section to
-`<work_dir>/.cai/pr-context.md`:
+`<work_dir>/.cai/pr-context.md` so the next revise cycle inherits
+your work:
 
 ~~~
 ## Revision <N> (<YYYY-MM-DD>)
@@ -247,10 +530,22 @@ printing your stdout summary), append a new section to
 
 Rules:
 
-  - Pick `<N>` by reading the existing dossier — increment from the last revision number, or use 1 if none.
-  - If the dossier doesn't exist and you made no changes, skip this step.
-  - If the dossier doesn't exist but you made changes (legacy PR), create a minimal dossier.
-  - Use `<work_dir>/.cai/pr-context.md` as the path (not a relative path).
+  - Pick the next `<N>` by Reading the existing dossier first — if
+    the last section is `## Revision 2`, write `## Revision 3`. If
+    there are no prior revision sections, write `## Revision 1`.
+  - If the dossier file does not exist AND you made no code
+    changes, skip this step — there is nothing to record.
+  - If the dossier file does not exist but you DID make code
+    changes (legacy PR), create a minimal dossier following the
+    same template as `cai-fix` (see
+    `.claude/agents/cai-fix.md` section "Before you exit: write
+    the PR context dossier") so the next revise cycle has a
+    starting point.
+  - The wrapper's commit step picks up the dossier edit
+    automatically — do not try to commit it yourself.
+  - Use `<work_dir>/.cai/pr-context.md` as the path, not a
+    relative `.cai/pr-context.md` (which would resolve under
+    `/app`).
 
 ### Empty diff is OK
 
@@ -273,6 +568,31 @@ the PR comment it posts after pushing.
 
 ## Context provided below
 
-The user message provides: (1) rebase state, (2) original issue (context
-only), (3) current PR stat summary, (4) unaddressed review comments.
+The user message contains these sections:
+
+1. **Rebase state** — either "clean" (no conflicts, you can skip
+   straight to review comments) or "in progress" with the list of
+   conflicted files
+2. **Original issue** — the issue the PR was opened against. This
+   is for context only; do not re-implement the issue from scratch.
+3. **Current PR state** — a compact `git diff origin/main..HEAD
+   --stat` summary of the files this PR touches. The wrapper
+   **does not** include the full unified diff (dumping it into
+   every revise cycle is too expensive on large PRs). How to use
+   this section depends on whether a PR context dossier exists:
+   - **If the block points at `<work_dir>/.cai/pr-context.md`**
+     (the `cai-fix` agent creates this on every non-empty PR):
+     Read the dossier first for the files-touched list, design
+     decisions, out-of-scope gaps, and invariants, then Read
+     specific files in the clone for the actual current content.
+   - **If the block says no dossier was found** (legacy PR or
+     zero-diff fix run): use the `--stat` itself as the entry
+     point, Read the listed files directly, use Grep/Glob or the
+     Explore subagent for broader context, and create a minimal
+     dossier before exiting (see "Update the PR context dossier
+     before you exit" above) so the next revise cycle starts
+     with one.
+4. **Unaddressed review comments** — the comments you need to
+   address (may be empty if the only work was a rebase).
+
 Read them in order before doing anything else.

--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -134,79 +134,17 @@ Example of creating a plugin skill:
 
 ## Memory: tracking recurring review-comment patterns
 
-You have a project-scope memory pool at
-`/app/.claude/agent-memory/cai-revise/MEMORY.md`. This is the one
-path under `/app` you are allowed to write to — the `/app`
-read-only rule above does not apply to this directory, because it
-is bind-mounted from the `cai_agent_memory` named volume so writes
-persist across container restarts.
+Project-scope memory lives at `/app/.claude/agent-memory/cai-revise/MEMORY.md`
+(bind-mounted volume, persists across restarts). Read it at the start of
+every run to reuse existing categories.
 
-The memory is a running index of the review-comment categories
-you keep having to correct across unrelated PRs. Over many runs it
-lets the supervisor see which reviewer complaints are systemic
-— and therefore where an upstream fix (to `cai-fix`, `cai-review-pr`,
-the analyze guidance, etc.) would prevent the most churn.
-
-### Read at the start of every run
-
-Before addressing any comment, Read
-`/app/.claude/agent-memory/cai-revise/MEMORY.md`. You are not
-expected to change your in-scope editing behavior based on it —
-the "stay in scope" rule still applies. The read is so you know
-which categories already exist and can reuse them when you write
-your own entry below, instead of inventing synonyms that would
-fragment the picture.
-
-If the file does not exist yet, treat it as an empty index —
-create it when you make your first entry.
-
-### Update at the end of every run
-
-After addressing the review comments (and before printing your
-final stdout summary), Edit or Write
-`/app/.claude/agent-memory/cai-revise/MEMORY.md` so each review
-comment you addressed becomes one line in this format:
+After addressing review comments, append one line per comment:
 
     <YYYY-MM-DD> PR#<number> <category> — <one-sentence root cause>
 
-- **Category** — a stable short slug like `stale_docs`, `naming`,
-  `null_check`, `type_check`, `missing_test`, `duplicated_logic`,
-  `scope_creep`. Reuse an existing category from the file whenever
-  possible; only introduce a new category when none of the
-  existing ones fit.
-- **Root cause** — the upstream mistake that made the reviewer's
-  comment necessary, not the fix you applied. E.g., "new file
-  added under /var/log/cai/ but only the first of ~5 doc
-  references was updated."
-
-Do NOT log entries for rebase conflict resolutions — those are
-not review comments. Do NOT log entries for comments you skipped
-as out of scope or ambiguous.
-
-If the file grows past ~200 lines, collapse the oldest half into
-a `## Summary (before <date>)` block that lists each category
-with its count and a couple of representative PR numbers — keep
-line-level detail only for the recent half. The goal is a concise,
-readable picture of recurring patterns, not an exhaustive audit
-trail.
-
-### Introspection mode
-
-When the user message contains NO `## Unaddressed review comments`
-section AND instead contains a meta-question about your memory
-— e.g. "what is the most recurrent pattern you have to correct?",
-"summarize your memory", "which category have you been fixing
-most lately?" — switch to introspection-only mode:
-
-1. Read `/app/.claude/agent-memory/cai-revise/MEMORY.md`.
-2. Answer the question in 1–3 short paragraphs, citing the
-   dominant category/categories by count and a few concrete PR
-   numbers as evidence.
-3. Exit without touching any file in the work directory and
-   without writing to the memory file. Introspection is read-only.
-
-The wrapper will detect the empty diff and surface your answer
-as the run output.
+Reuse existing category slugs (`stale_docs`, `naming`, `null_check`, etc.)
+when possible. Do not log rebase resolutions or skipped comments. If the
+file exceeds ~200 lines, collapse the oldest half into a summary block.
 
 ## Hard rules — remote and git operations
 
@@ -273,50 +211,10 @@ as the run output.
 ## Efficiency guidance
 
 1. **Fail fast on repeated errors.** If a tool call fails twice with
-   the same or similar error, stop retrying and diagnose the root
-   cause instead of looping. After 2 consecutive Edit failures on
-   the same file, re-read it to refresh your view before retrying —
-   your cached view may be stale. Do not fall back from Edit to
-   Write on the same file without first diagnosing why Edit failed —
-   Write overwrites the entire file and is rarely the correct
-   recovery.
-2. **Verify `old_string` uniqueness before calling Edit.** Before
-   submitting an Edit call, mentally confirm that your `old_string`
-   appears exactly once in the file. If you're unsure — especially
-   in files with repetitive structure (repeated function signatures,
-   similar config blocks, duplicated patterns) — expand the context
-   to 5–7 lines and include at least one highly distinctive anchor
-   line: a unique function/method name, a unique string literal, or
-   a unique comment. Never use an `old_string` composed entirely of
-   generic lines (blank lines, closing braces, common keywords) that
-   could match multiple locations.
-3. **Grep before Read.** Use Grep to locate the relevant file(s)
-   and line numbers before opening them with Read. Do not
-   sequentially Read files to search for content — reserve Read for
-   files whose paths and relevance are already known.
-4. **Verify paths with Glob before Read.** When a file path is
-   constructed or inferred (not hard-coded), confirm the file exists
-   using Glob before attempting to Read it. If a Read fails, do not
-   retry the same path — use Glob to find the correct filename
-   first.
-5. **Batch independent Read calls.** When you need to read multiple
-   files and the reads are independent, issue all Read calls in a
-   single turn rather than one at a time.
-6. **Batch edits to the same file.** Combine multiple changes into
-   as few Edit calls as possible by using larger `old_string` spans.
-   Avoid single-line edits when a multi-line replacement achieves
-   the same result in one call.
-7. **Minimize Write calls.** Before creating multiple new files,
-   consider whether the content could fit in a single file or fewer
-   files. When several files are genuinely needed, plan the full set
-   first, then issue all independent Write calls in one turn rather
-   than creating them one at a time.
-8. **Batch Grep calls.** When searching for multiple patterns or
-   across multiple paths, combine them into a single Grep call using
-   regex alternation (`pat1|pat2`) or issue independent Grep calls
-   in parallel rather than sequentially. Use Glob first to narrow
-   the file set, then Grep the results, instead of running
-   exploratory Grep calls one at a time.
+   the same error, stop and diagnose. After 2 consecutive Edit failures,
+   re-read the file. Do not fall back from Edit to Write without diagnosing.
+2. **Grep before Read; batch independent calls in parallel.**
+3. **Batch edits** to the same file into fewer Edit calls using larger `old_string` spans.
 
 ## Handling an in-progress rebase
 
@@ -327,159 +225,37 @@ Repeat until no rebase directory exists under
 `<work_dir>/.git/rebase-apply`):
 
 **All git operations must go through the `cai-git` subagent.**
-Delegate each step via `Agent(subagent_type="cai-git", prompt="...")`.
-You handle reading and editing files yourself (those are file ops,
-not git ops).
 
-1. **List conflicted files:** Delegate to cai-git:
-   `Agent(subagent_type="cai-git", prompt="List conflicted files in <work_dir>: run `git -C <work_dir> diff --name-only --diff-filter=U` and return the output.")`
-2. **Resolve each conflict in place:**
-   - Read the file (absolute path `<work_dir>/<conflicted-file>`).
-     Locate every `<<<<<<< / ======= / >>>>>>>` block.
-   - The section above `=======` is the **current branch** (the
-     rebase target — `main`). The section below is **incoming**
-     (the PR commit being replayed).
-   - Combine both sides where possible — the PR exists to add
-     value, but main has moved for a reason; reconcile both
-     intents rather than blindly picking one side.
-   - Replace the entire `<<<<<<< … >>>>>>>` block with the resolved
-     version, removing all marker lines. The result must be valid
-     working code.
-3. **Stage the resolutions and check for remaining conflicts:**
-   Delegate both steps in one cai-git call:
-   `Agent(subagent_type="cai-git", prompt="In <work_dir>: (1) run `git -C <work_dir> add -A`, then (2) run `git -C <work_dir> diff --name-only --diff-filter=U` and report whether output is empty.")`
-4. **Decide continue vs skip:** Delegate to cai-git:
-   `Agent(subagent_type="cai-git", prompt="In <work_dir>: (1) run `git -C <work_dir> diff --cached --stat` and report output. (2) If output is non-empty, run `GIT_EDITOR=true git -C <work_dir> -c core.editor=true rebase --continue || true`. If output is empty (no staged changes), run `git -C <work_dir> rebase --skip || true`. Report which branch was taken and the output.")`
-   The trailing `|| true` on both rebase commands is deliberate:
-   `git rebase --continue` / `--skip` exits non-zero whenever the
-   NEXT replayed commit hits a conflict — an expected state in this
-   loop, not a failure (step 5 handles it). Without `|| true`, every
-   mid-rebase conflict-hit inflates the Bash error metric tracked in
-   parse.py (see #382 / #323). Success vs mid-rebase-conflict is
-   distinguished via the rebase-state one-liner below, not via the
-   exit code.
-5. **If new conflicts surface** on the next replayed commit, loop
-   back to step 1.
-
-The rebase is fully done when neither
-`<work_dir>/.git/rebase-merge` nor `<work_dir>/.git/rebase-apply`
-exists. Confirm by delegating to cai-git:
-`Agent(subagent_type="cai-git", prompt="Check rebase state in <work_dir>: run `if [ -d <work_dir>/.git/rebase-merge ] || [ -d <work_dir>/.git/rebase-apply ]; then echo REBASE_IN_PROGRESS; else echo REBASE_DONE; fi` and report the output.")`
+1. **List conflicted files** via cai-git: `git -C <work_dir> diff --name-only --diff-filter=U`
+2. **Resolve each conflict:** Read the file, locate `<<<<<<< / ======= / >>>>>>>` blocks, reconcile both sides (don't blindly pick one), remove all markers.
+3. **Stage resolutions** via cai-git: `git -C <work_dir> add -A`
+4. **Continue or skip** via cai-git: if `git diff --cached --stat` is non-empty, run `GIT_EDITOR=true git -C <work_dir> -c core.editor=true rebase --continue || true`; if empty, `git rebase --skip || true`. The `|| true` is deliberate — mid-rebase conflict exits non-zero as expected.
+5. **If new conflicts surface**, loop back to step 1.
 
 ### When you cannot resolve a conflict
 
-If a conflict is genuinely ambiguous and you cannot make a confident
-judgement about how to merge the two sides:
-
-1. Delegate abort to cai-git:
-   `Agent(subagent_type="cai-git", prompt="Abort the rebase in <work_dir>: run `git -C <work_dir> rebase --abort`.")`
-2. Print a one-paragraph explanation to stdout naming the file,
-   the hunk, and why you couldn't resolve it.
-3. Exit. Do not then proceed to address review comments — if the
-   rebase failed, the branch is out of sync with main and the
-   review-comment addressing is moot. The wrapper will detect the
-   failure (no rebase in progress but HEAD is not on top of
-   origin/main) and post a manual-rebase comment on the PR.
-
-Bailing is a valid outcome — it is much better than merging wrong
-code.
+If a conflict is genuinely ambiguous: abort via cai-git (`git rebase --abort`),
+print an explanation naming the file and hunk, and exit without addressing
+review comments. Bailing is better than merging wrong code.
 
 ## Read the PR context dossier first
 
-Before looking at any review comment, Read
-`<work_dir>/.cai/pr-context.md` if it exists. The `cai-fix` agent
-writes this dossier when it opens the PR (and earlier revise cycles
-append to it), and it is the single most valuable context you have
-for this PR. It lists:
-
-- **Files touched** — the exact files already edited, with line
-  anchors, so you do not have to re-discover them via Grep/Glob.
-- **Files read (not touched) that matter** — adjacent context the
-  fix agent considered.
-- **Key symbols** — the functions/constants/labels the change
-  hinges on, with file:line anchors.
-- **Design decisions** — what was chosen and what was explicitly
-  rejected, so you do not revisit dead-ends.
-- **Out of scope / known gaps** — things the fix agent deliberately
-  did not touch. Use this to judge whether a review comment is
-  asking you to cross a gap boundary (usually out of scope for
-  revise; flag in your stdout summary if you choose to).
-- **Invariants this change relies on** — assumptions a review
-  comment's suggested edit must not break.
-
-**Treat the dossier as ground truth for the PR's intent**, NOT for
-its current state. It is a hint, not an assertion:
-
-  - If the dossier lists a `<path>:<line>` that does not match the
-    current file (because of a rebase, or because an earlier revise
-    round already touched that file), re-verify with Read before
-    editing.
-  - If the dossier file does not exist, the user message's
-    **`## Current PR state`** block will contain only a `git diff
-    origin/main..HEAD --stat` summary (no unified diff — the
-    wrapper no longer includes one). Use the stat as your entry
-    point: Read the listed files in the clone directly, use
-    Grep/Glob or the Explore subagent for broader context, and
-    treat the clone itself as ground truth. Legacy PRs opened
-    before the dossier was introduced, or PRs where `cai-fix`
-    exited with zero diff, will have no dossier file — this is
-    expected, and you must create a minimal dossier yourself
-    before exiting if you make any code changes (see the "Update
-    the PR context dossier before you exit" section below).
-  - If the dossier contradicts the actual files in the clone in a
-    non-trivial way (for example, a file the dossier says was
-    touched has none of the described changes), trust what you
-    Read from the clone — it is the authoritative ground truth —
-    and note the discrepancy in your stdout summary so the
-    supervisor can investigate.
-
-The goal is to eliminate exploratory Grep/Glob/Read rounds when the
-dossier already answers the question. Reading the dossier first is
-the cheapest way to do this — do it before anything else in the
-review-comment phase.
+Before addressing any review comment, Read `<work_dir>/.cai/pr-context.md`
+if it exists. It lists files touched, key symbols, design decisions, and
+out-of-scope gaps — saving exploratory Grep/Glob rounds. Treat it as
+ground truth for intent, not for current state: if a listed path doesn't
+match the file, re-verify with Read. If the dossier doesn't exist (legacy
+PR), use the `--stat` summary from the user message as your entry point
+and create a minimal dossier before exiting if you make code changes.
 
 ## Delegate bulk reading to a haiku Explore subagent
 
-Most of cai-revise's output tokens are spent on file reading and
-symbol search — operations that do not require sonnet-level
-reasoning. Delegating these to a haiku Explore subagent trades
-expensive sonnet output tokens for ~10× cheaper haiku tokens.
-
-**Use `Agent(subagent_type="Explore", model="haiku", ...)` for:**
-
-- Reading the PR context dossier and summarising it (if not already
-  summarised in this session)
-- Reading files referenced by review comments, returning only the
-  relevant sections
-- Grepping for symbols or patterns across the worktree
-- Checking whether paths exist and returning their content
-
-**Concrete example** — batching dossier read, file reads, and a
-symbol search into a single Explore call:
-
-```
-Agent(
-  subagent_type="Explore",
-  model="haiku",
-  description="Gather PR context",
-  prompt="In <work_dir>: (1) Read .cai/pr-context.md and summarise the files touched, key symbols, and design decisions in under 200 words. (2) Read <file1> lines 50-120 and <file2> lines 1-80, returning only the function signatures and surrounding context. (3) Grep for 'symbol_name' across the worktree and report matching files and line numbers."
-)
-```
-
-**Fall back to direct Read** only for small, single-file lookups
-where the subagent overhead is not worthwhile (fewer than 3 files,
-known paths, under 100 lines total). For anything larger — multiple
-files, large files, broad symbol searches — use the Explore subagent.
-
-**Hard rule: Do NOT delegate edits or decisions.** Only reading and
-search tasks go to the Explore subagent. All Edit/Write calls and
-all judgment about what to change stay in this sonnet session.
-
-**Note on cai-git vs Explore:** The Explore subagent handles
-read/search delegation only. Git operations (rebase, staging,
-status checks) must still go through the `cai-git` subagent as
-described in the rebase section above — never use Explore for git
-commands.
+Use `Agent(subagent_type="Explore", model="haiku", ...)` for reading
+the dossier, files referenced by review comments, and symbol searches
+— this trades expensive sonnet output tokens for ~10× cheaper haiku tokens.
+Fall back to direct Read only for small lookups (< 3 files, < 100 lines).
+**Do NOT delegate edits or decisions** — only reading and search.
+Git operations still go through `cai-git`, not Explore.
 
 ## Addressing review comments
 
@@ -509,8 +285,7 @@ one:
 
 After you finish addressing the review comments (and before
 printing your stdout summary), append a new section to
-`<work_dir>/.cai/pr-context.md` so the next revise cycle inherits
-your work:
+`<work_dir>/.cai/pr-context.md`:
 
 ~~~
 ## Revision <N> (<YYYY-MM-DD>)
@@ -530,22 +305,10 @@ your work:
 
 Rules:
 
-  - Pick the next `<N>` by Reading the existing dossier first — if
-    the last section is `## Revision 2`, write `## Revision 3`. If
-    there are no prior revision sections, write `## Revision 1`.
-  - If the dossier file does not exist AND you made no code
-    changes, skip this step — there is nothing to record.
-  - If the dossier file does not exist but you DID make code
-    changes (legacy PR), create a minimal dossier following the
-    same template as `cai-fix` (see
-    `.claude/agents/cai-fix.md` section "Before you exit: write
-    the PR context dossier") so the next revise cycle has a
-    starting point.
-  - The wrapper's commit step picks up the dossier edit
-    automatically — do not try to commit it yourself.
-  - Use `<work_dir>/.cai/pr-context.md` as the path, not a
-    relative `.cai/pr-context.md` (which would resolve under
-    `/app`).
+  - Pick `<N>` by reading the existing dossier — increment from the last revision number, or use 1 if none.
+  - If the dossier doesn't exist and you made no changes, skip this step.
+  - If the dossier doesn't exist but you made changes (legacy PR), create a minimal dossier.
+  - Use `<work_dir>/.cai/pr-context.md` as the path (not a relative path).
 
 ### Empty diff is OK
 
@@ -568,31 +331,6 @@ the PR comment it posts after pushing.
 
 ## Context provided below
 
-The user message contains these sections:
-
-1. **Rebase state** — either "clean" (no conflicts, you can skip
-   straight to review comments) or "in progress" with the list of
-   conflicted files
-2. **Original issue** — the issue the PR was opened against. This
-   is for context only; do not re-implement the issue from scratch.
-3. **Current PR state** — a compact `git diff origin/main..HEAD
-   --stat` summary of the files this PR touches. The wrapper
-   **does not** include the full unified diff (dumping it into
-   every revise cycle is too expensive on large PRs). How to use
-   this section depends on whether a PR context dossier exists:
-   - **If the block points at `<work_dir>/.cai/pr-context.md`**
-     (the `cai-fix` agent creates this on every non-empty PR):
-     Read the dossier first for the files-touched list, design
-     decisions, out-of-scope gaps, and invariants, then Read
-     specific files in the clone for the actual current content.
-   - **If the block says no dossier was found** (legacy PR or
-     zero-diff fix run): use the `--stat` itself as the entry
-     point, Read the listed files directly, use Grep/Glob or the
-     Explore subagent for broader context, and create a minimal
-     dossier before exiting (see "Update the PR context dossier
-     before you exit" above) so the next revise cycle starts
-     with one.
-4. **Unaddressed review comments** — the comments you need to
-   address (may be empty if the only work was a rebase).
-
+The user message provides: (1) rebase state, (2) original issue (context
+only), (3) current PR stat summary, (4) unaddressed review comments.
 Read them in order before doing anything else.

--- a/cai.py
+++ b/cai.py
@@ -765,39 +765,6 @@ def _fetch_closed_auto_improve_issues(limit: int = 50) -> list[dict]:
     return result
 
 
-def _closed_issues_block(closed: list[dict]) -> str:
-    """Format closed issues + their rationales as a prompt section."""
-    if not closed:
-        return ""
-    lines = [
-        "\n\n## Previously closed auto-improve issues",
-        "",
-        "These auto-improve issues have already been considered and "
-        "closed. Before raising any new finding, check the rationale "
-        "for each closed issue below. If your proposed finding "
-        "overlaps with one of these by topic, do NOT re-raise it — "
-        "the supervisor's reasoning still applies. The only exception: "
-        "you have concrete new evidence that the prior reasoning is "
-        "wrong, in which case raise a finding that explicitly "
-        "references the prior issue number and explains what changed.",
-        "",
-    ]
-    for ci in closed:
-        labels_str = ", ".join(ci["labels"]) if ci["labels"] else "(none)"
-        lines.append(f"### #{ci['number']} — {ci['title']}")
-        lines.append(f"- **Closed:** {ci['closedAt']}")
-        lines.append(f"- **Labels:** {labels_str}")
-        if ci["rationale"]:
-            lines.append(
-                f"- **Closing rationale (@{ci['rationale_author']}):** "
-                f"{ci['rationale']}"
-            )
-        else:
-            lines.append("- **Closing rationale:** (none recorded)")
-        lines.append("")
-    return "\n".join(lines)
-
-
 def _review_pr_pattern_summary() -> str:
     """Read the review-pr pattern log and return a markdown summary block.
 

--- a/cai.py
+++ b/cai.py
@@ -1777,14 +1777,16 @@ PLUGIN_STAGING_REL = Path(".cai-staging") / "plugins"
 
 
 def _setup_agent_edit_staging(work_dir: Path) -> Path:
-    """Create the staging directory where the agent writes proposed
-    `.claude/agents/*.md` updates. Idempotent.
+    """Create the staging directories where agents write proposed
+    `.claude/agents/*.md` and `.claude/plugins/` updates. Idempotent.
 
-    Returns the absolute staging directory path so the caller can
+    Returns the absolute agent-staging directory path so the caller can
     pass it to the agent via the user message.
     """
     staging = work_dir / AGENT_EDIT_STAGING_REL
     staging.mkdir(parents=True, exist_ok=True)
+    plugin_staging = work_dir / PLUGIN_STAGING_REL
+    plugin_staging.mkdir(parents=True, exist_ok=True)
     return staging
 
 

--- a/cai.py
+++ b/cai.py
@@ -497,9 +497,14 @@ def _run_claude_p(
     # array of stream events instead of a single envelope dict.
     if len(cmd) < 2 or cmd[0] != "claude" or cmd[1] != "-p":
         raise ValueError("_run_claude_p requires cmd[:2] == ['claude', '-p']")
+    plugin_dir = Path(".claude/plugins/cai-skills")
+    plugin_flags: list[str] = (
+        ["--plugin-dir", str(plugin_dir)] if plugin_dir.is_dir() else []
+    )
     full_cmd = (
         cmd[:2]
         + ["--output-format", "json", "--verbose"]
+        + plugin_flags
         + cmd[2:]
     )
 
@@ -963,18 +968,13 @@ def cmd_analyze(args) -> int:
             + "\n"
         )
 
-    # Closed-issue rationales — so the analyzer doesn't re-raise
-    # findings the supervisor has already reasoned through and
-    # rejected. See #260.
-    closed_issues = _fetch_closed_auto_improve_issues(limit=50)
-    closed_block = _closed_issues_block(closed_issues)
-
     # The system prompt, tool allowlist, and model choice all live
     # in `.claude/agents/cai-analyze.md`. Durable per-agent learnings
     # live in its `memory: project` pool. The wrapper only passes
-    # dynamic per-run context (parsed signals, open issues,
-    # closed-issue rationales, and review-pr pattern history) via
-    # stdin as the user message.
+    # dynamic per-run context (parsed signals, open issues, and
+    # review-pr pattern history) via stdin as the user message.
+    # Closed-issue rationale lookup is now on-demand via the
+    # skill:look-up-closed-finding plugin skill.
     review_pr_block = _review_pr_pattern_summary()
     user_message = (
         "## Parsed signals\n\n"
@@ -982,7 +982,6 @@ def cmd_analyze(args) -> int:
         f"{parsed_signals}\n"
         "```\n"
         f"{issues_block}"
-        f"{closed_block}"
         f"{review_pr_block}"
     )
 
@@ -1810,68 +1809,91 @@ def _setup_agent_edit_staging(work_dir: Path) -> Path:
 
 def _apply_agent_edit_staging(work_dir: Path) -> int:
     """Copy any files staged at `<work_dir>/.cai-staging/agents/`
-    back to `<work_dir>/.claude/agents/`, then remove the staging
-    directory so it doesn't land in the PR.
+    back to `<work_dir>/.claude/agents/`, copy any plugin tree staged
+    at `<work_dir>/.cai-staging/plugins/` to `<work_dir>/.claude/plugins/`,
+    then remove the staging directory so it doesn't land in the PR.
 
     Security boundaries:
 
-      1. Each staged file is copied to `<work_dir>/.claude/agents/`
+      1. Each staged agent file is copied to `<work_dir>/.claude/agents/`
          using the same basename. If no target exists a new file is
          created; if one exists it is overwritten.
-      2. The staging dir lives entirely inside `work_dir` so escapes
+      2. Staged plugin trees are merged into `<work_dir>/.claude/plugins/`
+         using shutil.copytree with dirs_exist_ok=True.
+      3. The staging dir lives entirely inside `work_dir` so escapes
          via `..` are not possible (the wrapper iterates one
          directory level via `iterdir()` and copies whole files).
-      3. The staging dir is removed unconditionally before commit.
+      4. The staging dir is removed unconditionally before commit.
 
     Returns the count of files successfully applied. If the staging
     dir doesn't exist or is empty, returns 0 with no side effects.
     """
     staging = work_dir / AGENT_EDIT_STAGING_REL
-    if not staging.exists() or not staging.is_dir():
-        return 0
-
-    target_dir = work_dir / ".claude" / "agents"
     applied = 0
-    for staged_file in sorted(staging.iterdir()):
-        if not staged_file.is_file():
-            continue
 
-        target = target_dir / staged_file.name
-        if not target.exists():
-            print(
-                f"[cai] agent edit staging: creating new agent file "
-                f".claude/agents/{staged_file.name}",
-                flush=True,
-            )
+    if staging.exists() and staging.is_dir():
+        target_dir = work_dir / ".claude" / "agents"
+        for staged_file in sorted(staging.iterdir()):
+            if not staged_file.is_file():
+                continue
 
+            target = target_dir / staged_file.name
+            if not target.exists():
+                print(
+                    f"[cai] agent edit staging: creating new agent file "
+                    f".claude/agents/{staged_file.name}",
+                    flush=True,
+                )
+
+            try:
+                content = staged_file.read_text()
+                target.write_text(content)
+                print(
+                    f"[cai] applied staged agent file: "
+                    f".claude/agents/{staged_file.name} "
+                    f"({len(content)} bytes)",
+                    flush=True,
+                )
+                applied += 1
+            except OSError as exc:
+                print(
+                    f"[cai] agent edit staging: failed to apply "
+                    f"{staged_file.name}: {exc}",
+                    file=sys.stderr,
+                )
+                continue
+
+    # Apply any plugin staging: .cai-staging/plugins/ → .claude/plugins/
+    plugin_staging = work_dir / ".cai-staging" / "plugins"
+    if plugin_staging.exists() and plugin_staging.is_dir():
+        plugin_target = work_dir / ".claude" / "plugins"
         try:
-            content = staged_file.read_text()
-            target.write_text(content)
+            shutil.copytree(str(plugin_staging), str(plugin_target),
+                            dirs_exist_ok=True)
             print(
-                f"[cai] applied staged agent file: "
-                f".claude/agents/{staged_file.name} "
-                f"({len(content)} bytes)",
+                f"[cai] applied staged plugin tree: .claude/plugins/ "
+                f"(merged from .cai-staging/plugins/)",
                 flush=True,
             )
             applied += 1
         except OSError as exc:
             print(
-                f"[cai] agent edit staging: failed to apply "
-                f"{staged_file.name}: {exc}",
+                f"[cai] agent edit staging: failed to apply plugin tree: {exc}",
                 file=sys.stderr,
             )
-            continue
 
     # Clean up the entire .cai-staging tree (one level above the
     # agents/ subdir) so nothing leaks into the PR.
-    try:
-        shutil.rmtree(work_dir / ".cai-staging")
-    except OSError as exc:
-        print(
-            f"[cai] agent edit staging: cleanup of "
-            f"{work_dir / '.cai-staging'} failed: {exc}",
-            file=sys.stderr,
-        )
+    cai_staging_root = work_dir / ".cai-staging"
+    if cai_staging_root.exists():
+        try:
+            shutil.rmtree(cai_staging_root)
+        except OSError as exc:
+            print(
+                f"[cai] agent edit staging: cleanup of "
+                f"{cai_staging_root} failed: {exc}",
+                file=sys.stderr,
+            )
 
     return applied
 

--- a/cai.py
+++ b/cai.py
@@ -1742,7 +1742,8 @@ def _update_parent_checklist_item(
 
 
 # ---------------------------------------------------------------------------
-# Wrapper-side `.claude/agents/*.md` writes (staging-directory pattern)
+# Wrapper-side `.claude/agents/*.md` and `.claude/plugins/` writes
+# (staging-directory pattern)
 # ---------------------------------------------------------------------------
 #
 # Background: claude-code's headless `claude -p` mode hardcodes a
@@ -1762,24 +1763,36 @@ def _update_parent_checklist_item(
 #
 # Workaround: a "staging directory" pattern.
 #
-#   1. Before invoking the agent, the wrapper creates an empty dir
-#      at `<work_dir>/.cai-staging/agents/`. This path is NOT under
-#      `.claude/agents/`, so claude-code's protection doesn't fire
-#      on writes to it.
+#   1. Before invoking the agent, the wrapper creates empty dirs
+#      at `<work_dir>/.cai-staging/agents/` and
+#      `<work_dir>/.cai-staging/plugins/`. These paths are NOT under
+#      `.claude/`, so claude-code's protection doesn't fire on
+#      writes to them.
 #
-#   2. The agent's prompt instructs it: when you need to update an
-#      `.claude/agents/<name>.md` file, do not Edit the protected
-#      path directly. Instead, use the Write tool to write the FULL
-#      new content to `<work_dir>/.cai-staging/agents/<name>.md`.
+#   2a. The agent's prompt instructs it: when you need to update an
+#       `.claude/agents/<name>.md` file, do not Edit the protected
+#       path directly. Instead, use the Write tool to write the FULL
+#       new content to `<work_dir>/.cai-staging/agents/<name>.md`.
 #
-#   3. After the agent exits successfully, the wrapper iterates the
-#      staging directory. For each file `<name>.md` found, it
-#      copies the contents to `<work_dir>/.claude/agents/<name>.md`
-#      via plain `pathlib.write_text` (the wrapper isn't a claude
-#      session and isn't subject to the protection).
+#   2b. To create or update plugin files under `.claude/plugins/`,
+#       write to `<work_dir>/.cai-staging/plugins/<plugin-path>`
+#       preserving the same relative directory structure. For example,
+#       to create `.claude/plugins/cai-skills/skills/foo/SKILL.md`,
+#       write to `.cai-staging/plugins/cai-skills/skills/foo/SKILL.md`.
+#
+#   3. After the agent exits successfully, the wrapper:
+#      - For each `<name>.md` in `.cai-staging/agents/`: copies it to
+#        `<work_dir>/.claude/agents/<name>.md` via `pathlib.write_text`.
+#      - For the tree at `.cai-staging/plugins/`: merges it into
+#        `<work_dir>/.claude/plugins/` using `shutil.copytree` with
+#        `dirs_exist_ok=True`.
+#      (The wrapper isn't a claude session and isn't subject to the
+#      protection.)
 #
 #   4. The wrapper removes the staging directory before committing
-#      so it doesn't land in the PR.
+#      so it doesn't land in the PR. If plugin staging fails, the
+#      staging directory is preserved for inspection rather than
+#      silently deleted.
 #
 # Full-file writes (not Edit-style old/new diffs) by design: the
 # agent writes the whole replacement content; the wrapper does an
@@ -1790,9 +1803,10 @@ def _update_parent_checklist_item(
 # hundred lines max).
 
 
-# Path of the staging directory inside a cloned worktree, relative
+# Paths of the staging directories inside a cloned worktree, relative
 # to the clone root.
 AGENT_EDIT_STAGING_REL = Path(".cai-staging") / "agents"
+PLUGIN_STAGING_REL = Path(".cai-staging") / "plugins"
 
 
 def _setup_agent_edit_staging(work_dir: Path) -> Path:
@@ -1823,7 +1837,10 @@ def _apply_agent_edit_staging(work_dir: Path) -> int:
       3. The staging dir lives entirely inside `work_dir` so escapes
          via `..` are not possible (the wrapper iterates one
          directory level via `iterdir()` and copies whole files).
-      4. The staging dir is removed unconditionally before commit.
+      4. The staging dir is removed before commit if all staging
+         operations succeeded. If plugin staging fails, the staging
+         dir is preserved for inspection and the function returns
+         early so staged content is not silently lost.
 
     Returns the count of files successfully applied. If the staging
     dir doesn't exist or is empty, returns 0 with no side effects.
@@ -1864,7 +1881,7 @@ def _apply_agent_edit_staging(work_dir: Path) -> int:
                 continue
 
     # Apply any plugin staging: .cai-staging/plugins/ → .claude/plugins/
-    plugin_staging = work_dir / ".cai-staging" / "plugins"
+    plugin_staging = work_dir / PLUGIN_STAGING_REL
     if plugin_staging.exists() and plugin_staging.is_dir():
         plugin_target = work_dir / ".claude" / "plugins"
         try:
@@ -1881,6 +1898,10 @@ def _apply_agent_edit_staging(work_dir: Path) -> int:
                 f"[cai] agent edit staging: failed to apply plugin tree: {exc}",
                 file=sys.stderr,
             )
+            # Preserve .cai-staging so staged plugin files are not
+            # silently lost when the copy fails — caller can inspect
+            # or retry. Do not fall through to shutil.rmtree below.
+            return applied
 
     # Clean up the entire .cai-staging tree (one level above the
     # agents/ subdir) so nothing leaks into the PR.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#308

**Issue:** #308 — Path A phase 9: evaluate and extract Claude Code skills where they fit

## PR Summary

### What this fixes
Implements the `skill:look-up-closed-finding` plugin skill for cai-analyze, replacing the bulk injection of up to 50 closed issues (~30 KB) into every `cmd_analyze` run with an on-demand `gh issue list` query. Also creates the necessary plugin scaffold and wires `--plugin-dir` into all `claude -p` invocations.

### What was changed
- **`cai.py` (`_run_claude_p`, ~line 470)**: Added `plugin_dir`/`plugin_flags` to inject `--plugin-dir .claude/plugins/cai-skills` into every `claude -p` invocation when the plugin directory exists (no-op when absent)
- **`cai.py` (`_apply_agent_edit_staging`, ~line 1522)**: Extended to also copy `.cai-staging/plugins/` → `.claude/plugins/` using `shutil.copytree(dirs_exist_ok=True)` before cleanup, enabling the fix agent to stage new plugin files
- **`cai.py` (`cmd_analyze`, ~line 915)**: Removed `_fetch_closed_auto_improve_issues` call, `closed_block` variable, and `{closed_block}` from the user_message; updated the surrounding comment to reference the new skill
- **`.claude/plugins/cai-skills/.claude-plugin/plugin.json`** (new, via staging): Plugin manifest for the cai-skills plugin
- **`.claude/plugins/cai-skills/skills/look-up-closed-finding/SKILL.md`** (new, via staging): Skill definition instructing agents to run `gh issue list --state closed` and extract the supervisor's closing rationale
- **`.claude/agents/cai-analyze.md`** (via staging): Added `Bash` to the tools line; removed item 3 (closed issues) from Input format section (renumbered); replaced Filter item 3's static-context instruction with an on-demand `skill:look-up-closed-finding` invocation instruction

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
