### PR TITLE
auto-improve: Cost logger under-reports token counts (misses subagent tokens)

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,33 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#438
+
+## Files touched
+- `cai.py:519` — replaced `next()` with full result-event collection; added subagent token aggregation and `parent_cost_usd`/`subagents` fields to the cost row
+
+## Files read (not touched) that matter
+- `cai.py:510–600` — `_run_claude_p` cost-row construction; only this section was changed
+
+## Key symbols
+- `_run_claude_p` (`cai.py:~480`) — wraps `claude -p` subprocess; constructs the cost row written to `cai-cost.jsonl`
+- `subagent_results` (`cai.py:520`) — new variable: list of result events before the last one (subagents)
+- `combined` (`cai.py:564`) — replaces `flat`; parent tokens + summed subagent tokens
+- `subagent_rows` (`cai.py:563`) — per-subagent token dicts with `cost_usd`; appended to `row["subagents"]`
+- `log_cost` (`cai.py:596`) — unchanged; writes the row to `cai-cost.jsonl`
+
+## Design decisions
+- Parent result = last `"type": "result"` event; subagents = all earlier ones — matches Claude Code emission order
+- `row.update(combined)` replaces `row.update(flat)` so flat token fields become combined totals
+- `parent_cost_usd = total_cost_usd - sum(subagent cost_usd)` — derived, not from a usage dict
+- `cost_usd` stays sourced from the parent envelope's `total_cost_usd` (already correct, no change)
+- Rejected: using `models` dict from parent envelope to split costs — too indirect; per-event `total_cost_usd` is more reliable
+
+## Out of scope / known gaps
+- `cmd_cost_report` reads `input_tokens`/`output_tokens`; now gets combined totals — correct behavior, no code change needed
+- Subagent `type` (e.g. "Explore") not extracted — not available on result events without additional parsing
+- If Claude Code changes result-event ordering, parent/subagent split breaks (combined totals still correct)
+
+## Invariants this change relies on
+- The last `"type": "result"` in the verbose JSON array is always the parent/top-level result
+- Subagent result events have their own `usage` dict with the same flat_keys structure
+- The parent envelope's `total_cost_usd` already covers all subagents (unchanged assumption)
+- `subagent_results` is `[]` when `parsed` is a dict (legacy format) — no behavioral change in that path

--- a/cai.py
+++ b/cai.py
@@ -517,16 +517,18 @@ def _run_claude_p(
     #      JSON array of stream events; the cost data lives on the
     #      element with `"type": "result"`.
     envelope: dict | None = None
+    subagent_results: list[dict] = []
     if isinstance(parsed, dict):
         envelope = parsed
     elif isinstance(parsed, list):
-        envelope = next(
-            (
-                e for e in parsed
-                if isinstance(e, dict) and e.get("type") == "result"
-            ),
-            None,
-        )
+        result_events = [
+            e for e in parsed
+            if isinstance(e, dict) and e.get("type") == "result"
+        ]
+        # The last result event is the parent (top-level) result;
+        # earlier ones are subagent results.
+        envelope = result_events[-1] if result_events else None
+        subagent_results = result_events[:-1] if len(result_events) > 1 else []
 
     if envelope is None:
         # Don't fail the caller, but make the silent-drop loud so a
@@ -557,6 +559,20 @@ def _run_claude_p(
             if isinstance(v, dict) and any(fk in v for fk in flat_keys)
         }
 
+        # -- Subagent token aggregation --
+        subagent_rows: list[dict] = []
+        combined = dict(flat)  # start with parent tokens
+        for sr in subagent_results:
+            sr_usage = sr.get("usage") or {}
+            sr_flat = {k: sr_usage[k] for k in flat_keys if isinstance(sr_usage.get(k), (int, float))}
+            if sr_flat:
+                for k in flat_keys:
+                    if k in sr_flat:
+                        combined[k] = combined.get(k, 0) + sr_flat[k]
+                sr_entry: dict = dict(sr_flat)
+                sr_entry["cost_usd"] = sr.get("total_cost_usd")
+                subagent_rows.append(sr_entry)
+
         row = {
             "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "category": category,
@@ -569,9 +585,14 @@ def _run_claude_p(
             "exit": proc.returncode,
             "is_error": bool(envelope.get("is_error", proc.returncode != 0)),
         }
-        row.update(flat)
+        row.update(combined)
         if models:
             row["models"] = models
+        if subagent_rows:
+            sub_cost_sum = sum(float(s.get("cost_usd") or 0.0) for s in subagent_rows)
+            total = float(envelope.get("total_cost_usd") or 0.0)
+            row["parent_cost_usd"] = round(total - sub_cost_sum, 6)
+            row["subagents"] = subagent_rows
         log_cost(row)
 
         # Rewrite stdout to the result text so existing callers stay


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#438

**Issue:** #438 — Cost logger under-reports token counts (misses subagent tokens)

## PR Summary

### What this fixes
`_run_claude_p` was logging `total_cost_usd` (which already covers parent + subagents) but only the **parent agent's** token counts from the first `"type": "result"` event in the verbose JSON array. Subagent tokens (~24% of cost for sessions running Explore agents) were silently excluded, making the logged token breakdown inconsistent with the reported cost.

### What was changed
- **`cai.py` (lines 519–596):** Replaced the `next()` call that grabbed only the first result event with a full scan of all `"type": "result"` entries. The last entry is treated as the parent (top-level) result; earlier entries are subagent results. Token counts from all subagent result events are summed into a `combined` dict and used in place of the parent-only `flat` dict when writing the cost row. Two new fields are added when subagents are present: `parent_cost_usd` (total minus subagent costs) and `subagents` (list of per-subagent token dicts with `cost_usd`). Sessions with no subagents are unaffected — `subagent_results` is empty, `combined == flat`, and no new fields are added.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
