### PR TITLE
auto-improve: Lower Watchtower poll rate to reduce mid-work restarts

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -23,3 +23,17 @@ Refs: robotsix-cai/cai#502
 ## Invariants this change relies on
 - Watchtower remains enabled; only the poll frequency changes
 - `cai.py` `timeout=1800` is a subagent timeout, unrelated to this interval
+
+## Revision 1 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `install.sh:86` — "every 30 minutes" → "every 12 hours" in user-facing Watchtower prompt
+
+### Decisions this revision
+- Used "every 12 hours" (without the `(43200 s)` parenthetical) to match the surrounding prose style of the existing `echo` lines
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,25 @@
+# PR Context Dossier
+Refs: robotsix-cai/cai#502
+
+## Files touched
+- `install.sh:107` — `--interval=1800` → `--interval=43200` in Watchtower service heredoc
+- `docker-compose.yml:105` — `#     - --interval=1800` → `#     - --interval=43200` in commented template
+- `README.md:394` — "every 30 minutes" → "every 12 hours (43200 s)"
+
+## Files read (not touched) that matter
+- `cai.py` — confirmed unrelated `timeout=1800` at ~line 7699 was not touched
+
+## Key symbols
+- `WATCHTOWER_SERVICE` (`install.sh:100-109`) — heredoc that generates the watchtower compose service block
+
+## Design decisions
+- 43200 s (12h) chosen per maintainer comment; matches issue proposal
+- Added `(43200 s)` to README prose so users can cross-reference the `--interval` flag without mental arithmetic
+
+## Out of scope / known gaps
+- Existing installs require manual update or re-running `install.sh`; README already documents this at lines 418-422
+- No change to Watchtower image pin, other flags, or Docker Compose structure
+
+## Invariants this change relies on
+- Watchtower remains enabled; only the poll frequency changes
+- `cai.py` `timeout=1800` is a subagent timeout, unrelated to this interval

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ The installer asks for the **auth mode**:
    written to a `.env` file (chmod 600).
 
 The installer also asks whether to enable **Watchtower** — a small
-sidecar container that polls Docker Hub every 30 minutes and
+sidecar container that polls Docker Hub every 12 hours (43200 s) and
 automatically pulls + restarts cai when a new image is published.
 Default is **no** (manual updates). If you answer yes, the generated
 `docker-compose.yml` includes a `watchtower` service alongside `cai`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
   #     - /var/run/docker.sock:/var/run/docker.sock
   #   command:
   #     - --label-enable
-  #     - --interval=1800
+  #     - --interval=43200
   #     - --cleanup
 
 volumes:

--- a/install.sh
+++ b/install.sh
@@ -83,7 +83,7 @@ echo
 echo "Enable Watchtower for automatic updates?"
 echo
 echo "Watchtower is a small sidecar container that polls Docker Hub"
-echo "every 30 minutes and automatically pulls + restarts cai when a"
+echo "every 12 hours and automatically pulls + restarts cai when a"
 echo "new image is published. Recommended for hands-off operation."
 echo
 echo "WARNING: if cai is mid-fix when watchtower restarts it, the"

--- a/install.sh
+++ b/install.sh
@@ -104,7 +104,7 @@ case "$ENABLE_WATCHTOWER" in
       - /var/run/docker.sock:/var/run/docker.sock
     command:
       - --label-enable
-      - --interval=1800
+      - --interval=43200
       - --cleanup
 WATCHTOWER
 )


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#502

**Issue:** #502 — Lower Watchtower poll rate to reduce mid-work restarts

## PR Summary

### What this fixes
Watchtower was polling Docker Hub every 30 minutes (`--interval=1800`), creating an unacceptably high chance of restarting the container mid-`cai fix`/`cai revise` run and losing in-progress work. Raising the interval to 12 hours dramatically reduces that risk while the longer-term continuity work (#501) is in flight.

### What was changed
- **`install.sh` line 107** — `--interval=1800` → `--interval=43200` in the Watchtower service heredoc
- **`docker-compose.yml` line 105** — `#     - --interval=1800` → `#     - --interval=43200` in the commented template block
- **`README.md` line 394** — "polls Docker Hub every 30 minutes" → "polls Docker Hub every 12 hours (43200 s)"

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
