### PR TITLE
auto-improve: Revise guard not blocking `needs-human-review` PR #419

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,33 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#432
+
+## Files touched
+- `cai.py:2940` — removed `LABEL_MERGE_BLOCKED` from the `remove=` list in `_recover_stuck_rebase_prs()` so recovered issues retain `merge-blocked`
+- `cai.py:2774` — initialized `pr_detail = None` before try block in `_select_revise_targets()`
+- `cai.py:2778` — added `labels` to `--json` fields in per-PR `gh pr view` call
+- `cai.py:2786-2796` — added secondary per-PR `needs-human-review` guard using fresh `gh pr view` label data
+
+## Files read (not touched) that matter
+- `cai.py:2707-2840` — `_select_revise_targets()` full body — primary revise guard logic
+- `cai.py:2843-2947` — `_recover_stuck_rebase_prs()` full body — recovery logic that was stripping `merge-blocked`
+- `cai.py:2950-2965` — `cmd_revise()` — recovery runs before target selection, explaining the ordering bug
+
+## Key symbols
+- `_recover_stuck_rebase_prs` (`cai.py:2843`) — ran first in cmd_revise; was stripping merge-blocked, nullifying the guard
+- `_select_revise_targets` (`cai.py:2707`) — primary guard; now has secondary fresh-label check
+- `LABEL_MERGE_BLOCKED` (`cai.py:202`) — `"merge-blocked"` — issue-level block label
+- `LABEL_PR_NEEDS_HUMAN` (`cai.py:209`) — `"needs-human-review"` — PR-level block label
+
+## Design decisions
+- Preserve `merge-blocked` in `_recover_stuck_rebase_prs` — intentional; cmd_merge explicitly evaluates merge-blocked PRs so it will re-evaluate any fresh PR and remove the label if appropriate
+- Add secondary per-PR label check after per-PR `gh pr view` — defense against stale `gh pr list` data for recently-labelled PRs
+- Guard placement: secondary check runs before `if not last_commit_date` so stale-label PRs are skipped with an explanatory log message rather than silently
+- Rejected: fixing only one of the two root causes — both are needed for defense-in-depth
+
+## Out of scope / known gaps
+- `cmd_fix` does not check `merge-blocked` before picking up `:refined` issues — this is intentional per the plan (cmd_fix should be able to re-attempt)
+- Did not add `merge-blocked` check to the secondary per-PR block (only checking `needs-human-review` there) because `merge-blocked` is an issue label, not a PR label
+
+## Invariants this change relies on
+- `cmd_merge` does NOT skip issues/PRs that have `merge-blocked` — it evaluates them and removes the label on success (confirmed at line ~6226 and ~6552)
+- `_recover_stuck_rebase_prs` runs before `_select_revise_targets` in `cmd_revise` — ordering at lines 2956 and 2963

--- a/cai.py
+++ b/cai.py
@@ -2771,11 +2771,12 @@ def _select_revise_targets() -> list[dict]:
             continue
 
         # Find the most recent commit date via `gh pr view`.
+        pr_detail = None
         try:
             pr_detail = _gh_json([
                 "pr", "view", str(pr["number"]),
                 "--repo", REPO,
-                "--json", "commits,mergeable,mergeStateStatus",
+                "--json", "commits,mergeable,mergeStateStatus,labels",
             ])
             commits = pr_detail.get("commits", [])
             if commits:
@@ -2784,6 +2785,20 @@ def _select_revise_targets() -> list[dict]:
                 last_commit_date = ""
         except Exception:
             last_commit_date = ""
+
+        # Secondary per-PR label check (issue #432): gh pr list may
+        # return stale label data for recently-modified PRs.  The
+        # per-PR gh pr view call above gives a fresh snapshot.
+        if pr_detail:
+            detail_label_names = {lbl["name"] for lbl in pr_detail.get("labels", [])}
+            if LABEL_PR_NEEDS_HUMAN in detail_label_names:
+                print(
+                    f"[cai revise] PR #{pr['number']}: skipping — "
+                    f"PR has :{LABEL_PR_NEEDS_HUMAN} (fresh per-PR check, "
+                    f"needs human decision)",
+                    flush=True,
+                )
+                continue
 
         if not last_commit_date:
             continue
@@ -2934,10 +2949,16 @@ def _recover_stuck_rebase_prs() -> int:
             continue
 
         # Reset the linked issue back to the eligible-for-fix state.
+        # NOTE: LABEL_MERGE_BLOCKED is intentionally NOT removed here.
+        # If cmd_fix opens a fresh PR for this issue, the revise guard
+        # in _select_revise_targets() must still see merge-blocked until
+        # cmd_merge re-evaluates the new PR and removes it.  cmd_merge
+        # explicitly does NOT skip on merge-blocked, so it will evaluate
+        # the new PR regardless.  Issue #432.
         _set_labels(
             issue_number,
             add=[LABEL_REFINED],
-            remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED, LABEL_REVISING],
+            remove=[LABEL_PR_OPEN, LABEL_REVISING],
             log_prefix="cai revise",
         )
         log_run("revise", repo=REPO, pr=pr_number, issue=issue_number,


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#432

**Issue:** #432 — Revise guard not blocking `needs-human-review` PR #419

## PR Summary

### What this fixes
PRs with `needs-human-review` (like PR #419) were still receiving revise runs after PR #405's guard merged, because `_recover_stuck_rebase_prs()` strips `merge-blocked` from the linked issue *before* `_select_revise_targets()` runs — so the guard's issue-label check always saw a clean issue. Additionally, `gh pr list` data can be stale for recently-labelled PRs, making the PR-level check unreliable.

### What was changed
- **`cai.py` (`_recover_stuck_rebase_prs`, ~line 2940):** Removed `LABEL_MERGE_BLOCKED` from the `remove=` list when resetting a recovered issue. `merge-blocked` is now preserved so the revise guard in `_select_revise_targets()` continues to fire for any new PR opened against that issue. `cmd_merge` explicitly evaluates merge-blocked PRs and removes the label on a successful verdict, so this does not block the merge pipeline.
- **`cai.py` (`_select_revise_targets`, ~line 2774–2796):** Initialized `pr_detail = None` before the try block; added `labels` to the per-PR `gh pr view --json` fields; inserted a secondary `needs-human-review` guard that uses the fresh per-PR label snapshot to catch cases where `gh pr list` returns stale label data for recently-modified PRs.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
