### PR TITLE
auto-improve: we should have a target agent focused on cost reduction, runned every week.

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,44 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#449
+
+## Files touched
+- `.cai-staging/agents/cai-cost-optimize.md`:1 — new agent definition (Read/Grep/Glob, sonnet-4-6, memory:project); proposal and evaluation output formats
+- `cai.py`:173 — added `COST_OPTIMIZE_MEMORY` constant
+- `cai.py`:4831 — added `_read_cost_optimize_memory`, `_save_cost_optimize_memory`, `cmd_cost_optimize`
+- `cai.py`:8273 — added `"cost-optimize"` argparse subcommand after `explore`
+- `cai.py`:8335 — added `"cost-optimize": cmd_cost_optimize` to handlers dict
+- `entrypoint.sh`:20 — added cost-optimize to task list comment
+- `entrypoint.sh`:53 — added `CAI_COST_OPTIMIZE_SCHEDULE` env var (default `0 5 * * 0`)
+- `entrypoint.sh`:75 — added cron line for cost-optimize
+- `README.md`:67 — added cost-optimize row to subcommand table
+- `README.md`:76 — added `CAI_COST_OPTIMIZE_SCHEDULE` to env var list
+
+## Files read (not touched) that matter
+- `cai.py` (lines 338–455) — `_load_cost_log`, `_row_ts`, `_build_cost_summary`: reused directly in `cmd_cost_optimize`
+- `cai.py` (lines 4833–4858) — `_read_propose_memory`/`_save_propose_memory` pattern followed exactly
+- `.claude/agents/cai-propose.md` — used as template for agent definition structure
+
+## Key symbols
+- `COST_OPTIMIZE_MEMORY` (`cai.py`:173) — path to `/var/log/cai/cost-optimize-memory.md`
+- `_read_cost_optimize_memory` (`cai.py`:~4833) — reads memory file for prior proposals
+- `_save_cost_optimize_memory` (`cai.py`:~4845) — persists `## Memory Update` block from agent output
+- `cmd_cost_optimize` (`cai.py`:~4860) — main handler; builds cost data, runs agent, creates issue or logs evaluation
+- `_by_agent_detailed` (inline in `cmd_cost_optimize`) — aggregates cost/tokens/cache per agent for WoW table
+
+## Design decisions
+- No repo clone needed: agent works on cost log data passed in user message, not source code
+- `_build_cost_summary(days=14, top_n=20)` reused directly to avoid duplicating health-report logic
+- `cache_read_input_tokens` field name used (not `cache_read_tokens`) per actual log schema
+- Evaluation conclusions tracked in memory only; no comment posted to original issue (keeps it simple for first iteration)
+- Proposal dedup via `cost-optimize-{key}` fingerprint in issue body, same pattern as `cai-propose`
+
+## Out of scope / known gaps
+- Evaluation results are not posted as comments on the original proposal issue (memory-only tracking)
+- No `--dry-run` flag (can be added later following health-report pattern)
+- Agent does not inspect source code/agent definitions; relies on cost data alone for proposals
+
+## Invariants this change relies on
+- `/var/log/cai/cai-cost.jsonl` rows contain `cache_read_input_tokens` field (not `cache_read_tokens`)
+- `_run_claude_p` signature: `(cmd, *, category, agent, **kwargs)` with `input` and `cwd` as kwargs
+- `_build_cost_summary` returns empty string when no rows exist (handled: early return on `not rows_14d`)
+- `log_run` accepts `exit` keyword argument (consistent with other callers)

--- a/.claude/agents/cai-cost-optimize.md
+++ b/.claude/agents/cai-cost-optimize.md
@@ -1,0 +1,95 @@
+---
+name: cai-cost-optimize
+description: Weekly cost-reduction agent — analyzes spending trends and proposes one optimization per run.
+tools: Read, Grep, Glob
+model: claude-sonnet-4-6
+memory: project
+---
+
+# Cost Optimization Agent
+
+You are the weekly cost-optimization agent for `robotsix-cai`. Your job
+is to analyze spending data for the last 14 days and either **propose**
+one concrete optimization or **evaluate** whether a prior proposal
+actually reduced costs.
+
+## What you receive
+
+The user message contains:
+
+- `## Cost data` — 14-day cost summary with per-category totals, top
+  invocations, and a per-agent WoW breakdown table (last 7d vs prior
+  7d, WoW Δ%, cache hit %)
+- `## Previous proposals` — memory from prior runs (proposals made,
+  their statuses, and any evaluations)
+
+## Decision logic
+
+1. **Evaluation mode**: If your memory contains a proposal with
+   `status: pending_evaluation` that is ≥7 days old, produce an
+   **Evaluation** block for that proposal. Compare the WoW cost delta
+   for the target agent/category in the cost data against the baseline.
+2. **Proposal mode**: Otherwise, produce a **Proposal** block
+   targeting the highest-cost agent or category, focusing on changes
+   that can realistically reduce cost.
+
+## Output format
+
+### Proposal mode
+
+Output exactly ONE proposal block, then the memory update:
+
+```
+### Proposal: <descriptive title>
+
+**Target:** <agent name or workflow name (e.g. "cai-fix", "propose", "fix")>
+**Key:** <short-slug-for-dedup (e.g. "cai-fix-model-sonnet")>
+**Current cost:** <last-7d cost for the target, from the data>
+**Expected savings:** <estimated % or $ reduction per week>
+**Approach:**
+1. <specific actionable step>
+2. <specific actionable step>
+...
+**Risks:** <what could go wrong>
+```
+
+Focus on concrete, actionable changes such as:
+- Switching a specific agent from a more expensive model to a cheaper one
+- Adding `head_limit` to Grep calls in a specific agent to reduce token volume
+- Reducing `Read` line counts in a specific agent
+- Restructuring a prompt to improve cache hit rates
+- Splitting expensive multi-step agents into cheaper sub-steps
+
+### Evaluation mode
+
+Output exactly ONE evaluation block, then the memory update:
+
+```
+### Evaluation: <original proposal title>
+
+**Original proposal date:** <date from memory>
+**Target:** <same agent/category as original proposal>
+**Measured change:** <WoW cost delta for the target from the cost data>
+**Conclusion:** <effective | ineffective | inconclusive>
+**Recommendation:** <keep | revert | iterate>
+**Notes:** <1-2 sentences on what the data shows>
+```
+
+## Memory update
+
+At the end of your output, always include a `## Memory Update` block:
+
+```
+## Memory Update
+
+### Proposals made
+- date: <YYYY-MM-DD>, target: <agent/category>, key: <slug>, expected_savings: <value>, status: <pending_evaluation | evaluated>, issue_url: <url or "tbd">
+
+### Evaluations done
+- date: <YYYY-MM-DD>, original_key: <slug>, measured_change: <WoW Δ%>, conclusion: <effective | ineffective | inconclusive>
+```
+
+Carry forward ALL prior entries from `## Previous proposals` into the
+memory update — do not drop old entries. Update the `status` of the
+evaluated proposal from `pending_evaluation` to `evaluated` when
+generating an evaluation.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ subprocess with no shared state.
 | `cai.py update-check` | `0 4 * * 1` (weekly Monday 04:00 UTC) | Claude Code release check — clones the repo, fetches the latest Claude Code releases from GitHub, and runs a Sonnet agent that compares the current pinned version against the latest releases; findings (new versions, deprecated flags, best practices) are published as `update-check` namespace issues |
 | `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → re-queued to `:refined` (up to 3 attempts), then escalated to `:needs-human-review` (Sonnet) |
 | `cai.py health-report` | `0 7 * * 1` (weekly Monday 07:00 UTC) | Automated pipeline health report with anomaly detection. Aggregates cost trends (last 7d vs prior 7d WoW delta), issue queue counts per label state, pipeline stalls, and fix quality metrics. Posts a GitHub-flavored markdown report with 🔴/🟡/🟢 traffic-light indicators as a `health-report` labelled issue. Use `--dry-run` to print to stdout without posting. |
+| `cai.py cost-optimize` | `0 5 * * 0` (weekly Sunday 05:00 UTC) | Weekly cost-reduction agent — loads 14 days of cost data, computes per-agent WoW deltas and cache hit rates, and proposes one concrete optimization targeting the most expensive agent or workflow. Alternates with evaluating previous proposals to track effectiveness. Files proposals as `auto-improve:raised` issues. |
 | `cai.py cycle` | _(startup + manual/on-demand)_ | Runs verify → fix → revise → review-pr → review-docs → merge → confirm in sequence. The entrypoint runs this once synchronously at `docker compose up -d` so the issue-solving pipeline produces immediate logs; not scheduled via cron (the individual steps have their own cron lines) |
 | `cai.py test` | _(manual/on-demand)_ | Runs the project test suite (`python -m unittest discover` under `tests/`) |
 
@@ -72,7 +73,7 @@ the env vars (`CAI_ANALYZER_SCHEDULE`, `CAI_FIX_SCHEDULE`,
 `CAI_REFINE_SCHEDULE`, `CAI_REVIEW_PR_SCHEDULE`, `CAI_MERGE_SCHEDULE`,
 `CAI_REVISE_SCHEDULE`, `CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`,
 `CAI_AUDIT_TRIAGE_SCHEDULE`, `CAI_CODE_AUDIT_SCHEDULE`,
-`CAI_PROPOSE_SCHEDULE`, `CAI_SPIKE_SCHEDULE`, `CAI_UPDATE_CHECK_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`, `CAI_HEALTH_REPORT_SCHEDULE`),
+`CAI_PROPOSE_SCHEDULE`, `CAI_SPIKE_SCHEDULE`, `CAI_UPDATE_CHECK_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`, `CAI_HEALTH_REPORT_SCHEDULE`, `CAI_COST_OPTIMIZE_SCHEDULE`),
 runs `cai.py cycle` once synchronously so the issue-solving pipeline
 produces immediate logs, then execs supercronic. Analysis, audit,
 proposal, refine, spike, and update-check agents are **not** run at

--- a/cai.py
+++ b/cai.py
@@ -170,6 +170,8 @@ CODE_AUDIT_MEMORY = Path("/var/log/cai/code-audit-memory.md")
 PROPOSE_MEMORY = Path("/var/log/cai/propose-memory.md")
 # Persistent memory file for the update-check agent.
 UPDATE_CHECK_MEMORY = Path("/var/log/cai/update-check-memory.md")
+# Persistent memory file for the cost-optimize agent.
+COST_OPTIMIZE_MEMORY = Path("/var/log/cai/cost-optimize-memory.md")
 
 # Persistent per-agent memory directory. Each declarative subagent
 # has `memory: project` in its frontmatter, which Claude Code stores
@@ -4826,6 +4828,249 @@ def _save_code_audit_memory(agent_output: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# cost-optimize — weekly cost-reduction proposals
+# ---------------------------------------------------------------------------
+
+
+def _read_cost_optimize_memory() -> str:
+    """Return the contents of the cost-optimize memory file, or empty string."""
+    if not COST_OPTIMIZE_MEMORY.exists():
+        return ""
+    try:
+        return COST_OPTIMIZE_MEMORY.read_text().strip()
+    except OSError:
+        return ""
+
+
+def _save_cost_optimize_memory(agent_output: str) -> None:
+    """Extract the ## Memory Update block from agent output and persist it."""
+    match = re.search(
+        r"^## Memory Update\s*\n(.*)",
+        agent_output,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not match:
+        return
+    try:
+        COST_OPTIMIZE_MEMORY.parent.mkdir(parents=True, exist_ok=True)
+        COST_OPTIMIZE_MEMORY.write_text(match.group(0).strip() + "\n")
+    except OSError as exc:
+        print(f"[cai cost-optimize] could not write memory: {exc}", flush=True)
+
+
+def cmd_cost_optimize(args) -> int:
+    """Analyze cost data and propose one optimization or evaluate a prior proposal."""
+    print("[cai cost-optimize] running weekly cost optimization", flush=True)
+    t0 = time.monotonic()
+
+    # 1. Build cost data for the agent.
+    rows_14d = _load_cost_log(days=14)
+    if not rows_14d:
+        print("[cai cost-optimize] no cost data available; skipping", flush=True)
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run("cost-optimize", repo=REPO, result="no_data", duration=dur, exit=0)
+        return 0
+
+    cost_summary = _build_cost_summary(days=14, top_n=20)
+
+    # Per-agent WoW breakdown.
+    now_ts = datetime.now(timezone.utc).timestamp()
+    boundary = now_ts - 7 * 86400
+    last_7d = [r for r in rows_14d if _row_ts(r) >= boundary]
+    prior_7d = [r for r in rows_14d if _row_ts(r) < boundary]
+
+    def _by_agent_detailed(rows: list[dict]) -> dict[str, dict]:
+        agg: dict[str, dict] = {}
+        for r in rows:
+            agent = r.get("agent") or "(none)"
+            try:
+                cost = float(r.get("cost_usd") or 0.0)
+            except (TypeError, ValueError):
+                cost = 0.0
+            tokens_in = int(r.get("input_tokens") or 0)
+            tokens_out = int(r.get("output_tokens") or 0)
+            cache_read = int(r.get("cache_read_input_tokens") or 0)
+            bucket = agg.setdefault(
+                agent,
+                {"calls": 0, "cost": 0.0, "tokens_in": 0,
+                 "tokens_out": 0, "cache_read": 0},
+            )
+            bucket["calls"] += 1
+            bucket["cost"] += cost
+            bucket["tokens_in"] += tokens_in
+            bucket["tokens_out"] += tokens_out
+            bucket["cache_read"] += cache_read
+        return agg
+
+    last_by_agent = _by_agent_detailed(last_7d)
+    prior_by_agent = _by_agent_detailed(prior_7d)
+    all_agents = sorted(set(list(last_by_agent) + list(prior_by_agent)))
+
+    agent_lines = []
+    for agent in all_agents:
+        lb = last_by_agent.get(
+            agent, {"calls": 0, "cost": 0.0, "tokens_in": 0, "cache_read": 0}
+        )
+        pb = prior_by_agent.get(agent, {"calls": 0, "cost": 0.0})
+        if pb["cost"] > 0:
+            delta = (lb["cost"] - pb["cost"]) / pb["cost"] * 100
+            delta_str = f"{delta:+.1f}%"
+        else:
+            delta_str = "n/a"
+        cache_pct = (
+            lb["cache_read"] / lb["tokens_in"] * 100
+            if lb["tokens_in"] > 0 else 0.0
+        )
+        agent_lines.append(
+            f"| {agent} | {lb['calls']} | ${lb['cost']:.4f}"
+            f" | {delta_str} | {cache_pct:.1f}% |"
+        )
+
+    agent_table = (
+        "### Per-agent WoW breakdown (last 7d vs prior 7d)\n\n"
+        "| agent | calls (7d) | cost (7d) | WoW Δ | cache hit % |\n"
+        "|---|---|---|---|---|\n"
+        + "\n".join(agent_lines)
+        + "\n"
+    )
+
+    # 2. Build user message.
+    memory = _read_cost_optimize_memory()
+    memory_section = "## Previous proposals\n\n"
+    if memory:
+        memory_section += memory + "\n"
+    else:
+        memory_section += "(first run — no prior proposals)\n"
+
+    user_message = (
+        "## Cost data\n\n"
+        + cost_summary + "\n\n"
+        + agent_table + "\n\n"
+        + memory_section
+    )
+
+    # 3. Run the cost-optimize agent.
+    print("[cai cost-optimize] running agent", flush=True)
+    result = _run_claude_p(
+        ["claude", "-p", "--agent", "cai-cost-optimize",
+         "--permission-mode", "acceptEdits"],
+        category="cost-optimize",
+        agent="cai-cost-optimize",
+        input=user_message,
+        cwd="/app",
+    )
+    if result.stdout:
+        print(result.stdout, flush=True)
+    if result.returncode != 0:
+        print(
+            f"[cai cost-optimize] agent failed (exit {result.returncode}):\n"
+            f"{result.stderr}",
+            file=sys.stderr, flush=True,
+        )
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run("cost-optimize", repo=REPO, result="agent_failed",
+                duration=dur, exit=result.returncode)
+        return result.returncode
+
+    # 4. Save memory.
+    _save_cost_optimize_memory(result.stdout)
+
+    # 5. Handle proposal output.
+    proposal_match = re.search(
+        r"^### Proposal:\s*(.+)$", result.stdout, flags=re.MULTILINE
+    )
+    if proposal_match:
+        proposal_title = proposal_match.group(1).strip()
+
+        # Extract key for dedup.
+        key_match = re.search(r"\*\*Key:\*\*\s*(\S+)", result.stdout)
+        proposal_key = key_match.group(1).strip() if key_match else uuid.uuid4().hex[:8]
+
+        # Extract proposal block.
+        block_match = re.search(
+            r"(### Proposal:.*?)(?=\n## Memory Update|\Z)",
+            result.stdout, flags=re.DOTALL,
+        )
+        proposal_body = (
+            block_match.group(1).strip() if block_match else result.stdout.strip()
+        )
+
+        # Dedup check.
+        fingerprint = f"<!-- fingerprint: cost-optimize-{proposal_key} -->"
+        dup_check = _run(
+            ["gh", "issue", "list",
+             "--repo", REPO,
+             "--search", f"cost-optimize-{proposal_key} in:body",
+             "--state", "all",
+             "--limit", "1",
+             "--json", "number"],
+            capture_output=True,
+        )
+        if (
+            dup_check.returncode == 0
+            and dup_check.stdout.strip() not in ("", "[]")
+        ):
+            print(
+                f"[cai cost-optimize] duplicate for key {proposal_key}; skipping",
+                flush=True,
+            )
+            dur = f"{int(time.monotonic() - t0)}s"
+            log_run("cost-optimize", repo=REPO, result="duplicate",
+                    duration=dur, exit=0)
+            return 0
+
+        # Create issue.
+        issue_body = (
+            f"{proposal_body}\n\n"
+            "---\n"
+            "_Proposed by the weekly cost-optimization agent"
+            " (`cai cost-optimize`)._\n\n"
+            f"{fingerprint}\n"
+        )
+        labels = ",".join(["auto-improve", LABEL_RAISED])
+        gh_result = _run(
+            ["gh", "issue", "create",
+             "--repo", REPO,
+             "--title", f"[cost] {proposal_title}",
+             "--body", issue_body,
+             "--label", labels],
+            capture_output=True,
+        )
+        if gh_result.returncode == 0:
+            url = gh_result.stdout.strip()
+            print(f"[cai cost-optimize] created proposal issue: {url}", flush=True)
+        else:
+            print(
+                f"[cai cost-optimize] failed to create issue: {gh_result.stderr}",
+                file=sys.stderr, flush=True,
+            )
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run("cost-optimize", repo=REPO, result="proposal_created",
+                duration=dur, exit=gh_result.returncode)
+        return gh_result.returncode
+
+    # 6. Handle evaluation output.
+    eval_match = re.search(
+        r"^### Evaluation:\s*(.+)$", result.stdout, flags=re.MULTILINE
+    )
+    if eval_match:
+        print(
+            f"[cai cost-optimize] evaluation: {eval_match.group(1).strip()}",
+            flush=True,
+        )
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run("cost-optimize", repo=REPO, result="evaluation_done",
+                duration=dur, exit=0)
+        return 0
+
+    # 7. No recognized output.
+    print("[cai cost-optimize] no proposal or evaluation found in output", flush=True)
+    dur = f"{int(time.monotonic() - t0)}s"
+    log_run("cost-optimize", repo=REPO, result="no_output", duration=dur, exit=0)
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # propose — creative improvement proposals
 # ---------------------------------------------------------------------------
 
@@ -8108,6 +8353,7 @@ def main() -> int:
     sub.add_parser("refine", help="Refine human-filed issues into structured plans")
     sub.add_parser("spike", help="Run the spike agent on :needs-spike issues")
     sub.add_parser("explore", help="Autonomous exploration/benchmarking of :needs-exploration issues")
+    sub.add_parser("cost-optimize", help="Weekly cost-reduction proposal or evaluation")
     sub.add_parser("cycle", help="Full cycle: verify, fix, revise, review-pr, review-docs, merge, confirm")
     sub.add_parser("test", help="Run the project test suite")
 
@@ -8168,6 +8414,7 @@ def main() -> int:
         "cycle": cmd_cycle,
         "cost-report": cmd_cost_report,
         "health-report": cmd_health_report,
+        "cost-optimize": cmd_cost_optimize,
         "test": cmd_test,
     }
     return handlers[args.command](args)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@
 #      - confirm:       verify merged fixes are actually solved
 #      - merge:         confidence-gated auto-merge for bot PRs
 #      - health-report: automated pipeline health report with anomaly detection
+#      - cost-optimize: weekly cost-reduction proposal or evaluation
 #    Each is its own crontab line so supercronic runs them as
 #    independent processes — natural concurrency, easy to add more.
 #
@@ -50,6 +51,7 @@ CAI_MERGE_SCHEDULE="${CAI_MERGE_SCHEDULE:-35 * * * *}"
 CAI_REFINE_SCHEDULE="${CAI_REFINE_SCHEDULE:-10 * * * *}"
 CAI_SPIKE_SCHEDULE="${CAI_SPIKE_SCHEDULE:-0 */2 * * *}"
 CAI_HEALTH_REPORT_SCHEDULE="${CAI_HEALTH_REPORT_SCHEDULE:-0 7 * * 1}"
+CAI_COST_OPTIMIZE_SCHEDULE="${CAI_COST_OPTIMIZE_SCHEDULE:-0 5 * * 0}"
 
 CRONTAB_PATH=/tmp/crontab
 
@@ -71,6 +73,7 @@ $CAI_CONFIRM_SCHEDULE python /app/cai.py confirm
 $CAI_REVIEW_PR_SCHEDULE python /app/cai.py review-pr
 $CAI_MERGE_SCHEDULE python /app/cai.py merge
 $CAI_HEALTH_REPORT_SCHEDULE python /app/cai.py health-report
+$CAI_COST_OPTIMIZE_SCHEDULE python /app/cai.py cost-optimize
 CRONTAB
 
 echo "[entrypoint] crontab:"


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#449

**Issue:** #449 — we should have a target agent focused on cost reduction, runned every week.

## PR Summary

### What this fixes
Issue #449 requested a weekly cost-reduction agent that proposes one optimization per week targeting the most expensive operations, and evaluates the impact of prior proposals the following week.

### What was changed
- **`.cai-staging/agents/cai-cost-optimize.md`** (new): Agent definition for the cost-optimization subagent — read-only tools (Read, Grep, Glob), `claude-sonnet-4-6`, project-scoped memory. Defines proposal and evaluation output formats with a decision rule (evaluate if a ≥7-day-old pending proposal exists, otherwise propose).
- **`cai.py`**: Added `COST_OPTIMIZE_MEMORY` constant (line 173); added `_read_cost_optimize_memory` / `_save_cost_optimize_memory` helpers following the `cmd_propose` pattern; added `cmd_cost_optimize` handler that loads 14 days of cost data via `_build_cost_summary` + a per-agent WoW/cache-hit table, runs the agent, creates a deduplicated `auto-improve:raised` issue for proposals, and logs evaluations to memory; registered `"cost-optimize"` in the argparse subparser and handlers dict.
- **`entrypoint.sh`**: Added `CAI_COST_OPTIMIZE_SCHEDULE` env var (default `0 5 * * 0` — weekly Sunday 05:00 UTC), cron line, and task-list comment.
- **`README.md`**: Added `cai.py cost-optimize` row to the subcommand table and `CAI_COST_OPTIMIZE_SCHEDULE` to the env var prose.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
