### PR TITLE
auto-improve: More deterministic workflow for issues fixing

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -39,3 +39,17 @@ Refs: robotsix/robotsix-cai#456
 - `args` namespace always has the new attribute when the subparser is invoked (argparse guarantees this)
 - `getattr(args, "pr", None)` returns `None` when the command is invoked via `cmd_cycle` (no `--pr` arg passed)
 - `_gh_json` raises `subprocess.CalledProcessError` on failure — all bypass paths handle this
+
+## Revision 1 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `README.md:292-317` — expanded "Triggering tasks ad-hoc" section to show `--pr` and `--issue` options for all 8 newly targeted commands (revise, confirm, review-pr, review-docs, merge, refine, spike, explore); also updated alias convenience block
+
+### Decisions this revision
+- Used reviewer's suggested concrete examples (with `--pr 45` / `--issue 12`) rather than a prose note — more scannable for operators
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,41 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#456
+
+## Files touched
+- `cai.py:8339` — converted 8 bare `sub.add_parser()` calls to named parsers with `--pr`/`--issue` arguments
+- `cai.py:3039` — `cmd_revise`: added `--pr` bypass using `_fetch_review_comments` + `_filter_unaddressed_comments`
+- `cai.py:5650` — `cmd_confirm`: added `--issue` bypass via `gh issue view`
+- `cai.py:5960` — `cmd_review_pr`: added `--pr` bypass via `gh pr view`
+- `cai.py:6185` — `cmd_review_docs`: added `--pr` bypass via `gh pr view`
+- `cai.py:6571` — `cmd_merge`: added `--pr` bypass via `gh pr view`
+- `cai.py:7050` — `cmd_refine`: added `--issue` bypass via `gh issue view`
+- `cai.py:7240` — `cmd_spike`: added `--issue` bypass via `gh issue view`
+- `cai.py:7700` — `cmd_explore` Phase 2: added `--issue` bypass via `gh issue view`
+
+## Files read (not touched) that matter
+- `cai.py:2762` — `_select_revise_targets()`: defines the dict structure (`pr_number`, `issue_number`, `branch`, `comments`, `needs_rebase`) that `cmd_revise` bypass must replicate
+- `cai.py:2667` — `_filter_unaddressed_comments()`: used in `cmd_revise` bypass to stay consistent with queue-based path
+- `cai.py:2712` — `_fetch_review_comments()`: used in `cmd_revise` bypass to merge line-by-line review comments
+
+## Key symbols
+- `_select_revise_targets` (`cai.py:2762`) — bypassed when `--pr` is set; bypass replicates its return dict structure
+- `_filter_unaddressed_comments` (`cai.py:2667`) — called in the `cmd_revise` bypass path
+- `_fetch_review_comments` (`cai.py:2712`) — called in the `cmd_revise` bypass path
+- `getattr(args, "pr/issue", None)` — pattern used consistently (matches `cmd_fix --issue`)
+
+## Design decisions
+- Use `getattr(args, "pr/issue", None)` guard — matches existing `cmd_fix` pattern (line 2118), safe when attr not present on namespace
+- `cmd_revise --pr`: use `_filter_unaddressed_comments` with actual commit timestamp rather than treating all comments as unaddressed — more accurate and consistent
+- `cmd_explore --issue`: only bypasses Phase 2 queue selection; Phase 1 (follow-up on `:exploration-done`) runs unconditionally since it's a separate concern
+- No label validation for direct targets — operator is explicitly choosing the item; matches `cmd_fix --issue` behavior
+- Rejected: modifying `_select_revise_targets` to accept a PR number — unnecessary coupling; bypass path is simpler
+
+## Out of scope / known gaps
+- `cmd_cycle` orchestration not changed — it still calls each command without `--pr`/`--issue`
+- No label validation (e.g., requiring `:needs-spike` for spike) when targeting directly — intentional
+- `cmd_revise --pr` does not skip PRs labeled `:needs-human` when targeted directly — operator's explicit choice
+
+## Invariants this change relies on
+- `args` namespace always has the new attribute when the subparser is invoked (argparse guarantees this)
+- `getattr(args, "pr", None)` returns `None` when the command is invoked via `cmd_cycle` (no `--pr` arg passed)
+- `_gh_json` raises `subprocess.CalledProcessError` on failure — all bypass paths handle this

--- a/README.md
+++ b/README.md
@@ -293,13 +293,24 @@ just-trying-things-out from the terminal would use:
 docker compose exec cai python /app/cai.py analyze
 docker compose exec cai python /app/cai.py fix              # automatic scoring-based selection
 docker compose exec cai python /app/cai.py fix --issue 12   # specific issue
-docker compose exec cai python /app/cai.py review-pr
-docker compose exec cai python /app/cai.py review-docs
-docker compose exec cai python /app/cai.py revise
+docker compose exec cai python /app/cai.py review-pr        # automatic queue-based selection
+docker compose exec cai python /app/cai.py review-pr --pr 45  # specific PR
+docker compose exec cai python /app/cai.py review-docs      # automatic queue-based selection
+docker compose exec cai python /app/cai.py review-docs --pr 45  # specific PR
+docker compose exec cai python /app/cai.py revise           # automatic queue-based selection
+docker compose exec cai python /app/cai.py revise --pr 45   # specific PR
 docker compose exec cai python /app/cai.py verify
 docker compose exec cai python /app/cai.py audit
-docker compose exec cai python /app/cai.py confirm
-docker compose exec cai python /app/cai.py merge
+docker compose exec cai python /app/cai.py confirm          # automatic queue-based selection
+docker compose exec cai python /app/cai.py confirm --issue 12  # specific issue
+docker compose exec cai python /app/cai.py merge            # automatic queue-based selection
+docker compose exec cai python /app/cai.py merge --pr 45    # specific PR
+docker compose exec cai python /app/cai.py refine           # automatic queue-based selection
+docker compose exec cai python /app/cai.py refine --issue 12  # specific issue
+docker compose exec cai python /app/cai.py spike            # automatic queue-based selection
+docker compose exec cai python /app/cai.py spike --issue 12   # specific issue
+docker compose exec cai python /app/cai.py explore          # automatic queue-based selection
+docker compose exec cai python /app/cai.py explore --issue 12  # specific issue
 ```
 
 A short alias makes this trivial:
@@ -307,13 +318,16 @@ A short alias makes this trivial:
 ```bash
 alias cai='docker compose -f ~/robotsix-cai/docker-compose.yml exec cai python /app/cai.py'
 cai fix --issue 12
-cai review-pr
-cai review-docs
-cai revise
+cai review-pr --pr 45
+cai review-docs --pr 45
+cai revise --pr 45
 cai verify
 cai audit
-cai confirm
-cai merge
+cai confirm --issue 12
+cai merge --pr 45
+cai refine --issue 12
+cai spike --issue 12
+cai explore --issue 12
 ```
 
 See the [tracking issue](https://github.com/damien-robotsix/robotsix-cai/issues/1)

--- a/cai.py
+++ b/cai.py
@@ -3036,7 +3036,53 @@ def cmd_revise(args) -> int:
             flush=True,
         )
 
-    targets = _select_revise_targets()
+    if getattr(args, "pr", None) is not None:
+        # Direct targeting: look up the specified PR and build a single-item target list.
+        try:
+            pr_detail = _gh_json([
+                "pr", "view", str(args.pr),
+                "--repo", REPO,
+                "--json", "number,headRefName,comments,labels,commits,mergeable,mergeStateStatus",
+            ])
+        except subprocess.CalledProcessError as e:
+            print(f"[cai revise] gh pr view #{args.pr} failed:\n{e.stderr}", file=sys.stderr)
+            log_run("revise", repo=REPO, pr=args.pr, result="pr_lookup_failed", exit=1)
+            return 1
+        branch = pr_detail.get("headRefName", "")
+        m = re.match(r"^auto-improve/(\d+)-", branch)
+        if not m:
+            print(f"[cai revise] PR #{args.pr} branch '{branch}' is not an auto-improve branch", file=sys.stderr)
+            log_run("revise", repo=REPO, pr=args.pr, result="not_auto_improve", exit=1)
+            return 1
+        issue_number = int(m.group(1))
+        # Collect comments (issue-level + line-by-line review).
+        issue_comments = pr_detail.get("comments", [])
+        line_comments = _fetch_review_comments(pr_detail["number"])
+        all_comments = issue_comments + line_comments
+        # Use commit timestamp to filter unaddressed comments.
+        commits = pr_detail.get("commits", [])
+        if commits:
+            last_commit_date = commits[-1].get("committedDate", "")
+            try:
+                commit_ts = datetime.strptime(
+                    last_commit_date, "%Y-%m-%dT%H:%M:%SZ"
+                ).replace(tzinfo=timezone.utc)
+            except ValueError:
+                commit_ts = datetime.min.replace(tzinfo=timezone.utc)
+        else:
+            commit_ts = datetime.min.replace(tzinfo=timezone.utc)
+        unaddressed = _filter_unaddressed_comments(all_comments, commit_ts)
+        needs_rebase = pr_detail.get("mergeable") == "CONFLICTING" or \
+            pr_detail.get("mergeStateStatus") == "DIRTY"
+        targets = [{
+            "pr_number": pr_detail["number"],
+            "issue_number": issue_number,
+            "branch": branch,
+            "comments": unaddressed,
+            "needs_rebase": needs_rebase,
+        }]
+    else:
+        targets = _select_revise_targets()
     if not targets:
         print("[cai revise] no PRs need revision; nothing to do", flush=True)
         log_run("revise", repo=REPO, result="no_targets",
@@ -5602,19 +5648,34 @@ def cmd_confirm(args) -> int:
     t0 = time.monotonic()
 
     # 1. Query open :merged issues.
-    try:
-        merged_issues = _gh_json([
-            "issue", "list", "--repo", REPO,
-            "--label", LABEL_MERGED,
-            "--state", "open",
-            "--json", "number,title,body,labels",
-            "--limit", "100",
-        ]) or []
-    except subprocess.CalledProcessError as e:
-        print(f"[cai confirm] gh issue list failed:\n{e.stderr}", file=sys.stderr)
-        log_run("confirm", repo=REPO, merged_checked=0, solved=0,
-                unsolved=0, inconclusive=0, exit=1)
-        return 1
+    if getattr(args, "issue", None) is not None:
+        # Direct targeting: look up the specified issue.
+        try:
+            target_issue = _gh_json([
+                "issue", "view", str(args.issue),
+                "--repo", REPO,
+                "--json", "number,title,body,labels",
+            ])
+        except subprocess.CalledProcessError as e:
+            print(f"[cai confirm] gh issue view #{args.issue} failed:\n{e.stderr}", file=sys.stderr)
+            log_run("confirm", repo=REPO, merged_checked=0, solved=0,
+                    unsolved=0, inconclusive=0, exit=1)
+            return 1
+        merged_issues = [target_issue]
+    else:
+        try:
+            merged_issues = _gh_json([
+                "issue", "list", "--repo", REPO,
+                "--label", LABEL_MERGED,
+                "--state", "open",
+                "--json", "number,title,body,labels",
+                "--limit", "100",
+            ]) or []
+        except subprocess.CalledProcessError as e:
+            print(f"[cai confirm] gh issue list failed:\n{e.stderr}", file=sys.stderr)
+            log_run("confirm", repo=REPO, merged_checked=0, solved=0,
+                    unsolved=0, inconclusive=0, exit=1)
+            return 1
 
     if not merged_issues:
         print("[cai confirm] no merged issues; nothing to do", flush=True)
@@ -5916,19 +5977,33 @@ def cmd_review_pr(args) -> int:
     print("[cai review-pr] checking open PRs against main", flush=True)
     t0 = time.monotonic()
 
-    try:
-        prs = _gh_json([
-            "pr", "list",
-            "--repo", REPO,
-            "--state", "open",
-            "--base", "main",
-            "--json", "number,title,author,headRefOid,comments",
-            "--limit", "50",
-        ]) or []
-    except subprocess.CalledProcessError as e:
-        print(f"[cai review-pr] gh pr list failed:\n{e.stderr}", file=sys.stderr)
-        log_run("review_pr", repo=REPO, result="pr_list_failed", exit=1)
-        return 1
+    if getattr(args, "pr", None) is not None:
+        # Direct targeting: look up the specified PR.
+        try:
+            target_pr = _gh_json([
+                "pr", "view", str(args.pr),
+                "--repo", REPO,
+                "--json", "number,title,author,headRefOid,comments",
+            ])
+        except subprocess.CalledProcessError as e:
+            print(f"[cai review-pr] gh pr view #{args.pr} failed:\n{e.stderr}", file=sys.stderr)
+            log_run("review_pr", repo=REPO, result="pr_lookup_failed", exit=1)
+            return 1
+        prs = [target_pr]
+    else:
+        try:
+            prs = _gh_json([
+                "pr", "list",
+                "--repo", REPO,
+                "--state", "open",
+                "--base", "main",
+                "--json", "number,title,author,headRefOid,comments",
+                "--limit", "50",
+            ]) or []
+        except subprocess.CalledProcessError as e:
+            print(f"[cai review-pr] gh pr list failed:\n{e.stderr}", file=sys.stderr)
+            log_run("review_pr", repo=REPO, result="pr_list_failed", exit=1)
+            return 1
 
     if not prs:
         print("[cai review-pr] no open PRs; nothing to do", flush=True)
@@ -6136,19 +6211,33 @@ def cmd_review_docs(args) -> int:
     print("[cai review-docs] checking open PRs against main", flush=True)
     t0 = time.monotonic()
 
-    try:
-        prs = _gh_json([
-            "pr", "list",
-            "--repo", REPO,
-            "--state", "open",
-            "--base", "main",
-            "--json", "number,title,author,headRefOid,comments",
-            "--limit", "50",
-        ]) or []
-    except subprocess.CalledProcessError as e:
-        print(f"[cai review-docs] gh pr list failed:\n{e.stderr}", file=sys.stderr)
-        log_run("review_docs", repo=REPO, result="pr_list_failed", exit=1)
-        return 1
+    if getattr(args, "pr", None) is not None:
+        # Direct targeting: look up the specified PR.
+        try:
+            target_pr = _gh_json([
+                "pr", "view", str(args.pr),
+                "--repo", REPO,
+                "--json", "number,title,author,headRefOid,comments",
+            ])
+        except subprocess.CalledProcessError as e:
+            print(f"[cai review-docs] gh pr view #{args.pr} failed:\n{e.stderr}", file=sys.stderr)
+            log_run("review_docs", repo=REPO, result="pr_lookup_failed", exit=1)
+            return 1
+        prs = [target_pr]
+    else:
+        try:
+            prs = _gh_json([
+                "pr", "list",
+                "--repo", REPO,
+                "--state", "open",
+                "--base", "main",
+                "--json", "number,title,author,headRefOid,comments",
+                "--limit", "50",
+            ]) or []
+        except subprocess.CalledProcessError as e:
+            print(f"[cai review-docs] gh pr list failed:\n{e.stderr}", file=sys.stderr)
+            log_run("review_docs", repo=REPO, result="pr_list_failed", exit=1)
+            return 1
 
     if not prs:
         print("[cai review-docs] no open PRs; nothing to do", flush=True)
@@ -6480,19 +6569,33 @@ def cmd_merge(args) -> int:
     threshold_rank = _CONFIDENCE_RANKS.get(_MERGE_THRESHOLD, _CONFIDENCE_RANKS["high"])
 
     # Fetch open PRs.
-    try:
-        prs = _gh_json([
-            "pr", "list",
-            "--repo", REPO,
-            "--state", "open",
-            "--base", "main",
-            "--json", "number,title,headRefName,headRefOid,comments,mergeable",
-            "--limit", "50",
-        ]) or []
-    except subprocess.CalledProcessError as e:
-        print(f"[cai merge] gh pr list failed:\n{e.stderr}", file=sys.stderr)
-        log_run("merge", repo=REPO, result="pr_list_failed", exit=1)
-        return 1
+    if getattr(args, "pr", None) is not None:
+        # Direct targeting: look up the specified PR.
+        try:
+            target_pr = _gh_json([
+                "pr", "view", str(args.pr),
+                "--repo", REPO,
+                "--json", "number,title,headRefName,headRefOid,comments,mergeable",
+            ])
+        except subprocess.CalledProcessError as e:
+            print(f"[cai merge] gh pr view #{args.pr} failed:\n{e.stderr}", file=sys.stderr)
+            log_run("merge", repo=REPO, result="pr_lookup_failed", exit=1)
+            return 1
+        prs = [target_pr]
+    else:
+        try:
+            prs = _gh_json([
+                "pr", "list",
+                "--repo", REPO,
+                "--state", "open",
+                "--base", "main",
+                "--json", "number,title,headRefName,headRefOid,comments,mergeable",
+                "--limit", "50",
+            ]) or []
+        except subprocess.CalledProcessError as e:
+            print(f"[cai merge] gh pr list failed:\n{e.stderr}", file=sys.stderr)
+            log_run("merge", repo=REPO, result="pr_list_failed", exit=1)
+            return 1
 
     if not prs:
         print("[cai merge] no open PRs; nothing to do", flush=True)
@@ -6945,33 +7048,49 @@ def cmd_refine(args) -> int:
     t0 = time.monotonic()
 
     # 1. Find candidates.
-    try:
-        issues = _gh_json([
-            "issue", "list",
-            "--repo", REPO,
-            "--label", LABEL_RAISED,
-            "--state", "open",
-            "--json", "number,title,body,labels,createdAt,comments",
-            "--limit", "100",
-        ]) or []
-    except subprocess.CalledProcessError as e:
-        print(
-            f"[cai refine] gh issue list failed:\n{e.stderr}",
-            file=sys.stderr,
-        )
-        log_run("refine", repo=REPO, result="list_failed", exit=1)
-        return 1
+    if getattr(args, "issue", None) is not None:
+        # Direct targeting: look up the specified issue.
+        try:
+            issue = _gh_json([
+                "issue", "view", str(args.issue),
+                "--repo", REPO,
+                "--json", "number,title,body,labels,createdAt,comments",
+            ])
+        except subprocess.CalledProcessError as e:
+            print(f"[cai refine] gh issue view #{args.issue} failed:\n{e.stderr}", file=sys.stderr)
+            log_run("refine", repo=REPO, result="issue_lookup_failed", exit=1)
+            return 1
+        issue_number = issue["number"]
+        title = issue["title"]
+        print(f"[cai refine] targeting #{issue_number}: {title}", flush=True)
+    else:
+        try:
+            issues = _gh_json([
+                "issue", "list",
+                "--repo", REPO,
+                "--label", LABEL_RAISED,
+                "--state", "open",
+                "--json", "number,title,body,labels,createdAt,comments",
+                "--limit", "100",
+            ]) or []
+        except subprocess.CalledProcessError as e:
+            print(
+                f"[cai refine] gh issue list failed:\n{e.stderr}",
+                file=sys.stderr,
+            )
+            log_run("refine", repo=REPO, result="list_failed", exit=1)
+            return 1
 
-    if not issues:
-        print("[cai refine] no :raised issues; nothing to do", flush=True)
-        log_run("refine", repo=REPO, result="no_eligible_issues", exit=0)
-        return 0
+        if not issues:
+            print("[cai refine] no :raised issues; nothing to do", flush=True)
+            log_run("refine", repo=REPO, result="no_eligible_issues", exit=0)
+            return 0
 
-    # 2. Pick the oldest.
-    issue = min(issues, key=lambda i: i["createdAt"])
-    issue_number = issue["number"]
-    title = issue["title"]
-    print(f"[cai refine] picked #{issue_number}: {title}", flush=True)
+        # 2. Pick the oldest.
+        issue = min(issues, key=lambda i: i["createdAt"])
+        issue_number = issue["number"]
+        title = issue["title"]
+        print(f"[cai refine] picked #{issue_number}: {title}", flush=True)
 
     # 3. Build user message and invoke cai-refine (read-only, no clone needed).
     user_message = _build_issue_block(issue)
@@ -7119,30 +7238,50 @@ def cmd_spike(args) -> int:
     t0 = time.monotonic()
 
     # 1. Find candidates.
-    try:
-        issues = _gh_json([
-            "issue", "list",
-            "--repo", REPO,
-            "--label", LABEL_NEEDS_SPIKE,
-            "--state", "open",
-            "--json", "number,title,body,labels,createdAt,comments",
-            "--limit", "100",
-        ]) or []
-    except subprocess.CalledProcessError as e:
-        print(f"[cai spike] gh issue list failed:\n{e.stderr}", file=sys.stderr)
-        log_run("spike", repo=REPO, result="list_failed", exit=1)
-        return 1
+    if getattr(args, "issue", None) is not None:
+        # Direct targeting: look up the specified issue.
+        try:
+            issue = _gh_json([
+                "issue", "view", str(args.issue),
+                "--repo", REPO,
+                "--json", "number,title,body,labels,createdAt,comments",
+            ])
+        except subprocess.CalledProcessError as e:
+            print(f"[cai spike] gh issue view #{args.issue} failed:\n{e.stderr}", file=sys.stderr)
+            log_run("spike", repo=REPO, result="issue_lookup_failed", exit=1)
+            return 1
+        if issue.get("state", "").upper() == "CLOSED":
+            print(f"[cai spike] issue #{args.issue} is closed; nothing to do", flush=True)
+            log_run("spike", repo=REPO, issue=args.issue, result="not_open", exit=0)
+            return 0
+        issue_number = issue["number"]
+        title = issue["title"]
+        print(f"[cai spike] targeting #{issue_number}: {title}", flush=True)
+    else:
+        try:
+            issues = _gh_json([
+                "issue", "list",
+                "--repo", REPO,
+                "--label", LABEL_NEEDS_SPIKE,
+                "--state", "open",
+                "--json", "number,title,body,labels,createdAt,comments",
+                "--limit", "100",
+            ]) or []
+        except subprocess.CalledProcessError as e:
+            print(f"[cai spike] gh issue list failed:\n{e.stderr}", file=sys.stderr)
+            log_run("spike", repo=REPO, result="list_failed", exit=1)
+            return 1
 
-    if not issues:
-        print("[cai spike] no :needs-spike issues; nothing to do", flush=True)
-        log_run("spike", repo=REPO, result="no_eligible_issues", exit=0)
-        return 0
+        if not issues:
+            print("[cai spike] no :needs-spike issues; nothing to do", flush=True)
+            log_run("spike", repo=REPO, result="no_eligible_issues", exit=0)
+            return 0
 
-    # 2. Pick the oldest.
-    issue = min(issues, key=lambda i: i["createdAt"])
-    issue_number = issue["number"]
-    title = issue["title"]
-    print(f"[cai spike] picked #{issue_number}: {title}", flush=True)
+        # 2. Pick the oldest.
+        issue = min(issues, key=lambda i: i["createdAt"])
+        issue_number = issue["number"]
+        title = issue["title"]
+        print(f"[cai spike] picked #{issue_number}: {title}", flush=True)
 
     # 3. Lock: :needs-spike → :in-progress.
     if not _set_labels(
@@ -7564,29 +7703,45 @@ def cmd_explore(args) -> int:
     print("[cai explore] phase 2: looking for :needs-exploration issues", flush=True)
     t0 = time.monotonic()
 
-    try:
-        issues = _gh_json([
-            "issue", "list",
-            "--repo", REPO,
-            "--label", LABEL_NEEDS_EXPLORATION,
-            "--state", "open",
-            "--json", "number,title,body,labels,createdAt,comments",
-            "--limit", "100",
-        ]) or []
-    except subprocess.CalledProcessError as e:
-        print(f"[cai explore] gh issue list failed:\n{e.stderr}", file=sys.stderr)
-        log_run("explore", repo=REPO, result="list_failed", exit=1)
-        return 1
+    if getattr(args, "issue", None) is not None:
+        # Direct targeting: look up the specified issue.
+        try:
+            issue = _gh_json([
+                "issue", "view", str(args.issue),
+                "--repo", REPO,
+                "--json", "number,title,body,labels,createdAt,comments",
+            ])
+        except subprocess.CalledProcessError as e:
+            print(f"[cai explore] gh issue view #{args.issue} failed:\n{e.stderr}", file=sys.stderr)
+            log_run("explore", repo=REPO, result="issue_lookup_failed", exit=1)
+            return 1
+        issue_number = issue["number"]
+        title = issue["title"]
+        print(f"[cai explore] targeting #{issue_number}: {title}", flush=True)
+    else:
+        try:
+            issues = _gh_json([
+                "issue", "list",
+                "--repo", REPO,
+                "--label", LABEL_NEEDS_EXPLORATION,
+                "--state", "open",
+                "--json", "number,title,body,labels,createdAt,comments",
+                "--limit", "100",
+            ]) or []
+        except subprocess.CalledProcessError as e:
+            print(f"[cai explore] gh issue list failed:\n{e.stderr}", file=sys.stderr)
+            log_run("explore", repo=REPO, result="list_failed", exit=1)
+            return 1
 
-    if not issues:
-        print("[cai explore] no :needs-exploration issues; nothing to do", flush=True)
-        log_run("explore", repo=REPO, result="no_eligible_issues", exit=0)
-        return 0
+        if not issues:
+            print("[cai explore] no :needs-exploration issues; nothing to do", flush=True)
+            log_run("explore", repo=REPO, result="no_eligible_issues", exit=0)
+            return 0
 
-    issue = min(issues, key=lambda i: i["createdAt"])
-    issue_number = issue["number"]
-    title = issue["title"]
-    print(f"[cai explore] picked #{issue_number}: {title}", flush=True)
+        issue = min(issues, key=lambda i: i["createdAt"])
+        issue_number = issue["number"]
+        title = issue["title"]
+        print(f"[cai explore] picked #{issue_number}: {title}", flush=True)
 
     # Lock: :needs-exploration → :in-progress.
     if not _set_labels(
@@ -8336,7 +8491,11 @@ def main() -> int:
         help="Target a specific issue number instead of using automatic scoring-based selection",
     )
 
-    sub.add_parser("revise", help="Iterate on open PRs based on review comments")
+    revise_parser = sub.add_parser("revise", help="Iterate on open PRs based on review comments")
+    revise_parser.add_argument(
+        "--pr", type=int, default=None,
+        help="Target a specific PR number instead of using queue-based selection",
+    )
     sub.add_parser("verify", help="Update labels based on PR merge state")
     sub.add_parser("audit", help="Run the queue/PR consistency audit")
     sub.add_parser(
@@ -8346,13 +8505,41 @@ def main() -> int:
     sub.add_parser("code-audit", help="Audit repo source code for inconsistencies")
     sub.add_parser("propose", help="Weekly creative improvement proposal")
     sub.add_parser("update-check", help="Check Claude Code releases for workspace improvements")
-    sub.add_parser("confirm", help="Verify merged issues are actually solved")
-    sub.add_parser("review-pr", help="Pre-merge consistency review of open PRs")
-    sub.add_parser("review-docs", help="Pre-merge documentation review of open PRs")
-    sub.add_parser("merge", help="Confidence-gated auto-merge for bot PRs")
-    sub.add_parser("refine", help="Refine human-filed issues into structured plans")
-    sub.add_parser("spike", help="Run the spike agent on :needs-spike issues")
-    sub.add_parser("explore", help="Autonomous exploration/benchmarking of :needs-exploration issues")
+    confirm_parser = sub.add_parser("confirm", help="Verify merged issues are actually solved")
+    confirm_parser.add_argument(
+        "--issue", type=int, default=None,
+        help="Target a specific issue number instead of using queue-based selection",
+    )
+    review_pr_parser = sub.add_parser("review-pr", help="Pre-merge consistency review of open PRs")
+    review_pr_parser.add_argument(
+        "--pr", type=int, default=None,
+        help="Target a specific PR number instead of using queue-based selection",
+    )
+    review_docs_parser = sub.add_parser("review-docs", help="Pre-merge documentation review of open PRs")
+    review_docs_parser.add_argument(
+        "--pr", type=int, default=None,
+        help="Target a specific PR number instead of using queue-based selection",
+    )
+    merge_parser = sub.add_parser("merge", help="Confidence-gated auto-merge for bot PRs")
+    merge_parser.add_argument(
+        "--pr", type=int, default=None,
+        help="Target a specific PR number instead of using queue-based selection",
+    )
+    refine_parser = sub.add_parser("refine", help="Refine human-filed issues into structured plans")
+    refine_parser.add_argument(
+        "--issue", type=int, default=None,
+        help="Target a specific issue number instead of using queue-based selection",
+    )
+    spike_parser = sub.add_parser("spike", help="Run the spike agent on :needs-spike issues")
+    spike_parser.add_argument(
+        "--issue", type=int, default=None,
+        help="Target a specific issue number instead of using queue-based selection",
+    )
+    explore_parser = sub.add_parser("explore", help="Autonomous exploration/benchmarking of :needs-exploration issues")
+    explore_parser.add_argument(
+        "--issue", type=int, default=None,
+        help="Target a specific issue number instead of using queue-based selection",
+    )
     sub.add_parser("cost-optimize", help="Weekly cost-reduction proposal or evaluation")
     sub.add_parser("cycle", help="Full cycle: verify, fix, revise, review-pr, review-docs, merge, confirm")
     sub.add_parser("test", help="Run the project test suite")


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#456

**Issue:** #456 — More deterministic workflow for issues fixing

## PR Summary

### What this fixes
Workflow commands (`revise`, `spike`, `refine`, `merge`, `review-pr`, `review-docs`, `explore`, `confirm`) had no way to target a specific issue or PR — operators could only rely on queue-based selection. This made it impossible to manually re-run a stuck PR revision, force-spike a specific issue, etc.

### What was changed
- **`cai.py` (parser section, ~line 8339)**: Converted 8 bare `sub.add_parser()` calls to named parsers (`revise_parser`, `confirm_parser`, `review_pr_parser`, `review_docs_parser`, `merge_parser`, `refine_parser`, `spike_parser`, `explore_parser`) and added `--pr N` or `--issue N` arguments to each.
- **`cmd_revise`**: Added `--pr N` bypass that fetches the specified PR, builds the same dict structure as `_select_revise_targets()` using `_fetch_review_comments` and `_filter_unaddressed_comments`, and skips queue selection.
- **`cmd_confirm`**: Added `--issue N` bypass that fetches the specified issue directly via `gh issue view`.
- **`cmd_review_pr`**: Added `--pr N` bypass that fetches the specified PR via `gh pr view`.
- **`cmd_review_docs`**: Added `--pr N` bypass that fetches the specified PR via `gh pr view`.
- **`cmd_merge`**: Added `--pr N` bypass that fetches the specified PR via `gh pr view`.
- **`cmd_refine`**: Added `--issue N` bypass that fetches the specified issue via `gh issue view`.
- **`cmd_spike`**: Added `--issue N` bypass that fetches the specified issue via `gh issue view`.
- **`cmd_explore`** (Phase 2 only): Added `--issue N` bypass that fetches the specified issue via `gh issue view`; Phase 1 (follow-up) runs unconditionally.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
