### PR TITLE
auto-improve: Fix agent should execute multi-step plans with per-step verification

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -35,3 +35,17 @@ Refs: robotsix/robotsix-cai#312
 
 ### New gaps / deferred
 - None
+
+## Revision 2 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- README.md:136 — added new "### Filing issues with multi-step plans" section between the issue lifecycle `:no-action` paragraph and the "### Audit findings" heading
+
+### Decisions this revision
+- Added user-facing documentation for the `### Plan` / `### Verification` issue format per reviewer finding; placed in the issue lifecycle section since that's where users learn how issues flow through the system
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -21,3 +21,17 @@ Refs: robotsix/robotsix-cai#312
 ## Invariants this change relies on
 - The wrapper copies `.cai-staging/agents/*.md` to `.claude/agents/` after a successful exit
 - The new section only activates when the issue body contains a `### Plan` section; issues without one are unaffected
+
+## Revision 1 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- .claude/agents/cai-fix.md:4 — added `TodoWrite` to `tools:` frontmatter field
+
+### Decisions this revision
+- Added TodoWrite to tools list — reviewer correctly identified the new ## Multi-step plans section references TodoWrite in two places but the tool was absent from the frontmatter; the original issue author's claim that it was available "via the shared deferred-tool set" was incorrect for declarative subagents
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,23 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#312
+
+## Files touched
+- .claude/agents/cai-fix.md:315 — inserted new `## Multi-step plans` section (22 lines) between `## When to make changes` and `## Raising complementary issues`
+
+## Files read (not touched) that matter
+- .claude/agents/cai-fix.md — source file; read to determine exact insertion point at line 314/315 boundary
+
+## Key symbols
+- `## Multi-step plans` (.claude/agents/cai-fix.md:315) — new section added; guides fix agent to execute numbered plan steps sequentially with per-step Read/Grep verification
+
+## Design decisions
+- Inserted via staging path `.cai-staging/agents/cai-fix.md` — direct writes to `.claude/agents/` are blocked by claude-code sensitive-file protection
+- Placed between `## When to make changes` and `## Raising complementary issues` — logically follows the "when to act" guidance and precedes the "side effects" guidance
+
+## Out of scope / known gaps
+- No frontmatter changes (tools, model, memory fields unchanged)
+- No changes to any other agent definitions or wrapper code
+
+## Invariants this change relies on
+- The wrapper copies `.cai-staging/agents/*.md` to `.claude/agents/` after a successful exit
+- The new section only activates when the issue body contains a `### Plan` section; issues without one are unaffected

--- a/.claude/agents/cai-fix.md
+++ b/.claude/agents/cai-fix.md
@@ -312,6 +312,29 @@ When the issue clearly identifies:
 …then make exactly that change. Read the file(s), verify the
 remediation matches the current code, edit precisely, and stop.
 
+## Multi-step plans
+
+If the issue body contains a `### Plan` section with numbered steps,
+execute them **sequentially** rather than in parallel. For each step:
+
+1. **Decompose if needed** — if a step is itself complex, break it
+   into sub-actions in your internal TodoWrite list.
+2. **Make the edits** for that step only.
+3. **Verify** — use Read and Grep to confirm the edit landed correctly:
+   re-read the changed file to confirm the expected content is present,
+   grep for the before/after patterns, or check that a function
+   signature matches what the plan expected. If the issue body has a
+   `### Verification` section with explicit checks, run those checks now.
+4. **If verification fails**, do not proceed to step N+1. Either fix
+   step N or exit with zero diff explaining which step failed and why.
+5. **If verification passes**, mark the step complete in TodoWrite and
+   move to the next step.
+
+Multi-step plans are NOT a license to make larger changes. The scope
+cap — minimal, targeted, only what the issue asks — still applies to
+each individual step. If the issue has no `### Plan` section, ignore
+this section entirely and proceed with your normal single-pass approach.
+
 ## Raising complementary issues
 
 While working on the fix, you may notice related problems that are

--- a/.claude/agents/cai-fix.md
+++ b/.claude/agents/cai-fix.md
@@ -1,7 +1,7 @@
 ---
 name: cai-fix
 description: Autonomous code-editing subagent for `robotsix-cai`. Makes the smallest targeted change that addresses an auto-improve issue handed by the wrapper. Cannot run git or gh — the wrapper handles all remote state and PR opening.
-tools: Read, Edit, Write, Grep, Glob
+tools: Read, Edit, Write, Grep, Glob, TodoWrite
 model: claude-sonnet-4-6
 memory: project
 ---
@@ -35,8 +35,8 @@ path the wrapper provides in the user message** (look for the
 `docker-compose.yml`, the README, and the GitHub workflows under
 `.github/workflows/`.
 
-You have Read, Edit, Write, Grep, and Glob — Bash is not in your
-tool allowlist.
+You have Read, Edit, Write, Grep, Glob, and TodoWrite — Bash is not
+in your tool allowlist.
 
 **Use absolute paths under the work directory for everything you
 read or edit.** Relative paths resolve to `/app` (the canonical,

--- a/README.md
+++ b/README.md
@@ -134,6 +134,33 @@ on the issue. A human can either close the issue (agreeing with the
 bot), re-label to `:refined` to retry the fix directly, or re-label to
 `:raised` to re-run through the refine step first.
 
+### Filing issues with multi-step plans
+
+When filing an auto-improve issue, you can optionally include a
+`### Plan` section with numbered steps. The fix agent will execute
+the steps **sequentially**, verifying each one before proceeding to
+the next. You can also include a `### Verification` section with
+explicit checks the fix agent should run after each step.
+
+Example of a well-structured multi-step issue:
+
+```markdown
+### Plan
+
+1. Read `src/foo.py` and locate the `process()` function.
+2. Add a null-check for the `data` parameter at the top of `process()`.
+3. Update the docstring to document the new guard.
+
+### Verification
+
+- `process(None)` no longer raises `AttributeError`
+- Docstring mentions the null-check behaviour
+```
+
+Each step should be a distinct, atomic action. If an issue has no
+`### Plan` section, the fix agent uses its standard single-pass
+approach and this guidance does not apply.
+
 ### Audit findings
 
 The `audit` subcommand uses a **separate label namespace** (`audit:*`)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#312

**Issue:** #312 — Fix agent should execute multi-step plans with per-step verification

## PR Summary

### What this fixes
`cai-fix.md` had no guidance for issues that contain a numbered `### Plan` section, causing the fix agent to either execute steps in parallel (missing dependencies) or sequence them implicitly without verifying each step before proceeding to the next.

### What was changed
- `.claude/agents/cai-fix.md` (via staging at `.cai-staging/agents/cai-fix.md`): inserted a new `## Multi-step plans` section (22 lines) between `## When to make changes` and `## Raising complementary issues`. The section instructs the fix agent to execute numbered plan steps sequentially, verify each step with Read/Grep before proceeding, and exit with zero diff if any step's verification fails. Issues without a `### Plan` section are unaffected.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
