### PR TITLE
auto-improve: [Step 1/2] Create initial `/docs` skeleton

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -76,3 +76,20 @@ Refs: damien-robotsix/robotsix-cai#499
 
 ### New gaps / deferred
 - None
+
+## Revision 4 (2026-04-13)
+
+### Rebase
+- resolved: docs/agents.md, docs/architecture.md, docs/cli.md, docs/configuration.md (both-added conflicts with main; HEAD kept throughout — main's versions from PR #492 were more complete)
+
+### Files touched this revision
+- docs/configuration.md — added Agent Schedules section with all 17 CAI_*_SCHEDULE variables and defaults; added Transcript Analysis Variables section (CAI_TRANSCRIPT_WINDOW_DAYS, CAI_TRANSCRIPT_MAX_FILES)
+- docs/architecture.md — Lifecycle Labels table now includes all labels: `:requested`, `:revising`, `auto-improve:parent`, `audit:needs-human`, `merge-blocked`, `needs-human-review`
+
+### Decisions this revision
+- Conflict resolution kept HEAD (main) content for all 4 files — main had nav_order frontmatter, correct structure, and review-cycle fixes from PR #492
+- Schedule vars and label additions address the two `missing_co_change` review findings from @damien-robotsix in the same pass as conflict resolution
+- No separate editing pass needed since HEAD content was written with the review fixes already incorporated
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -31,3 +31,19 @@ Refs: damien-robotsix/robotsix-cai#499
 ## Invariants this change relies on
 - just-the-docs theme renders nav_order as sidebar position; pages without nav_order may be hidden
 - Subcommand descriptions sourced from cai.py argparse help strings — will drift if cai.py is updated
+
+## Revision 1 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- docs/cli.md:31 — `analyze` description corrected to match argparse help string ("Run the analyzer + publish findings")
+- docs/cli.md:38 — `audit-triage` description corrected to match argparse help string ("no PRs" not "no PRs opened")
+- docs/cli.md:46 — `init` description corrected to match argparse help string ("if no transcripts exist" not "yet")
+
+### Decisions this revision
+- All three changes are verbatim corrections to match cai.py argparse help strings — no paraphrasing
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -61,3 +61,18 @@ Refs: damien-robotsix/robotsix-cai#499
 
 ### New gaps / deferred
 - None
+
+## Revision 3 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- docs/architecture.md:36-45 — replaced incorrect issue lifecycle labels (`:planned`, `:review`, `:confirmed`) with actual labels from cai.py constants (`:raised`, `:refined`, `:in-progress`, `:pr-open`, `:merged`, `:solved`)
+
+### Decisions this revision
+- Accurate labels sourced from cai.py lines 193-212 (LABEL_* constants) and cross-checked against README.md lifecycle diagram (lines 89-130)
+- Added `:no-action` and re-queue / `needs-human-review` outcomes to match the full state machine
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -93,3 +93,18 @@ Refs: damien-robotsix/robotsix-cai#499
 
 ### New gaps / deferred
 - None
+
+## Revision 5 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- docs/configuration.md:17 — introductory sentence updated: "most are also explicitly configured in `docker-compose.yml`" instead of "both files set all defaults"
+
+### Decisions this revision
+- Used reviewer's suggested wording verbatim: clarifies that only most (not all) schedule vars appear in docker-compose.yml
+- Did not add CAI_SPIKE_SCHEDULE/CAI_COST_OPTIMIZE_SCHEDULE to docker-compose.yml — behavioral change outside this docs PR's scope
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -47,3 +47,17 @@ Refs: damien-robotsix/robotsix-cai#499
 
 ### New gaps / deferred
 - None
+
+## Revision 2 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- docs/cli.md:39 — `code-audit` description corrected to match argparse help string (removed "and dead code")
+
+### Decisions this revision
+- Verbatim correction to match cai.py:8495 argparse help string exactly per dossier invariant
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,33 @@
+# PR Context Dossier
+Refs: damien-robotsix/robotsix-cai#499
+
+## Files touched
+- docs/architecture.md — new file: pipeline overview, issue lifecycle, supporting processes, orchestration
+- docs/cli.md — new file: subcommands grouped by category (core pipeline, issue processing, maintenance, utilities)
+- docs/agents.md — new file: all 21 agents grouped by role with model, access level, and purpose
+- docs/configuration.md — new file: environment variables and Docker volumes
+
+## Files read (not touched) that matter
+- docs/index.md — existing home page; not modified (just-the-docs builds sidebar from nav_order automatically)
+- docs/_config.yml — confirmed just-the-docs theme is in use; nav_order frontmatter drives sidebar
+- cai.py:8472-8562 — argparse subcommand definitions used as source of truth for cli.md descriptions
+- .claude/agents/*.md — frontmatter of all 21 agents used as source of truth for agents.md
+
+## Key symbols
+- `nav_order` (docs/*.md frontmatter) — controls sidebar ordering in just-the-docs; required for visibility
+- `sub.add_parser` (cai.py:8475-8535) — authoritative subcommand help strings
+
+## Design decisions
+- No changes to index.md — just-the-docs sidebar is theme-driven via nav_order, not a hand-maintained link list
+- architecture.md gets nav_order:1, cli.md nav_order:2, agents.md nav_order:3, configuration.md nav_order:4
+- cai-cost-optimize classified as read-only (tools: Read, Grep, Glob only — verified from frontmatter)
+- Agents table includes all 21 agents found in .claude/agents/
+
+## Out of scope / known gaps
+- index.md not touched per plan; already has title:Home which places it first in sidebar
+- No exhaustive API-level reference; stubs with accurate summaries only
+- cai-propose-review is in review group (not maintenance) since it gates creative proposals before they enter pipeline
+
+## Invariants this change relies on
+- just-the-docs theme renders nav_order as sidebar position; pages without nav_order may be hidden
+- Subcommand descriptions sourced from cai.py argparse help strings — will drift if cai.py is updated

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,39 @@
 - `medium` — also auto-merge `medium` confidence verdicts
 - `disabled` — skip auto-merge entirely (useful during testing)
 
+## Agent Schedules
+
+All pipeline agents run on cron schedules configurable via environment variables. Default values are set in `docker-compose.yml` and `entrypoint.sh`.
+
+| Variable | Default | Description |
+|---|---|---|
+| `CAI_ANALYZER_SCHEDULE` | `0 0 * * *` | Daily transcript analysis and issue raising |
+| `CAI_FIX_SCHEDULE` | `15 * * * *` | Hourly fix agent run |
+| `CAI_REFINE_SCHEDULE` | `10 * * * *` | Hourly issue refinement |
+| `CAI_REVISE_SCHEDULE` | `30 * * * *` | Hourly PR revision (review comments + rebase) |
+| `CAI_VERIFY_SCHEDULE` | `45 * * * *` | Hourly label sync with PR state |
+| `CAI_REVIEW_PR_SCHEDULE` | `20 * * * *` | Hourly pre-merge consistency review |
+| `CAI_MERGE_SCHEDULE` | `35 * * * *` | Hourly confidence-gated auto-merge |
+| `CAI_CONFIRM_SCHEDULE` | `0 2 * * *` | Daily post-merge confirmation |
+| `CAI_AUDIT_SCHEDULE` | `0 */6 * * *` | Every 6 hours — queue/PR lifecycle audit |
+| `CAI_AUDIT_TRIAGE_SCHEDULE` | `10 */6 * * *` | Every 6 hours — resolve `audit:raised` findings |
+| `CAI_SPIKE_SCHEDULE` | `0 */2 * * *` | Every 2 hours — research `:needs-spike` issues |
+| `CAI_CODE_AUDIT_SCHEDULE` | `0 3 * * 0` | Weekly (Sunday 03:00 UTC) — source tree audit |
+| `CAI_PROPOSE_SCHEDULE` | `0 4 * * 0` | Weekly (Sunday 04:00 UTC) — creative proposals |
+| `CAI_COST_OPTIMIZE_SCHEDULE` | `0 5 * * 0` | Weekly (Sunday 05:00 UTC) — cost-reduction analysis |
+| `CAI_UPDATE_CHECK_SCHEDULE` | `0 4 * * 1` | Weekly (Monday 04:00 UTC) — Claude Code release check |
+| `CAI_HEALTH_REPORT_SCHEDULE` | `0 7 * * 1` | Weekly (Monday 07:00 UTC) — pipeline health report |
+| `CAI_CHECK_WORKFLOWS_SCHEDULE` | `0 */6 * * *` | Every 6 hours — GitHub Actions workflow check |
+
+Schedule values use standard cron format: `minute hour day month weekday`. To disable a scheduled agent, set its variable to an empty string or a comment value.
+
+## Transcript Analysis Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `CAI_TRANSCRIPT_WINDOW_DAYS` | `7` | Only parse session transcripts from the last N days |
+| `CAI_TRANSCRIPT_MAX_FILES` | `50` | Read at most N recent transcript files (0 = no limit) |
+
 ## Settings File
 
 `.claude/settings.json` configures Claude Code for both interactive and headless sessions.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@
 
 ## Agent Schedules
 
-All pipeline agents run on cron schedules configurable via environment variables. Default values are set in `docker-compose.yml` and `entrypoint.sh`.
+All pipeline agents run on cron schedules configurable via environment variables. Default values are set in `entrypoint.sh`; most are also explicitly configured in `docker-compose.yml`.
 
 | Variable | Default | Description |
 |---|---|---|


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#499

**Issue:** #499 — [Step 1/2] Create initial `/docs` skeleton

## PR Summary

### What this fixes
The `/docs` directory lacked content beyond `index.md`, causing `cai-review-docs` to always output "No documentation updates needed." without surfacing real gaps in PRs.

### What was changed
- **`docs/architecture.md`** (new) — pipeline flow diagram, issue lifecycle label progression, supporting-process agents, orchestration overview
- **`docs/cli.md`** (new) — all subcommands grouped by category (core pipeline, issue processing, maintenance & auditing, utilities) with help strings sourced from `cai.py`'s argparse definitions
- **`docs/agents.md`** (new) — all 21 agents in tables grouped by role (analysis, planning, execution, review, maintenance) with model, access level, and purpose from frontmatter
- **`docs/configuration.md`** (new) — environment variables (`ANTHROPIC_API_KEY`, `CAI_MERGE_CONFIDENCE_THRESHOLD`, `INSTALL_DIR`, `IMAGE_TAG`) and Docker volumes (`cai_home`, `cai_agent_memory`, `cai_logs`)
- `docs/index.md` not modified — the just-the-docs theme builds the sidebar from `nav_order` frontmatter automatically

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
