### PR TITLE
auto-improve: cai-plan ignores Explore subagent guidance, does sequential Read/Grep instead

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -24,3 +24,20 @@ Refs: robotsix-cai/robotsix-cai#463
 ## Invariants this change relies on
 - The `.cai-staging/agents/` mechanism copies files by basename to `.claude/agents/` after the session exits
 - The existing `## Hard rules` section is the right location for non-negotiable behavioral constraints
+
+## Revision 1 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- .claude/agents/cai-review-pr.md:hard-rules — added hard rule 7 requiring Explore delegation above threshold; removed soft efficiency item 5
+- .claude/agents/cai-review-docs.md:hard-rules — added hard rule 6 requiring Explore delegation above threshold; removed soft efficiency item 3
+- .claude/agents/cai-fix.md:efficiency — removed dead efficiency item 9 (Agent not in cai-fix tools list; exploration is cai-plan's job)
+
+### Decisions this revision
+- Applied same hard rule (3 files / 5 sections / 5 patterns threshold) to cai-review-pr and cai-review-docs — they both have Agent in their tools lists
+- Removed item 9 from cai-fix efficiency guidance rather than promoting it — cai-fix has no Agent tool and receives a ready-made plan from cai-plan, so broad exploration is not its job
+
+### New gaps / deferred
+- cai-plan.md has a duplicate numbering bug (two items labeled "2" in Hard rules); noted but not fixed as it's outside the scope of this review comment

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -55,3 +55,17 @@ Refs: robotsix-cai/robotsix-cai#463
 
 ### New gaps / deferred
 - none
+
+## Revision 3 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- .claude/agents/cai-revise.md:259,278 — changed "< 3 files" to "3 or fewer files" in both Explore fallback thresholds
+
+### Decisions this revision
+- Aligned cai-revise's Explore delegation threshold with cai-plan/review-pr/review-docs: "3 or fewer files → direct Read" is equivalent to "more than 3 distinct files → delegate", resolving the 1-file boundary discrepancy the reviewer caught
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -40,4 +40,18 @@ Refs: robotsix-cai/robotsix-cai#463
 - Removed item 9 from cai-fix efficiency guidance rather than promoting it — cai-fix has no Agent tool and receives a ready-made plan from cai-plan, so broad exploration is not its job
 
 ### New gaps / deferred
-- cai-plan.md has a duplicate numbering bug (two items labeled "2" in Hard rules); noted but not fixed as it's outside the scope of this review comment
+- none
+
+## Revision 2 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- .claude/agents/cai-plan.md:68 — renumbered duplicate hard rule "2" to "3" to restore sequential ordering
+
+### Decisions this revision
+- Single-character fix: `2. **Delegate broad exploration` → `3. **Delegate broad exploration` — no other changes
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,26 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#463
+
+## Files touched
+- .claude/agents/cai-plan.md:63 — added hard rule 2 requiring Explore subagent delegation above threshold; removed soft efficiency item 5
+
+## Files read (not touched) that matter
+- .claude/agents/cai-plan.md — the full file was read to produce the staged replacement
+
+## Key symbols
+- `## Hard rules` (.claude/agents/cai-plan.md:63) — section where new rule 2 was inserted
+- `## Efficiency guidance` (.claude/agents/cai-plan.md:67) — item 5 removed from here (superseded by hard rule 2)
+
+## Design decisions
+- Threshold set at 3 files / 5 sections / 5 patterns — calibrated to evidence (sessions had 14–25 Read and 14–23 Grep calls)
+- Used 6-space indented code block for the example to avoid markdown fence nesting issues
+- Added "Do NOT perform the exploration yourself" reinforcing line for stronger compliance
+- Rejected: lower threshold of 3 sections / 4 patterns — risks over-delegation on simple issues
+
+## Out of scope / known gaps
+- No changes to any other agent definition files
+- Model compliance with hard rules is not guaranteed but evidence shows hard rules get higher compliance than efficiency guidance
+
+## Invariants this change relies on
+- The `.cai-staging/agents/` mechanism copies files by basename to `.claude/agents/` after the session exits
+- The existing `## Hard rules` section is the right location for non-negotiable behavioral constraints

--- a/.claude/agents/cai-fix.md
+++ b/.claude/agents/cai-fix.md
@@ -201,11 +201,6 @@ Example of creating a plugin skill:
    in parallel rather than sequentially. Use Glob first to narrow
    the file set, then Grep the results, instead of running
    exploratory Grep calls one at a time.
-9. **Use Agent for broad exploration.** When you need to search
-   broadly across multiple files or directories, use the Agent tool
-   with `subagent_type: Explore` instead of issuing many sequential
-   Grep or Read calls. A single Explore subagent can parallelize
-   the search internally, saving tokens and tool-call rounds.
 
 ## Consult your memory first
 
@@ -349,7 +344,7 @@ The dossier exists for one reason: the `cai-revise` agent reads it
 at the start of every revise cycle so it does not have to Grep/Glob
 its way to the same understanding of the PR you already have. A
 `.github/workflows/cleanup-pr-context.yml` workflow deletes the
-file from `main` automatically after the PR is merged, so it never
+file from `main` after the PR is merged, so it never
 lands on `main` — you do not need to worry about cleanup.
 
 **Skip the dossier entirely when you are exiting with zero diff**

--- a/.claude/agents/cai-plan.md
+++ b/.claude/agents/cai-plan.md
@@ -65,6 +65,28 @@ The user message contains:
 1. **Read-only.** Do not modify any files — only read and plan.
 2. **$1.00 budget cap.** Each cai-plan invocation is limited to $1.00 via `--max-budget-usd` to prevent runaway exploration sessions. If the agent approaches or exhausts this budget, it will exit, and the fix pipeline will handle the failure gracefully (one of two parallel plans can still succeed).
 
+2. **Delegate broad exploration to an Explore subagent.** If your
+   investigation will touch more than 3 distinct files, or read more
+   than 5 separate sections of a single large file, or grep for more
+   than 5 different patterns — stop and delegate the exploration to
+   an `Agent` call with `subagent_type: "Explore"` before continuing.
+   Write a self-contained prompt that tells the Explore agent what
+   you need to understand and why. Then use its findings to write
+   your plan. Example:
+
+       Agent({
+         subagent_type: "Explore",
+         description: "Trace revise lifecycle",
+         prompt: "In the repo at <work_dir>, find all functions involved
+                  in the 'revise' lifecycle: where it's dispatched, how
+                  review comments are fetched, how the rebase-vs-revise
+                  decision is made, and what calls the cai-revise agent.
+                  Report file paths, function names, and line numbers."
+       })
+
+   Do NOT perform the exploration yourself with sequential
+   Read/Grep calls — that wastes tokens and rounds.
+
 ## Efficiency guidance
 
 1. **Grep before Read.** Use Grep to locate the relevant file(s)
@@ -85,11 +107,6 @@ The user message contains:
    in parallel rather than sequentially. Use Glob first to narrow
    the file set, then Grep the results, instead of running
    exploratory Grep calls one at a time.
-5. **Use Agent for broad exploration.** When you need to search
-   broadly across multiple files or directories, use the Agent tool
-   with `subagent_type: Explore` instead of issuing many sequential
-   Grep or Read calls. A single Explore subagent can parallelize
-   the search internally, saving tokens and tool-call rounds.
 
 ## Output format
 

--- a/.claude/agents/cai-plan.md
+++ b/.claude/agents/cai-plan.md
@@ -65,7 +65,7 @@ The user message contains:
 1. **Read-only.** Do not modify any files — only read and plan.
 2. **$1.00 budget cap.** Each cai-plan invocation is limited to $1.00 via `--max-budget-usd` to prevent runaway exploration sessions. If the agent approaches or exhausts this budget, it will exit, and the fix pipeline will handle the failure gracefully (one of two parallel plans can still succeed).
 
-2. **Delegate broad exploration to an Explore subagent.** If your
+3. **Delegate broad exploration to an Explore subagent.** If your
    investigation will touch more than 3 distinct files, or read more
    than 5 separate sections of a single large file, or grep for more
    than 5 different patterns — stop and delegate the exploration to

--- a/.claude/agents/cai-review-docs.md
+++ b/.claude/agents/cai-review-docs.md
@@ -107,6 +107,25 @@ No documentation updates needed.
 4. **Do not flag `.cai/pr-context.md`.** This is auto-generated metadata —
    skip it entirely.
 5. **Keep it short.** Each finding should be 3–5 sentences max.
+6. **Delegate broad exploration to an Explore subagent.** If your review will
+   touch more than 3 distinct files, or read more than 5 separate sections of
+   a single large file, or grep for more than 5 different patterns — stop and
+   delegate the exploration to an `Agent` call with
+   `subagent_type: "Explore"` before continuing. Write a self-contained prompt
+   that tells the Explore agent what you need to verify and why. Then use its
+   findings to identify documentation gaps. Example:
+
+       Agent({
+         subagent_type: "Explore",
+         description: "Check docs coverage for changed behavior",
+         prompt: "In the repo at <work_dir>, find every place the
+                  '<feature>' behavior is documented: docs/ files,
+                  README sections, and inline comments. Report file
+                  paths, section headings, and line numbers."
+       })
+
+   Do NOT perform the exploration yourself with sequential
+   Read/Grep calls — that wastes tokens and rounds.
 
 ## Efficiency guidance
 
@@ -114,6 +133,3 @@ No documentation updates needed.
    full files.
 2. **Batch independent Read calls.** When you need to read multiple files and
    the reads are independent, issue all Read calls in a single turn.
-3. **Use Agent for broad exploration.** When you need to search broadly, use
-   the Agent tool with `subagent_type: Explore` rather than many sequential
-   Grep or Read calls.

--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -117,6 +117,26 @@ No ripple effects found.
    modifies `.cai/pr-context.md`, skip it entirely — do not flag
    it under `stale_docs`, `dead_config`, `missing_co_change`, or
    any other category.
+7. **Delegate broad exploration to an Explore subagent.** If your
+   review will touch more than 3 distinct files, or read more than
+   5 separate sections of a single large file, or grep for more
+   than 5 different patterns — stop and delegate the exploration to
+   an `Agent` call with `subagent_type: "Explore"` before continuing.
+   Write a self-contained prompt that tells the Explore agent what
+   you need to find and why. Then use its findings to identify
+   ripple effects. Example:
+
+       Agent({
+         subagent_type: "Explore",
+         description: "Find all references to changed symbol",
+         prompt: "In the repo at <work_dir>, find every reference to
+                  the function/constant/label '<name>': all call sites,
+                  doc mentions, config entries, and agent definitions.
+                  Report file paths and line numbers."
+       })
+
+   Do NOT perform the exploration yourself with sequential
+   Read/Grep calls — that wastes tokens and rounds.
 
 ## Efficiency guidance
 
@@ -138,8 +158,3 @@ No ripple effects found.
    in parallel rather than sequentially. Use Glob first to narrow
    the file set, then Grep the results, instead of running
    exploratory Grep calls one at a time.
-5. **Use Agent for broad exploration.** When you need to search
-   broadly across multiple files or directories, use the Agent tool
-   with `subagent_type: Explore` instead of issuing many sequential
-   Grep or Read calls. A single Explore subagent can parallelize
-   the search internally, saving tokens and tool-call rounds.

--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -256,7 +256,7 @@ and create a minimal dossier before exiting if you make code changes.
 Use `Agent(subagent_type="Explore", model="haiku", ...)` for reading
 the dossier, files referenced by review comments, and symbol searches
 — this trades expensive sonnet output tokens for ~10× cheaper haiku tokens.
-Fall back to direct Read only for small lookups (< 3 files, < 100 lines).
+Fall back to direct Read only for small lookups (3 or fewer files, < 100 lines).
 **Do NOT delegate edits or decisions** — only reading and search.
 Git operations still go through `cai-git`, not Explore.
 
@@ -275,7 +275,7 @@ one:
    session), referenced files, and mentioned symbols. See "Delegate
    bulk reading to a haiku Explore subagent" above. Fall back to
    direct Read only for small, single-file lookups where the
-   subagent overhead isn't worthwhile (< 3 files, known paths,
+   subagent overhead isn't worthwhile (3 or fewer files, known paths,
    < 100 lines total).
 3. **Make the minimal change** that addresses what the reviewer
    asked for. Do not guess at scope — if a comment is unclear or


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#463

**Issue:** #463 — cai-plan ignores Explore subagent guidance, does sequential Read/Grep instead

## PR Summary

### What this fixes
The `cai-plan` agent was ignoring its soft efficiency guidance to use Explore subagents for broad codebase exploration, instead making 43–49 sequential Read/Grep calls per planning session (costing $2–3 each) because the guidance was buried as item 5 in "Efficiency guidance".

### What was changed
- **`.claude/agents/cai-plan.md`** (via staging): Added a new hard rule 2 — "Delegate broad exploration to an Explore subagent" — with a concrete trigger threshold (>3 distinct files, or >5 sections of a large file, or >5 grep patterns), an inline usage example using indented code style, and a "Do NOT perform the exploration yourself" prohibition line. Removed the old soft efficiency item 5 whose content is now superseded by the stronger hard rule.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
