### PR TITLE
auto-improve: Missing labels should be created automatically in the repo

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -71,3 +71,17 @@ Refs: damien-robotsix/robotsix-cai#498
 
 ### New gaps / deferred
 - None
+
+## Revision 4 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `.claude/agents/cai-refine.md` (via staging) — added wrapper-behavior paragraph after `## Multi-Step Decomposition` template explaining that wrapper creates sub-issues, labels parent `auto-improve:parent`, and adds checklist
+
+### Decisions this revision
+- Added wrapper-behavior note between the closing ~~~ of the template and the "Multi-step guidelines:" list, matching the pattern in cai-audit-triage.md and cai-spike.md
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -43,3 +43,17 @@ Refs: damien-robotsix/robotsix-cai#498
 
 ### New gaps / deferred
 - None
+
+## Revision 2 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `README.md:164` — Added paragraph documenting `auto-improve:parent` label behavior and sub-issue creation after "Filing issues with multi-step plans" section
+
+### Decisions this revision
+- Added user-facing description of what happens when a `### Plan` issue is accepted by the refine subagent: parent gets `auto-improve:parent` label, sub-issues created, checklist added
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -57,3 +57,17 @@ Refs: damien-robotsix/robotsix-cai#498
 
 ### New gaps / deferred
 - None
+
+## Revision 3 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `README.md:165-170` — Corrected description of sub-issue creation: it happens on `## Multi-Step Decomposition` output (refine detects multi-step), not when a `### Plan` section already exists (which causes refine to skip refinement); added note that pre-existing `### Plan` issues skip refinement and sub-issues are not created
+
+### Decisions this revision
+- Adopted reviewer's suggested text verbatim — accurately describes actual cai-refine.md behavior (early exit on structured headings vs. Multi-Step Decomposition output)
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,31 @@
+# PR Context Dossier
+Refs: damien-robotsix/robotsix-cai#498
+
+## Files touched
+- `publish.py:89` — Added `auto-improve:parent` label to LABELS list
+- `publish.py:102` — Added `audit:needs-human` label to AUDIT_LABELS list
+- `publish.py:279` — Added new `ensure_all_labels()` function that creates labels from all namespaces with deduplication
+- `cai.py:147` — Added `from publish import ensure_all_labels` import
+- `cai.py:8574` — Added `ensure_all_labels()` call in `main()` after auth checks, before handler dispatch
+
+## Files read (not touched) that matter
+- `publish.py` — Contains LABELS, AUDIT_LABELS, CODE_AUDIT_LABELS, UPDATE_CHECK_LABELS constants and existing `ensure_labels()` pattern
+- `cai.py` — Entry point with `main()` function; auth checks at lines 8565-8571
+
+## Key symbols
+- `ensure_all_labels` (`publish.py:279`) — New function; iterates all 4 label sets with deduplication, calls `gh label create` for each unique label
+- `ensure_labels` (`publish.py:262`) — Existing per-namespace function; `ensure_all_labels` follows same `check=False` pattern
+- `LABELS`, `AUDIT_LABELS`, `CODE_AUDIT_LABELS`, `UPDATE_CHECK_LABELS` (`publish.py:77-132`) — All 4 label set constants iterated by `ensure_all_labels`
+
+## Design decisions
+- Called unconditionally in `main()` before handler dispatch — ensures all labels exist regardless of subcommand
+- `seen` set deduplicates labels that appear in multiple sets (e.g. `auto-improve`, `auto-improve:raised` appear in LABELS, CODE_AUDIT_LABELS, UPDATE_CHECK_LABELS)
+- Rejected: calling `ensure_all_labels()` lazily in each handler — would miss handlers and add complexity
+
+## Out of scope / known gaps
+- Performance: adds ~30 `gh label create` calls per invocation; acceptable for background cron jobs
+- No TTL cache to skip the check — can be added later if latency becomes a concern
+
+## Invariants this change relies on
+- `publish.py` does not import from `cai.py` (no circular dependency)
+- `gh label create` returns non-zero when label already exists; `check=False` handles this correctly

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -29,3 +29,17 @@ Refs: damien-robotsix/robotsix-cai#498
 ## Invariants this change relies on
 - `publish.py` does not import from `cai.py` (no circular dependency)
 - `gh label create` returns non-zero when label already exists; `check=False` handles this correctly
+
+## Revision 1 (2026-04-12)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `README.md:179` — Added `audit:needs-human` row to audit label table
+
+### Decisions this revision
+- Added `audit:needs-human` to README label table to match the new label added in `publish.py:AUDIT_LABELS` — label was already referenced in cai-audit-triage.md but missing from README
+
+### New gaps / deferred
+- None

--- a/.claude/agents/cai-refine.md
+++ b/.claude/agents/cai-refine.md
@@ -130,6 +130,11 @@ Produce a `## Multi-Step Decomposition` block **instead of**
 ...
 ~~~
 
+When the wrapper receives a `## Multi-Step Decomposition` output,
+it will: create sub-issues for each step, label the parent issue
+`auto-improve:parent`, and add a checklist to the parent issue
+tracking sub-issue completion.
+
 Multi-step guidelines:
 - Each step must be a standalone change (own PR, own tests)
 - Later steps may depend on earlier steps being merged first

--- a/README.md
+++ b/README.md
@@ -163,12 +163,12 @@ Each step should be a distinct, atomic action. If an issue has no
 `### Plan` section, the fix agent uses its standard single-pass
 approach and this guidance does not apply.
 
-When an issue with a `### Plan` section is accepted, the refine subagent:
+If the refine subagent detects that work requires multiple independent steps, it produces a `## Multi-Step Decomposition` output. The wrapper then:
 1. Labels the parent issue `auto-improve:parent`
 2. Creates one sub-issue per step (each sub-issue body includes a back-reference to the parent)
 3. Adds a checklist to the parent issue to track sub-issue completion
 
-You can watch the parent issue's checklist to monitor progress.
+You can watch the parent issue's checklist to monitor progress. Note: if an issue already has a structured `### Plan` section when filed, the refine subagent will skip refinement, and no sub-issues will be created — the fix subagent will execute the steps directly from the issue body.
 
 ### Audit findings
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ first, which relabels eligible ones to `auto-improve:raised` so the
 |---|---|
 | `audit:raised` | Freshly raised audit finding |
 | `audit:solved` | Addressed (manually closed or auto-resolved on next audit) |
+| `audit:needs-human` | Finding requires human judgement and cannot be resolved autonomously |
 
 Audit categories: `stale_lifecycle`, `lock_corruption`, `loop_stuck`,
 `prompt_contradiction`, `topic_duplicate`, `silent_failure`.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ Each step should be a distinct, atomic action. If an issue has no
 `### Plan` section, the fix agent uses its standard single-pass
 approach and this guidance does not apply.
 
+When an issue with a `### Plan` section is accepted, the refine subagent:
+1. Labels the parent issue `auto-improve:parent`
+2. Creates one sub-issue per step (each sub-issue body includes a back-reference to the parent)
+3. Adds a checklist to the parent issue to track sub-issue completion
+
+You can watch the parent issue's checklist to monitor progress.
+
 ### Audit findings
 
 The `audit` subcommand uses a **separate label namespace** (`audit:*`)

--- a/cai.py
+++ b/cai.py
@@ -152,6 +152,8 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from publish import ensure_all_labels
+
 
 REPO = "damien-robotsix/robotsix-cai"
 SMOKE_PROMPT = "Say hello in one short sentence."
@@ -8717,6 +8719,8 @@ def main() -> int:
     auth_rc = check_claude_auth()
     if auth_rc != 0:
         return auth_rc
+
+    ensure_all_labels()
 
     handlers = {
         "init": cmd_init,

--- a/publish.py
+++ b/publish.py
@@ -96,6 +96,7 @@ LABELS = [
     ("auto-improve:planned", "e4e669", "Plan generated and stored in issue body; awaiting human approval"),
     ("auto-improve:plan-approved", "0e8a16", "Plan approved by human; ready for fix subagent"),
     ("human:submitted", "bfd4f2", "Human-submitted issue awaiting refinement"),
+    ("auto-improve:parent", "c5def5", "Parent issue with sub-issues"),
     ("merge-blocked", "e11d48", "Merge subcommand reviewed and decided not to auto-merge; awaiting human"),
     ("needs-human-review", "e11d48", "PR needs a human decision before merge"),
     ("category:reliability", "d73a4a", "Errors, failures, flaky behavior"),
@@ -107,6 +108,7 @@ LABELS = [
 AUDIT_LABELS = [
     ("audit", "c5def5", "Queue/PR consistency audit finding"),
     ("audit:raised", "0e8a16", "Audit finding freshly raised; needs human triage"),
+    ("audit:needs-human", "e11d48", "Audit finding needs human decision"),
     ("audit:solved", "6f42c1", "Audit finding addressed"),
     ("category:stale_lifecycle", "d93f0b", "Issue stuck in a state longer than expected"),
     ("category:lock_corruption", "e11d48", "Mutually exclusive labels or dangling references"),
@@ -292,6 +294,31 @@ def ensure_labels(namespace: str = "auto-improve") -> None:
             check=False,
             capture_output=True,
         )
+
+
+def ensure_all_labels() -> None:
+    """Create labels for ALL namespaces. Idempotent.
+
+    Deduplicates labels that appear in multiple sets (e.g.
+    auto-improve and auto-improve:raised appear in both LABELS
+    and CODE_AUDIT_LABELS).
+    """
+    seen: set[str] = set()
+    for label_set in (LABELS, AUDIT_LABELS, CODE_AUDIT_LABELS, UPDATE_CHECK_LABELS):
+        for name, color, description in label_set:
+            if name in seen:
+                continue
+            seen.add(name)
+            subprocess.run(
+                [
+                    "gh", "label", "create", name,
+                    "--color", color,
+                    "--description", description,
+                    "--repo", REPO,
+                ],
+                check=False,
+                capture_output=True,
+            )
 
 
 def issue_exists(key: str) -> bool:


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#498

**Issue:** #498 — Missing labels should be created automatically in the repo

## PR Summary

### What this fixes
Several labels referenced by `cai` subcommands (`auto-improve:parent`, `audit:needs-human`) were missing from the label definitions, and no code path guaranteed all labels existed before any handler ran, causing failures when issues were assigned unlisted labels.

### What was changed
- **`publish.py`**: Added `("auto-improve:parent", "c5def5", ...)` to `LABELS` and `("audit:needs-human", "e11d48", ...)` to `AUDIT_LABELS`. Added new `ensure_all_labels()` function that iterates all four label sets (`LABELS`, `AUDIT_LABELS`, `CODE_AUDIT_LABELS`, `UPDATE_CHECK_LABELS`) with a deduplication `seen` set and calls `gh label create` for each unique label.
- **`cai.py`**: Added `from publish import ensure_all_labels` import. Added `ensure_all_labels()` call in `main()` immediately after the auth checks (line ~8574), before the handler dispatch dict, so all labels are guaranteed to exist on every `cai` invocation regardless of subcommand.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
