### PR TITLE
auto-improve: [Step 2/2] Fix `cai-review-docs` silent bailout when `/docs` is missing or empty

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,23 @@
+# PR Context Dossier
+Refs: robotsix-cai/cai#493
+
+## Files touched
+- .claude/agents/cai-review-docs.md:74-80 — replaced unconditional `No documentation updates needed.` bailout with conditional: no user-facing changes → silent pass; user-facing changes present → emit `### Finding: stale_docs` referencing the existing output format section
+
+## Files read (not touched) that matter
+- .claude/agents/cai-review-docs.md — the agent definition being modified; lines 74-75 had the unconditional bailout; lines 81-90 have the existing finding template
+
+## Key symbols
+- `### Finding: stale_docs` (.claude/agents/cai-review-docs.md:82) — existing output format template the new conditional references rather than duplicating
+
+## Design decisions
+- Cross-reference existing "Output format" section instead of duplicating the finding template inline — keeps the file DRY and avoids a markdown heading collision
+- Rejected: Plan 1's approach of embedding the full finding template at lines 74-75 — duplicates the template already at lines 81-90 and introduces a raw `### Finding:` heading in the middle of the "How to work" section
+
+## Out of scope / known gaps
+- Did not touch `cai.py` (`cmd_review_docs`) — the Python wrapper just invokes the agent; logic lives in the agent definition
+- Did not restructure or add sections to the agent file
+
+## Invariants this change relies on
+- The "Output format" section (now at lines 82-95 after the 5-line insertion) continues to define the `### Finding: stale_docs` template that the new conditional references
+- The "Changes that do NOT warrant documentation review" section at lines 59-64 remains the authoritative list the new conditional cross-references

--- a/.claude/agents/cai-review-docs.md
+++ b/.claude/agents/cai-review-docs.md
@@ -71,8 +71,15 @@ Changes that **do NOT warrant documentation review**:
    post-PR code
 4. For each gap, emit a `### Finding: stale_docs` block
 
-If the `docs/` directory does not exist or is empty, output
-`No documentation updates needed.`
+If the `docs/` directory does not exist or is empty:
+- If the PR diff contains no user-facing changes (see "Changes that do NOT
+  warrant documentation review" above), output
+  `No documentation updates needed.`
+- If the PR diff **does** contain user-facing changes, emit a
+  `### Finding: stale_docs` block (using the format below) with
+  file `docs/ (missing or empty)`, describing that the PR changes user-facing
+  behavior but no documentation exists to verify, and suggesting the team
+  create or populate `/docs` before merging.
 
 ## Output format
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#493

**Issue:** #493 — [Step 2/2] Fix `cai-review-docs` silent bailout when `/docs` is missing or empty

## PR Summary

### What this fixes
The `cai-review-docs` agent unconditionally output `No documentation updates needed.` whenever `docs/` was missing or empty, silently rubber-stamping any PR with user-facing changes when no docs directory existed to check.

### What was changed
- `.claude/agents/cai-review-docs.md` (lines 74–75, via staging): Replaced the two-line unconditional bailout with a 7-line conditional. When `docs/` is missing or empty and the PR diff contains **no** user-facing changes, the agent still outputs `No documentation updates needed.`. When the PR diff **does** contain user-facing changes, the agent now emits a `### Finding: stale_docs` block (referencing the existing "Output format" section for the template) indicating that user-facing behavior is being changed but no documentation exists to verify.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
