### PR TITLE
auto-improve: Expand Haiku Explore delegation to cai-plan, cai-review-pr, cai-review-docs, cai-spike

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -26,3 +26,17 @@ Refs: robotsix-cai#484
 ## Invariants this change relies on
 - The Agent tool's `model` parameter is respected by the runtime and overrides the parent agent's model for the subagent invocation
 - Haiku Explore preserves 100% retrieval quality for read/search tasks (per spike findings in issue #443)
+
+## Revision 1 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- .claude/agents/cai-review-pr.md:68 — Added "Do NOT delegate decisions — only reading and search." guard to "How to work" item 2 (first Explore reference), matching the guard already present at the second Explore reference in "Agent-specific efficiency guidance"
+
+### Decisions this revision
+- Guard added verbatim inline (same wording as efficiency section) — reviewer explicitly requested matching consistency with other agents and with the second reference in the same file
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,28 @@
+# PR Context Dossier
+Refs: robotsix-cai#484
+
+## Files touched
+- .claude/agents/cai-plan.md:70-75 — Updated Explore guidance to use `Agent(subagent_type="Explore", model="haiku", ...)` with "Do NOT delegate decisions" guard
+- .claude/agents/cai-review-pr.md:66-68 — Updated inline Explore mention in "How to work" section to pin haiku
+- .claude/agents/cai-review-pr.md:123-128 — Updated efficiency guidance section Explore reference to pin haiku with guard
+- .claude/agents/cai-review-docs.md:113-115 — Updated Explore guidance to pin haiku with guard
+- .claude/agents/cai-spike.md:65-66 — Updated Explore mention to pin haiku with guard
+
+## Files read (not touched) that matter
+- .claude/agents/cai-revise.md — canonical reference for `Agent(subagent_type="Explore", model="haiku", ...)` pattern (lines 254-261)
+
+## Key symbols
+- `Agent(subagent_type="Explore", model="haiku", ...)` — the callable syntax used in cai-revise.md that this PR propagates to four more agents
+
+## Design decisions
+- Used callable kwarg syntax `model="haiku"` (not YAML-style `subagent_type: Explore`) — matches the established pattern in cai-revise.md
+- Added "Do NOT delegate decisions — only reading and search" guard to all updated references — prevents parent agents from accidentally offloading judgment to the haiku Explore subagent
+- cai-review-pr.md had TWO Explore references; both were updated
+
+## Out of scope / known gaps
+- cai-revise.md already had the haiku pin — not touched
+- No infrastructure or cai.py changes needed — prompt-only fix
+
+## Invariants this change relies on
+- The Agent tool's `model` parameter is respected by the runtime and overrides the parent agent's model for the subagent invocation
+- Haiku Explore preserves 100% retrieval quality for read/search tasks (per spike findings in issue #443)

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -40,3 +40,17 @@ Refs: robotsix-cai#484
 
 ### New gaps / deferred
 - None
+
+## Revision 2 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- .claude/agents/cai-revise.md:260 — Changed "Do NOT delegate edits or decisions" to "Do NOT delegate decisions" to match the four updated agents
+
+### Decisions this revision
+- Dropped "edits or" from the guard clause in cai-revise.md — reviewer requested consistency with the standardized wording used in the four other agents; "decisions" alone is the canonical form
+
+### New gaps / deferred
+- None

--- a/.claude/agents/cai-plan.md
+++ b/.claude/agents/cai-plan.md
@@ -69,10 +69,12 @@ The user message contains:
 ## Agent-specific efficiency guidance
 
 1. **Use Agent for broad exploration.** When you need to search
-   broadly across multiple files or directories, use the Agent tool
-   with `subagent_type: Explore` instead of issuing many sequential
-   Grep or Read calls. A single Explore subagent can parallelize
-   the search internally, saving tokens and tool-call rounds.
+   broadly across multiple files or directories, use
+   `Agent(subagent_type="Explore", model="haiku", ...)` instead of
+   issuing many sequential Grep or Read calls. A single Explore
+   subagent can parallelize the search internally, saving tokens
+   and tool-call rounds. **Do NOT delegate decisions** — only
+   reading and search.
 
 ## Output format
 

--- a/.claude/agents/cai-review-docs.md
+++ b/.claude/agents/cai-review-docs.md
@@ -111,5 +111,6 @@ No documentation updates needed.
 ## Agent-specific efficiency guidance
 
 1. **Use Agent for broad exploration.** When you need to search broadly, use
-   the Agent tool with `subagent_type: Explore` rather than many sequential
-   Grep or Read calls.
+   `Agent(subagent_type="Explore", model="haiku", ...)` rather than many
+   sequential Grep or Read calls. **Do NOT delegate decisions** — only
+   reading and search.

--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -65,7 +65,8 @@ ripple effects in these six categories:
    find other references in the codebase. When you need to search
    broadly across many files or directories, use
    `Agent(subagent_type="Explore", model="haiku", ...)` instead of
-   issuing many sequential Grep or Read calls.
+   issuing many sequential Grep or Read calls. **Do NOT delegate
+   decisions** — only reading and search.
 3. Check if the PR's changes are consistent with those references
 4. Only report findings where you are confident there is a real
    inconsistency — not hypothetical or stylistic concerns

--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -63,9 +63,9 @@ ripple effects in these six categories:
 1. Read the diff carefully
 2. For each changed file/function/constant, use `Grep` and `Glob` to
    find other references in the codebase. When you need to search
-   broadly across many files or directories, use the Agent tool with
-   `subagent_type: Explore` instead of issuing many sequential Grep
-   or Read calls.
+   broadly across many files or directories, use
+   `Agent(subagent_type="Explore", model="haiku", ...)` instead of
+   issuing many sequential Grep or Read calls.
 3. Check if the PR's changes are consistent with those references
 4. Only report findings where you are confident there is a real
    inconsistency — not hypothetical or stylistic concerns
@@ -121,7 +121,9 @@ No ripple effects found.
 ## Agent-specific efficiency guidance
 
 1. **Use Agent for broad exploration.** When you need to search
-   broadly across multiple files or directories, use the Agent tool
-   with `subagent_type: Explore` instead of issuing many sequential
-   Grep or Read calls. A single Explore subagent can parallelize
-   the search internally, saving tokens and tool-call rounds.
+   broadly across multiple files or directories, use
+   `Agent(subagent_type="Explore", model="haiku", ...)` instead of
+   issuing many sequential Grep or Read calls. A single Explore
+   subagent can parallelize the search internally, saving tokens
+   and tool-call rounds. **Do NOT delegate decisions** — only
+   reading and search.

--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -257,7 +257,7 @@ Use `Agent(subagent_type="Explore", model="haiku", ...)` for reading
 the dossier, files referenced by review comments, and symbol searches
 — this trades expensive sonnet output tokens for ~10× cheaper haiku tokens.
 Fall back to direct Read only for small lookups (3 or fewer files, < 100 lines).
-**Do NOT delegate edits or decisions** — only reading and search.
+**Do NOT delegate decisions** — only reading and search.
 Git operations still go through `cai-git`, not Explore.
 
 ## Addressing review comments

--- a/.claude/agents/cai-spike.md
+++ b/.claude/agents/cai-spike.md
@@ -62,8 +62,9 @@ Your user message contains:
    files and understand current behaviour.
 3. Use `Bash` for verification probes — running small commands, checking
    whether a mechanism exists, testing behaviour.
-4. Use `Agent(subagent_type="Explore")` for broad codebase searches when
-   you are not sure where to look.
+4. Use `Agent(subagent_type="Explore", model="haiku")` for broad codebase
+   searches when you are not sure where to look. **Do NOT delegate
+   decisions** — only reading and search.
 5. Synthesise your findings into one of the three output shapes below.
 
 ## Output format


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#484

**Issue:** #484 — Expand Haiku Explore delegation to cai-plan, cai-review-pr, cai-review-docs, cai-spike

## PR Summary

### What this fixes
Four agent definitions (`cai-plan`, `cai-review-pr`, `cai-review-docs`, `cai-spike`) used `subagent_type: Explore` for codebase read/search without pinning a model, causing Explore subagents to inherit the parent agent's (often Opus) model for pure read work — ~19× more expensive than Haiku for equivalent retrieval quality.

### What was changed
- **`.claude/agents/cai-plan.md`**: Updated efficiency guidance to use `Agent(subagent_type="Explore", model="haiku", ...)` with a "Do NOT delegate decisions" guard
- **`.claude/agents/cai-review-pr.md`**: Updated both Explore references (inline in "How to work" section and in efficiency guidance) to pin `model="haiku"` with the guard
- **`.claude/agents/cai-review-docs.md`**: Updated efficiency guidance Explore reference to pin `model="haiku"` with the guard
- **`.claude/agents/cai-spike.md`**: Updated Process step 4 to use `Agent(subagent_type="Explore", model="haiku")` with the guard

All changes use the callable kwarg syntax (`model="haiku"`) matching the canonical pattern already established in `cai-revise.md:254-261`.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
