### PR TITLE
Add cai-explore agent for autonomous exploration and benchmarking

### DIFF
--- a/.claude/agents/cai-explore.md
+++ b/.claude/agents/cai-explore.md
@@ -1,0 +1,135 @@
+---
+name: cai-explore
+description: Autonomous exploration and benchmarking agent. Investigates open-ended questions (cost comparisons, architecture alternatives, feasibility studies) by building prototypes, running measurements, and producing a structured report for human decision.
+tools: Read, Grep, Glob, Bash, Agent, Write, Edit
+model: claude-opus-4-6
+memory: project
+---
+
+# Exploration Agent
+
+You are the autonomous exploration and benchmarking agent for `robotsix-cai`.
+The wrapper (`cai.py explore`) has cloned the repository and handed you an
+issue that requires open-ended investigation — cost comparisons, architecture
+alternatives, feasibility studies, or prototype benchmarking.
+
+**Your job is to explore the question thoroughly, run concrete measurements
+where possible, and produce a structured report.** The wrapper posts your
+report as a comment on the issue for human review.
+
+## Consult your memory first
+
+Read `.claude/agent-memory/cai-explore/MEMORY.md` before doing anything else.
+It records prior exploration findings that may be relevant.
+
+## Your working directory and the canonical /app location
+
+**Your `cwd` is `/app`, NOT the clone.** This is intentional: `/app` is where
+your declarative agent definition and project-scope memory live.
+
+**Your actual work happens on the fresh clone at the path given in the
+`## Work directory` block in your user message.** Use absolute paths under
+that directory for all `Read`, `Grep`, `Glob`, and `Bash` calls that target
+the clone.
+
+## What you receive
+
+Your user message contains:
+
+1. **`## Work directory`** — absolute path to the clone. You have full
+   read/write access to this directory.
+2. **`## Issue`** — the full issue body describing what to explore.
+
+## Process
+
+1. **Understand the question.** Read the issue carefully. Identify what
+   alternatives or approaches need to be compared and what metrics matter
+   (cost, latency, accuracy, complexity, etc.).
+
+2. **Research the current state.** Explore the codebase to understand the
+   existing implementation that the exploration relates to. Document your
+   baseline understanding.
+
+3. **Design experiments.** Plan concrete, measurable comparisons. Write
+   scripts or prototypes in the work directory if needed. You have full Bash
+   access — you can install packages (`pip install`, `npm install`, etc.),
+   run scripts, and execute benchmarks.
+
+4. **Run measurements.** Execute your experiments and collect data. Focus on
+   quantitative results where possible (token counts, latency, cost
+   estimates, accuracy metrics).
+
+5. **Analyse and compare.** Synthesise your findings into a clear comparison
+   of the alternatives with trade-offs.
+
+6. **Produce your report.** Emit the structured output block described below.
+
+## Output format
+
+You MUST emit exactly ONE output block as the final section of your output.
+The wrapper matches the header literally — do not rename or nest it.
+
+```
+## Exploration Report
+
+### Question
+<restatement of the exploration question>
+
+### Current State
+<brief description of how things work today, with relevant metrics if measurable>
+
+### Alternatives Explored
+
+#### Alternative 1: <name>
+**Approach:** <what this alternative involves>
+**Findings:** <what you measured or discovered>
+**Pros:** <advantages>
+**Cons:** <disadvantages>
+**Estimated effort:** <rough scope of implementation>
+
+#### Alternative 2: <name>
+...
+
+### Comparison Summary
+<table or concise comparison of alternatives on key metrics>
+
+### Recommendation
+<your recommendation with reasoning — which alternative(s) merit follow-up,
+or whether the current approach is already optimal>
+
+### Suggested Follow-up Issues
+<if your recommendation involves changes, outline what issues should be
+created — each with a title and one-line scope description>
+```
+
+If you cannot reach a conclusion, emit this instead:
+
+```
+## Exploration Blocked
+
+### What I tried
+<summary of exploration attempts>
+
+### Why I couldn't conclude
+<specific reason — e.g., "requires access to production metrics",
+"needs a decision on acceptable latency trade-off">
+```
+
+## Hard rules
+
+1. **Never commit or push.** You can modify files in the clone for
+   prototyping, but do not push changes.
+2. **Always use absolute paths** under the work directory for all tool calls
+   that target the clone.
+3. **Verify paths with Glob before Read.** If a path is inferred, confirm it
+   exists before attempting to open it.
+4. **Output exactly ONE of the two outcome blocks.** Do not emit more than
+   one. Do not emit partial or malformed blocks.
+5. **Bash is unrestricted** — you can install packages, run benchmarks, write
+   and execute scripts. Use this freedom to produce concrete data. Clean up
+   any temporary files outside the work directory when done.
+6. **30-minute cap.** If you are approaching the timeout without a
+   conclusion, emit `## Exploration Blocked` with an honest account of what
+   you tried and why you could not conclude.
+7. **Quantify where possible.** Vague statements like "probably cheaper" are
+   not useful — measure token counts, estimate costs, time operations.

--- a/cai.py
+++ b/cai.py
@@ -182,6 +182,8 @@ LABEL_MERGED = "auto-improve:merged"
 LABEL_SOLVED = "auto-improve:solved"
 LABEL_NO_ACTION = "auto-improve:no-action"
 LABEL_NEEDS_SPIKE = "auto-improve:needs-spike"
+LABEL_NEEDS_EXPLORATION = "auto-improve:needs-exploration"
+LABEL_EXPLORATION_DONE = "auto-improve:exploration-done"
 LABEL_REFINED = "auto-improve:refined"
 LABEL_REVISING = "auto-improve:revising"
 LABEL_MERGE_BLOCKED = "merge-blocked"
@@ -6248,6 +6250,380 @@ def cmd_spike(args) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Explore (autonomous exploration / benchmarking)
+# ---------------------------------------------------------------------------
+
+def _find_exploration_report_comment(comments: list[dict]) -> dict | None:
+    """Return the bot comment containing '## Exploration Report', or None."""
+    for c in reversed(comments or []):
+        body = c.get("body", "")
+        if "## Exploration Report" in body:
+            return c
+    return None
+
+
+def _has_human_comment_after(comments: list[dict], bot_comment: dict) -> dict | None:
+    """Return the first human comment posted after *bot_comment*, or None."""
+    bot_time = bot_comment.get("createdAt", "")
+    bot_login = bot_comment.get("author", {}).get("login", "")
+    for c in comments or []:
+        if c.get("createdAt", "") > bot_time:
+            author = c.get("author", {}).get("login", "")
+            if author != bot_login and author != "github-actions[bot]":
+                return c
+    return None
+
+
+def cmd_explore(args) -> int:
+    """Two-phase exploration command.
+
+    Phase 1 (follow-up): check :exploration-done issues for human feedback
+    and create follow-up issues.
+    Phase 2 (exploration): pick up :needs-exploration issues and run the
+    cai-explore agent.
+    """
+    print("[cai explore] starting", flush=True)
+
+    # ------------------------------------------------------------------
+    # Phase 1: Follow-up — check :exploration-done issues for human reply
+    # ------------------------------------------------------------------
+    print("[cai explore] phase 1: checking for human decisions on exploration-done issues", flush=True)
+    try:
+        done_issues = _gh_json([
+            "issue", "list",
+            "--repo", REPO,
+            "--label", LABEL_EXPLORATION_DONE,
+            "--state", "open",
+            "--json", "number,title,body,labels,createdAt,comments",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(f"[cai explore] gh issue list failed:\n{e.stderr}", file=sys.stderr)
+        done_issues = []
+
+    for issue in done_issues:
+        issue_number = issue["number"]
+        comments = issue.get("comments") or []
+
+        report_comment = _find_exploration_report_comment(comments)
+        if not report_comment:
+            continue
+
+        human_reply = _has_human_comment_after(comments, report_comment)
+        if not human_reply:
+            continue
+
+        # Human has replied — parse their decision and create follow-up issues.
+        print(f"[cai explore] #{issue_number}: human replied, creating follow-up issues", flush=True)
+        t0 = time.monotonic()
+
+        _uid = uuid.uuid4().hex[:8]
+        work_dir = Path(f"/tmp/cai-explore-followup-{issue_number}-{_uid}")
+
+        try:
+            if work_dir.exists():
+                shutil.rmtree(work_dir)
+
+            _run(["gh", "auth", "setup-git"], capture_output=True)
+            clone = _run(
+                ["git", "clone", "--depth", "1",
+                 f"https://github.com/{REPO}.git", str(work_dir)],
+                capture_output=True,
+            )
+            if clone.returncode != 0:
+                print(f"[cai explore] clone failed for follow-up on #{issue_number}", file=sys.stderr)
+                continue
+
+            human_body = human_reply.get("body", "")
+            human_author = human_reply.get("author", {}).get("login", "unknown")
+            report_body = report_comment.get("body", "")
+
+            user_message = (
+                _work_directory_block(work_dir)
+                + "\n"
+                + _build_issue_block(issue)
+                + "\n## Exploration Report (posted earlier)\n\n"
+                + report_body
+                + f"\n\n## Human Decision\n\n"
+                + f"**{human_author}** replied:\n\n{human_body}\n\n"
+                + "## Your task\n\n"
+                + "Based on the human's decision above, create follow-up issues.\n"
+                + "For each issue to create, emit a block:\n\n"
+                + "```\n"
+                + "## Follow-up Issue\n\n"
+                + "### Title\n<issue title>\n\n"
+                + "### Body\n<issue body in markdown — include problem, plan, "
+                + "verification, scope guardrails, and files likely to touch>\n"
+                + "```\n\n"
+                + "You may emit multiple `## Follow-up Issue` blocks.\n"
+                + "If the human decided no action is needed, emit:\n\n"
+                + "```\n## No Follow-up\n\n<reason>\n```\n"
+            )
+
+            result = _run_claude_p(
+                ["claude", "-p", "--agent", "cai-explore",
+                 "--dangerously-skip-permissions",
+                 "--add-dir", str(work_dir)],
+                category="explore-followup",
+                agent="cai-explore",
+                input=user_message,
+                cwd="/app",
+                timeout=600,  # 10 min for follow-up
+            )
+            if result.stdout:
+                print(result.stdout, flush=True)
+
+            stdout = result.stdout or ""
+
+            # Parse follow-up issues from output.
+            created = 0
+            issue_blocks = re.split(r"(?=## Follow-up Issue\b)", stdout)
+            for block in issue_blocks:
+                if not block.startswith("## Follow-up Issue"):
+                    continue
+                title_match = re.search(r"###\s*Title\s*\n+(.+)", block)
+                body_match = re.search(
+                    r"###\s*Body\s*\n+([\s\S]+?)(?=\n## |\Z)", block,
+                )
+                if not title_match:
+                    continue
+                fu_title = title_match.group(1).strip()
+                fu_body = body_match.group(1).strip() if body_match else ""
+                fu_body += (
+                    f"\n\n---\n"
+                    f"_Created from exploration on #{issue_number}._\n"
+                )
+                labels = ",".join(["auto-improve", LABEL_RAISED])
+                cr = _run(
+                    ["gh", "issue", "create",
+                     "--repo", REPO,
+                     "--title", fu_title,
+                     "--body", fu_body,
+                     "--label", labels],
+                    capture_output=True,
+                )
+                if cr.returncode == 0:
+                    url = cr.stdout.strip()
+                    print(f"[cai explore] created follow-up: {url}", flush=True)
+                    created += 1
+                else:
+                    print(
+                        f"[cai explore] failed to create '{fu_title}': {cr.stderr}",
+                        file=sys.stderr,
+                    )
+
+            # Close the exploration issue.
+            close_body = (
+                f"Exploration complete. Human decision received from @{human_author}.\n\n"
+            )
+            if created:
+                close_body += f"Created {created} follow-up issue(s).\n"
+            else:
+                no_followup_pos = stdout.find("## No Follow-up")
+                if no_followup_pos != -1:
+                    close_body += "Decision: no follow-up needed.\n"
+                else:
+                    close_body += "No follow-up issues were created.\n"
+            close_body += "\n---\n_Closed by `cai explore` (follow-up phase)._"
+
+            _run(
+                ["gh", "issue", "comment", str(issue_number),
+                 "--repo", REPO,
+                 "--body", close_body],
+                capture_output=True,
+            )
+            _run(
+                ["gh", "issue", "close", str(issue_number),
+                 "--repo", REPO],
+                capture_output=True,
+            )
+            _set_labels(
+                issue_number,
+                remove=[LABEL_EXPLORATION_DONE],
+                log_prefix="cai explore",
+            )
+
+            dur = f"{int(time.monotonic() - t0)}s"
+            print(
+                f"[cai explore] #{issue_number} follow-up done "
+                f"({created} issues created) in {dur}",
+                flush=True,
+            )
+            log_run("explore-followup", repo=REPO, issue=issue_number,
+                    duration=dur, issues_created=created, exit=0)
+
+        except Exception as exc:
+            print(f"[cai explore] follow-up error on #{issue_number}: {exc}", file=sys.stderr)
+            log_run("explore-followup", repo=REPO, issue=issue_number, result="error", exit=1)
+        finally:
+            if work_dir.exists():
+                shutil.rmtree(work_dir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Phase 2: Exploration — run the cai-explore agent on oldest candidate
+    # ------------------------------------------------------------------
+    print("[cai explore] phase 2: looking for :needs-exploration issues", flush=True)
+    t0 = time.monotonic()
+
+    try:
+        issues = _gh_json([
+            "issue", "list",
+            "--repo", REPO,
+            "--label", LABEL_NEEDS_EXPLORATION,
+            "--state", "open",
+            "--json", "number,title,body,labels,createdAt,comments",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(f"[cai explore] gh issue list failed:\n{e.stderr}", file=sys.stderr)
+        log_run("explore", repo=REPO, result="list_failed", exit=1)
+        return 1
+
+    if not issues:
+        print("[cai explore] no :needs-exploration issues; nothing to do", flush=True)
+        log_run("explore", repo=REPO, result="no_eligible_issues", exit=0)
+        return 0
+
+    issue = min(issues, key=lambda i: i["createdAt"])
+    issue_number = issue["number"]
+    title = issue["title"]
+    print(f"[cai explore] picked #{issue_number}: {title}", flush=True)
+
+    # Lock: :needs-exploration → :in-progress.
+    if not _set_labels(
+        issue_number,
+        add=[LABEL_IN_PROGRESS],
+        remove=[LABEL_NEEDS_EXPLORATION],
+        log_prefix="cai explore",
+    ):
+        print(f"[cai explore] could not lock #{issue_number}", file=sys.stderr)
+        log_run("explore", repo=REPO, issue=issue_number, result="lock_failed", exit=1)
+        return 1
+
+    _uid = uuid.uuid4().hex[:8]
+    work_dir = Path(f"/tmp/cai-explore-{issue_number}-{_uid}")
+
+    def rollback() -> None:
+        _set_labels(
+            issue_number,
+            add=[LABEL_NEEDS_EXPLORATION],
+            remove=[LABEL_IN_PROGRESS],
+            log_prefix="cai explore",
+        )
+
+    try:
+        if work_dir.exists():
+            shutil.rmtree(work_dir)
+
+        _run(["gh", "auth", "setup-git"], capture_output=True)
+        clone = _run(
+            ["git", "clone", "--depth", "1",
+             f"https://github.com/{REPO}.git", str(work_dir)],
+            capture_output=True,
+        )
+        if clone.returncode != 0:
+            print(f"[cai explore] git clone failed:\n{clone.stderr}", file=sys.stderr)
+            rollback()
+            log_run("explore", repo=REPO, issue=issue_number, result="clone_failed", exit=1)
+            return 1
+
+        user_message = (
+            _work_directory_block(work_dir)
+            + "\n"
+            + _build_issue_block(issue)
+        )
+        print(f"[cai explore] running cai-explore subagent for {work_dir}", flush=True)
+        result = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-explore",
+             "--dangerously-skip-permissions",
+             "--add-dir", str(work_dir)],
+            category="explore",
+            agent="cai-explore",
+            input=user_message,
+            cwd="/app",
+            timeout=1800,  # 30 min cap
+        )
+        if result.stdout:
+            print(result.stdout, flush=True)
+
+        if result.returncode != 0:
+            print(
+                f"[cai explore] subagent failed (exit {result.returncode}):\n"
+                f"{result.stderr}",
+                file=sys.stderr,
+            )
+            rollback()
+            dur = f"{int(time.monotonic() - t0)}s"
+            log_run("explore", repo=REPO, issue=issue_number,
+                    duration=dur, result="agent_failed", exit=result.returncode)
+            return result.returncode
+
+        stdout = result.stdout or ""
+
+        # Outcome 1: Exploration Report
+        report_pos = stdout.find("## Exploration Report")
+        if report_pos != -1:
+            report_block = stdout[report_pos:].strip()
+            _run(
+                ["gh", "issue", "comment", str(issue_number),
+                 "--repo", REPO,
+                 "--body", f"{report_block}\n\n---\n_Posted by `cai explore`. "
+                          f"Reply with your decision to trigger follow-up issue creation._"],
+                capture_output=True,
+            )
+            _set_labels(
+                issue_number,
+                add=[LABEL_EXPLORATION_DONE],
+                remove=[LABEL_IN_PROGRESS],
+                log_prefix="cai explore",
+            )
+            dur = f"{int(time.monotonic() - t0)}s"
+            print(f"[cai explore] #{issue_number} report posted, awaiting decision in {dur}", flush=True)
+            log_run("explore", repo=REPO, issue=issue_number,
+                    duration=dur, result="report_posted", exit=0)
+            return 0
+
+        # Outcome 2: Exploration Blocked
+        blocked_pos = stdout.find("## Exploration Blocked")
+        if blocked_pos != -1:
+            blocked_block = stdout[blocked_pos:].strip()
+            _run(
+                ["gh", "issue", "comment", str(issue_number),
+                 "--repo", REPO,
+                 "--body", f"{blocked_block}\n\n---\n_Escalated by `cai explore`._"],
+                capture_output=True,
+            )
+            _set_labels(
+                issue_number,
+                add=[LABEL_PR_NEEDS_HUMAN],
+                remove=[LABEL_IN_PROGRESS],
+                log_prefix="cai explore",
+            )
+            dur = f"{int(time.monotonic() - t0)}s"
+            print(f"[cai explore] #{issue_number} blocked/escalated in {dur}", flush=True)
+            log_run("explore", repo=REPO, issue=issue_number,
+                    duration=dur, result="blocked", exit=0)
+            return 0
+
+        # No recognised marker — rollback.
+        rollback()
+        dur = f"{int(time.monotonic() - t0)}s"
+        print(f"[cai explore] #{issue_number} no outcome marker; rolling back in {dur}", flush=True)
+        log_run("explore", repo=REPO, issue=issue_number,
+                duration=dur, result="no_marker", exit=0)
+        return 0
+
+    except Exception as exc:
+        print(f"[cai explore] unexpected error: {exc}", file=sys.stderr)
+        rollback()
+        log_run("explore", repo=REPO, issue=issue_number, result="error", exit=1)
+        return 1
+    finally:
+        if work_dir.exists():
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
 # Cycle (full pipeline without analyze)
 # ---------------------------------------------------------------------------
 
@@ -6327,6 +6703,7 @@ def main() -> int:
     sub.add_parser("merge", help="Confidence-gated auto-merge for bot PRs")
     sub.add_parser("refine", help="Refine human-filed issues into structured plans")
     sub.add_parser("spike", help="Run the spike agent on :needs-spike issues")
+    sub.add_parser("explore", help="Autonomous exploration/benchmarking of :needs-exploration issues")
     sub.add_parser("cycle", help="Full cycle: verify, fix, revise, review-pr, merge, confirm")
     sub.add_parser("test", help="Run the project test suite")
 
@@ -6373,6 +6750,7 @@ def main() -> int:
         "merge": cmd_merge,
         "refine": cmd_refine,
         "spike": cmd_spike,
+        "explore": cmd_explore,
         "cycle": cmd_cycle,
         "cost-report": cmd_cost_report,
         "test": cmd_test,

--- a/publish.py
+++ b/publish.py
@@ -83,6 +83,8 @@ LABELS = [
     ("auto-improve:merged", "0e8a16", "PR was merged; awaiting verify"),
     ("auto-improve:no-action", "c5def5", "Fix subagent reviewed and decided no code change is needed; awaiting human triage"),
     ("auto-improve:needs-spike", "e99695", "Issue needs a research spike before code changes (handled by cai-spike, see #314)"),
+    ("auto-improve:needs-exploration", "c2e0c6", "Issue needs autonomous exploration/benchmarking (handled by cai-explore)"),
+    ("auto-improve:exploration-done", "0e8a16", "Exploration complete; awaiting human decision before follow-up issues are created"),
     ("auto-improve:refined", "0e8a16", "Issue has been reviewed/refined and is ready for the fix subagent"),
     ("auto-improve:revising", "d4c5f9", "Revise subagent is actively iterating on a PR"),
     ("auto-improve:solved", "0e8a16", "Pattern verified absent from recent transcripts"),


### PR DESCRIPTION
## Summary

- Adds a new `cai explore` command with a two-phase lifecycle for autonomous exploration/benchmarking tasks (e.g., "explore RAG vs Explore subagent for cost reduction")
- **Phase 1 (follow-up)**: scans `exploration-done` issues for human comments, creates follow-up `auto-improve:raised` issues based on the human's decision, then closes the exploration issue
- **Phase 2 (exploration)**: picks the oldest `needs-exploration` issue, runs the `cai-explore` agent (30 min timeout, unrestricted Bash, Write/Edit), and posts a structured report as an issue comment
- New labels: `auto-improve:needs-exploration`, `auto-improve:exploration-done`
- New agent definition: `.claude/agents/cai-explore.md` (Opus 4.6, full tool access including package installs and benchmarking)

### Lifecycle
```
needs-exploration → in-progress → (agent explores) → exploration-done
                                                           ↓
                                                   human replies on issue
                                                           ↓
                                                   cai explore (phase 1)
                                                           ↓
                                                   creates auto-improve:raised issues
                                                           ↓
                                                   closes exploration issue
```

## Test plan

- [ ] Verify `python -m py_compile cai.py` passes
- [ ] Verify `python -m unittest discover -s tests -v` passes (13/13)
- [ ] Create a test issue with `auto-improve:needs-exploration` label and run `cai explore`
- [ ] Verify exploration report is posted as issue comment
- [ ] Reply on the issue and re-run `cai explore` to verify follow-up issue creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)