### PR TITLE
auto-improve: we need a agent, run just before merge that checks for needs for update of documentation in the /docs relative to the modifications made in the MR

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -78,6 +78,23 @@ Refs: robotsix/robotsix-cai#454
 ### New gaps / deferred
 - None
 
+## Revision 4 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:181` — added `cai-review-docs` to cloned-worktree agents list in AGENT_MEMORY_DIR comment
+- `cai.py:1903` — added `cai-review-docs` to cloned-worktree agents list in `_work_directory_block` docstring
+- `docker-compose.yml:82` — added `review-docs` to cloned-worktree agents list in volume comment
+- `README.md:494` — added `review-docs` to cloned-worktree agents list in volumes section
+
+### Decisions this revision
+- All four missing_co_change locations updated to include `cai-review-docs` / `review-docs` after `review-pr`
+
+### New gaps / deferred
+- None
+
 ## Invariants this change relies on
 - `_BOT_COMMENT_MARKERS` clean-heading match suppresses revise re-processing; findings heading absence ensures revise acts on docs gaps
 - The `_DOCS_REVIEW_COMMENT_HEADING_FINDINGS` prefix (`"## cai docs review"`) is distinct from `"## cai pre-merge review"` — no collision

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -63,6 +63,21 @@ Refs: robotsix/robotsix-cai#454
 ### New gaps / deferred
 - None
 
+## Revision 3 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `entrypoint.sh:24` — cycle comment: added `review-docs` between `review-pr` and `merge`
+- `cai.py:122` — module docstring subcommand list: added `review-docs` between `review-pr` and `merge`
+
+### Decisions this revision
+- Both locations are pure documentation; no logic changed
+
+### New gaps / deferred
+- None
+
 ## Invariants this change relies on
 - `_BOT_COMMENT_MARKERS` clean-heading match suppresses revise re-processing; findings heading absence ensures revise acts on docs gaps
 - The `_DOCS_REVIEW_COMMENT_HEADING_FINDINGS` prefix (`"## cai docs review"`) is distinct from `"## cai pre-merge review"` — no collision

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -46,6 +46,23 @@ Refs: robotsix/robotsix-cai#454
 ### New gaps / deferred
 - None
 
+## Revision 2 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `README.md:67` — cycle table row pipeline description: added `review-docs` between `review-pr` and `merge`
+- `README.md:290` — ad-hoc docker compose example: added `review-docs` after `review-pr`
+- `README.md:303` — alias convenience example: added `cai review-docs` after `cai review-pr`
+- `README.md:540` — run log description: added `review-docs` to the command list
+
+### Decisions this revision
+- All four stale README locations updated per reviewer findings
+
+### New gaps / deferred
+- None
+
 ## Invariants this change relies on
 - `_BOT_COMMENT_MARKERS` clean-heading match suppresses revise re-processing; findings heading absence ensures revise acts on docs gaps
 - The `_DOCS_REVIEW_COMMENT_HEADING_FINDINGS` prefix (`"## cai docs review"`) is distinct from `"## cai pre-merge review"` — no collision

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,38 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#454
+
+## Files touched
+- `.cai-staging/agents/cai-review-docs.md` — new agent definition for pre-merge docs review
+- `cai.py:2556` — added `"## cai docs review (clean)"` to `_BOT_COMMENT_MARKERS`
+- `cai.py:5732` — added `_DOCS_REVIEW_COMMENT_HEADING_FINDINGS` / `_DOCS_REVIEW_COMMENT_HEADING_CLEAN` constants
+- `cai.py:5751` — added `cmd_review_docs` function (mirrors `cmd_review_pr`)
+- `cai.py:6211` — added safety filter 7b in `cmd_merge`: gate on `review-docs` having reviewed head SHA
+- `cai.py:7143` — added `review-docs` step to `_drain_pending_prs`
+- `cai.py:7701` — registered `review-docs` argparse subcommand
+- `cai.py:7757` — registered `review-docs` in handlers dict
+
+## Files read (not touched) that matter
+- `.claude/agents/cai-review-pr.md` — primary template for the new agent definition and `cmd_review_docs` structure
+
+## Key symbols
+- `cmd_review_docs` (`cai.py:5751`) — new function; mirrors `cmd_review_pr` exactly but targets `cai-review-docs` agent and uses docs-review headings
+- `_DOCS_REVIEW_COMMENT_HEADING_FINDINGS` (`cai.py:5732`) — heading for actionable findings comments; NOT in `_BOT_COMMENT_MARKERS` so revise picks them up
+- `_DOCS_REVIEW_COMMENT_HEADING_CLEAN` (`cai.py:5733`) — heading for clean comments; IS in `_BOT_COMMENT_MARKERS` so revise skips them
+- `has_docs_review_at_sha` (`cai.py:6211`) — merge gate variable analogous to `has_review_at_sha`
+
+## Design decisions
+- Modeled `cmd_review_docs` exactly on `cmd_review_pr` for consistency — same clone strategy, same comment structure, same SHA-idempotency check
+- Merge gate (safety filter 7b) runs after the review-pr gate so both reviews must pass before merge
+- Clean heading added to `_BOT_COMMENT_MARKERS` so revise ignores "no docs needed" comments
+- Findings heading NOT added to `_BOT_COMMENT_MARKERS` so revise sees and addresses docs findings
+- Rejected: reusing `_log_review_pr_findings` for docs — the log is specifically named for review-pr patterns; docs findings don't need the same analytics
+
+## Out of scope / known gaps
+- No `REVIEW_DOCS_PATTERN_LOG` analytics — kept minimal per issue scope
+- The `docs/` directory is currently empty; agent handles this gracefully with "No documentation updates needed."
+- The cycle command docstring still mentions only "review-pr" in the flow description — could be updated separately
+
+## Invariants this change relies on
+- `_BOT_COMMENT_MARKERS` clean-heading match suppresses revise re-processing; findings heading absence ensures revise acts on docs gaps
+- The `_DOCS_REVIEW_COMMENT_HEADING_FINDINGS` prefix (`"## cai docs review"`) is distinct from `"## cai pre-merge review"` — no collision
+- `_drain_pending_prs` runs steps sequentially; `review-docs` runs after `review-pr` and before `merge`

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -30,7 +30,21 @@ Refs: robotsix/robotsix-cai#454
 ## Out of scope / known gaps
 - No `REVIEW_DOCS_PATTERN_LOG` analytics — kept minimal per issue scope
 - The `docs/` directory is currently empty; agent handles this gracefully with "No documentation updates needed."
-- The cycle command docstring still mentions only "review-pr" in the flow description — could be updated separately
+
+## Revision 1 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:7376` — updated `cmd_cycle` docstring flow: "revise → review-pr → merge" → "revise → review-pr → review-docs → merge"
+- `cai.py:7929` — updated cycle subcommand help text to include `review-docs` in the pipeline list
+
+### Decisions this revision
+- Both flow-description locations updated to match the actual `_drain_pending_prs` pipeline order (already updated by the PR)
+
+### New gaps / deferred
+- None
 
 ## Invariants this change relies on
 - `_BOT_COMMENT_MARKERS` clean-heading match suppresses revise re-processing; findings heading absence ensures revise acts on docs gaps

--- a/.claude/agents/cai-review-docs.md
+++ b/.claude/agents/cai-review-docs.md
@@ -1,0 +1,119 @@
+---
+name: cai-review-docs
+description: Pre-merge documentation review for an open PR. Checks whether changes to user-facing behavior, CLI interface, configuration, or architecture require updates to files in /docs. Emits `### Finding: stale_docs` blocks the wrapper posts as a PR comment. Read-only.
+tools: Read, Grep, Glob, Agent
+model: claude-haiku-4-5
+memory: project
+---
+
+# Pre-Merge Documentation Review
+
+You are the pre-merge documentation review agent for `robotsix-cai`. Your job
+is to check whether a pull request's changes require updates to the
+documentation in the `/docs` directory. You have read-only access via `Read`,
+`Grep`, `Glob`, and the `Agent` tool.
+
+## Your working directory and the canonical /app location
+
+**Your `cwd` is `/app`, NOT the cloned PR.** `/app` is where your declarative
+agent definition and per-agent memory live. The actual PR you're reviewing is
+at the path the wrapper provides in the user message (look for the
+`## Work directory` section).
+
+**Use absolute paths under the work directory for all `Read`, `Grep`, and
+`Glob` operations.** Relative paths resolve to `/app` (the canonical,
+baked-in source). Examples:
+
+  - GOOD: `Read("<work_dir>/docs/index.md")`
+  - GOOD: `Glob("docs/**/*.md", path="<work_dir>")`
+  - BAD:  `Read("docs/index.md")`           (reads /app/docs/index.md)
+
+**Note:** `cai.py` is ~63 k tokens — a whole-file Read will exceed the token
+limit. Use `Grep(pattern, path="<work_dir>")` for symbol search and
+`Read("<work_dir>/cai.py", offset=N, limit=200)` for targeted sections.
+
+## What you receive
+
+In the user message, in order:
+
+1. **Work directory** — where the cloned PR lives
+2. **PR metadata** — number, title, author, base branch, head SHA
+3. **PR diff** — the full unified diff of the PR
+
+## What to check
+
+Walk the diff and identify changes that affect **user-facing behavior**. Then
+read the documentation files at `<work_dir>/docs/` and check whether each
+documented behavior still matches the updated code.
+
+Changes that **warrant documentation review**:
+- New or renamed CLI subcommands (e.g. `cai <cmd>`)
+- New, renamed, or removed environment variables or configuration options
+- New or changed docker-compose volumes, ports, or service definitions
+- Changes to the install flow (`install.sh`, `Dockerfile`)
+- Changes to the cron schedule or autonomous loop behavior
+- New agent types or major changes to existing agent behavior
+- Changes to the pipeline architecture (new steps, reordered steps)
+- Changes to how the user is expected to interact with the system
+
+Changes that **do NOT warrant documentation review**:
+- Internal refactors that preserve external behavior
+- Test-only changes (`tests/`, `.github/workflows/`)
+- Logging, telemetry, or cost-tracking changes with no user-visible effect
+- Bug fixes that restore behavior to what is already documented
+- Changes only to `.cai/pr-context.md` (auto-generated metadata)
+
+## How to work
+
+1. Read the diff carefully and identify user-facing changes (if any)
+2. Use `Glob("docs/**/*.md", path="<work_dir>")` to find all doc files
+3. Read each doc file and check whether the documented behavior matches the
+   post-PR code
+4. For each gap, emit a `### Finding: stale_docs` block
+
+If the `docs/` directory does not exist or is empty, output
+`No documentation updates needed.`
+
+## Output format
+
+If docs need updating, emit one block per finding:
+
+```
+### Finding: stale_docs
+
+**File(s):** <doc file that needs updating>
+
+**Description:** <what changed in the PR and why the doc is now stale>
+
+**Suggested update:** <concrete, specific suggestion — quote the stale text and
+give the replacement>
+```
+
+If no doc updates are needed, output exactly:
+
+```
+No documentation updates needed.
+```
+
+## Hard rules
+
+1. **Only report real documentation gaps.** Do not flag style, formatting, or
+   things that "could be improved." Report only cases where the docs describe
+   behavior that no longer matches the code after this PR.
+2. **Be specific.** Name the exact doc file, the stale section or sentence, and
+   the concrete update needed.
+3. **Do not suggest docs for internal changes.** If the change has no
+   user-visible effect, do not flag it.
+4. **Do not flag `.cai/pr-context.md`.** This is auto-generated metadata —
+   skip it entirely.
+5. **Keep it short.** Each finding should be 3–5 sentences max.
+
+## Efficiency guidance
+
+1. **Grep before Read.** Use Grep to locate relevant sections before reading
+   full files.
+2. **Batch independent Read calls.** When you need to read multiple files and
+   the reads are independent, issue all Read calls in a single turn.
+3. **Use Agent for broad exploration.** When you need to search broadly, use
+   the Agent tool with `subagent_type: Explore` rather than many sequential
+   Grep or Read calls.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ subprocess with no shared state.
 | `cai.py update-check` | `0 4 * * 1` (weekly Monday 04:00 UTC) | Claude Code release check — clones the repo, fetches the latest Claude Code releases from GitHub, and runs a Sonnet agent that compares the current pinned version against the latest releases; findings (new versions, deprecated flags, best practices) are published as `update-check` namespace issues |
 | `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → re-queued to `:refined` (up to 3 attempts), then escalated to `:needs-human-review` (Sonnet) |
 | `cai.py health-report` | `0 7 * * 1` (weekly Monday 07:00 UTC) | Automated pipeline health report with anomaly detection. Aggregates cost trends (last 7d vs prior 7d WoW delta), issue queue counts per label state, pipeline stalls, and fix quality metrics. Posts a GitHub-flavored markdown report with 🔴/🟡/🟢 traffic-light indicators as a `health-report` labelled issue. Use `--dry-run` to print to stdout without posting. |
-| `cai.py cycle` | _(startup + manual/on-demand)_ | Runs verify → fix → revise → review-pr → merge → confirm in sequence. The entrypoint runs this once synchronously at `docker compose up -d` so the issue-solving pipeline produces immediate logs; not scheduled via cron (the individual steps have their own cron lines) |
+| `cai.py cycle` | _(startup + manual/on-demand)_ | Runs verify → fix → revise → review-pr → review-docs → merge → confirm in sequence. The entrypoint runs this once synchronously at `docker compose up -d` so the issue-solving pipeline produces immediate logs; not scheduled via cron (the individual steps have their own cron lines) |
 | `cai.py test` | _(manual/on-demand)_ | Runs the project test suite (`python -m unittest discover` under `tests/`) |
 
 On `docker compose up -d` the entrypoint templates the crontab from
@@ -293,6 +293,7 @@ docker compose exec cai python /app/cai.py analyze
 docker compose exec cai python /app/cai.py fix              # automatic scoring-based selection
 docker compose exec cai python /app/cai.py fix --issue 12   # specific issue
 docker compose exec cai python /app/cai.py review-pr
+docker compose exec cai python /app/cai.py review-docs
 docker compose exec cai python /app/cai.py revise
 docker compose exec cai python /app/cai.py verify
 docker compose exec cai python /app/cai.py audit
@@ -306,6 +307,7 @@ A short alias makes this trivial:
 alias cai='docker compose -f ~/robotsix-cai/docker-compose.yml exec cai python /app/cai.py'
 cai fix --issue 12
 cai review-pr
+cai review-docs
 cai revise
 cai verify
 cai audit
@@ -545,7 +547,7 @@ docker run --rm -v cai_home:/data alpine ls -R /data
 
 A **run log** is written to `/var/log/cai/cai.log` inside the container
 (persisted in the `cai_logs` named volume). Each `init`, `analyze`,
-`fix`, `review-pr`, `revise`, `verify`, `audit`, `code-audit`, `propose`, `confirm`, `merge`, and `health-report` invocation appends one key=value line so you can
+`fix`, `review-pr`, `review-docs`, `revise`, `verify`, `audit`, `code-audit`, `propose`, `confirm`, `merge`, and `health-report` invocation appends one key=value line so you can
 watch cycle activity:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ The container uses three Docker named volumes:
   `.claude/agent-memory/<agent-name>/MEMORY.md`. The /app agents
   (analyze, audit, confirm, merge, audit-triage) read/write this
   volume directly. The cloned-worktree agents (fix, revise,
-  review-pr, code-audit, propose, propose-review, update-check,
+  review-pr, review-docs, code-audit, propose, propose-review, update-check,
   plan, select, git) also access their
   memory directly from `/app/.claude/agent-memory/<agent-name>/`
   via the mounted `cai_agent_memory` volume — no copy in/out by

--- a/cai.py
+++ b/cai.py
@@ -2566,6 +2566,7 @@ _BOT_COMMENT_MARKERS = (
     "## Revise subagent:",
     "## Revision summary",
     "## cai pre-merge review (clean)",
+    "## cai docs review (clean)",
     "## cai merge verdict",
 )
 
@@ -5790,6 +5791,205 @@ def cmd_review_pr(args) -> int:
 
 
 # ---------------------------------------------------------------------------
+# review-docs — pre-merge documentation review
+# ---------------------------------------------------------------------------
+
+# docs-review posts two comment variants depending on whether the
+# review found stale documentation:
+#
+#   * `_DOCS_REVIEW_COMMENT_HEADING_FINDINGS` — actionable, contains
+#     `### Finding: stale_docs` blocks. NOT in `_BOT_COMMENT_MARKERS`
+#     so the revise subagent picks them up and addresses them.
+#
+#   * `_DOCS_REVIEW_COMMENT_HEADING_CLEAN` — informational only, says
+#     "no documentation updates needed". IS in `_BOT_COMMENT_MARKERS`
+#     so the revise subagent skips it (no actionable content).
+#
+# Both forms include the head SHA at the end of the heading line so
+# the SHA-idempotency check can recognize either as "already
+# reviewed at this commit".
+_DOCS_REVIEW_COMMENT_HEADING_FINDINGS = "## cai docs review"
+_DOCS_REVIEW_COMMENT_HEADING_CLEAN = "## cai docs review (clean)"
+
+
+def cmd_review_docs(args) -> int:
+    """Review open PRs for stale documentation and post findings as PR comments."""
+    print("[cai review-docs] checking open PRs against main", flush=True)
+    t0 = time.monotonic()
+
+    try:
+        prs = _gh_json([
+            "pr", "list",
+            "--repo", REPO,
+            "--state", "open",
+            "--base", "main",
+            "--json", "number,title,author,headRefOid,comments",
+            "--limit", "50",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(f"[cai review-docs] gh pr list failed:\n{e.stderr}", file=sys.stderr)
+        log_run("review_docs", repo=REPO, result="pr_list_failed", exit=1)
+        return 1
+
+    if not prs:
+        print("[cai review-docs] no open PRs; nothing to do", flush=True)
+        log_run("review_docs", repo=REPO, result="no_open_prs", exit=0)
+        return 0
+
+    reviewed = 0
+    skipped = 0
+
+    for pr in prs:
+        pr_number = pr["number"]
+        head_sha = pr["headRefOid"]
+        title = pr["title"]
+
+        # Check if we already posted a docs review for this SHA.
+        already_reviewed = False
+        for comment in pr.get("comments", []):
+            body = (comment.get("body") or "")
+            first_line = body.split("\n", 1)[0]
+            if (
+                first_line.startswith(_DOCS_REVIEW_COMMENT_HEADING_FINDINGS)
+                and head_sha in first_line
+            ):
+                already_reviewed = True
+                break
+        if already_reviewed:
+            print(
+                f"[cai review-docs] PR #{pr_number}: already reviewed at {head_sha[:8]}; skipping",
+                flush=True,
+            )
+            skipped += 1
+            continue
+
+        print(f"[cai review-docs] reviewing PR #{pr_number}: {title}", flush=True)
+
+        # Get the diff.
+        diff_result = _run(
+            ["gh", "pr", "diff", str(pr_number), "--repo", REPO],
+            capture_output=True,
+        )
+        if diff_result.returncode != 0:
+            print(
+                f"[cai review-docs] could not fetch diff for PR #{pr_number}:\n"
+                f"{diff_result.stderr}",
+                file=sys.stderr,
+            )
+            continue
+        pr_diff = diff_result.stdout
+
+        # Clone the repo for the agent to walk.
+        _uid = uuid.uuid4().hex[:8]
+        work_dir = Path(f"/tmp/cai-review-docs-{pr_number}-{_uid}")
+        try:
+            if work_dir.exists():
+                shutil.rmtree(work_dir)
+
+            clone = _run(
+                ["git", "clone", "--depth", "1",
+                 f"https://github.com/{REPO}.git", str(work_dir)],
+                capture_output=True,
+            )
+            if clone.returncode != 0:
+                print(
+                    f"[cai review-docs] clone failed for PR #{pr_number}:\n{clone.stderr}",
+                    file=sys.stderr,
+                )
+                continue
+
+            author_login = pr.get("author", {}).get("login", "unknown")
+            user_message = (
+                _work_directory_block(work_dir)
+                + "\n"
+                + f"## PR metadata\n\n"
+                + f"- **Number:** #{pr_number}\n"
+                + f"- **Title:** {title}\n"
+                + f"- **Author:** @{author_login}\n"
+                + f"- **Base:** main\n"
+                + f"- **HEAD SHA:** {head_sha}\n\n"
+                + f"## PR diff\n\n"
+                + f"```diff\n{pr_diff}\n```\n"
+            )
+
+            # Invoke the declared cai-review-docs subagent.
+            agent = _run_claude_p(
+                ["claude", "-p", "--agent", "cai-review-docs",
+                 "--permission-mode", "acceptEdits",
+                 "--add-dir", str(work_dir)],
+                category="review-docs",
+                agent="cai-review-docs",
+                input=user_message,
+                cwd="/app",
+            )
+            if agent.stdout:
+                print(agent.stdout, flush=True)
+            if agent.returncode != 0:
+                print(
+                    f"[cai review-docs] agent failed for PR #{pr_number} "
+                    f"(exit {agent.returncode}):\n{agent.stderr}",
+                    file=sys.stderr,
+                )
+                continue
+
+            agent_output = (agent.stdout or "").strip()
+
+            # Determine if there are findings.
+            has_findings = (
+                "### Finding:" in agent_output
+                and "No documentation updates needed" not in agent_output
+            )
+
+            if has_findings:
+                comment_body = (
+                    f"{_DOCS_REVIEW_COMMENT_HEADING_FINDINGS} \u2014 {head_sha}\n\n"
+                    f"{agent_output}\n\n"
+                    f"---\n"
+                    f"_Pre-merge documentation review by `cai review-docs`. "
+                    f"Address the findings above or explain why they don't "
+                    f"apply, then push a new commit to trigger a re-review._"
+                )
+            else:
+                comment_body = (
+                    f"{_DOCS_REVIEW_COMMENT_HEADING_CLEAN} \u2014 {head_sha}\n\n"
+                    f"No documentation updates needed.\n\n"
+                    f"---\n"
+                    f"_Pre-merge documentation review by `cai review-docs`._"
+                )
+
+            _run(
+                ["gh", "pr", "comment", str(pr_number),
+                 "--repo", REPO, "--body", comment_body],
+                capture_output=True,
+            )
+
+            finding_word = "with findings" if has_findings else "clean"
+            print(
+                f"[cai review-docs] posted review on PR #{pr_number} ({finding_word})",
+                flush=True,
+            )
+            reviewed += 1
+
+        except Exception as e:
+            print(
+                f"[cai review-docs] unexpected failure for PR #{pr_number}: {e!r}",
+                file=sys.stderr,
+            )
+        finally:
+            if work_dir.exists():
+                shutil.rmtree(work_dir, ignore_errors=True)
+
+    dur = f"{int(time.monotonic() - t0)}s"
+    print(
+        f"[cai review-docs] reviewed={reviewed} skipped={skipped}",
+        flush=True,
+    )
+    log_run("review_docs", repo=REPO, reviewed=reviewed, skipped=skipped,
+            duration=dur, exit=0)
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Merge — confidence-gated auto-merge for bot PRs
 # ---------------------------------------------------------------------------
 
@@ -6071,6 +6271,27 @@ def cmd_merge(args) -> int:
         if not has_review_at_sha:
             print(
                 f"[cai merge] PR #{pr_number}: review-pr has not reviewed "
+                f"{head_sha[:8]} yet; waiting",
+                flush=True,
+            )
+            continue
+
+        # Safety filter 7b: require `cai review-docs` to have reviewed
+        # the current head SHA before running a merge verdict.
+        has_docs_review_at_sha = False
+        for comment in pr.get("comments", []):
+            body = (comment.get("body") or "")
+            first_line = body.split("\n", 1)[0]
+            if (
+                first_line.startswith(_DOCS_REVIEW_COMMENT_HEADING_FINDINGS)
+                and head_sha in first_line
+            ):
+                has_docs_review_at_sha = True
+                break
+
+        if not has_docs_review_at_sha:
+            print(
+                f"[cai merge] PR #{pr_number}: review-docs has not reviewed "
                 f"{head_sha[:8]} yet; waiting",
                 flush=True,
             )
@@ -7197,10 +7418,11 @@ def _run_step(name: str, handler, args) -> int:
 
 
 def _drain_pending_prs(args) -> dict:
-    """Revise → review-pr → merge all pending PRs. Returns step results."""
+    """Revise → review-pr → review-docs → merge all pending PRs. Returns step results."""
     results: dict[str, int] = {}
     results["revise"] = _run_step("revise", cmd_revise, args)
     results["review-pr"] = _run_step("review-pr", cmd_review_pr, args)
+    results["review-docs"] = _run_step("review-docs", cmd_review_docs, args)
     results["merge"] = _run_step("merge", cmd_merge, args)
     return results
 
@@ -7759,6 +7981,7 @@ def main() -> int:
     sub.add_parser("update-check", help="Check Claude Code releases for workspace improvements")
     sub.add_parser("confirm", help="Verify merged issues are actually solved")
     sub.add_parser("review-pr", help="Pre-merge consistency review of open PRs")
+    sub.add_parser("review-docs", help="Pre-merge documentation review of open PRs")
     sub.add_parser("merge", help="Confidence-gated auto-merge for bot PRs")
     sub.add_parser("refine", help="Refine human-filed issues into structured plans")
     sub.add_parser("spike", help="Run the spike agent on :needs-spike issues")
@@ -7815,6 +8038,7 @@ def main() -> int:
         "update-check": cmd_update_check,
         "confirm": cmd_confirm,
         "review-pr": cmd_review_pr,
+        "review-docs": cmd_review_docs,
         "merge": cmd_merge,
         "refine": cmd_refine,
         "spike": cmd_spike,

--- a/cai.py
+++ b/cai.py
@@ -178,7 +178,7 @@ UPDATE_CHECK_MEMORY = Path("/var/log/cai/update-check-memory.md")
 # restarts. ALL subagents (both /app agents and the cloned-worktree
 # agents) now read/write this path directly because they're all
 # invoked with `cwd=/app`. The cloned-worktree agents
-# (cai-fix, cai-revise, cai-rebase, cai-review-pr, cai-code-audit, cai-propose,
+# (cai-fix, cai-revise, cai-rebase, cai-review-pr, cai-review-docs, cai-code-audit, cai-propose,
 # cai-propose-review, cai-update-check, cai-plan, cai-select, cai-git) operate
 # on a clone elsewhere via absolute paths —
 # see `_work_directory_block` for the user-message section that
@@ -1900,7 +1900,7 @@ def _work_directory_block(work_dir: Path) -> str:
     files via the staging directory.
 
     All cloned-worktree subagents (cai-fix, cai-revise, cai-rebase,
-    cai-review-pr, cai-code-audit, cai-propose, cai-propose-review,
+    cai-review-pr, cai-review-docs, cai-code-audit, cai-propose, cai-propose-review,
     cai-update-check, cai-plan, cai-select, cai-git) are invoked with `cwd=/app`
     rather than `cwd=<clone>`. This makes their canonical agent
     definition (`/app/.claude/agents/<name>.md`) and per-agent memory

--- a/cai.py
+++ b/cai.py
@@ -7433,7 +7433,7 @@ def cmd_cycle(args) -> int:
     Flow:
       1. verify + confirm  (sync label state)
       1.5. recover stale locks (:in-progress / :revising)
-      2. drain pending PRs (revise → review-pr → merge)
+      2. drain pending PRs (revise → review-pr → review-docs → merge)
       2.5. refine one :raised issue
       3. loop: verify → fix → drain → refine → repeat
       4. final confirm
@@ -7986,7 +7986,7 @@ def main() -> int:
     sub.add_parser("refine", help="Refine human-filed issues into structured plans")
     sub.add_parser("spike", help="Run the spike agent on :needs-spike issues")
     sub.add_parser("explore", help="Autonomous exploration/benchmarking of :needs-exploration issues")
-    sub.add_parser("cycle", help="Full cycle: verify, fix, revise, review-pr, merge, confirm")
+    sub.add_parser("cycle", help="Full cycle: verify, fix, revise, review-pr, review-docs, merge, confirm")
     sub.add_parser("test", help="Run the project test suite")
 
     cost_parser = sub.add_parser(

--- a/cai.py
+++ b/cai.py
@@ -119,7 +119,7 @@ Subcommands:
                             --dry-run to print to stdout without posting.
 
 The container runs `entrypoint.sh`, which executes `init`, `analyze`,
-`verify`, `refine`, `spike`, `fix`, `revise`, `review-pr`, `merge`, `audit`, `code-audit`, `propose`, `update-check`, and `confirm` once synchronously at
+`verify`, `refine`, `spike`, `fix`, `revise`, `review-pr`, `review-docs`, `merge`, `audit`, `code-audit`, `propose`, `update-check`, and `confirm` once synchronously at
 startup, then hands off to supercronic. Each cron tick is a fresh process.
 
 The gh auth check is done once per subcommand invocation. We want a

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       # `.claude/agent-memory/<agent-name>/`. The /app agents
       # (analyze, audit, confirm, merge, audit-triage) read/write
       # this volume directly. The cloned-worktree agents (fix,
-      # revise, review-pr, code-audit, propose,
+      # revise, review-pr, review-docs, code-audit, propose,
       # propose-review, update-check, plan, select, git) also
       # access their memory directly from the mounted volume.
       # (cai-rebase is excluded — lightweight agent, no memory

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@
 #    independent processes — natural concurrency, easy to add more.
 #
 # 2. Do one synchronous `cai.py cycle` pass (verify → fix → revise →
-#    review-pr → merge → confirm) so `docker compose up -d` produces
+#    review-pr → review-docs → merge → confirm) so `docker compose up -d` produces
 #    useful logs immediately rather than waiting for the first cron
 #    tick. Only the issue-solving cycle runs at startup; analysis,
 #    audit, proposal, spike, refine, and update-check agents wait for


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#454

**Issue:** #454 — we need a agent, run just before merge that checks for needs for update of documentation in the /docs relative to the modifications made in the MR

## PR Summary

### What this fixes
Adds a `cai review-docs` pipeline step that runs just before merge and checks whether a PR's changes to user-facing behavior require updates to documentation files in `/docs`. Without this step, docs could silently drift out of sync with the code.

### What was changed
- **`.cai-staging/agents/cai-review-docs.md`** (new): Declarative agent definition for the docs-review agent — modeled after `cai-review-pr.md`, uses `Read/Grep/Glob/Agent` tools, emits `### Finding: stale_docs` blocks for stale documentation
- **`cai.py`**: Added `"## cai docs review (clean)"` to `_BOT_COMMENT_MARKERS`; added `_DOCS_REVIEW_COMMENT_HEADING_FINDINGS`/`_DOCS_REVIEW_COMMENT_HEADING_CLEAN` constants; added `cmd_review_docs` function (mirrors `cmd_review_pr` but targets `cai-review-docs` agent); added safety filter 7b in `cmd_merge` requiring `review-docs` to have reviewed the current SHA; added `review-docs` step to `_drain_pending_prs` between `review-pr` and `merge`; registered `review-docs` in argparse subcommands and handlers dict

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
