### PR TITLE
auto-improve: [Step 1/4] Extend active-job writes to all long-running subcommands

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,41 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#509
+
+## Files touched
+- `cai.py:234` — `_write_active_job` signature changed from `(cmd, issue: int)` to `(cmd, target_type, target_id: int | None)`; JSON fields `"target_type"` and `"target_id"` replace bare `"issue"`
+- `cai.py:2260` — `cmd_fix` call site updated to `_write_active_job("fix", "issue", issue_number)`
+- `cai.py:3219` — `cmd_revise` call site updated to `_write_active_job("revise", "issue", issue_number)`
+- `cai.py:7433` — `cmd_spike` call site updated to `_write_active_job("spike", "issue", issue_number)`
+- `cai.py:7700` — `cmd_explore` call site updated to `_write_active_job("explore", "issue", issue_number)`
+- `cai.py:990` — `cmd_analyze`: added write/try-finally/clear around `_run_claude_p` call
+- `cai.py:4339` — `cmd_audit`: added write/try-finally/clear around `_run_claude_p` call
+- `cai.py:5110` — `cmd_cost_optimize`: added write/try-finally/clear around `_run_claude_p` call only
+- `cai.py:5303` — `cmd_propose`: added write/try-finally/clear around creative `_run_claude_p` call only
+- `cai.py:5685` — `cmd_update_check`: added write/try-finally/clear around `_run_claude_p` call only
+- `cai.py:5896` — `cmd_confirm`: added write/try-finally/clear around `_run_claude_p` call only
+- `cai.py:6229` — `cmd_review_pr`: added `_write_active_job("review-pr", "pr", pr_number)` before agent call; `_clear_active_job()` in existing `finally` block
+- `cai.py:6452` — `cmd_review_docs`: same pattern as `cmd_review_pr`
+- `cai.py:7002` — `cmd_merge`: added write before agent call, inline clear after it (no try/finally — matches existing error-handling style in that loop)
+- `cai.py:7229` — `cmd_refine`: added write/try-finally/clear around `_run_claude_p` call
+
+## Files read (not touched) that matter
+- `cai.py` (lines 234–254) — existing `_write_active_job`/`_clear_active_job` definitions
+
+## Key symbols
+- `_write_active_job` (`cai.py:234`) — now takes `target_type: str` and `target_id: int | None` instead of bare `issue: int`
+- `_clear_active_job` (`cai.py:249`) — unchanged; called in finally blocks for all new sites
+
+## Design decisions
+- `cmd_confirm` uses `target_type="none"` with a single write/clear pair — because it batches all issues in one agent call, not a per-issue loop
+- `cmd_propose`, `cmd_update_check`, `cmd_cost_optimize`: write/clear wraps only the primary agent call (not the full function) since the subsequent logic is fast
+- `cmd_merge`: bare `_clear_active_job()` after agent call rather than try/finally — consistent with existing error-handling style in that loop (no try/except wrapping the agent call)
+- `cmd_review_pr`/`cmd_review_docs`: `_clear_active_job()` added to existing `finally` blocks so it fires on both success and exception paths
+- Rejected: wrapping all of `cmd_cost_optimize` in try/finally — would require re-indenting ~115 lines of complex code
+
+## Out of scope / known gaps
+- `cmd_confirm` does not write per-issue as described in issue plan item 9 — the actual code batches all issues in one agent call, so per-issue tracking would require architectural changes
+- `cmd_merge` has no try/finally around the agent call, so if `_run_claude_p` raises unexpectedly, `_clear_active_job` won't fire — matches existing error-handling philosophy
+
+## Invariants this change relies on
+- `_write_active_job` and `_clear_active_job` both never raise (OSError is caught)
+- `_run_claude_p` does not raise exceptions in normal operation (it returns a CompletedProcess-like object with returncode)

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -39,3 +39,21 @@ Refs: robotsix/robotsix-cai#509
 ## Invariants this change relies on
 - `_write_active_job` and `_clear_active_job` both never raise (OSError is caught)
 - `_run_claude_p` does not raise exceptions in normal operation (it returns a CompletedProcess-like object with returncode)
+
+## Revision 1 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:4563` — added `_write_active_job("audit-triage", "none", None)` + try/finally around `_run_claude_p` in `cmd_audit_triage`
+- `cai.py:5551` — added `_write_active_job("code-audit", "none", None)` + try/finally around `_run_claude_p` in `cmd_code_audit`
+- `cai.py:8576` — added `_write_active_job("check-workflows", "none", None)` + try/finally around `_run_claude_p` in `cmd_check_workflows`
+- `docs/configuration.md:37` — updated cai-active.json description to reflect new JSON schema and broader command coverage
+
+### Decisions this revision
+- Wrapped only the `_run_claude_p` call (not full function) in try/finally — matches `cmd_cost_optimize` pattern; subsequent logic (verdict parsing, publish) is fast enough not to warrant full wrapping
+- Used `target_type="none"` for all three commands — they don't target a specific issue or PR
+
+### New gaps / deferred
+- (none)

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -57,3 +57,17 @@ Refs: robotsix/robotsix-cai#509
 
 ### New gaps / deferred
 - (none)
+
+## Revision 2 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `docs/configuration.md:70` — changed `(issue/PR/none)` to `(issue/pr/none)` to match actual string values used in `_write_active_job()` calls
+
+### Decisions this revision
+- Lowercase "pr" matches the actual `target_type` string values in the code; uppercase "PR" was a documentation typo
+
+### New gaps / deferred
+- (none)

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -71,3 +71,18 @@ Refs: robotsix/robotsix-cai#509
 
 ### New gaps / deferred
 - (none)
+
+## Revision 3 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:5371` — wrapped `cai-propose-review` `_run_claude_p` call in `_write_active_job("propose-review", "none", None)` + try/finally with `_clear_active_job()`
+
+### Decisions this revision
+- Used cmd name `"propose-review"` to distinguish the review phase from the creative phase (`"propose"`) for observability granularity
+- Pattern matches the creative agent wrapping immediately above in the same function
+
+### New gaps / deferred
+- (none)

--- a/cai.py
+++ b/cai.py
@@ -231,14 +231,15 @@ OUTCOME_LOG_PATH = Path("/var/log/cai/cai-outcomes.jsonl")
 ACTIVE_JOB_PATH = Path("/var/log/cai/cai-active.json")
 
 
-def _write_active_job(cmd: str, issue: int) -> None:
+def _write_active_job(cmd: str, target_type: str, target_id: int | None) -> None:
     """Write active-job state for observability. Never raises."""
     try:
         ACTIVE_JOB_PATH.parent.mkdir(parents=True, exist_ok=True)
         ACTIVE_JOB_PATH.write_text(json.dumps({
             "pid": os.getpid(),
             "cmd": cmd,
-            "issue": issue,
+            "target_type": target_type,
+            "target_id": target_id,
             "start_ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         }))
     except OSError:
@@ -986,35 +987,39 @@ def cmd_analyze(args) -> int:
         f"{review_pr_block}"
     )
 
-    analyzer = _run_claude_p(
-        ["claude", "-p", "--agent", "cai-analyze"],
-        category="analyze",
-        agent="cai-analyze",
-        input=user_message,
-    )
-    print(analyzer.stdout, flush=True)
-    if analyzer.returncode != 0:
-        print(
-            f"[cai analyze] claude -p failed (exit {analyzer.returncode}):\n"
-            f"{analyzer.stderr}",
-            flush=True,
+    _write_active_job("analyze", "none", None)
+    try:
+        analyzer = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-analyze"],
+            category="analyze",
+            agent="cai-analyze",
+            input=user_message,
+        )
+        print(analyzer.stdout, flush=True)
+        if analyzer.returncode != 0:
+            print(
+                f"[cai analyze] claude -p failed (exit {analyzer.returncode}):\n"
+                f"{analyzer.stderr}",
+                flush=True,
+            )
+            dur = f"{int(time.monotonic() - t0)}s"
+            log_run("analyze", repo=REPO, sessions=session_count,
+                    tool_calls=tool_calls, in_tokens=in_tokens,
+                    out_tokens=out_tokens, duration=dur, exit=analyzer.returncode)
+            return analyzer.returncode
+
+        print("[cai analyze] publishing findings", flush=True)
+        published = _run(
+            ["python", str(PUBLISH_SCRIPT)],
+            input=analyzer.stdout,
         )
         dur = f"{int(time.monotonic() - t0)}s"
         log_run("analyze", repo=REPO, sessions=session_count,
                 tool_calls=tool_calls, in_tokens=in_tokens,
-                out_tokens=out_tokens, duration=dur, exit=analyzer.returncode)
-        return analyzer.returncode
-
-    print("[cai analyze] publishing findings", flush=True)
-    published = _run(
-        ["python", str(PUBLISH_SCRIPT)],
-        input=analyzer.stdout,
-    )
-    dur = f"{int(time.monotonic() - t0)}s"
-    log_run("analyze", repo=REPO, sessions=session_count,
-            tool_calls=tool_calls, in_tokens=in_tokens,
-            out_tokens=out_tokens, duration=dur, exit=published.returncode)
-    return published.returncode
+                out_tokens=out_tokens, duration=dur, exit=published.returncode)
+        return published.returncode
+    finally:
+        _clear_active_job()
 
 
 # ---------------------------------------------------------------------------
@@ -2252,7 +2257,7 @@ def cmd_fix(args) -> int:
         log_run("fix", repo=REPO, issue=issue_number, result="lock_failed", exit=1)
         return 1
     print(f"[cai fix] locked #{issue_number} (label {LABEL_IN_PROGRESS})", flush=True)
-    _write_active_job("fix", issue_number)
+    _write_active_job("fix", "issue", issue_number)
 
     # Make sure git can authenticate over HTTPS via the gh token. This
     # is also done in entrypoint.sh, but redoing it here is cheap and
@@ -3211,7 +3216,7 @@ def cmd_revise(args) -> int:
             continue
 
         _run(["gh", "auth", "setup-git"], capture_output=True)
-        _write_active_job("revise", issue_number)
+        _write_active_job("revise", "issue", issue_number)
 
         _uid = uuid.uuid4().hex[:8]
         work_dir = Path(f"/tmp/cai-revise-{issue_number}-{_uid}")
@@ -4331,42 +4336,46 @@ def cmd_audit(args) -> int:
     )
 
     # Step 3: Invoke the declared cai-audit subagent.
-    audit = _run_claude_p(
-        ["claude", "-p", "--agent", "cai-audit"],
-        category="audit",
-        agent="cai-audit",
-        input=user_message,
-    )
-    print(audit.stdout, flush=True)
-    if audit.returncode != 0:
-        print(
-            f"[cai audit] claude -p failed (exit {audit.returncode}):\n"
-            f"{audit.stderr}",
-            flush=True,
+    _write_active_job("audit", "none", None)
+    try:
+        audit = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-audit"],
+            category="audit",
+            agent="cai-audit",
+            input=user_message,
+        )
+        print(audit.stdout, flush=True)
+        if audit.returncode != 0:
+            print(
+                f"[cai audit] claude -p failed (exit {audit.returncode}):\n"
+                f"{audit.stderr}",
+                flush=True,
+            )
+            dur = f"{int(time.monotonic() - t0)}s"
+            log_run("audit", repo=REPO, duration=dur,
+                    pr_open_recovered=len(recovered_pr_open),
+                    branches_cleaned=len(deleted_orphaned),
+                    no_action_unstuck=len(unstuck_no_action),
+                    merged_flagged=len(flagged_merged),
+                    exit=audit.returncode)
+            return audit.returncode
+
+        # Step 4: Publish findings via publish.py with audit namespace.
+        print("[cai audit] publishing audit findings", flush=True)
+        published = _run(
+            ["python", str(PUBLISH_SCRIPT), "--namespace", "audit"],
+            input=audit.stdout,
         )
         dur = f"{int(time.monotonic() - t0)}s"
-        log_run("audit", repo=REPO, duration=dur,
+        log_run("audit", repo=REPO, rollbacks=len(rolled_back),
                 pr_open_recovered=len(recovered_pr_open),
                 branches_cleaned=len(deleted_orphaned),
                 no_action_unstuck=len(unstuck_no_action),
                 merged_flagged=len(flagged_merged),
-                exit=audit.returncode)
-        return audit.returncode
-
-    # Step 4: Publish findings via publish.py with audit namespace.
-    print("[cai audit] publishing audit findings", flush=True)
-    published = _run(
-        ["python", str(PUBLISH_SCRIPT), "--namespace", "audit"],
-        input=audit.stdout,
-    )
-    dur = f"{int(time.monotonic() - t0)}s"
-    log_run("audit", repo=REPO, rollbacks=len(rolled_back),
-            pr_open_recovered=len(recovered_pr_open),
-            branches_cleaned=len(deleted_orphaned),
-            no_action_unstuck=len(unstuck_no_action),
-            merged_flagged=len(flagged_merged),
-            duration=dur, exit=published.returncode)
-    return published.returncode
+                duration=dur, exit=published.returncode)
+        return published.returncode
+    finally:
+        _clear_active_job()
 
 
 # ---------------------------------------------------------------------------
@@ -5098,14 +5107,18 @@ def cmd_cost_optimize(args) -> int:
 
     # 3. Run the cost-optimize agent.
     print("[cai cost-optimize] running agent", flush=True)
-    result = _run_claude_p(
-        ["claude", "-p", "--agent", "cai-cost-optimize",
-         "--permission-mode", "acceptEdits"],
-        category="cost-optimize",
-        agent="cai-cost-optimize",
-        input=user_message,
-        cwd="/app",
-    )
+    _write_active_job("cost-optimize", "none", None)
+    try:
+        result = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-cost-optimize",
+             "--permission-mode", "acceptEdits"],
+            category="cost-optimize",
+            agent="cai-cost-optimize",
+            input=user_message,
+            cwd="/app",
+        )
+    finally:
+        _clear_active_job()
     if result.stdout:
         print(result.stdout, flush=True)
     if result.returncode != 0:
@@ -5287,15 +5300,19 @@ def cmd_propose(args) -> int:
 
     # 3. Run the creative proposal agent.
     print(f"[cai propose] running creative agent for {work_dir}", flush=True)
-    creative = _run_claude_p(
-        ["claude", "-p", "--agent", "cai-propose",
-         "--permission-mode", "acceptEdits",
-         "--add-dir", str(work_dir)],
-        category="propose",
-        agent="cai-propose",
-        input=user_message,
-        cwd="/app",
-    )
+    _write_active_job("propose", "none", None)
+    try:
+        creative = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-propose",
+             "--permission-mode", "acceptEdits",
+             "--add-dir", str(work_dir)],
+            category="propose",
+            agent="cai-propose",
+            input=user_message,
+            cwd="/app",
+        )
+    finally:
+        _clear_active_job()
     if creative.stdout:
         print(creative.stdout, flush=True)
     if creative.returncode != 0:
@@ -5665,15 +5682,19 @@ def cmd_update_check(args) -> int:
     #    reads its definition + memory from the canonical /app paths
     #    while examining the clone via absolute paths.
     print(f"[cai update-check] running agent for {work_dir}", flush=True)
-    agent = _run_claude_p(
-        ["claude", "-p", "--agent", "cai-update-check",
-         "--permission-mode", "acceptEdits",
-         "--add-dir", str(work_dir)],
-        category="update-check",
-        agent="cai-update-check",
-        input=user_message,
-        cwd="/app",
-    )
+    _write_active_job("update-check", "none", None)
+    try:
+        agent = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-update-check",
+             "--permission-mode", "acceptEdits",
+             "--add-dir", str(work_dir)],
+            category="update-check",
+            agent="cai-update-check",
+            input=user_message,
+            cwd="/app",
+        )
+    finally:
+        _clear_active_job()
     if agent.stdout:
         print(agent.stdout, flush=True)
     if agent.returncode != 0:
@@ -5872,12 +5893,16 @@ def cmd_confirm(args) -> int:
     )
 
     # 4. Invoke the declared cai-confirm subagent.
-    confirm = _run_claude_p(
-        ["claude", "-p", "--agent", "cai-confirm"],
-        category="confirm",
-        agent="cai-confirm",
-        input=user_message,
-    )
+    _write_active_job("confirm", "none", None)
+    try:
+        confirm = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-confirm"],
+            category="confirm",
+            agent="cai-confirm",
+            input=user_message,
+        )
+    finally:
+        _clear_active_job()
     if confirm.returncode != 0:
         print(
             f"[cai confirm] claude -p failed (exit {confirm.returncode}):\n"
@@ -6201,6 +6226,7 @@ def cmd_review_pr(args) -> int:
             # so it reads its definition + memory from the canonical
             # /app paths while reviewing the cloned PR via absolute
             # paths.
+            _write_active_job("review-pr", "pr", pr_number)
             agent = _run_claude_p(
                 ["claude", "-p", "--agent", "cai-review-pr",
                  "--permission-mode", "acceptEdits",
@@ -6272,6 +6298,7 @@ def cmd_review_pr(args) -> int:
                 file=sys.stderr,
             )
         finally:
+            _clear_active_job()
             if work_dir.exists():
                 shutil.rmtree(work_dir, ignore_errors=True)
 
@@ -6422,6 +6449,7 @@ def cmd_review_docs(args) -> int:
             )
 
             # Invoke the declared cai-review-docs subagent.
+            _write_active_job("review-docs", "pr", pr_number)
             agent = _run_claude_p(
                 ["claude", "-p", "--agent", "cai-review-docs",
                  "--permission-mode", "acceptEdits",
@@ -6485,6 +6513,7 @@ def cmd_review_docs(args) -> int:
                 file=sys.stderr,
             )
         finally:
+            _clear_active_job()
             if work_dir.exists():
                 shutil.rmtree(work_dir, ignore_errors=True)
 
@@ -6970,12 +6999,14 @@ def cmd_merge(args) -> int:
         )
 
         # Invoke the declared cai-merge subagent.
+        _write_active_job("merge", "pr", pr_number)
         agent = _run_claude_p(
             ["claude", "-p", "--agent", "cai-merge"],
             category="merge",
             agent="cai-merge",
             input=user_message,
         )
+        _clear_active_job()
         if agent.returncode != 0:
             print(
                 f"[cai merge] model failed for PR #{pr_number} "
@@ -7195,13 +7226,17 @@ def cmd_refine(args) -> int:
 
     # 3. Build user message and invoke cai-refine (read-only, no clone needed).
     user_message = _build_issue_block(issue)
-    result = _run_claude_p(
-        ["claude", "-p", "--agent", "cai-refine",
-         "--dangerously-skip-permissions"],
-        category="refine",
-        agent="cai-refine",
-        input=user_message,
-    )
+    _write_active_job("refine", "issue", issue_number)
+    try:
+        result = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-refine",
+             "--dangerously-skip-permissions"],
+            category="refine",
+            agent="cai-refine",
+            input=user_message,
+        )
+    finally:
+        _clear_active_job()
     print(result.stdout, flush=True)
 
     if result.returncode != 0:
@@ -7395,7 +7430,7 @@ def cmd_spike(args) -> int:
         log_run("spike", repo=REPO, issue=issue_number, result="lock_failed", exit=1)
         return 1
 
-    _write_active_job("spike", issue_number)
+    _write_active_job("spike", "issue", issue_number)
     _uid = uuid.uuid4().hex[:8]
     work_dir = Path(f"/tmp/cai-spike-{issue_number}-{_uid}")
 
@@ -7662,7 +7697,7 @@ def cmd_explore(args) -> int:
         log_run("explore", repo=REPO, issue=issue_number, result="lock_failed", exit=1)
         return 1
 
-    _write_active_job("explore", issue_number)
+    _write_active_job("explore", "issue", issue_number)
     _uid = uuid.uuid4().hex[:8]
     work_dir = Path(f"/tmp/cai-explore-{issue_number}-{_uid}")
 

--- a/cai.py
+++ b/cai.py
@@ -5369,15 +5369,19 @@ def cmd_propose(args) -> int:
     )
 
     print("[cai propose] running review agent", flush=True)
-    review = _run_claude_p(
-        ["claude", "-p", "--agent", "cai-propose-review",
-         "--permission-mode", "acceptEdits",
-         "--add-dir", str(work_dir)],
-        category="propose",
-        agent="cai-propose-review",
-        input=review_message,
-        cwd="/app",
-    )
+    _write_active_job("propose-review", "none", None)
+    try:
+        review = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-propose-review",
+             "--permission-mode", "acceptEdits",
+             "--add-dir", str(work_dir)],
+            category="propose",
+            agent="cai-propose-review",
+            input=review_message,
+            cwd="/app",
+        )
+    finally:
+        _clear_active_job()
     if review.stdout:
         print(review.stdout, flush=True)
     if review.returncode != 0:

--- a/cai.py
+++ b/cai.py
@@ -4561,12 +4561,16 @@ def cmd_audit_triage(args) -> int:
     )
 
     # 4. Invoke the declared cai-audit-triage subagent.
-    triage = _run_claude_p(
-        ["claude", "-p", "--agent", "cai-audit-triage"],
-        category="audit-triage",
-        agent="cai-audit-triage",
-        input=user_message,
-    )
+    _write_active_job("audit-triage", "none", None)
+    try:
+        triage = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-audit-triage"],
+            category="audit-triage",
+            agent="cai-audit-triage",
+            input=user_message,
+        )
+    finally:
+        _clear_active_job()
     print(triage.stdout, flush=True)
     if triage.returncode != 0:
         print(
@@ -5549,15 +5553,19 @@ def cmd_code_audit(args) -> int:
     #    the agent reads its definition + memory from the canonical
     #    /app paths while auditing the clone via absolute paths.
     print(f"[cai code-audit] running agent for {work_dir}", flush=True)
-    agent = _run_claude_p(
-        ["claude", "-p", "--agent", "cai-code-audit",
-         "--permission-mode", "acceptEdits",
-         "--add-dir", str(work_dir)],
-        category="code-audit",
-        agent="cai-code-audit",
-        input=user_message,
-        cwd="/app",
-    )
+    _write_active_job("code-audit", "none", None)
+    try:
+        agent = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-code-audit",
+             "--permission-mode", "acceptEdits",
+             "--add-dir", str(work_dir)],
+            category="code-audit",
+            agent="cai-code-audit",
+            input=user_message,
+            cwd="/app",
+        )
+    finally:
+        _clear_active_job()
     if agent.stdout:
         print(agent.stdout, flush=True)
     if agent.returncode != 0:
@@ -8574,15 +8582,19 @@ def cmd_check_workflows(args) -> int:
         f"[cai check-workflows] running agent on {len(recent_runs)} failure(s)",
         flush=True,
     )
-    agent = _run_claude_p(
-        ["claude", "-p", "--agent", "cai-check-workflows",
-         "--max-turns", "3",
-         "--permission-mode", "acceptEdits"],
-        category="check-workflows",
-        agent="cai-check-workflows",
-        input=user_message,
-        cwd="/app",
-    )
+    _write_active_job("check-workflows", "none", None)
+    try:
+        agent = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-check-workflows",
+             "--max-turns", "3",
+             "--permission-mode", "acceptEdits"],
+            category="check-workflows",
+            agent="cai-check-workflows",
+            input=user_message,
+            cwd="/app",
+        )
+    finally:
+        _clear_active_job()
     if agent.stdout:
         print(agent.stdout, flush=True)
     if agent.returncode != 0:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,4 +67,4 @@ Agent-level overrides live in `.claude/agents/<name>.md` YAML frontmatter (`tool
 | `/var/log/cai/cai-cost.jsonl` | Per-invocation cost log (input/output tokens + USD) |
 | `/var/log/cai/cai-outcomes.jsonl` | Fix/revise outcome log (issue number, verdict, PR URL) |
 | `/var/log/cai/review-pr-patterns.jsonl` | Review-PR finding category log (used by `cai analyze`) |
-| `/var/log/cai/cai-active.json` | Active job state — tracks the current long-running subcommand, target type (issue/PR/none), and start timestamp for observability monitoring. Contains `{pid, cmd, target_type, target_id, start_ts}`. Cleared when the subcommand completes. |
+| `/var/log/cai/cai-active.json` | Active job state — tracks the current long-running subcommand, target type (issue/pr/none), and start timestamp for observability monitoring. Contains `{pid, cmd, target_type, target_id, start_ts}`. Cleared when the subcommand completes. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,4 +67,4 @@ Agent-level overrides live in `.claude/agents/<name>.md` YAML frontmatter (`tool
 | `/var/log/cai/cai-cost.jsonl` | Per-invocation cost log (input/output tokens + USD) |
 | `/var/log/cai/cai-outcomes.jsonl` | Fix/revise outcome log (issue number, verdict, PR URL) |
 | `/var/log/cai/review-pr-patterns.jsonl` | Review-PR finding category log (used by `cai analyze`) |
-| `/var/log/cai/cai-active.json` | Active job lock — prevents concurrent `cai fix`/`revise` runs |
+| `/var/log/cai/cai-active.json` | Active job state — tracks the current long-running subcommand, target type (issue/PR/none), and start timestamp for observability monitoring. Contains `{pid, cmd, target_type, target_id, start_ts}`. Cleared when the subcommand completes. |


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#509

**Issue:** #509 — [Step 1/4] Extend active-job writes to all long-running subcommands

## PR Summary

### What this fixes
`_write_active_job` was only called in 4 of 14 long-running subcommands (`fix`, `revise`, `spike`, `explore`), leaving `cai-active.json` as an incomplete picture of in-flight work. The signature also used a bare `issue: int` field that couldn't represent PR-targeting or target-less commands.

### What was changed
- **`cai.py:234`** — `_write_active_job` signature changed from `(cmd, issue: int)` to `(cmd, target_type: str, target_id: int | None)`; JSON now emits `"target_type"` and `"target_id"` fields instead of `"issue"`
- **4 existing call sites** (`fix`, `revise`, `spike`, `explore`) — updated to pass `"issue"` as `target_type` and the issue number as `target_id`
- **`cmd_analyze`** — `_write_active_job("analyze", "none", None)` + `try/finally` with `_clear_active_job()` wrapping the agent call through final return
- **`cmd_audit`** — same pattern with `"audit"` and `"none"`
- **`cmd_cost_optimize`** — write before agent call, `try/finally` around just the agent call
- **`cmd_propose`** — write before creative agent call, `try/finally` around just that call
- **`cmd_update_check`** — write before agent call, `try/finally` around just the agent call
- **`cmd_confirm`** — write before the single batched agent call, `try/finally` around it; uses `target_type="none"` since all issues are processed in one call
- **`cmd_refine`** — `_write_active_job("refine", "issue", issue_number)` + `try/finally` around the agent call
- **`cmd_review_pr`** — `_write_active_job("review-pr", "pr", pr_number)` inside the per-PR loop before the agent call; `_clear_active_job()` added to the existing `finally` block
- **`cmd_review_docs`** — same pattern as `cmd_review_pr`
- **`cmd_merge`** — `_write_active_job("merge", "pr", pr_number)` before the agent call; bare `_clear_active_job()` inline after it (consistent with existing error-handling style)

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
