### PR TITLE
auto-improve: Github workflow faillures should be checked automatically by an agent, that shouuld create an issue accordingly

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -43,6 +43,21 @@ Refs: damien-robotsix/robotsix-cai#497
 - No log fetching — agent only sees run metadata (URL, branch, SHA, conclusion), not logs
 - No success/flake detection — flake categorization requires multi-run history not fetched
 
+## Revision 1 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- cai.py:1256 — added "check-workflows" to _BASE_NAMESPACES set
+- README.md:80 — added "check-workflows" to the "not run at startup" agent list
+
+### Decisions this revision
+- _BASE_NAMESPACES addition is minimal and exactly mirrors the audit namespace pattern
+
+### New gaps / deferred
+- none
+
 ## Invariants this change relies on
 - _gh_json raises CalledProcessError on non-zero exit; cmd_check_workflows catches it
 - publish.py's parse_findings() splits on `### Finding:` headers; agent must use that format

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,49 @@
+# PR Context Dossier
+Refs: damien-robotsix/robotsix-cai#497
+
+## Files touched
+- publish.py:67-76 — Added CHECK_WORKFLOWS_CATEGORIES set
+- publish.py:125-132 — Added CHECK_WORKFLOWS_LABELS list
+- publish.py:258-259 — Added check-workflows branch in _label_set_for()
+- publish.py:318-320 — Added check-workflows branch in create_issue() source attribution
+- publish.py:343-347 — Added check-workflows branch in create_issue() label assignment
+- publish.py:367,374-375 — Added check-workflows to argparse choices and valid_cats dispatch
+- cai.py:8458-8547 — Added cmd_check_workflows() function before cmd_test
+- cai.py:~8636 — Added check-workflows to argparse subparsers
+- cai.py:~8698 — Added check-workflows to handlers dict
+- entrypoint.sh:21 — Added check-workflows comment to task list
+- entrypoint.sh:55 — Added CAI_CHECK_WORKFLOWS_SCHEDULE env var (default: 0 */6 * * *)
+- entrypoint.sh:77 — Added crontab line for check-workflows
+- README.md:68 — Added check-workflows row in subcommand table
+- README.md:76 — Added CAI_CHECK_WORKFLOWS_SCHEDULE to env var list
+
+## Files read (not touched) that matter
+- cai.py:5000-5209 — cmd_cost_optimize pattern (agent invocation + custom issue creation)
+- cai.py:5574-5698 — cmd_update_check pattern (publish.py routing)
+- cai.py:5478-5566 — cmd_code_audit pattern (clone + agent + publish)
+- publish.py — full file, to understand namespace extension points
+
+## Key symbols
+- `cmd_check_workflows` (cai.py:8458) — new command handler
+- `CHECK_WORKFLOWS_CATEGORIES` (publish.py:67) — valid category set for the namespace
+- `CHECK_WORKFLOWS_LABELS` (publish.py:125) — GitHub label definitions
+- `_run_claude_p` (cai.py:492) — wraps claude -p, injects cost logging
+- `_gh_json` (cai.py:644) — runs gh CLI and parses JSON output
+- `PUBLISH_SCRIPT` (cai.py:166) — path to publish.py
+
+## Design decisions
+- Used `--max-turns 3` to cap agent cost since it only reads stdin (no tool use needed)
+- Filters bot branches (`auto-improve/`) in the Python wrapper, not in the agent prompt
+- 24-hour lookback window keeps the issue volume low and avoids re-reporting old failures
+- Chose every-6-hours schedule (same as audit) as a sensible default
+- Routed through publish.py for free fingerprint dedup, not custom issue creation logic
+- Rejected: one-issue-per-SHA approach — would create noise for repeated failures
+
+## Out of scope / known gaps
+- No log fetching — agent only sees run metadata (URL, branch, SHA, conclusion), not logs
+- No success/flake detection — flake categorization requires multi-run history not fetched
+
+## Invariants this change relies on
+- _gh_json raises CalledProcessError on non-zero exit; cmd_check_workflows catches it
+- publish.py's parse_findings() splits on `### Finding:` headers; agent must use that format
+- The check-workflows labels must be created before issues are filed; ensure_labels() handles this

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -73,6 +73,23 @@ Refs: damien-robotsix/robotsix-cai#497
 ### New gaps / deferred
 - none
 
+## Revision 3 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- docker-compose.yml:46 — added CAI_CHECK_WORKFLOWS_SCHEDULE after CAI_HEALTH_REPORT_SCHEDULE
+- install.sh:150 — added CAI_CHECK_WORKFLOWS_SCHEDULE in OAuth YAML template block
+- install.sh:218 — added CAI_CHECK_WORKFLOWS_SCHEDULE in API-key YAML template block
+
+### Decisions this revision
+- Used same schedule as audit ("0 */6 * * *") matching entrypoint.sh default and reviewer suggestion
+- Placed after CAI_HEALTH_REPORT_SCHEDULE (last schedule var before non-schedule config) in all three files
+
+### New gaps / deferred
+- none
+
 ## Invariants this change relies on
 - _gh_json raises CalledProcessError on non-zero exit; cmd_check_workflows catches it
 - publish.py's parse_findings() splits on `### Finding:` headers; agent must use that format

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -90,6 +90,20 @@ Refs: damien-robotsix/robotsix-cai#497
 ### New gaps / deferred
 - none
 
+## Revision 4 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- cai.py:126 (module docstring) — changed "Sonnet agent" to "Haiku agent" for check-workflows description
+
+### Decisions this revision
+- Minimal one-word fix; README.md already had the correct "Haiku agent" wording (added in original PR), so only the module docstring needed updating
+
+### New gaps / deferred
+- none
+
 ## Invariants this change relies on
 - _gh_json raises CalledProcessError on non-zero exit; cmd_check_workflows catches it
 - publish.py's parse_findings() splits on `### Finding:` headers; agent must use that format

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -58,6 +58,21 @@ Refs: damien-robotsix/robotsix-cai#497
 ### New gaps / deferred
 - none
 
+## Revision 2 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- cai.py:114 (module docstring) — added check-workflows entry following health-report
+
+### Decisions this revision
+- Entry follows the same indentation/format as other cron-only commands (code-audit, propose, update-check, health-report)
+- Placed between health-report and the startup description paragraph
+
+### New gaps / deferred
+- none
+
 ## Invariants this change relies on
 - _gh_json raises CalledProcessError on non-zero exit; cmd_check_workflows catches it
 - publish.py's parse_findings() splits on `### Finding:` headers; agent must use that format

--- a/.claude/agents/cai-check-workflows.md
+++ b/.claude/agents/cai-check-workflows.md
@@ -1,0 +1,60 @@
+---
+name: cai-check-workflows
+description: Analyze recent GitHub Actions workflow failures and emit structured findings for new, unreported failures. Groups related failures and identifies root causes.
+tools: Read, Grep, Glob
+model: haiku
+---
+
+# Workflow Failure Checker
+
+You are the workflow-failure checker for `robotsix-cai`. Your job is
+to analyze recent GitHub Actions workflow failures provided in the
+user message and emit structured findings for failures that need
+human attention.
+
+## What you receive
+
+The user message contains:
+
+1. **Failed workflow runs** — JSON data with run ID, name, branch,
+   commit SHA, event trigger, timestamp, URL, and conclusion.
+2. **Existing open check-workflows issues** — so you can avoid
+   duplicates.
+
+## What you produce
+
+For each **new, unreported** failure (or group of related failures),
+emit exactly one finding block:
+
+    ### Finding: <title>
+
+    - **Category:** <workflow_failure|workflow_flake|workflow_config_error>
+    - **Key:** <deterministic fingerprint, e.g. wf-{workflow_name}-{branch}-{sha8}>
+    - **Confidence:** <low|medium|high>
+    - **Evidence:**
+      - <run URL, branch, commit, error summary>
+    - **Remediation:** <what to investigate or fix>
+
+## Rules
+
+1. **Group related failures.** If the same workflow fails on the same
+   branch across multiple commits, emit one finding for the most
+   recent failure, noting the pattern.
+2. **Skip bot branches.** Ignore failures on branches starting with
+   `auto-improve/` — those are handled by the fix/revise pipeline.
+3. **Skip already-reported failures.** If an existing open issue
+   covers the same workflow+branch combination, do not re-raise it.
+4. **Categorize intelligently:**
+   - `workflow_failure`: a genuine build/test failure
+   - `workflow_flake`: the same workflow alternates pass/fail on the
+     same branch (if data suggests it)
+   - `workflow_config_error`: the failure is in workflow setup itself
+     (e.g. missing secret, invalid YAML, action version issue)
+5. **Be concise.** The finding title should be actionable, e.g.
+   "CI failure: tests on main (abc1234d)" not "Workflow failed".
+6. **Use a stable key.** The key must be deterministic so the
+   publish pipeline can dedup across runs. Use the format
+   `wf-<workflow_name_slug>-<branch_slug>-<sha8>` where slugs have
+   spaces and slashes replaced with dashes and are lowercased.
+7. **If there are no new findings**, output nothing — an empty
+   response is valid and correct.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ the env vars (`CAI_ANALYZER_SCHEDULE`, `CAI_FIX_SCHEDULE`,
 `CAI_PROPOSE_SCHEDULE`, `CAI_SPIKE_SCHEDULE`, `CAI_UPDATE_CHECK_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`, `CAI_HEALTH_REPORT_SCHEDULE`, `CAI_COST_OPTIMIZE_SCHEDULE`, `CAI_CHECK_WORKFLOWS_SCHEDULE`),
 runs `cai.py cycle` once synchronously so the issue-solving pipeline
 produces immediate logs, then execs supercronic. Analysis, audit,
-proposal, refine, spike, and update-check agents are **not** run at
+proposal, refine, spike, update-check, and check-workflows agents are **not** run at
 startup — they wait for their own cron ticks so container restarts
 don't re-trigger token-heavy analysis passes.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ subprocess with no shared state.
 | `cai.py confirm` | `0 2 * * *` (daily 02:00 UTC) | Re-analyzes the recent transcript window to verify whether `:merged` issues are actually solved. Patterns that disappeared → closed with `:solved`; patterns that persist → re-queued to `:refined` (up to 3 attempts), then escalated to `:needs-human-review` (Sonnet) |
 | `cai.py health-report` | `0 7 * * 1` (weekly Monday 07:00 UTC) | Automated pipeline health report with anomaly detection. Aggregates cost trends (last 7d vs prior 7d WoW delta), issue queue counts per label state, pipeline stalls, and fix quality metrics. Posts a GitHub-flavored markdown report with 🔴/🟡/🟢 traffic-light indicators as a `health-report` labelled issue. Use `--dry-run` to print to stdout without posting. |
 | `cai.py cost-optimize` | `0 5 * * 0` (weekly Sunday 05:00 UTC) | Weekly cost-reduction agent — loads 14 days of cost data, computes per-agent WoW deltas and cache hit rates, and proposes one concrete optimization targeting the most expensive agent or workflow. Alternates with evaluating previous proposals to track effectiveness. Files proposals as `auto-improve:raised` issues. |
+| `cai.py check-workflows` | `0 */6 * * *` (every 6 hours) | GitHub Actions failure monitor — fetches recent failed workflow runs (last 24 h), filters out bot branches, and runs a Haiku agent to group related failures and identify root causes; findings are published as `check-workflows` namespace issues. |
 | `cai.py cycle` | _(startup + manual/on-demand)_ | Runs verify → fix → revise → review-pr → review-docs → merge → confirm in sequence. The entrypoint runs this once synchronously at `docker compose up -d` so the issue-solving pipeline produces immediate logs; not scheduled via cron (the individual steps have their own cron lines) |
 | `cai.py test` | _(manual/on-demand)_ | Runs the project test suite (`python -m unittest discover` under `tests/`) |
 
@@ -73,7 +74,7 @@ the env vars (`CAI_ANALYZER_SCHEDULE`, `CAI_FIX_SCHEDULE`,
 `CAI_REFINE_SCHEDULE`, `CAI_REVIEW_PR_SCHEDULE`, `CAI_MERGE_SCHEDULE`,
 `CAI_REVISE_SCHEDULE`, `CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`,
 `CAI_AUDIT_TRIAGE_SCHEDULE`, `CAI_CODE_AUDIT_SCHEDULE`,
-`CAI_PROPOSE_SCHEDULE`, `CAI_SPIKE_SCHEDULE`, `CAI_UPDATE_CHECK_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`, `CAI_HEALTH_REPORT_SCHEDULE`, `CAI_COST_OPTIMIZE_SCHEDULE`),
+`CAI_PROPOSE_SCHEDULE`, `CAI_SPIKE_SCHEDULE`, `CAI_UPDATE_CHECK_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`, `CAI_HEALTH_REPORT_SCHEDULE`, `CAI_COST_OPTIMIZE_SCHEDULE`, `CAI_CHECK_WORKFLOWS_SCHEDULE`),
 runs `cai.py cycle` once synchronously so the issue-solving pipeline
 produces immediate logs, then execs supercronic. Analysis, audit,
 proposal, refine, spike, and update-check agents are **not** run at

--- a/cai.py
+++ b/cai.py
@@ -1253,7 +1253,7 @@ def _set_labels(issue_number: int, *, add: list[str] = (), remove: list[str] = (
     # Auto-add the base label for any state-prefixed label being added.
     # This is defensive: create_issue already applies base labels, but
     # auto-adding here self-heals issues that lost theirs.
-    _BASE_NAMESPACES = {"auto-improve", "audit"}
+    _BASE_NAMESPACES = {"auto-improve", "audit", "check-workflows"}
     auto_added_bases: set[str] = set()
     for label in add:
         if ":" in label:

--- a/cai.py
+++ b/cai.py
@@ -123,7 +123,7 @@ Subcommands:
     python cai.py check-workflows  Periodic GitHub Actions workflow failure
                             monitor. Fetches recent workflow runs, filters
                             out bot branches (auto-improve/), and runs a
-                            Sonnet agent to identify persistent failures.
+                            Haiku agent to identify persistent failures.
                             Findings are published via publish.py with the
                             `check-workflows` namespace. Runs every 6 hours
                             by default (CAI_CHECK_WORKFLOWS_SCHEDULE).

--- a/cai.py
+++ b/cai.py
@@ -120,6 +120,14 @@ Subcommands:
                             issue with the `health-report` label. Use
                             --dry-run to print to stdout without posting.
 
+    python cai.py check-workflows  Periodic GitHub Actions workflow failure
+                            monitor. Fetches recent workflow runs, filters
+                            out bot branches (auto-improve/), and runs a
+                            Sonnet agent to identify persistent failures.
+                            Findings are published via publish.py with the
+                            `check-workflows` namespace. Runs every 6 hours
+                            by default (CAI_CHECK_WORKFLOWS_SCHEDULE).
+
 The container runs `entrypoint.sh`, which executes `init`, `analyze`,
 `verify`, `refine`, `spike`, `fix`, `revise`, `review-pr`, `review-docs`, `merge`, `audit`, `code-audit`, `propose`, `update-check`, and `confirm` once synchronously at
 startup, then hands off to supercronic. Each cron tick is a fresh process.

--- a/cai.py
+++ b/cai.py
@@ -8455,6 +8455,117 @@ def cmd_health_report(args) -> int:
     return result.returncode
 
 
+def cmd_check_workflows(args) -> int:
+    """Check GitHub Actions for recent workflow failures and raise findings."""
+    print("[cai check-workflows] running workflow check", flush=True)
+    t0 = time.monotonic()
+
+    # 1. Fetch recent failed runs from GitHub Actions.
+    try:
+        runs = _gh_json([
+            "run", "list",
+            "--repo", REPO,
+            "--status", "failure",
+            "--json", "databaseId,name,headBranch,conclusion,createdAt,url,event,headSha",
+            "--limit", "20",
+        ]) or []
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"[cai check-workflows] gh run list failed: {exc}",
+            file=sys.stderr, flush=True,
+        )
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run("check-workflows", repo=REPO, result="gh_failed", duration=dur, exit=1)
+        return 1
+
+    # 2. Filter: last 24 hours only, skip bot branches.
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+    recent_runs = []
+    for r in runs:
+        try:
+            created = datetime.fromisoformat(r["createdAt"].replace("Z", "+00:00"))
+        except (KeyError, ValueError):
+            continue
+        if created < cutoff:
+            continue
+        if r.get("headBranch", "").startswith("auto-improve/"):
+            continue
+        recent_runs.append(r)
+
+    if not recent_runs:
+        dur = f"{int(time.monotonic() - t0)}s"
+        print("[cai check-workflows] no recent failures found", flush=True)
+        log_run("check-workflows", repo=REPO, failures=0, duration=dur, exit=0)
+        return 0
+
+    # 3. Fetch existing open check-workflows issues for dedup context.
+    try:
+        existing = _gh_json([
+            "issue", "list",
+            "--repo", REPO,
+            "--label", "check-workflows",
+            "--state", "open",
+            "--json", "number,title,body",
+            "--limit", "50",
+        ]) or []
+    except subprocess.CalledProcessError:
+        existing = []
+
+    # 4. Build user message.
+    runs_section = "## Recent failed workflow runs\n\n"
+    runs_section += json.dumps(recent_runs, indent=2) + "\n\n"
+
+    existing_section = "## Existing open check-workflows issues\n\n"
+    if existing:
+        for iss in existing:
+            existing_section += f"- #{iss['number']}: {iss['title']}\n"
+            body_snippet = (iss.get("body") or "")[:300]
+            existing_section += f"  Body: {body_snippet}\n"
+    else:
+        existing_section += "(none)\n"
+
+    user_message = runs_section + existing_section
+
+    # 5. Invoke the declared cai-check-workflows agent.
+    print(
+        f"[cai check-workflows] running agent on {len(recent_runs)} failure(s)",
+        flush=True,
+    )
+    agent = _run_claude_p(
+        ["claude", "-p", "--agent", "cai-check-workflows",
+         "--max-turns", "3",
+         "--permission-mode", "acceptEdits"],
+        category="check-workflows",
+        agent="cai-check-workflows",
+        input=user_message,
+        cwd="/app",
+    )
+    if agent.stdout:
+        print(agent.stdout, flush=True)
+    if agent.returncode != 0:
+        print(
+            f"[cai check-workflows] agent failed (exit {agent.returncode}):\n"
+            f"{agent.stderr}",
+            file=sys.stderr, flush=True,
+        )
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run("check-workflows", repo=REPO, result="agent_failed",
+                duration=dur, exit=agent.returncode)
+        return agent.returncode
+
+    # 6. Publish findings via publish.py with check-workflows namespace.
+    print("[cai check-workflows] publishing findings", flush=True)
+    published = _run(
+        ["python", str(PUBLISH_SCRIPT), "--namespace", "check-workflows"],
+        input=agent.stdout,
+    )
+
+    dur = f"{int(time.monotonic() - t0)}s"
+    log_run("check-workflows", repo=REPO, failures=len(recent_runs),
+            duration=dur, exit=published.returncode)
+    return published.returncode
+
+
 def cmd_test(args) -> int:
     """Run the project test suite."""
     result = _run(
@@ -8531,6 +8642,7 @@ def main() -> int:
         help="Target a specific issue number instead of using queue-based selection",
     )
     sub.add_parser("cost-optimize", help="Weekly cost-reduction proposal or evaluation")
+    sub.add_parser("check-workflows", help="Check GitHub Actions for recent workflow failures and raise findings")
     sub.add_parser("cycle", help="Full cycle: verify, fix, revise, review-pr, review-docs, merge, confirm")
     sub.add_parser("test", help="Run the project test suite")
 
@@ -8592,6 +8704,7 @@ def main() -> int:
         "cost-report": cmd_cost_report,
         "health-report": cmd_health_report,
         "cost-optimize": cmd_cost_optimize,
+        "check-workflows": cmd_check_workflows,
         "test": cmd_test,
     }
     return handlers[args.command](args)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       CAI_REVIEW_PR_SCHEDULE: "20 * * * *"  # hourly at :20 (pre-merge consistency review)
       CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly at :35 (auto-merge confident PRs)
       CAI_HEALTH_REPORT_SCHEDULE: "0 7 * * 1" # weekly Monday 07:00 UTC (pipeline health report)
+      CAI_CHECK_WORKFLOWS_SCHEDULE: "0 */6 * * *" # every 6h (check for CI workflow failures)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "50"        # read at most N recent transcript files (0 = no limit)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,7 @@
 #      - merge:         confidence-gated auto-merge for bot PRs
 #      - health-report: automated pipeline health report with anomaly detection
 #      - cost-optimize: weekly cost-reduction proposal or evaluation
+#      - check-workflows: monitor GitHub Actions for failures
 #    Each is its own crontab line so supercronic runs them as
 #    independent processes — natural concurrency, easy to add more.
 #
@@ -52,6 +53,7 @@ CAI_REFINE_SCHEDULE="${CAI_REFINE_SCHEDULE:-10 * * * *}"
 CAI_SPIKE_SCHEDULE="${CAI_SPIKE_SCHEDULE:-0 */2 * * *}"
 CAI_HEALTH_REPORT_SCHEDULE="${CAI_HEALTH_REPORT_SCHEDULE:-0 7 * * 1}"
 CAI_COST_OPTIMIZE_SCHEDULE="${CAI_COST_OPTIMIZE_SCHEDULE:-0 5 * * 0}"
+CAI_CHECK_WORKFLOWS_SCHEDULE="${CAI_CHECK_WORKFLOWS_SCHEDULE:-0 */6 * * *}"
 
 CRONTAB_PATH=/tmp/crontab
 
@@ -74,6 +76,7 @@ $CAI_REVIEW_PR_SCHEDULE python /app/cai.py review-pr
 $CAI_MERGE_SCHEDULE python /app/cai.py merge
 $CAI_HEALTH_REPORT_SCHEDULE python /app/cai.py health-report
 $CAI_COST_OPTIMIZE_SCHEDULE python /app/cai.py cost-optimize
+$CAI_CHECK_WORKFLOWS_SCHEDULE python /app/cai.py check-workflows
 CRONTAB
 
 echo "[entrypoint] crontab:"

--- a/install.sh
+++ b/install.sh
@@ -147,6 +147,7 @@ services:
       CAI_REVIEW_PR_SCHEDULE: "20 * * * *"  # hourly :20 (pre-merge consistency review)
       CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly :35 (auto-merge confident PRs)
       CAI_HEALTH_REPORT_SCHEDULE: "0 7 * * 1" # weekly Monday 07:00 UTC (pipeline health report)
+      CAI_CHECK_WORKFLOWS_SCHEDULE: "0 */6 * * *" # every 6h (check for CI workflow failures)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "50"        # read at most N recent transcript files (0 = no limit)
@@ -215,6 +216,7 @@ services:
       CAI_REVIEW_PR_SCHEDULE: "20 * * * *"  # hourly :20 (pre-merge consistency review)
       CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly :35 (auto-merge confident PRs)
       CAI_HEALTH_REPORT_SCHEDULE: "0 7 * * 1" # weekly Monday 07:00 UTC (pipeline health report)
+      CAI_CHECK_WORKFLOWS_SCHEDULE: "0 */6 * * *" # every 6h (check for CI workflow failures)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "50"        # read at most N recent transcript files (0 = no limit)

--- a/publish.py
+++ b/publish.py
@@ -71,6 +71,12 @@ UPDATE_CHECK_CATEGORIES = {
     "best_practice",
 }
 
+CHECK_WORKFLOWS_CATEGORIES = {
+    "workflow_failure",
+    "workflow_flake",
+    "workflow_config_error",
+}
+
 # Labels we ensure exist before creating issues. The first two are the
 # state labels; the rest are the category labels. Idempotent — `gh label
 # create` returns non-zero if the label already exists, which we ignore.
@@ -129,6 +135,14 @@ UPDATE_CHECK_LABELS = [
     ("category:feature_adoption", "0075ca", "New feature that could improve the workspace"),
     ("category:deprecation", "e11d48", "Deprecated flag or pattern we use"),
     ("category:best_practice", "5319e7", "Best-practice change from release notes"),
+]
+
+CHECK_WORKFLOWS_LABELS = [
+    ("check-workflows", "e11d48", "GitHub Actions workflow failure finding"),
+    ("check-workflows:raised", "d73a4a", "Workflow failure freshly raised"),
+    ("category:workflow_failure", "b60205", "GitHub Actions run failed"),
+    ("category:workflow_flake", "fbca04", "Flaky or intermittent workflow failure"),
+    ("category:workflow_config_error", "0075ca", "Workflow YAML misconfiguration"),
 ]
 
 
@@ -256,6 +270,8 @@ def _label_set_for(namespace: str):
         return CODE_AUDIT_LABELS
     if namespace == "update-check":
         return UPDATE_CHECK_LABELS
+    if namespace == "check-workflows":
+        return CHECK_WORKFLOWS_LABELS
     return LABELS
 
 
@@ -313,6 +329,9 @@ def create_issue(f: Finding, namespace: str = "auto-improve") -> int:
     elif namespace == "update-check":
         source_note = "cai update-check agent"
         source_file = ".claude/agents/cai-update-check.md"
+    elif namespace == "check-workflows":
+        source_note = "cai check-workflows agent"
+        source_file = ".claude/agents/cai-check-workflows.md"
     else:
         source_note = "cai self-analyzer"
         source_file = ".claude/agents/cai-analyze.md"
@@ -339,6 +358,12 @@ def create_issue(f: Finding, namespace: str = "auto-improve") -> int:
             "audit:raised",
             f"category:{f.category}",
         ])
+    elif namespace == "check-workflows":
+        labels = ",".join([
+            "check-workflows",
+            "check-workflows:raised",
+            f"category:{f.category}",
+        ])
     else:
         labels = ",".join([
             "auto-improve",
@@ -363,7 +388,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Publish findings as GitHub issues")
     parser.add_argument(
         "--namespace", default="auto-improve",
-        choices=["auto-improve", "audit", "code-audit", "update-check"],
+        choices=["auto-improve", "audit", "code-audit", "update-check", "check-workflows"],
         help="Label namespace to use (default: auto-improve)",
     )
     args = parser.parse_args()
@@ -374,6 +399,8 @@ def main() -> int:
         valid_cats = CODE_AUDIT_CATEGORIES
     elif namespace == "update-check":
         valid_cats = UPDATE_CHECK_CATEGORIES
+    elif namespace == "check-workflows":
+        valid_cats = CHECK_WORKFLOWS_CATEGORIES
     else:
         valid_cats = VALID_CATEGORIES
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#497

**Issue:** #497 — Github workflow faillures should be checked automatically by an agent, that shouuld create an issue accordingly

## PR Summary

### What this fixes
GitHub Actions workflow failures were not automatically monitored — there was no mechanism to detect, group, or raise issues when CI runs failed on the repository. This PR adds an agent-based `cai check-workflows` command that periodically checks for workflow failures and creates structured GitHub issues for them.

### What was changed
- **`publish.py`**: Added `check-workflows` namespace — `CHECK_WORKFLOWS_CATEGORIES` set, `CHECK_WORKFLOWS_LABELS` list, and corresponding branches in `_label_set_for()`, `create_issue()`, and `main()` argument parser.
- **`.cai-staging/agents/cai-check-workflows.md`**: New Haiku agent definition that reads failed run metadata from stdin, groups related failures, categorizes them (`workflow_failure` / `workflow_flake` / `workflow_config_error`), and emits `### Finding:` blocks for the publish pipeline.
- **`cai.py`**: Added `cmd_check_workflows()` function that fetches the last 20 failed runs via `gh run list`, filters to the past 24 hours and skips `auto-improve/` branches, invokes the `cai-check-workflows` agent (capped at 3 turns), and routes output through `publish.py --namespace check-workflows`. Registered the new command in argparse and the handlers dict.
- **`entrypoint.sh`**: Added `CAI_CHECK_WORKFLOWS_SCHEDULE` env var (default: `0 */6 * * *`), a crontab line, and a comment in the task list.
- **`README.md`**: Added the `cai check-workflows` row in the subcommand table and `CAI_CHECK_WORKFLOWS_SCHEDULE` to the env var prose list.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
