### PR TITLE
auto-improve: Some way to restart work were is was where restarting CAI

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,48 @@
+# PR Context Dossier
+Refs: damien-robotsix/robotsix-cai#457
+
+## Files touched
+- `cai.py:223` — Added `ACTIVE_JOB_PATH = Path("/var/log/cai/cai-active.json")`
+- `cai.py:226-244` — Added `_write_active_job(cmd, issue)` and `_clear_active_job()` helpers
+- `cai.py:3865-3872` — Added `immediate: bool = False` keyword-only param to `_rollback_stale_in_progress()`
+- `cai.py:3935` — Changed `threshold = ttl_hours * 3600` to `threshold = 0 if immediate else ttl_hours * 3600`
+- `cai.py:7964` — Changed `cmd_cycle` call to `_rollback_stale_in_progress(immediate=True)`
+- `cai.py:2188` — Added `_write_active_job("fix", issue_number)` after lock in `cmd_fix`
+- `cai.py:2217,2237` — Added `_clear_active_job()` before early returns in pre-screen path of `cmd_fix`
+- `cai.py:2618` — Added `_clear_active_job()` in `cmd_fix` finally block
+- `cai.py:3146` — Added `_write_active_job("revise", issue_number)` after lock in `cmd_revise`
+- `cai.py:3618` — Added `_clear_active_job()` in `cmd_revise` per-target finally block
+- `cai.py:7330` — Added `_write_active_job("spike", issue_number)` after lock in `cmd_spike`
+- `cai.py:7520` — Added `_clear_active_job()` in `cmd_spike` finally block
+- `tests/test_rollback.py` — New test file covering `immediate=True` vs `immediate=False` behavior
+
+## Files read (not touched) that matter
+- `cai.py` (lines 3838–3945) — `_rollback_stale_in_progress()` full body
+- `cai.py` (lines 2155–2240) — `cmd_fix` lock + pre-screen area
+- `cai.py` (lines 3107–3150) — `cmd_revise` per-target lock area
+- `cai.py` (lines 7286–7330) — `cmd_spike` lock area
+
+## Key symbols
+- `_rollback_stale_in_progress` (`cai.py:3865`) — adds `immediate` kwarg; when True sets threshold=0
+- `_write_active_job` (`cai.py:226`) — writes JSON state to ACTIVE_JOB_PATH
+- `_clear_active_job` (`cai.py:240`) — writes `{}` to ACTIVE_JOB_PATH
+- `ACTIVE_JOB_PATH` (`cai.py:223`) — `/var/log/cai/cai-active.json`
+- `cmd_cycle` (`cai.py:7964`) — now passes `immediate=True` for instant restart recovery
+- `cmd_audit` (`cai.py:4104`) — unchanged, uses default `immediate=False`
+
+## Design decisions
+- `threshold = 0` when `immediate=True`: age > 0 is always true for any non-zero-age issue, so all locks roll back
+- `_clear_active_job()` writes `{}` not deletes: easier to parse than missing file, avoids TOCTOU
+- `immediate` is keyword-only (`*`): prevents accidental positional usage
+- Active-job writes placed AFTER the lock check succeeds but BEFORE the work_dir setup
+- Pre-screen early returns in `cmd_fix` also call `_clear_active_job()` since the lock was already acquired
+
+## Out of scope / known gaps
+- Did not add `_write_active_job` / `_clear_active_job` to `cmd_explore` (not in scope per issue guardrails)
+- Did not change TTL constants `_STALE_IN_PROGRESS_HOURS` / `_STALE_REVISING_HOURS`
+- State file is write-only observability; no logic reads it to gate pipeline decisions
+
+## Invariants this change relies on
+- `cmd_cycle` is only called from `entrypoint.sh` at container start — `immediate=True` is safe there
+- `cmd_audit`'s `_rollback_stale_in_progress()` call continues using default `immediate=False` (TTL-based)
+- `/var/log/cai/` directory already exists (created by other log helpers like `OUTCOME_LOG_PATH`)

--- a/cai.py
+++ b/cai.py
@@ -220,6 +220,29 @@ LOG_PATH = Path("/var/log/cai/cai.log")
 COST_LOG_PATH = Path("/var/log/cai/cai-cost.jsonl")
 REVIEW_PR_PATTERN_LOG = Path("/var/log/cai/review-pr-patterns.jsonl")
 OUTCOME_LOG_PATH = Path("/var/log/cai/cai-outcomes.jsonl")
+ACTIVE_JOB_PATH = Path("/var/log/cai/cai-active.json")
+
+
+def _write_active_job(cmd: str, issue: int) -> None:
+    """Write active-job state for observability. Never raises."""
+    try:
+        ACTIVE_JOB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        ACTIVE_JOB_PATH.write_text(json.dumps({
+            "pid": os.getpid(),
+            "cmd": cmd,
+            "issue": issue,
+            "start_ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }))
+    except OSError:
+        pass
+
+
+def _clear_active_job() -> None:
+    """Clear active-job state file. Never raises."""
+    try:
+        ACTIVE_JOB_PATH.write_text("{}")
+    except OSError:
+        pass
 
 
 def log_run(category: str, **fields) -> None:
@@ -2162,6 +2185,7 @@ def cmd_fix(args) -> int:
         log_run("fix", repo=REPO, issue=issue_number, result="lock_failed", exit=1)
         return 1
     print(f"[cai fix] locked #{issue_number} (label {LABEL_IN_PROGRESS})", flush=True)
+    _write_active_job("fix", issue_number)
 
     # Make sure git can authenticate over HTTPS via the gh token. This
     # is also done in entrypoint.sh, but redoing it here is cheap and
@@ -2190,6 +2214,7 @@ def cmd_fix(args) -> int:
             capture_output=True,
         )
         log_run("fix", repo=REPO, issue=issue_number, result="pre_screen_spike", exit=0)
+        _clear_active_job()
         return 0
 
     if ps_verdict == "ambiguous":
@@ -2209,6 +2234,7 @@ def cmd_fix(args) -> int:
             capture_output=True,
         )
         log_run("fix", repo=REPO, issue=issue_number, result="pre_screen_ambiguous", exit=0)
+        _clear_active_job()
         return 0
 
     _uid = uuid.uuid4().hex[:8]
@@ -2589,6 +2615,7 @@ def cmd_fix(args) -> int:
                 result=f"unexpected_error", exit=1)
         return 1
     finally:
+        _clear_active_job()
         if work_dir.exists():
             shutil.rmtree(work_dir, ignore_errors=True)
 
@@ -3116,6 +3143,7 @@ def cmd_revise(args) -> int:
             continue
 
         _run(["gh", "auth", "setup-git"], capture_output=True)
+        _write_active_job("revise", issue_number)
 
         _uid = uuid.uuid4().hex[:8]
         work_dir = Path(f"/tmp/cai-revise-{issue_number}-{_uid}")
@@ -3587,6 +3615,7 @@ def cmd_revise(args) -> int:
                     result="unexpected_error", exit=1)
             had_failure = True
         finally:
+            _clear_active_job()
             if work_dir.exists():
                 shutil.rmtree(work_dir, ignore_errors=True)
 
@@ -3835,8 +3864,12 @@ def _cleanup_orphaned_branches() -> list[str]:
     return deleted
 
 
-def _rollback_stale_in_progress() -> list[dict]:
+def _rollback_stale_in_progress(*, immediate: bool = False) -> list[dict]:
     """Deterministic rollback: :in-progress or :revising issues with no recent activity.
+
+    When ``immediate=True`` every locked issue is rolled back regardless of age
+    (used by ``cmd_cycle`` on container restart where all in-flight locks are
+    guaranteed to be orphaned).
 
     Returns the list of issues that were rolled back.
     """
@@ -3899,7 +3932,7 @@ def _rollback_stale_in_progress() -> list[dict]:
         issue_num = issue["number"]
         lock_label = issue.get("_lock_label", LABEL_IN_PROGRESS)
         ttl_hours = _STALE_REVISING_HOURS if lock_label == LABEL_REVISING else _STALE_IN_PROGRESS_HOURS
-        threshold = ttl_hours * 3600
+        threshold = 0 if immediate else ttl_hours * 3600
         last_fix = fix_timestamps.get(issue_num)
         if last_fix is not None:
             age = now - last_fix
@@ -7294,6 +7327,7 @@ def cmd_spike(args) -> int:
         log_run("spike", repo=REPO, issue=issue_number, result="lock_failed", exit=1)
         return 1
 
+    _write_active_job("spike", issue_number)
     _uid = uuid.uuid4().hex[:8]
     work_dir = Path(f"/tmp/cai-spike-{issue_number}-{_uid}")
 
@@ -7483,6 +7517,7 @@ def cmd_spike(args) -> int:
         log_run("spike", repo=REPO, issue=issue_number, result="error", exit=1)
         return 1
     finally:
+        _clear_active_job()
         if work_dir.exists():
             shutil.rmtree(work_dir, ignore_errors=True)
 
@@ -7926,7 +7961,7 @@ def cmd_cycle(args) -> int:
             had_failure = True
 
     # --- Phase 1.5: recover stale locks ----------------------------------
-    rolled_back = _rollback_stale_in_progress()
+    rolled_back = _rollback_stale_in_progress(immediate=True)
     if rolled_back:
         nums = ", ".join(f"#{i['number']}" for i in rolled_back)
         print(f"[cai cycle] recovered {len(rolled_back)} stale lock(s): {nums}",

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -1,0 +1,109 @@
+"""Tests for _rollback_stale_in_progress immediate=True/False behaviour."""
+import sys
+import os
+import unittest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch, MagicMock
+
+# Ensure the repo root is on the import path so `import cai` works
+# regardless of how the test runner is invoked.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import cai
+
+
+def _make_issue(number, label, age_hours):
+    """Build a minimal fake issue dict with updatedAt set to age_hours ago."""
+    updated = datetime.now(timezone.utc) - timedelta(hours=age_hours)
+    return {
+        "number": number,
+        "title": f"Test issue {number}",
+        "updatedAt": updated.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "createdAt": updated.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "labels": [{"name": label}],
+    }
+
+
+class TestRollbackStaleInProgress(unittest.TestCase):
+
+    def _run_rollback(self, immediate, issues_by_label):
+        """Run _rollback_stale_in_progress with mocked gh calls."""
+
+        def fake_gh_json(args, **kwargs):
+            # Extract the --label argument
+            label = args[args.index("--label") + 1]
+            return issues_by_label.get(label, [])
+
+        with patch.object(cai, "_gh_json", side_effect=fake_gh_json), \
+             patch.object(cai, "_set_labels", return_value=True), \
+             patch.object(cai, "log_run"), \
+             patch.object(cai, "LOG_PATH", MagicMock(exists=lambda: False)):
+            return cai._rollback_stale_in_progress(immediate=immediate)
+
+    def test_immediate_true_rolls_back_all(self):
+        """immediate=True should roll back all locked issues regardless of age."""
+        # 1-hour-old :in-progress (TTL is 6h — normally would NOT be rolled back)
+        ip_issue = _make_issue(101, cai.LABEL_IN_PROGRESS, age_hours=1)
+        # 30-minute-old :revising (TTL is 1h — normally would NOT be rolled back)
+        rev_issue = _make_issue(102, cai.LABEL_REVISING, age_hours=0.5)
+
+        result = self._run_rollback(
+            immediate=True,
+            issues_by_label={
+                cai.LABEL_IN_PROGRESS: [ip_issue],
+                cai.LABEL_REVISING: [rev_issue],
+            },
+        )
+        nums = {i["number"] for i in result}
+        self.assertIn(101, nums, "1h-old :in-progress should be rolled back when immediate=True")
+        self.assertIn(102, nums, "0.5h-old :revising should be rolled back when immediate=True")
+
+    def test_immediate_false_respects_ttl_in_progress(self):
+        """immediate=False should NOT roll back :in-progress issues within the 6h TTL."""
+        ip_issue = _make_issue(201, cai.LABEL_IN_PROGRESS, age_hours=1)
+
+        result = self._run_rollback(
+            immediate=False,
+            issues_by_label={
+                cai.LABEL_IN_PROGRESS: [ip_issue],
+                cai.LABEL_REVISING: [],
+            },
+        )
+        nums = {i["number"] for i in result}
+        self.assertNotIn(201, nums, "1h-old :in-progress should NOT be rolled back when immediate=False (TTL=6h)")
+
+    def test_immediate_false_respects_ttl_revising(self):
+        """immediate=False should NOT roll back :revising issues within the 1h TTL."""
+        rev_issue = _make_issue(301, cai.LABEL_REVISING, age_hours=0.5)
+
+        result = self._run_rollback(
+            immediate=False,
+            issues_by_label={
+                cai.LABEL_IN_PROGRESS: [],
+                cai.LABEL_REVISING: [rev_issue],
+            },
+        )
+        nums = {i["number"] for i in result}
+        self.assertNotIn(301, nums, "0.5h-old :revising should NOT be rolled back when immediate=False (TTL=1h)")
+
+    def test_immediate_false_rolls_back_stale(self):
+        """immediate=False should roll back issues that exceed their TTL."""
+        # 7-hour-old :in-progress (TTL is 6h — should be rolled back)
+        ip_issue = _make_issue(401, cai.LABEL_IN_PROGRESS, age_hours=7)
+        # 2-hour-old :revising (TTL is 1h — should be rolled back)
+        rev_issue = _make_issue(402, cai.LABEL_REVISING, age_hours=2)
+
+        result = self._run_rollback(
+            immediate=False,
+            issues_by_label={
+                cai.LABEL_IN_PROGRESS: [ip_issue],
+                cai.LABEL_REVISING: [rev_issue],
+            },
+        )
+        nums = {i["number"] for i in result}
+        self.assertIn(401, nums, "7h-old :in-progress should be rolled back (TTL=6h)")
+        self.assertIn(402, nums, "2h-old :revising should be rolled back (TTL=1h)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#457

**Issue:** #457 — Some way to restart work were is was where restarting CAI

## PR Summary

### What this fixes
When the CAI container restarts mid-operation, any issue labelled `:in-progress` or `:revising` had no live process holding its lock, but `_rollback_stale_in_progress()` enforced a 6-hour TTL for `:in-progress` and 1-hour for `:revising` — stalling the pipeline for up to 6 hours. Additionally, there was no way to observe what CAI was doing at the time of a crash.

### What was changed
- **`cai.py`**: Added `ACTIVE_JOB_PATH` constant and two helpers `_write_active_job(cmd, issue)` / `_clear_active_job()` that write/clear a JSON state file at `/var/log/cai/cai-active.json` for observability
- **`cai.py`**: Added `immediate: bool = False` keyword-only parameter to `_rollback_stale_in_progress()`; when `True`, sets `threshold = 0` so all locked issues roll back regardless of age
- **`cai.py`**: Changed `cmd_cycle`'s call to `_rollback_stale_in_progress(immediate=True)` so container-restart recovery is instant
- **`cai.py`**: Added `_write_active_job` calls after successful lock acquisition in `cmd_fix`, `cmd_spike`, and `cmd_revise`; added `_clear_active_job` calls in each command's `finally` block (and before `cmd_fix`'s pre-screen early returns)
- **`tests/test_rollback.py`**: New test file covering `immediate=True` (rolls back all regardless of age) vs `immediate=False` (respects TTLs for both `:in-progress` and `:revising`)

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
