### PR TITLE
auto-improve: [Step 2/2] Fix `cai-review-docs` silent bailout when `/docs` is missing or empty

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,22 @@
+# PR Context Dossier
+Refs: robotsix-cai/cai#500
+
+## Files touched
+- `.claude/agents/cai-review-docs.md`:74-83 — replaced silent bailout with explicit `### Finding: stale_docs` blocks for missing/empty docs directory
+
+## Files read (not touched) that matter
+- `.claude/agents/cai-review-docs.md` — the only file changed; lines 74–83 replaced
+
+## Key symbols
+- `### Finding: stale_docs` (cai-review-docs.md:88) — output format the wrapper detects to mark a PR as having documentation findings
+
+## Design decisions
+- Split the old single "does not exist or is empty" condition into two separate cases (missing vs. empty) with distinct finding descriptions for clarity
+- Kept the "No documentation updates needed." output valid only when docs exist, contain `.md` files, AND no user-facing changes are present
+- Rejected: keeping the conditional user-facing-changes check for the missing/empty case — the issue asks to always emit a finding
+
+## Out of scope / known gaps
+- No changes to `cai.py` — `cmd_review_docs` already detects `### Finding:` in agent output
+
+## Invariants this change relies on
+- `cmd_review_docs` in `cai.py` (~line 6387) already checks for `### Finding:` in agent output to mark a review as having findings

--- a/.claude/agents/cai-review-docs.md
+++ b/.claude/agents/cai-review-docs.md
@@ -71,15 +71,22 @@ Changes that **do NOT warrant documentation review**:
    post-PR code
 4. For each gap, emit a `### Finding: stale_docs` block
 
-If the `docs/` directory does not exist or is empty:
-- If the PR diff contains no user-facing changes (see "Changes that do NOT
-  warrant documentation review" above), output
-  `No documentation updates needed.`
-- If the PR diff **does** contain user-facing changes, emit a
-  `### Finding: stale_docs` block (using the format below) with
-  file `docs/ (missing or empty)`, describing that the PR changes user-facing
-  behavior but no documentation exists to verify, and suggesting the team
-  create or populate `/docs` before merging.
+If the `docs/` directory does not exist:
+- Emit a single `### Finding: stale_docs` block with file `docs/ (missing)`,
+  description "The `/docs` directory does not exist in this repository.
+  Documentation review cannot be performed.", and suggested update "Bootstrap
+  a `/docs` directory with at least an `index.md` covering the CLI and agent
+  inventory."
+
+If the `docs/` directory exists but contains no `.md` files:
+- Emit a single `### Finding: stale_docs` block with file `docs/ (empty)`,
+  description "The `/docs` directory is empty — no Markdown files found.
+  Documentation review cannot be performed.", and suggested update "Populate
+  `/docs` with at least an `index.md` covering the CLI and agent inventory."
+
+Only output `No documentation updates needed.` when the `docs/` directory
+exists, contains `.md` files, AND the PR introduces no user-facing changes
+that require documentation updates.
 
 ## Output format
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#500

**Issue:** #500 — [Step 2/2] Fix `cai-review-docs` silent bailout when `/docs` is missing or empty

## PR Summary

### What this fixes
The `cai-review-docs` agent silently output "No documentation updates needed." whenever the `/docs` directory was missing or empty (regardless of whether the PR had user-facing changes), causing the merge gate to never flag a missing-docs condition.

### What was changed
- **`.claude/agents/cai-review-docs.md`** (via staging): Replaced lines 74–83 (the "does not exist or is empty" bailout block) with two separate rules — one for a missing `docs/` directory and one for an empty `docs/` directory — each of which always emits a `### Finding: stale_docs` block. The `No documentation updates needed.` output is now only permitted when docs exist, contain `.md` files, AND the PR introduces no user-facing changes.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
