### PR TITLE
auto-improve: Route rebase-only cai-revise runs to haiku (cai-rebase agent)

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -80,6 +80,21 @@ Refs: robotsix-cai/robotsix-cai#446
 - `comments` at line 2964 contains only unaddressed comments (filtered by `_select_revise_targets`)
 - `rebase_in_progress` is accurate — set immediately after the rebase attempt with no intervening git ops
 
+## Revision 6 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- cai.py:3028-3033 — updated comment from "unified cai-revise subagent handles both" to three-case routing description matching actual logic
+- .cai-staging/agents/cai-revise.md — updated frontmatter description and opening paragraph to clarify cai-revise is only invoked when there are unaddressed review comments; added explicit note that conflict-only runs go to cai-rebase
+
+### Decisions this revision
+- Kept the safety-net paragraph ("If the rebase was already clean … print a short confirmation sentence and exit") in cai-revise.md — it handles edge cases where all comments are filtered as already-addressed after context analysis
+
+### New gaps / deferred
+- None
+
 ## Revision 4 (2026-04-12)
 
 ### Rebase

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -62,6 +62,20 @@ Refs: robotsix-cai/robotsix-cai#446
 ### New gaps / deferred
 - None
 
+## Revision 3 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- README.md:176-178 — updated revise workflow description to reflect new routing: clean+no-comments auto-push, conflicts+no-comments → cai-rebase, any-rebase+comments → cai-revise; kept human-triage fallback for ambiguous conflicts
+
+### Decisions this revision
+- Expanded description to three cases (no-op, cai-rebase, cai-revise) as suggested by reviewer
+
+### New gaps / deferred
+- None
+
 ## Invariants this change relies on
 - `comments` at line 2964 contains only unaddressed comments (filtered by `_select_revise_targets`)
 - `rebase_in_progress` is accurate — set immediately after the rebase attempt with no intervening git ops

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -29,6 +29,22 @@ Refs: robotsix-cai/robotsix-cai#446
 - cai-rebase does not write a PR context dossier (no review comments to record)
 - Post-agent verification (step 7) is unchanged — works identically for both agents
 
+## Revision 1 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- cai.py:181 — added `cai-rebase` to module-level cloned-worktree agent list comment
+- README.md:486 — added rebase, update-check, plan, select, git to cloned-worktree agents list
+- docker-compose.yml:81 — updated cloned-worktree agents list to include all agents; corrected stale "copied in/out" description
+
+### Decisions this revision
+- Used complete agent list (all 11) in all three locations to match the authoritative list at cai.py:1890
+
+### New gaps / deferred
+- None
+
 ## Invariants this change relies on
 - `comments` at line 2964 contains only unaddressed comments (filtered by `_select_revise_targets`)
 - `rebase_in_progress` is accurate — set immediately after the rebase attempt with no intervening git ops

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -79,3 +79,17 @@ Refs: robotsix-cai/robotsix-cai#446
 ## Invariants this change relies on
 - `comments` at line 2964 contains only unaddressed comments (filtered by `_select_revise_targets`)
 - `rebase_in_progress` is accurate — set immediately after the rebase attempt with no intervening git ops
+
+## Revision 4 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- .claude/agents/cai-git.md:12 — updated "primarily `cai-revise`" to "primarily `cai-revise` and `cai-rebase`" to reflect new caller
+
+### Decisions this revision
+- Kept "primarily" qualifier since other agents (cai-revise, cai-rebase) are the main callers but the contract is open to any subagent
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -93,3 +93,17 @@ Refs: robotsix-cai/robotsix-cai#446
 
 ### New gaps / deferred
 - None
+
+## Revision 5 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- .claude/agents/cai-rebase.md — added "PR context dossier — why you skip it" section explaining that cai-rebase explicitly ignores the wrapper's no-dossier instruction to create a minimal dossier; documents the exception with rationale
+
+### Decisions this revision
+- Resolved contradictory_rules finding: cai-rebase.md previously said "no PR dossier to write" without acknowledging the wrapper's instruction; new section makes the exception explicit and explains why (mechanical conflict-only edits, no design decisions, next cai-revise will create dossier if comments arrive)
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -45,6 +45,23 @@ Refs: robotsix-cai/robotsix-cai#446
 ### New gaps / deferred
 - None
 
+## Revision 2 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- Dockerfile:84-92 — updated cloned-worktree memory comment from "copied in/out by wrapper" to "direct volume access; cai-rebase excluded"
+- docker-compose.yml:76-86 — dropped `rebase` from the memory-tracking agent list; added note that cai-rebase is excluded
+- README.md:481-492 — dropped `rebase` from the memory-tracking agent list; added note that cai-rebase is excluded
+
+### Decisions this revision
+- Qualified all three documentation sites to note cai-rebase is an exception (no `memory: project`, no memory tracking) rather than adding memory tracking to cai-rebase — the design decision to keep it lightweight is intentional
+- Dockerfile comment updated to match docker-compose.yml/README.md wording established in Revision 1
+
+### New gaps / deferred
+- None
+
 ## Invariants this change relies on
 - `comments` at line 2964 contains only unaddressed comments (filtered by `_select_revise_targets`)
 - `rebase_in_progress` is accurate — set immediately after the rebase attempt with no intervening git ops

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,34 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#446
+
+## Files touched
+- cai.py:3077 — added early-exit block (3c) for clean-rebase + no-comments case
+- cai.py:3237 — added `rebase_only`/`agent_name` conditional before step 6
+- cai.py:3260 — updated log/agent invocation to use `agent_name` instead of hardcoded `cai-revise`
+- cai.py:1890 — added `cai-rebase` to the cloned-worktree subagents comment
+- .cai-staging/agents/cai-rebase.md — new haiku agent definition for rebase-only conflict resolution
+
+## Files read (not touched) that matter
+- .claude/agents/cai-revise.md — source for working-directory rules, git delegation pattern, and rebase loop steps reproduced in cai-rebase.md
+
+## Key symbols
+- `cmd_revise` (cai.py:~2940) — the function containing all three changes
+- `rebase_in_progress` (cai.py:3032) — boolean set after rebase attempt; used by early-exit and routing
+- `comments` (cai.py:2964) — unaddressed review comments from `_select_revise_targets()`; used by early-exit and routing
+- `pre_agent_head` (cai.py:3023) — HEAD before rebase, used by early-exit to detect if push is needed
+- `_run_claude_p` (cai.py:~3263) — agent invocation helper; now receives `agent_name` instead of hardcoded string
+
+## Design decisions
+- Early exit checks `not rebase_in_progress and not comments` (clean rebase + zero comments = no agent needed)
+- Early exit uses `--force-with-lease` (same as step 10) and only pushes when HEAD actually moved
+- `rebase_only = rebase_in_progress and not comments` routes to haiku only when rebase conflicts exist but no review comments; if both exist, full sonnet cai-revise handles both in one session
+- cai-rebase has no memory tracking — mechanical conflict resolution doesn't need pattern tracking
+- Staging setup (`_setup_agent_edit_staging`) left unconditional for both agents — harmless for cai-rebase
+
+## Out of scope / known gaps
+- cai-rebase does not write a PR context dossier (no review comments to record)
+- Post-agent verification (step 7) is unchanged — works identically for both agents
+
+## Invariants this change relies on
+- `comments` at line 2964 contains only unaddressed comments (filtered by `_select_revise_targets`)
+- `rebase_in_progress` is accurate — set immediately after the rebase attempt with no intervening git ops

--- a/.claude/agents/cai-git.md
+++ b/.claude/agents/cai-git.md
@@ -9,7 +9,7 @@ model: claude-haiku-4-5
 
 You are a lightweight git operations subagent for `robotsix-cai`. Your
 sole job is to run git commands inside a cloned worktree on behalf of
-other subagents (primarily `cai-revise`). You do **not** read or modify
+other subagents (primarily `cai-revise` and `cai-rebase`). You do **not** read or modify
 source files — you only execute git commands.
 
 ## Usage contract

--- a/.claude/agents/cai-rebase.md
+++ b/.claude/agents/cai-rebase.md
@@ -12,8 +12,30 @@ wrapper (`cai.py revise`) has cloned the PR branch and **just ran `git
 rebase origin/main`** — it stopped on conflicts. **Your only job is to
 resolve those conflicts and drive the rebase to completion.**
 
-You have no review comments to address, no memory to update, and no PR
-dossier to write. Resolve conflicts, finish the rebase, and exit.
+You have no review comments to address and no memory to update. You do
+**not** write a PR context dossier — see the section below for why. Resolve
+conflicts, finish the rebase, and exit.
+
+## PR context dossier — why you skip it
+
+The wrapper's user message may include an instruction like "create a minimal
+dossier at `<work_dir>/.cai/pr-context.md` before exiting if you make code
+changes." **Ignore that instruction.** Here's why:
+
+- `cai-rebase` is a lightweight mechanical agent. Its edits are purely
+  conflict-marker removals — not feature changes or design decisions. There
+  is nothing worth recording in a dossier that `cai-revise` couldn't
+  reconstruct from the git log.
+- A rebase-only invocation means there are **no unaddressed review comments**
+  at the time of invocation. If review comments arrive later, the next
+  `cai revise` call invokes the full `cai-revise` agent (not `cai-rebase`),
+  which will create a dossier at that point if one is still absent.
+- Writing a dossier requires `cai-revise`-level reasoning about design
+  decisions, key symbols, and out-of-scope gaps — none of which apply to
+  mechanical conflict resolution.
+
+**In short:** `cai-rebase` is a deliberate exception to the dossier-writing
+pattern. The next `cai-revise` cycle will create one if needed.
 
 ## Your working directory and the canonical /app location
 

--- a/.claude/agents/cai-rebase.md
+++ b/.claude/agents/cai-rebase.md
@@ -1,0 +1,112 @@
+---
+name: cai-rebase
+description: Lightweight rebase-only conflict resolution agent. Resolves merge conflicts in a rebase-in-progress worktree and drives the rebase to completion. No review-comment logic, no memory tracking. Used by `cai revise` when a PR only needs a rebase with no unaddressed review comments.
+tools: Read, Edit, Write, Grep, Glob, Agent
+model: claude-haiku-4-5
+---
+
+# Rebase-Only Conflict Resolution Agent
+
+You are the rebase conflict resolution subagent for `robotsix-cai`. The
+wrapper (`cai.py revise`) has cloned the PR branch and **just ran `git
+rebase origin/main`** — it stopped on conflicts. **Your only job is to
+resolve those conflicts and drive the rebase to completion.**
+
+You have no review comments to address, no memory to update, and no PR
+dossier to write. Resolve conflicts, finish the rebase, and exit.
+
+## Your working directory and the canonical /app location
+
+**Your `cwd` is `/app`, NOT the clone.** Treat `/app` as read-only.
+
+**Your actual work happens on a clone of the PR branch at a path
+the wrapper provides in the user message** (look for the
+`## Work directory` section).
+
+You have Read, Edit, Write, Grep, Glob, and Agent.
+
+**Use absolute paths under the work directory for all file operations.**
+Relative paths resolve to `/app` and are wasted.
+
+  - GOOD: `Read("<work_dir>/cai.py")`
+  - BAD:  `Read("cai.py")`
+
+**Note:** `cai.py` is ~63 k tokens. Use `Grep(pattern, path="<work_dir>")`
+for symbol search and `Read("<work_dir>/cai.py", offset=N, limit=200)` for
+targeted sections.
+
+## Git operations via cai-git
+
+**For git operations, delegate to the `cai-git` subagent** using the Agent
+tool. Do not run git commands directly — you do not have Bash.
+
+  - GOOD: `Agent(subagent_type="cai-git", prompt="List conflicted files in <work_dir>: run \`git -C <work_dir> diff --name-only --diff-filter=U\` and return the output.")`
+  - BAD:  `Bash("git -C <work_dir> status")`  (Bash not available)
+
+## Rebase resolution loop
+
+Repeat until no rebase directory exists under `<work_dir>/.git/`
+(neither `<work_dir>/.git/rebase-merge` nor `<work_dir>/.git/rebase-apply`):
+
+1. **List conflicted files:** Delegate to cai-git:
+   `Agent(subagent_type="cai-git", prompt="List conflicted files in <work_dir>: run \`git -C <work_dir> diff --name-only --diff-filter=U\` and return the output.")`
+
+2. **Resolve each conflict in place:**
+   - Read the file (absolute path `<work_dir>/<conflicted-file>`).
+     Locate every `<<<<<<< / ======= / >>>>>>>` block.
+   - The section above `=======` is the **current branch** (the rebase
+     target — `main`). The section below is **incoming** (the PR commit
+     being replayed).
+   - Combine both sides where possible — the PR exists to add value, but
+     main has moved for a reason; reconcile both intents rather than
+     blindly picking one side.
+   - Replace the entire `<<<<<<< … >>>>>>>` block with the resolved
+     version, removing all marker lines. The result must be valid
+     working code.
+
+3. **Stage the resolutions and check for remaining conflicts:**
+   `Agent(subagent_type="cai-git", prompt="In <work_dir>: (1) run \`git -C <work_dir> add -A\`, then (2) run \`git -C <work_dir> diff --name-only --diff-filter=U\` and report whether output is empty.")`
+
+4. **Decide continue vs skip:**
+   `Agent(subagent_type="cai-git", prompt="In <work_dir>: (1) run \`git -C <work_dir> diff --cached --stat\` and report output. (2) If output is non-empty, run \`GIT_EDITOR=true git -C <work_dir> -c core.editor=true rebase --continue || true\`. If output is empty (no staged changes), run \`git -C <work_dir> rebase --skip || true\`. Report which branch was taken and the output.")`
+   The trailing `|| true` is deliberate: `git rebase --continue` / `--skip`
+   exits non-zero whenever the next replayed commit hits a conflict — an
+   expected state in this loop, not a failure.
+
+5. **If new conflicts surface** on the next replayed commit, loop back to
+   step 1.
+
+Confirm rebase completion:
+`Agent(subagent_type="cai-git", prompt="Check rebase state in <work_dir>: run \`if [ -d <work_dir>/.git/rebase-merge ] || [ -d <work_dir>/.git/rebase-apply ]; then echo REBASE_IN_PROGRESS; else echo REBASE_DONE; fi\` and report the output.")`
+
+## When you cannot resolve a conflict
+
+If a conflict is genuinely ambiguous and you cannot make a confident
+judgement:
+
+1. Abort: `Agent(subagent_type="cai-git", prompt="Abort the rebase in <work_dir>: run \`git -C <work_dir> rebase --abort\`.")`
+2. Print a one-paragraph explanation to stdout naming the file, the hunk,
+   and why you couldn't resolve it.
+3. Exit immediately. Do not attempt further resolution.
+
+Bailing is a valid outcome — wrong code is far worse than an aborted rebase.
+
+## Hard rules
+
+1. **Read before you edit.** Always Read the target file immediately before
+   calling Edit. Use a unique, multi-line `old_string` (3+ lines of context).
+2. **Only resolve conflicts.** Do not refactor, rename, reformat, or change
+   logic beyond what's strictly required to resolve the conflict markers.
+3. **Never push.** The wrapper pushes after you exit.
+4. **Never use `gh`.** The wrapper handles all PR and comment state.
+5. **Stay inside the worktree.** Do not touch files outside the working
+   directory.
+
+## Final output
+
+When the rebase is complete, print a concise summary to stdout:
+- How many commits were replayed
+- Which files had conflicts and how you resolved them (one line each)
+- Confirmation that the rebase is done (no rebase-merge or rebase-apply dir)
+
+Be specific. The wrapper includes your summary in its PR comment.

--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -1,6 +1,6 @@
 ---
 name: cai-revise
-description: Handle an auto-improve PR that needs attention — resolve any in-progress rebase against main AND address unaddressed reviewer comments, in one session. Used by `cai revise` after the wrapper has cloned, checked out, and attempted `git rebase origin/main`.
+description: Handle review comments on an auto-improve PR — resolve any in-progress rebase against main AND address unaddressed reviewer comments, in one session. Only invoked by the wrapper when there are unaddressed review comments. (Conflict-only runs go to `cai-rebase`.)
 tools: Read, Edit, Write, Grep, Glob, Agent
 model: claude-sonnet-4-6
 memory: project
@@ -10,8 +10,11 @@ memory: project
 
 You are the revise subagent for `robotsix-cai`. The wrapper script
 (`cai.py revise`) has cloned the PR branch, configured your git
-identity, and **just attempted `git rebase origin/main`**. Depending
-on what happened, you have two possible jobs — both in one session:
+identity, and **just attempted `git rebase origin/main`**. You are
+only invoked when there are **unaddressed review comments** — the
+wrapper routes conflict-only runs to `cai-rebase` (haiku) and
+clean-rebase + no-comment runs to an early exit. Depending on
+what happened, you have two possible jobs — both in one session:
 
 1. **If the rebase stopped on conflicts** (there is a rebase in
    progress and there are unmerged files), **drive the rebase to

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,10 +84,12 @@ RUN wget -nv -O /usr/local/bin/supercronic \
 #   - /app/.claude/agent-memory/  → cai_agent_memory  (per-agent
 #                                    durable memory across container
 #                                    restarts; the /app agents
-#                                    read/write it directly, the
-#                                    cloned-worktree agents have it
-#                                    copied in/out by the wrapper
-#                                    around each invocation)
+#                                    read/write it directly, as do
+#                                    the cloned-worktree agents that
+#                                    have memory tracking via the
+#                                    mounted volume; cai-rebase is
+#                                    excluded — it has no memory
+#                                    tracking by design)
 #   - /var/log/cai/               → cai_logs          (run log — one
 #                                    key=value line per cai invocation;
 #                                    named volume avoids host permission

--- a/README.md
+++ b/README.md
@@ -483,8 +483,9 @@ The container uses three Docker named volumes:
   `memory: project` in its frontmatter, which Claude Code stores at
   `.claude/agent-memory/<agent-name>/MEMORY.md`. The /app agents
   (analyze, audit, confirm, merge, audit-triage) read/write this
-  volume directly. The cloned-worktree agents (fix, revise,
-  review-pr, code-audit, propose, propose-review) also access their
+  volume directly. The cloned-worktree agents (fix, revise, rebase,
+  review-pr, code-audit, propose, propose-review, update-check,
+  plan, select, git) also access their
   memory directly from `/app/.claude/agent-memory/<agent-name>/`
   via the mounted `cai_agent_memory` volume — no copy in/out by
   the wrapper.

--- a/README.md
+++ b/README.md
@@ -483,12 +483,13 @@ The container uses three Docker named volumes:
   `memory: project` in its frontmatter, which Claude Code stores at
   `.claude/agent-memory/<agent-name>/MEMORY.md`. The /app agents
   (analyze, audit, confirm, merge, audit-triage) read/write this
-  volume directly. The cloned-worktree agents (fix, revise, rebase,
+  volume directly. The cloned-worktree agents (fix, revise,
   review-pr, code-audit, propose, propose-review, update-check,
   plan, select, git) also access their
   memory directly from `/app/.claude/agent-memory/<agent-name>/`
   via the mounted `cai_agent_memory` volume — no copy in/out by
-  the wrapper.
+  the wrapper. (cai-rebase is excluded — it is a lightweight
+  agent with no memory tracking by design.)
 - **`cai_logs`** (mounted at `/var/log/cai`) — run log. One
   key=value line per `cai` invocation. Using a named volume avoids
   the host permission issues that a bind-mount causes.

--- a/README.md
+++ b/README.md
@@ -174,8 +174,14 @@ instead of closing it. The `revise` subcommand (default: hourly at
 `:30`) picks up any PR comment posted **after the most recent commit**
 on the branch and feeds it to the revise subagent. It also
 auto-rebases unmergeable PRs onto current main before processing
-comments; if the rebase has conflicts it posts a comment for human
-triage instead.
+comments. Clean rebases with no unaddressed comments are pushed
+automatically with no agent invocation. Rebases with conflicts but
+no unaddressed comments are handled by the lightweight `cai-rebase`
+haiku agent for automatic conflict resolution. Rebases (clean or
+conflicted) with unaddressed comments are handled by `cai-revise`
+which resolves any rebase and addresses the comments in one session.
+If a conflict is genuinely ambiguous, the agent aborts and posts a
+comment for human triage instead.
 
 How it works:
 

--- a/cai.py
+++ b/cai.py
@@ -1899,9 +1899,9 @@ def _work_directory_block(work_dir: Path) -> str:
     happens, and how to update protected `.claude/agents/*.md`
     files via the staging directory.
 
-    All cloned-worktree subagents (cai-fix, cai-revise, cai-review-pr,
-    cai-code-audit, cai-propose, cai-propose-review, cai-update-check,
-    cai-plan, cai-select, cai-git) are invoked with `cwd=/app`
+    All cloned-worktree subagents (cai-fix, cai-revise, cai-rebase,
+    cai-review-pr, cai-code-audit, cai-propose, cai-propose-review,
+    cai-update-check, cai-plan, cai-select, cai-git) are invoked with `cwd=/app`
     rather than `cwd=<clone>`. This makes their canonical agent
     definition (`/app/.claude/agents/<name>.md`) and per-agent memory
     (`/app/.claude/agent-memory/<name>/`) directly available via
@@ -3086,6 +3086,49 @@ def cmd_revise(args) -> int:
                     "to addressing review comments (if any).\n"
                 )
 
+            # 3c. Early exit: clean rebase with no comments.
+            #     If the rebase completed without conflicts AND there
+            #     are no unaddressed review comments, skip agent
+            #     invocation entirely. Just force-push if HEAD moved
+            #     (rebase may have advanced commits) and unlock.
+            if not rebase_in_progress and not comments:
+                post_rebase_head = _git(
+                    work_dir, "rev-parse", "HEAD", check=False,
+                ).stdout.strip()
+                if pre_agent_head != post_rebase_head:
+                    push = _run(
+                        ["git", "-C", str(work_dir), "push",
+                         "--force-with-lease", "origin", branch],
+                        capture_output=True,
+                    )
+                    if push.returncode != 0:
+                        print(
+                            f"[cai revise] noop push failed:\n{push.stderr}",
+                            file=sys.stderr,
+                        )
+                        _set_labels(issue_number, remove=[LABEL_REVISING],
+                                    log_prefix="cai revise")
+                        log_run("revise", repo=REPO, pr=pr_number,
+                                result="noop_push_failed", exit=1)
+                        had_failure = True
+                        continue
+                    print(
+                        f"[cai revise] clean rebase pushed for PR #{pr_number} "
+                        "(no comments to address)",
+                        flush=True,
+                    )
+                else:
+                    print(
+                        f"[cai revise] PR #{pr_number}: rebase was no-op and "
+                        "no comments to address; skipping agent",
+                        flush=True,
+                    )
+                _set_labels(issue_number, remove=[LABEL_REVISING],
+                            log_prefix="cai revise")
+                log_run("revise", repo=REPO, pr=pr_number,
+                        result="noop_clean", exit=0)
+                continue
+
             # 4. Fetch original issue body.
             try:
                 issue_data = _gh_json([
@@ -3203,7 +3246,12 @@ def cmd_revise(args) -> int:
             #     workaround.
             _setup_agent_edit_staging(work_dir)
 
-            # 6. Invoke the declared cai-revise subagent.
+            # 5c. Choose agent: rebase-only conflicts → haiku agent,
+            #     otherwise → full cai-revise.
+            rebase_only = rebase_in_progress and not comments
+            agent_name = "cai-rebase" if rebase_only else "cai-revise"
+
+            # 6. Invoke the declared subagent.
             #    Runs with `cwd=/app` and `--add-dir <work_dir>` so
             #    the agent reads its own definition (and memory)
             #    from the canonical /app paths while operating on
@@ -3216,20 +3264,20 @@ def cmd_revise(args) -> int:
             #    self-modifications through the staging directory
             #    instead (see _work_directory_block).
             #
-            #    cai-revise delegates git rebase ops to the cai-git
-            #    haiku subagent via the Agent tool instead of running
-            #    git commands directly — see cai-revise.md and the
-            #    cai-git agent definition for details.
+            #    cai-revise/cai-rebase delegate git rebase ops to the
+            #    cai-git haiku subagent via the Agent tool instead of
+            #    running git commands directly — see the respective
+            #    agent definition files for details.
             print(
-                f"[cai revise] running cai-revise subagent for {work_dir}",
+                f"[cai revise] running {agent_name} subagent for {work_dir}",
                 flush=True,
             )
             agent = _run_claude_p(
-                ["claude", "-p", "--agent", "cai-revise",
+                ["claude", "-p", "--agent", agent_name,
                  "--dangerously-skip-permissions",
                  "--add-dir", str(work_dir)],
                 category="revise",
-                agent="cai-revise",
+                agent=agent_name,
                 input=user_message,
                 cwd="/app",
             )

--- a/cai.py
+++ b/cai.py
@@ -178,7 +178,7 @@ UPDATE_CHECK_MEMORY = Path("/var/log/cai/update-check-memory.md")
 # restarts. ALL subagents (both /app agents and the cloned-worktree
 # agents) now read/write this path directly because they're all
 # invoked with `cwd=/app`. The cloned-worktree agents
-# (cai-fix, cai-revise, cai-review-pr, cai-code-audit, cai-propose,
+# (cai-fix, cai-revise, cai-rebase, cai-review-pr, cai-code-audit, cai-propose,
 # cai-propose-review, cai-update-check, cai-plan, cai-select, cai-git) operate
 # on a clone elsewhere via absolute paths —
 # see `_work_directory_block` for the user-message section that

--- a/cai.py
+++ b/cai.py
@@ -3027,10 +3027,10 @@ def cmd_revise(args) -> int:
 
             # 3b. Deterministically attempt the rebase onto main.
             #     We always rebase — if main hasn't moved, it's a
-            #     no-op. The unified cai-revise subagent handles both
-            #     conflict resolution AND review-comment addressing
-            #     in one session, so the wrapper doesn't need to
-            #     branch on `needs_rebase` anymore.
+            #     no-op. Depending on what's needed, the wrapper
+            #     routes to: (a) early exit if clean + no comments,
+            #     (b) cai-rebase (haiku) if conflicts + no comments,
+            #     or (c) cai-revise (sonnet) if comments ± conflicts.
             _git(work_dir, "fetch", "origin", "main")
             pre_agent_head = _git(
                 work_dir, "rev-parse", "HEAD", check=False,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,9 +79,9 @@ services:
       # `.claude/agent-memory/<agent-name>/`. The /app agents
       # (analyze, audit, confirm, merge, audit-triage) read/write
       # this volume directly. The cloned-worktree agents (fix,
-      # revise, review-pr, code-audit) have memory copied in/out
-      # of their per-issue clones by the wrapper around each
-      # invocation.
+      # revise, rebase, review-pr, code-audit, propose,
+      # propose-review, update-check, plan, select, git) also
+      # access their memory directly from the mounted volume.
       - cai_agent_memory:/app/.claude/agent-memory
       - cai_logs:/var/log/cai
     # Required if Watchtower is enabled (uncommented below):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,9 +79,11 @@ services:
       # `.claude/agent-memory/<agent-name>/`. The /app agents
       # (analyze, audit, confirm, merge, audit-triage) read/write
       # this volume directly. The cloned-worktree agents (fix,
-      # revise, rebase, review-pr, code-audit, propose,
+      # revise, review-pr, code-audit, propose,
       # propose-review, update-check, plan, select, git) also
       # access their memory directly from the mounted volume.
+      # (cai-rebase is excluded — lightweight agent, no memory
+      # tracking by design.)
       - cai_agent_memory:/app/.claude/agent-memory
       - cai_logs:/var/log/cai
     # Required if Watchtower is enabled (uncommented below):


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#446

**Issue:** #446 — Route rebase-only cai-revise runs to haiku (cai-rebase agent)

## PR Summary

### What this fixes
When `cai-revise` runs for a PR that only needs a rebase (no review comments), it was spending a full sonnet session (~$0.59) on mechanical work. Additionally, PRs with a clean rebase and no comments still invoked the agent just to have it print "nothing to do".

### What was changed
- **`.cai-staging/agents/cai-rebase.md`** (new): Created a focused haiku (`claude-haiku-4-5`) agent definition for rebase-only conflict resolution. Contains working-directory rules, git delegation to `cai-git`, the rebase resolution loop, conflict-abort handling, and hard rules — no memory tracking, no review-comment logic, no dossier management.
- **`cai.py` — early exit (section 3c, after line 3075)**: Added a new block that, when `not rebase_in_progress and not comments`, skips agent invocation entirely. Force-pushes if HEAD moved (clean rebase advanced commits), logs `result="noop_clean"`, and continues to the next PR.
- **`cai.py` — conditional routing (section 5c, before step 6)**: Added `rebase_only = rebase_in_progress and not comments` and `agent_name = "cai-rebase" if rebase_only else "cai-revise"`. Updated the log message, `--agent` flag, and `agent=` kwarg to use `agent_name`.
- **`cai.py` line 1890**: Added `cai-rebase` to the comment listing cloned-worktree subagents.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
