### PR TITLE
auto-improve: [Step 1/2] Create initial `/docs` skeleton

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -69,3 +69,17 @@ Refs: robotsix-cai/robotsix-cai#492
 
 ### New gaps / deferred
 - none
+
+## Revision 3 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- none
+
+### Decisions this revision
+- Review comment (cross_cutting_ref: cai-revise missing from worktree list) was already resolved in Revision 2 — cai-revise is present at docs/architecture.md:52 in the current branch. Comment was filed against an earlier commit (9e5c55a7b3566f3b7a6d5596008dfc5c178619d3) that predated Revision 2.
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -45,3 +45,27 @@ Refs: robotsix-cai/robotsix-cai#492
 
 ### New gaps / deferred
 - none
+
+## Revision 2 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- docs/agents.md:10 — cai-code-audit mode Read-only → Worktree
+- docs/agents.md:13 — cai-explore mode Worktree → Clone (new mode)
+- docs/agents.md:17-19 — cai-plan, cai-propose, cai-propose-review mode Read-only → Worktree
+- docs/agents.md:22-23 — cai-review-docs, cai-review-pr mode Read-only → Worktree
+- docs/agents.md:25 — cai-select mode Inline-only → Worktree
+- docs/agents.md:26 — cai-spike mode Worktree → Clone
+- docs/agents.md:27 — cai-update-check mode Read-only → Worktree
+- docs/agents.md:29 — footnote expanded to describe Worktree (code-editing vs. review/planning sub-types), Clone, and Read-only modes
+- docs/architecture.md:50-62 — Worktree agents section rewritten: full list per cai.py:186, split into code-editing vs. review/planning sub-types; added Clone agents subsection for cai-explore/cai-spike; updated Read-only agents list
+
+### Decisions this revision
+- Introduced "Clone" as a 4th mode for cai-explore and cai-spike — per cai.py cmd_explore/cmd_spike, these agents clone the repo via --add-dir and post outcomes directly to GitHub issues (no branch, no PR); using "Worktree" was misleading because the architecture.md Worktree description said "opens a PR"
+- Worktree agents list in architecture.md now matches cai.py:186 exactly: cai-fix, cai-revise, cai-rebase, cai-review-pr, cai-review-docs, cai-code-audit, cai-propose, cai-propose-review, cai-update-check, cai-plan, cai-select, cai-git
+- cai-merge added to Read-only list in architecture.md (it was previously in agents.md as Inline-only; the architecture.md Read-only description "receive context in prompt" covers inline-only behavior accurately)
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,33 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#492
+
+## Files touched
+- docs/cli.md:1 — new file documenting all 22 cai subcommands with descriptions and argument tables
+- docs/configuration.md:1 — new file documenting environment variables, settings.json structure, and runtime paths
+- docs/architecture.md:1 — new file documenting the pipeline lifecycle, labels, cycle command flow, and agent modes
+- docs/agents.md:1 — new file with a table of all 21 agents (name, description, tools, model, mode)
+
+## Files read (not touched) that matter
+- cai.py — argparse setup (lines 8472–8596) for subcommand names/args; cmd_* docstrings for descriptions
+- .claude/agents/*.md — frontmatter (tools, model, description) for all 21 agents
+
+## Key symbols
+- `cmd_*` (cai.py:717–8464) — one function per subcommand; docstrings used for docs/cli.md descriptions
+- `main()` / `sub.add_parser` (cai.py:8471–8596) — arg definitions used for cli.md argument tables
+- `CAI_MERGE_CONFIDENCE_THRESHOLD` (cai.py:6501) — env var documented in configuration.md
+- `ANTHROPIC_API_KEY` (cai.py:689) — env var documented in configuration.md
+
+## Design decisions
+- Alphabetical ordering for cli.md subcommands — easier for humans and cai-review-docs to cross-reference
+- Alphabetical ordering for agents.md table — matches Plan 1 selection rationale
+- Used frontmatter `model:` values verbatim (e.g. `claude-sonnet-4-6` → displayed as `sonnet`)
+- Kept descriptions concise to stay under ~150 line budget per file
+
+## Out of scope / known gaps
+- No existing files were modified
+- Did not document internal helper functions or constants in cai.py
+- `cai-cai-confirm` model listed as `sonnet` per frontmatter (not `opus`)
+
+## Invariants this change relies on
+- The docs/ directory is new — no existing docs were overwritten
+- Subcommand names in cli.md use hyphenated CLI form (cost-report), not Python underscore form

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -31,3 +31,17 @@ Refs: robotsix-cai/robotsix-cai#492
 ## Invariants this change relies on
 - The docs/ directory is new — no existing docs were overwritten
 - Subcommand names in cli.md use hyphenated CLI form (cost-report), not Python underscore form
+
+## Revision 1 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- docs/agents.md:15 — changed cai-git mode from "Git ops" to "Worktree" to match cai.py:186 classification
+
+### Decisions this revision
+- Used "Worktree" rather than defining a new "Git ops" mode — cai.py explicitly classifies cai-git as a cloned-worktree agent; "Worktree" accurately reflects that it runs git commands in a clone via Bash
+
+### New gaps / deferred
+- none

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -12,7 +12,7 @@ Agents are defined in `.claude/agents/*.md` with YAML frontmatter (`name`, `desc
 | `cai-cost-optimize` | Weekly cost-reduction agent — analyzes spending trends, proposes one optimization | Read, Grep, Glob | sonnet | Read-only |
 | `cai-explore` | Autonomous exploration and benchmarking of `:needs-exploration` issues | Read, Grep, Glob, Bash, Agent, Write, Edit | opus | Worktree |
 | `cai-fix` | Autonomous code-editing subagent — makes the smallest targeted change for an issue | Read, Edit, Write, Grep, Glob, TodoWrite | sonnet | Worktree |
-| `cai-git` | Lightweight subagent that executes git operations on behalf of other agents | Bash | haiku | Git ops |
+| `cai-git` | Lightweight subagent that executes git operations on behalf of other agents | Bash | haiku | Worktree |
 | `cai-merge` | Assess whether a PR correctly implements its linked issue and emit a merge verdict | Read | opus | Inline-only |
 | `cai-plan` | Generate a detailed fix plan for an issue (first of two serial planners) | Read, Grep, Glob, Agent | opus | Read-only |
 | `cai-propose` | Weekly creative agent that proposes ambitious improvements | Read, Grep, Glob | sonnet | Read-only |

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -7,23 +7,23 @@ Agents are defined in `.claude/agents/*.md` with YAML frontmatter (`name`, `desc
 | `cai-analyze` | Analyze parsed transcript signals and raise auto-improve findings | Read, Grep, Glob, Skill | sonnet | Read-only |
 | `cai-audit` | Audit issue queue and PRs for lifecycle state-machine inconsistencies | Read, Grep, Glob | sonnet | Read-only |
 | `cai-audit-triage` | Triage `audit:raised` findings and emit close/passthrough/escalate verdicts | Read | sonnet | Inline-only |
-| `cai-code-audit` | Read-only source tree audit for inconsistencies, dead code, and missing cross-file references | Read, Grep, Glob | sonnet | Read-only |
+| `cai-code-audit` | Read-only source tree audit for inconsistencies, dead code, and missing cross-file references | Read, Grep, Glob | sonnet | Worktree |
 | `cai-confirm` | Verify each `auto-improve:merged` issue is actually resolved | Read, Grep, Glob | sonnet | Read-only |
 | `cai-cost-optimize` | Weekly cost-reduction agent — analyzes spending trends, proposes one optimization | Read, Grep, Glob | sonnet | Read-only |
-| `cai-explore` | Autonomous exploration and benchmarking of `:needs-exploration` issues | Read, Grep, Glob, Bash, Agent, Write, Edit | opus | Worktree |
+| `cai-explore` | Autonomous exploration and benchmarking of `:needs-exploration` issues | Read, Grep, Glob, Bash, Agent, Write, Edit | opus | Clone |
 | `cai-fix` | Autonomous code-editing subagent — makes the smallest targeted change for an issue | Read, Edit, Write, Grep, Glob, TodoWrite | sonnet | Worktree |
 | `cai-git` | Lightweight subagent that executes git operations on behalf of other agents | Bash | haiku | Worktree |
 | `cai-merge` | Assess whether a PR correctly implements its linked issue and emit a merge verdict | Read | opus | Inline-only |
-| `cai-plan` | Generate a detailed fix plan for an issue (first of two serial planners) | Read, Grep, Glob, Agent | opus | Read-only |
-| `cai-propose` | Weekly creative agent that proposes ambitious improvements | Read, Grep, Glob | sonnet | Read-only |
-| `cai-propose-review` | Evaluate creative proposals for feasibility and value before filing issues | Read, Grep, Glob | sonnet | Read-only |
+| `cai-plan` | Generate a detailed fix plan for an issue (first of two serial planners) | Read, Grep, Glob, Agent | opus | Worktree |
+| `cai-propose` | Weekly creative agent that proposes ambitious improvements | Read, Grep, Glob | sonnet | Worktree |
+| `cai-propose-review` | Evaluate creative proposals for feasibility and value before filing issues | Read, Grep, Glob | sonnet | Worktree |
 | `cai-rebase` | Lightweight rebase conflict resolution for PRs with no unaddressed review comments | Read, Edit, Write, Grep, Glob, Agent | haiku | Worktree |
 | `cai-refine` | Rewrite human-filed issues into structured plans with steps, verification, and scope guardrails | Read, Grep, Glob | sonnet | Read-only |
-| `cai-review-docs` | Pre-merge documentation review — checks whether PR changes require `/docs` updates | Read, Grep, Glob, Agent | haiku | Read-only |
-| `cai-review-pr` | Pre-merge ripple-effect review — finds inconsistencies the PR introduced but didn't update | Read, Grep, Glob, Agent | haiku | Read-only |
+| `cai-review-docs` | Pre-merge documentation review — checks whether PR changes require `/docs` updates | Read, Grep, Glob, Agent | haiku | Worktree |
+| `cai-review-pr` | Pre-merge ripple-effect review — finds inconsistencies the PR introduced but didn't update | Read, Grep, Glob, Agent | haiku | Worktree |
 | `cai-revise` | Handle PR review comments: resolve rebase conflicts AND address unaddressed reviewer comments | Read, Edit, Write, Grep, Glob, Agent | sonnet | Worktree |
-| `cai-select` | Evaluate two fix plans and select the better one | Read | opus | Inline-only |
-| `cai-spike` | Research/verification agent for `:needs-spike` issues — produces Findings, Refined Issue, or Blocked output | Read, Grep, Glob, Bash, Agent | opus | Worktree |
-| `cai-update-check` | Periodic Claude Code release checker — emits findings for new versions, deprecations, and best-practice changes | Read, Grep, Glob | sonnet | Read-only |
+| `cai-select` | Evaluate two fix plans and select the better one | Read | opus | Worktree |
+| `cai-spike` | Research/verification agent for `:needs-spike` issues — produces Findings, Refined Issue, or Blocked output | Read, Grep, Glob, Bash, Agent | opus | Clone |
+| `cai-update-check` | Periodic Claude Code release checker — emits findings for new versions, deprecations, and best-practice changes | Read, Grep, Glob | sonnet | Worktree |
 
-**Inline-only** agents receive all context in the user message and require no file access. **Worktree** agents run in a fresh git clone and can edit files; the `cai.py` wrapper handles commit, push, and PR creation. **Read-only** agents read the repo or external data without making any changes.
+**Inline-only** agents receive all context in the user message and require no file access. **Worktree** agents run in a fresh git clone provided by the wrapper; code-editing agents (`cai-fix`, `cai-revise`, `cai-rebase`) commit changes and open PRs, while review/planning agents (`cai-code-audit`, `cai-git`, `cai-plan`, `cai-propose`, `cai-propose-review`, `cai-review-docs`, `cai-review-pr`, `cai-select`, `cai-update-check`) read from the clone and emit structured output. **Clone** agents (`cai-explore`, `cai-spike`) also run against a fresh repo clone but post outcomes directly to GitHub issues rather than opening PRs. **Read-only** agents read the repo or external data without writing anything.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,29 @@
+# Agents
+
+Agents are defined in `.claude/agents/*.md` with YAML frontmatter (`name`, `description`, `tools`, `model`). The `cai.py` wrapper selects the appropriate agent for each pipeline phase and passes context via the prompt.
+
+| Agent | Description | Tools | Model | Mode |
+|---|---|---|---|---|
+| `cai-analyze` | Analyze parsed transcript signals and raise auto-improve findings | Read, Grep, Glob, Skill | sonnet | Read-only |
+| `cai-audit` | Audit issue queue and PRs for lifecycle state-machine inconsistencies | Read, Grep, Glob | sonnet | Read-only |
+| `cai-audit-triage` | Triage `audit:raised` findings and emit close/passthrough/escalate verdicts | Read | sonnet | Inline-only |
+| `cai-code-audit` | Read-only source tree audit for inconsistencies, dead code, and missing cross-file references | Read, Grep, Glob | sonnet | Read-only |
+| `cai-confirm` | Verify each `auto-improve:merged` issue is actually resolved | Read, Grep, Glob | sonnet | Read-only |
+| `cai-cost-optimize` | Weekly cost-reduction agent — analyzes spending trends, proposes one optimization | Read, Grep, Glob | sonnet | Read-only |
+| `cai-explore` | Autonomous exploration and benchmarking of `:needs-exploration` issues | Read, Grep, Glob, Bash, Agent, Write, Edit | opus | Worktree |
+| `cai-fix` | Autonomous code-editing subagent — makes the smallest targeted change for an issue | Read, Edit, Write, Grep, Glob, TodoWrite | sonnet | Worktree |
+| `cai-git` | Lightweight subagent that executes git operations on behalf of other agents | Bash | haiku | Git ops |
+| `cai-merge` | Assess whether a PR correctly implements its linked issue and emit a merge verdict | Read | opus | Inline-only |
+| `cai-plan` | Generate a detailed fix plan for an issue (first of two serial planners) | Read, Grep, Glob, Agent | opus | Read-only |
+| `cai-propose` | Weekly creative agent that proposes ambitious improvements | Read, Grep, Glob | sonnet | Read-only |
+| `cai-propose-review` | Evaluate creative proposals for feasibility and value before filing issues | Read, Grep, Glob | sonnet | Read-only |
+| `cai-rebase` | Lightweight rebase conflict resolution for PRs with no unaddressed review comments | Read, Edit, Write, Grep, Glob, Agent | haiku | Worktree |
+| `cai-refine` | Rewrite human-filed issues into structured plans with steps, verification, and scope guardrails | Read, Grep, Glob | sonnet | Read-only |
+| `cai-review-docs` | Pre-merge documentation review — checks whether PR changes require `/docs` updates | Read, Grep, Glob, Agent | haiku | Read-only |
+| `cai-review-pr` | Pre-merge ripple-effect review — finds inconsistencies the PR introduced but didn't update | Read, Grep, Glob, Agent | haiku | Read-only |
+| `cai-revise` | Handle PR review comments: resolve rebase conflicts AND address unaddressed reviewer comments | Read, Edit, Write, Grep, Glob, Agent | sonnet | Worktree |
+| `cai-select` | Evaluate two fix plans and select the better one | Read | opus | Inline-only |
+| `cai-spike` | Research/verification agent for `:needs-spike` issues — produces Findings, Refined Issue, or Blocked output | Read, Grep, Glob, Bash, Agent | opus | Worktree |
+| `cai-update-check` | Periodic Claude Code release checker — emits findings for new versions, deprecations, and best-practice changes | Read, Grep, Glob | sonnet | Read-only |
+
+**Inline-only** agents receive all context in the user message and require no file access. **Worktree** agents run in a fresh git clone and can edit files; the `cai.py` wrapper handles commit, push, and PR creation. **Read-only** agents read the repo or external data without making any changes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,14 +49,19 @@
 
 ### Worktree agents
 
-`cai-fix`, `cai-revise`, `cai-rebase`, `cai-explore`, `cai-spike` run in a **fresh git worktree clone**. The wrapper:
+`cai-code-audit`, `cai-fix`, `cai-git`, `cai-plan`, `cai-propose`, `cai-propose-review`, `cai-rebase`, `cai-review-docs`, `cai-review-pr`, `cai-revise`, `cai-select`, `cai-update-check` run in a **fresh git worktree clone**. The wrapper clones the repo and passes the clone path as the agent's work directory. The agent itself never runs `git push` or `gh` — the wrapper owns all remote state.
+
+For code-editing agents (`cai-fix`, `cai-revise`, `cai-rebase`), the wrapper also:
 - Creates an isolated branch (`auto-improve/<issue>-<slug>`)
-- Runs the agent with the clone path as its work directory
 - Commits all changes, pushes the branch, and opens (or updates) a PR
 - Deletes the worktree on completion
 
-The agent itself never runs `git` or `gh` — the wrapper owns all remote state.
+For review and planning agents (`cai-code-audit`, `cai-git`, `cai-plan`, `cai-propose`, `cai-propose-review`, `cai-review-docs`, `cai-review-pr`, `cai-select`, `cai-update-check`), the clone provides read access to the full repo tree; these agents emit structured output (findings, plans, verdicts) that the wrapper acts on deterministically — no commit or PR is created.
+
+### Clone agents
+
+`cai-explore`, `cai-spike` also operate on a fresh repo clone but follow a different pattern. The wrapper clones the repo and passes it via `--add-dir` (not as `cwd`). These agents post outcomes (Findings, Refined Issue, Blocked) directly to the GitHub issue via `gh issue` commands. They do not create branches or PRs.
 
 ### Read-only agents
 
-`cai-analyze`, `cai-audit`, `cai-audit-triage`, `cai-code-audit`, `cai-confirm`, `cai-cost-optimize`, `cai-plan`, `cai-propose`, `cai-propose-review`, `cai-refine`, `cai-review-docs`, `cai-review-pr`, `cai-select`, `cai-update-check` receive all context in their prompt or read the repo without writing to it. They emit structured output (findings, verdicts, plans) that the wrapper acts on deterministically.
+`cai-analyze`, `cai-audit`, `cai-audit-triage`, `cai-confirm`, `cai-cost-optimize`, `cai-merge`, `cai-refine` receive all context in their prompt or read the live repo without a dedicated clone. They emit structured output (findings, verdicts, label transitions) that the wrapper acts on deterministically.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,62 @@
+# Architecture
+
+## Pipeline Overview
+
+`robotsix-cai` is a self-improving agent system. The continuous loop runs inside a long-lived Docker container and drives GitHub issues through a well-defined lifecycle:
+
+1. **Raise** — `cai analyze`, `cai propose`, `cai code-audit`, `cai audit`, or a human files an issue labeled `auto-improve:raised`.
+2. **Refine** — `cai refine` calls `cai-refine` to rewrite the issue into a structured plan with steps, verification, and scope guardrails. Label transitions to `auto-improve:refined`.
+3. **Fix** — `cai fix` calls `cai-fix` in a fresh git worktree. The wrapper commits, pushes, and opens a PR. Label transitions to `auto-improve:in-progress` → `auto-improve:pr-open`.
+4. **Review** — `cai review-pr` checks for ripple-effect inconsistencies; `cai review-docs` checks for stale documentation. Findings are posted as PR comments.
+5. **Revise** — `cai revise` calls `cai-revise` or `cai-rebase` to address review comments or rebase conflicts. Label transitions to `auto-improve:revising`.
+6. **Merge** — `cai merge` calls `cai-merge` to assess confidence and auto-merges PRs that meet the threshold. Label transitions to `auto-improve:merged`.
+7. **Confirm** — `cai confirm` calls `cai-confirm` to verify the merged fix actually resolved the original issue. Label transitions to `auto-improve:solved` or re-queues to `:refined`.
+
+## Lifecycle Labels
+
+| Label | Meaning |
+|---|---|
+| `auto-improve:raised` | Newly filed, awaiting refinement |
+| `auto-improve:refined` | Has a structured plan, ready for fix |
+| `auto-improve:in-progress` | Fix agent is running (lock; 6 h stale timeout) |
+| `auto-improve:pr-open` | PR created, awaiting review and merge |
+| `auto-improve:revising` | Revise agent is running (lock; 1 h stale timeout) |
+| `auto-improve:merged` | PR merged, awaiting confirmation |
+| `auto-improve:solved` | Confirmed resolved |
+| `auto-improve:no-action` | No fix needed (7 d stale timeout → re-queued to `:raised`) |
+| `auto-improve:needs-spike` | Needs research investigation (`cai spike`) |
+| `auto-improve:needs-exploration` | Needs autonomous exploration (`cai explore`) |
+| `auto-improve:requested` | Explicitly requested by a human |
+| `auto-improve:parent` | Parent issue; child sub-issues carry the work |
+| `audit:raised` | Audit finding awaiting triage by `cai audit-triage` |
+| `audit:needs-human` | Audit finding escalated to human |
+| `merge-blocked` | PR has a blocking review finding; will not auto-merge |
+| `needs-human-review` | Issue or PR requires human attention |
+
+## The Cycle Command
+
+`cai cycle` orchestrates the full pipeline in a single blocking run:
+
+1. **Verify + confirm** — sync label state with actual PR/issue state.
+2. **Recover stale locks** — roll back `:in-progress` and `:revising` issues past their timeout.
+3. **Ingest unlabeled** — attach `auto-improve` to any unlabeled issues that belong to the pipeline.
+4. **Drain PRs** — for each open auto-improve PR: revise → review-pr → review-docs → merge.
+5. **Refine one** — call `refine` on the oldest `:raised` issue.
+6. **Fix loop** — repeatedly call `fix`, `spike`, or `explore` until no eligible issues remain, draining PRs after each fix.
+7. **Final confirm** — one last confirm pass.
+
+## Agent Execution Modes
+
+### Worktree agents
+
+`cai-fix`, `cai-revise`, `cai-rebase`, `cai-explore`, `cai-spike` run in a **fresh git worktree clone**. The wrapper:
+- Creates an isolated branch (`auto-improve/<issue>-<slug>`)
+- Runs the agent with the clone path as its work directory
+- Commits all changes, pushes the branch, and opens (or updates) a PR
+- Deletes the worktree on completion
+
+The agent itself never runs `git` or `gh` — the wrapper owns all remote state.
+
+### Read-only agents
+
+`cai-analyze`, `cai-audit`, `cai-audit-triage`, `cai-code-audit`, `cai-confirm`, `cai-cost-optimize`, `cai-plan`, `cai-propose`, `cai-propose-review`, `cai-refine`, `cai-review-docs`, `cai-review-pr`, `cai-select`, `cai-update-check` receive all context in their prompt or read the repo without writing to it. They emit structured output (findings, verdicts, plans) that the wrapper acts on deterministically.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,163 @@
+# CLI Reference
+
+`cai` is the main entry point. Usage: `cai <subcommand> [options]`
+
+Run inside the container: `docker compose exec cai python /app/cai.py <subcommand>`
+
+---
+
+## analyze
+
+Parse prior Claude Code transcripts, invoke the `cai-analyze` agent, and publish findings as GitHub issues labeled `auto-improve:raised`.
+
+No arguments.
+
+## audit
+
+Run the periodic queue/PR consistency audit: roll back stale `:in-progress` locks, clean up orphaned branches, unstick stale `:no-action` issues, recover closed-PR issues, and invoke the `cai-audit` agent for a full state-machine review.
+
+No arguments.
+
+## audit-triage
+
+Autonomously resolve `audit:raised` findings without opening a PR. Calls `cai-audit-triage` which classifies each finding as `close_duplicate`, `close_resolved`, `passthrough`, or `escalate`.
+
+No arguments.
+
+## code-audit
+
+Clone the repo and run `cai-code-audit` to find concrete inconsistencies, dead code, and missing cross-file references.
+
+No arguments.
+
+## confirm
+
+Re-analyze recent transcript signals to verify that `auto-improve:merged` issues are actually resolved. Re-queues unsolved issues (up to 3 attempts) or escalates to `:needs-human-review`.
+
+| Argument | Type | Description |
+|---|---|---|
+| `--issue INT` | optional | Target a specific issue number instead of queue-based selection |
+
+## cost-optimize
+
+Run the weekly `cai-cost-optimize` agent to analyze spending trends and propose one cost-reduction optimization.
+
+No arguments.
+
+## cost-report
+
+Print a human-readable cost report from `/var/log/cai/cai-cost.jsonl`.
+
+| Argument | Type | Default | Description |
+|---|---|---|---|
+| `--days INT` | optional | 7 | Window in days to include |
+| `--top INT` | optional | 10 | Number of most-expensive invocations to list |
+| `--by {category,agent,day}` | optional | category | Aggregation grouping |
+
+## cycle
+
+Continuously run the full pipeline until nothing is left to do: verify + confirm → recover stale locks → drain pending PRs (revise → review-pr → review-docs → merge) → refine one `:raised` issue → fix/spike/explore loop → final confirm.
+
+No arguments.
+
+## explore
+
+Run `cai-explore` on the oldest `auto-improve:needs-exploration` issue. Outcomes: close with findings, re-queue to `:raised`, hand off directly to `:refined`, or escalate to `:needs-human-review`.
+
+| Argument | Type | Description |
+|---|---|---|
+| `--issue INT` | optional | Target a specific issue number |
+
+## fix
+
+Run the `cai-fix` agent against one eligible `auto-improve:refined` issue in a fresh git worktree. The wrapper handles commit, push, and PR creation.
+
+| Argument | Type | Description |
+|---|---|---|
+| `--issue INT` | optional | Target a specific issue number instead of scoring-based selection |
+
+## health-report
+
+Generate an automated pipeline health report with anomaly detection: cost trends, issue throughput, pipeline stalls, and fix quality metrics. Posts the report as a GitHub issue.
+
+| Argument | Type | Description |
+|---|---|---|
+| `--dry-run` | flag | Print report to stdout without posting a GitHub issue |
+
+## init
+
+Seed the loop with a smoke test, but only if no prior transcripts exist. If transcripts already exist, exits immediately.
+
+No arguments.
+
+## merge
+
+Confidence-gated auto-merge for bot PRs. Uses `cai-merge` to assess each open PR and merges those meeting the configured confidence threshold.
+
+| Argument | Type | Description |
+|---|---|---|
+| `--pr INT` | optional | Target a specific PR number |
+
+## propose
+
+Clone the repo and run `cai-propose` (creative improvements) followed by `cai-propose-review` to evaluate feasibility before filing issues.
+
+No arguments.
+
+## refine
+
+Invoke `cai-refine` on the oldest `auto-improve:raised` issue to produce a structured implementation plan (transitions to `:refined`).
+
+| Argument | Type | Description |
+|---|---|---|
+| `--issue INT` | optional | Target a specific issue number |
+
+## review-docs
+
+Review open PRs for stale documentation using `cai-review-docs`. Posts `### Finding: stale_docs` blocks as PR comments.
+
+| Argument | Type | Description |
+|---|---|---|
+| `--pr INT` | optional | Target a specific PR number |
+
+## review-pr
+
+Review open PRs for ripple-effect inconsistencies using `cai-review-pr`. Posts `### Finding:` blocks as PR comments.
+
+| Argument | Type | Description |
+|---|---|---|
+| `--pr INT` | optional | Target a specific PR number |
+
+## revise
+
+Iterate on open PRs that have unaddressed review comments. Runs `cai-revise` (or `cai-rebase` for conflict-only cases) to address comments and push updates.
+
+| Argument | Type | Description |
+|---|---|---|
+| `--pr INT` | optional | Target a specific PR number |
+
+## spike
+
+Run `cai-spike` on the oldest `auto-improve:needs-spike` issue to investigate unanswered questions. Outcomes mirror `explore`: close, re-queue, refine, or escalate.
+
+| Argument | Type | Description |
+|---|---|---|
+| `--issue INT` | optional | Target a specific issue number |
+
+## test
+
+Run the project test suite via `unittest discover`.
+
+No arguments.
+
+## update-check
+
+Clone the repo and run `cai-update-check` to compare the current pinned Claude Code version against latest releases and emit findings for new versions or deprecations.
+
+No arguments.
+
+## verify
+
+Walk `auto-improve:pr-open` issues and transition labels based on actual PR state (merged → `:merged`, closed → `:raised`, etc.).
+
+No arguments.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,37 @@
+# Configuration
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | API authentication for headless `claude` invocations inside the container | Required |
+| `CAI_MERGE_CONFIDENCE_THRESHOLD` | Minimum confidence level for `cai merge` auto-merge (`high`, `medium`, `disabled`) | `high` |
+
+`CAI_MERGE_CONFIDENCE_THRESHOLD` controls how aggressively the merge agent promotes PRs:
+- `high` — only auto-merge when `cai-merge` emits a `high` confidence verdict
+- `medium` — also auto-merge `medium` confidence verdicts
+- `disabled` — skip auto-merge entirely (useful during testing)
+
+## Settings File
+
+`.claude/settings.json` configures Claude Code for both interactive and headless sessions.
+
+Key fields:
+
+- **`permissions.allow`** — tool allowlist rules. Headless (`claude -p`) sessions inherit these rules. The fix/revise/rebase agents run with a restricted allowlist (no `Bash`, no `git push`) enforced by per-agent `tools:` frontmatter.
+- **`model`** — default model for interactive sessions (agents override this via their own `model:` frontmatter).
+- **`env`** — environment variables injected into every Claude Code session.
+
+Agent-level overrides live in `.claude/agents/<name>.md` YAML frontmatter (`tools:`, `model:`, `description:`).
+
+## Paths and Directories
+
+| Path | Purpose |
+|---|---|
+| `/home/cai/.claude/projects` | Transcript directory — Claude Code writes `.jsonl` session files here |
+| `/app/.claude/agent-memory` | Per-agent persistent memory files (checked into git) |
+| `/var/log/cai/cai.log` | Structured run log (JSON lines, one entry per `cai` invocation) |
+| `/var/log/cai/cai-cost.jsonl` | Per-invocation cost log (input/output tokens + USD) |
+| `/var/log/cai/cai-outcomes.jsonl` | Fix/revise outcome log (issue number, verdict, PR URL) |
+| `/var/log/cai/review-pr-patterns.jsonl` | Review-PR finding category log (used by `cai analyze`) |
+| `/var/log/cai/cai-active.json` | Active job lock — prevents concurrent `cai fix`/`revise` runs |


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#492

**Issue:** #492 — [Step 1/2] Create initial `/docs` skeleton

## PR Summary

### What this fixes
The `/docs` directory did not exist, leaving `cai-review-docs` with nothing to compare against and users with no reference for CLI usage, configuration, or architecture.

### What was changed
- **`docs/cli.md`** *(new)*: Documents all 22 `cai` subcommands (alphabetical) with one-paragraph descriptions drawn from `cmd_*` docstrings and argument tables from the argparse setup.
- **`docs/configuration.md`** *(new)*: Documents `ANTHROPIC_API_KEY` and `CAI_MERGE_CONFIDENCE_THRESHOLD` environment variables, `.claude/settings.json` structure, and key runtime paths (`/var/log/cai/`, transcript dir, agent memory dir).
- **`docs/architecture.md`** *(new)*: Overview of the 7-phase pipeline (raise → refine → fix → review → revise → merge → confirm), all 15 lifecycle labels with meanings, the `cai cycle` phase sequence, and the worktree vs read-only agent distinction.
- **`docs/agents.md`** *(new)*: Table of all 21 agents (alphabetical) with description, tools, model, and execution mode (worktree / read-only / inline-only), sourced from `.claude/agents/*.md` frontmatter.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
