### PR TITLE
auto-improve: [Step 2/3] `cmd_plan` standalone command

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -167,3 +167,17 @@ Refs: robotsix-cai/cai#518
 
 ### New gaps / deferred
 - none
+
+## Revision 9 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- none
+
+### Decisions this revision
+- All four `stale_docs` findings from fourth review comment (docs/cli.md ## plan section, docs/configuration.md CAI_PLAN_SCHEDULE row, docs/architecture.md Plan step 3 + Cycle Command step 5) were already addressed in Revision 2. Verified by reading all three files — every referenced change is present in the clone.
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -56,4 +56,25 @@ Refs: robotsix-cai/cai#518
 - Default schedule `0 11 * * *` (daily at 11:00) — arbitrary but consistent with other daily tasks
 
 ### New gaps / deferred
-- `docker-compose.yml` and `install.sh` YAML templates not updated with `CAI_PLAN_SCHEDULE` — reviewer did not flag these; will surface in review-pr if needed
+- none
+
+## Revision 2 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `README.md` — added `cai.py plan` row to command table; added `CAI_PLAN_SCHEDULE` to env vars list; added "plan" to "not run at startup" list
+- `docs/configuration.md` — added `CAI_PLAN_SCHEDULE` row to Agent Schedules table
+- `docker-compose.yml` — added `CAI_PLAN_SCHEDULE: "0 11 * * *"` after `CAI_CHECK_WORKFLOWS_SCHEDULE`
+- `install.sh` — added `CAI_PLAN_SCHEDULE: "0 11 * * *"` to both YAML template sections (replace_all)
+- `docs/cli.md` — added `## plan` section between `refine` and `review-docs`
+- `docs/architecture.md` — added Plan step (step 3) to Pipeline Overview; updated Cycle Command step 5 to mention plan
+
+### Decisions this revision
+- Inserted Plan as step 3 in Pipeline Overview, renumbering Fix→Review→Revise→Merge→Confirm accordingly
+- Added `## plan` section in docs/cli.md between `refine` and `review-docs` (alphabetical proximity to `refine`)
+- `replace_all: true` on install.sh because both YAML templates had identical `CAI_CHECK_WORKFLOWS_SCHEDULE` lines
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -153,3 +153,17 @@ Refs: robotsix-cai/cai#518
 
 ### New gaps / deferred
 - docs/cli.md, docs/configuration.md, docs/architecture.md findings from second review comment were already addressed in Revision 2 — no changes needed
+
+## Revision 8 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- none
+
+### Decisions this revision
+- All four `stale_docs` findings from third review comment (docs/cli.md ## plan section, docs/configuration.md CAI_PLAN_SCHEDULE row, docs/architecture.md Plan step + Cycle Command, README.md command table + env vars + startup list) were already addressed in Revision 2. Verified by reading all four files — every referenced change is present in the clone.
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -38,3 +38,22 @@ Refs: robotsix-cai/cai#518
 - `_run_plan_select_pipeline` is called with `(issue, work_dir, attempt_history_block)` — signature unchanged
 - `LABEL_PLANNED` (`auto-improve:planned`) is already defined at line 217
 - `_set_labels`, `log_run`, `_fetch_previous_fix_attempts`, `_build_attempt_history_block`, `_run`, `_gh_json` all exist and accept the call signatures used
+
+## Revision 1 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:73` — added `plan` subcommand entry to module docstring (after `refine`)
+- `cai.py:131` — added clarifying note that `plan` runs on cron, not synchronous startup
+- `entrypoint.sh:22` — added `plan` to independent cron-scheduled tasks comment
+- `entrypoint.sh:56` — added `CAI_PLAN_SCHEDULE` env var (default `0 11 * * *`)
+- `entrypoint.sh:79` — added `$CAI_PLAN_SCHEDULE python /app/cai.py plan` cron entry
+
+### Decisions this revision
+- `plan` documented as cron-only (not startup) — matches its nature as an async planning step
+- Default schedule `0 11 * * *` (daily at 11:00) — arbitrary but consistent with other daily tasks
+
+### New gaps / deferred
+- `docker-compose.yml` and `install.sh` YAML templates not updated with `CAI_PLAN_SCHEDULE` — reviewer did not flag these; will surface in review-pr if needed

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,40 @@
+# PR Context Dossier
+Refs: robotsix-cai/cai#518
+
+## Files touched
+- `cai.py:1263` — added `_select_plan_target` helper (queue-based + specific issue lookup)
+- `cai.py:1576` — added `_extract_stored_plan` helper (parses `<!-- cai-plan-start/end -->` markers)
+- `cai.py:1591` — added `_strip_stored_plan_block` helper (removes existing plan block before re-prepending)
+- `cai.py:1606` — added `cmd_plan` function (orchestrates plan-select pipeline + stores result in issue body)
+- `cai.py:8127` — added Phase 2.6 in `cmd_cycle` (runs `cmd_plan` after Phase 2.5 refine)
+- `cai.py:8859` — registered `plan` subparser with `--issue` argument
+- `cai.py:8931` — added `"plan": cmd_plan` to `handlers` dict
+
+## Files read (not touched) that matter
+- `cai.py:1155` — `_select_fix_target` as the naming/structure template for `_select_plan_target`
+- `cai.py:2210` — `cmd_fix` as the structural template for `cmd_plan`
+- `cai.py:1489` — `_run_plan_select_pipeline` (reused unchanged by `cmd_plan`)
+
+## Key symbols
+- `_select_plan_target` (`cai.py:1263`) — queue-based or specific-issue selection for planning
+- `_extract_stored_plan` (`cai.py:1576`) — parses plan from `<!-- cai-plan-start/end -->` markers in issue body
+- `_strip_stored_plan_block` (`cai.py:1591`) — removes old plan block before re-prepending on re-run
+- `cmd_plan` (`cai.py:1606`) — full planning command: select → clone → pipeline → store → label transition
+- `LABEL_PLANNED` (`cai.py:217`) — `auto-improve:planned` label applied after successful planning
+
+## Design decisions
+- `_select_plan_target` placed right after `_select_fix_target` (before `_set_labels`) for naming convention consistency
+- `_extract_stored_plan`, `_strip_stored_plan_block`, and `cmd_plan` placed right after `_run_plan_select_pipeline` for logical grouping
+- Plan markers: `<!-- cai-plan-start -->` / `<!-- cai-plan-end -->` with `## Selected Implementation Plan` heading inside
+- Phase 2.6 runs immediately after Phase 2.5 (refine) in `cmd_cycle` — a just-refined issue can be planned in the same cycle
+- Rejected: modifying `_select_fix_target` or `cmd_fix` — scope guardrails explicitly forbid it for this step
+
+## Out of scope / known gaps
+- `cmd_fix` still runs the plan pipeline inline and picks up `:refined` issues — backward compat unchanged until Step 3
+- `_extract_stored_plan` is added but not yet consumed by `cmd_fix` — that wiring is Step 3's job
+- No `:in-progress` lock during planning (planning is non-destructive; matches existing pattern)
+
+## Invariants this change relies on
+- `_run_plan_select_pipeline` is called with `(issue, work_dir, attempt_history_block)` — signature unchanged
+- `LABEL_PLANNED` (`auto-improve:planned`) is already defined at line 217
+- `_set_labels`, `log_run`, `_fetch_previous_fix_attempts`, `_build_attempt_history_block`, `_run`, `_gh_json` all exist and accept the call signatures used

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -196,6 +196,20 @@ Refs: robotsix-cai/cai#518
 ### New gaps / deferred
 - none
 
+## Revision 11 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `.claude/agents/cai-audit.md:64` — added `:planned` and `:plan-approved` to the active states list
+
+### Decisions this revision
+- docs/cli.md, docs/configuration.md, docs/architecture.md findings were already addressed in prior revisions; only cai-audit.md active states list needed updating.
+
+### New gaps / deferred
+- none
+
 ## Revision 10 (2026-04-13)
 
 ### Rebase

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -78,3 +78,17 @@ Refs: robotsix-cai/cai#518
 
 ### New gaps / deferred
 - none
+
+## Revision 3 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- none
+
+### Decisions this revision
+- All four `stale_docs` findings from cai-review-docs were already addressed in Revision 2; no changes needed.
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -109,3 +109,17 @@ Refs: robotsix-cai/cai#518
 
 ### New gaps / deferred
 - none
+
+## Revision 5 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:8481` — added `("planned", LABEL_PLANNED)` and `("plan-approved", LABEL_PLAN_APPROVED)` to `label_states` in `cmd_health_report` Issue Throughput section
+
+### Decisions this revision
+- Inserted after `"refined"` to maintain pipeline order (raised → refined → planned → plan-approved → in-progress → pr-open → …)
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -123,3 +123,19 @@ Refs: robotsix-cai/cai#518
 
 ### New gaps / deferred
 - none
+
+## Revision 6 (2026-04-13)
+
+### Rebase
+- resolved: docs/architecture.md (conflict between PR's Plan step 3 and HEAD's enhanced Review description from PR #522)
+
+### Files touched this revision
+- `docs/architecture.md:9-19` — resolved conflict: kept Plan as step 3, Fix as step 4, took HEAD's enhanced Review description (with review-docs ordering note), renumbered Review→Revise→Merge→Confirm to steps 5→6→7→8
+- `cai.py:4019` — added `LABEL_PLAN_APPROVED` to cmd_verify pr-open recovery cleanup list alongside `LABEL_PLANNED`
+
+### Decisions this revision
+- Took HEAD's enhanced Review description (includes review-docs ordering enforcement note from PR #522) over the PR branch's shorter version — HEAD version is strictly more complete
+- Added LABEL_PLAN_APPROVED to cmd_verify cleanup: both plan-related labels are symmetric intermediate states that should be cleaned up when a PR is found, per reviewer finding
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -92,3 +92,20 @@ Refs: robotsix-cai/cai#518
 
 ### New gaps / deferred
 - none
+
+## Revision 4 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:950` — added `LABEL_PLAN_APPROVED: 3` and `LABEL_PLANNED: 3` to `_STATE_PRIORITY` dict so `_issue_state_label` reports these states correctly instead of "other"
+- `cai.py:1187` — added NOTE comment to `_select_fix_target` docstring explaining `:planned`/`:plan-approved` issues are intentionally excluded until Step 3
+- `cai.py:4011` — added `LABEL_PLANNED` to `cmd_verify` recovery cleanup list so conflicting `:planned` + `:pr-open` states are resolved correctly
+
+### Decisions this revision
+- `LABEL_PLANNED` and `LABEL_PLAN_APPROVED` both assigned priority 3 (same as `LABEL_REFINED`) — they are all "queued/ready" states at similar pipeline depth; collision is harmless since the dict picks the one that appears first when labels co-occur
+- `_select_fix_target` unchanged per scope guardrails; comment added instead to document the intentional gap and point to Step 3
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -157,6 +157,20 @@ Refs: robotsix-cai/cai#518
 ## Revision 8 (2026-04-13)
 
 ### Rebase
+- resolved: docs/architecture.md (conflict between PR's Plan step numbering and HEAD's enhanced Review description from PR #522)
+
+### Files touched this revision
+- `docs/architecture.md:9-22` — resolved conflict: kept Plan as step 3, took HEAD's enhanced Review description (with review-docs ordering note and direct-fix detail), renumbered steps 5→8
+
+### Decisions this revision
+- Review comment from @damien-robotsix flagged 3 missing registrations (\_STATE\_PRIORITY, cmd\_verify cleanup, label\_states) — all three were already addressed in Revisions 4, 5, and 6 respectively; no changes needed
+
+### New gaps / deferred
+- none
+
+## Revision 8 (2026-04-13)
+
+### Rebase
 - clean
 
 ### Files touched this revision

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -195,3 +195,17 @@ Refs: robotsix-cai/cai#518
 
 ### New gaps / deferred
 - none
+
+## Revision 10 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:92-94` — removed accidental markdown table (argument table) that was embedded inside the module docstring `plan` entry; plain-text prose only belongs in a module docstring
+
+### Decisions this revision
+- All five `stale_docs` findings from fifth review comment were already addressed except the embedded table: docs/cli.md, docs/configuration.md, docs/architecture.md, README.md changes all present; cai.py module docstring had the plan entry and cron note but also had 3 spurious table lines that were removed.
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -139,3 +139,17 @@ Refs: robotsix-cai/cai#518
 
 ### New gaps / deferred
 - none
+
+## Revision 7 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:8175-8182` — added Phase 2.6 to `cmd_cycle` docstring Flow section
+
+### Decisions this revision
+- Inserted `2.6. plan one :refined issue (plan-select pipeline → store plan → :planned)` between 2.5 and 3 in the docstring to match implementation
+
+### New gaps / deferred
+- docs/cli.md, docs/configuration.md, docs/architecture.md findings from second review comment were already addressed in Revision 2 — no changes needed

--- a/.claude/agents/cai-audit.md
+++ b/.claude/agents/cai-audit.md
@@ -61,7 +61,7 @@ a soft `forgotten_backlog` finding with **low** confidence as a gentle
 reminder. This is distinct from `stale_lifecycle`, which applies only
 to issues that have entered an active state.
 
-Active states (`:raised`, `:refined`, `:requested`, `:in-progress`, `:pr-open`,
+Active states (`:raised`, `:refined`, `:planned`, `:plan-approved`, `:requested`, `:in-progress`, `:pr-open`,
 `:merged`, `:no-action`, `:needs-spike`, `:revising`) should continue to be checked
 normally against all the rules below. (Note: stale `:no-action`
 issues are rolled back to `:raised` before the LLM audit runs, and

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ subprocess with no shared state.
 | `cai.py health-report` | `0 7 * * 1` (weekly Monday 07:00 UTC) | Automated pipeline health report with anomaly detection. Aggregates cost trends (last 7d vs prior 7d WoW delta), issue queue counts per label state, pipeline stalls, and fix quality metrics. Posts a GitHub-flavored markdown report with 🔴/🟡/🟢 traffic-light indicators as a `health-report` labelled issue. Use `--dry-run` to print to stdout without posting. |
 | `cai.py cost-optimize` | `0 5 * * 0` (weekly Sunday 05:00 UTC) | Weekly cost-reduction agent — loads 14 days of cost data, computes per-agent WoW deltas and cache hit rates, and proposes one concrete optimization targeting the most expensive agent or workflow. Alternates with evaluating previous proposals to track effectiveness. Files proposals as `auto-improve:raised` issues. |
 | `cai.py check-workflows` | `0 */6 * * *` (every 6 hours) | GitHub Actions failure monitor — fetches recent failed workflow runs (last 24 h), filters out bot branches, and runs a Haiku agent to group related failures and identify root causes; findings are published as `check-workflows` namespace issues. |
+| `cai.py plan` | `0 11 * * *` (daily 11:00 UTC) | Plan-select pipeline — clones the repo, runs 2 serial plan agents followed by a select agent on the oldest `:refined` issue, stores the chosen plan in the issue body inside `<!-- cai-plan-start/end -->` markers, and transitions the label to `auto-improve:planned`. |
 | `cai.py cycle` | _(startup + manual/on-demand)_ | Runs verify → fix → revise → review-pr → review-docs → merge → confirm in sequence. The entrypoint runs this once synchronously at `docker compose up -d` so the issue-solving pipeline produces immediate logs; not scheduled via cron (the individual steps have their own cron lines) |
 | `cai.py test` | _(manual/on-demand)_ | Runs the project test suite (`python -m unittest discover` under `tests/`) |
 
@@ -74,10 +75,10 @@ the env vars (`CAI_ANALYZER_SCHEDULE`, `CAI_FIX_SCHEDULE`,
 `CAI_REFINE_SCHEDULE`, `CAI_REVIEW_PR_SCHEDULE`, `CAI_MERGE_SCHEDULE`,
 `CAI_REVISE_SCHEDULE`, `CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`,
 `CAI_AUDIT_TRIAGE_SCHEDULE`, `CAI_CODE_AUDIT_SCHEDULE`,
-`CAI_PROPOSE_SCHEDULE`, `CAI_SPIKE_SCHEDULE`, `CAI_UPDATE_CHECK_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`, `CAI_HEALTH_REPORT_SCHEDULE`, `CAI_COST_OPTIMIZE_SCHEDULE`, `CAI_CHECK_WORKFLOWS_SCHEDULE`),
+`CAI_PROPOSE_SCHEDULE`, `CAI_SPIKE_SCHEDULE`, `CAI_UPDATE_CHECK_SCHEDULE`, `CAI_CONFIRM_SCHEDULE`, `CAI_HEALTH_REPORT_SCHEDULE`, `CAI_COST_OPTIMIZE_SCHEDULE`, `CAI_CHECK_WORKFLOWS_SCHEDULE`, `CAI_PLAN_SCHEDULE`),
 runs `cai.py cycle` once synchronously so the issue-solving pipeline
 produces immediate logs, then execs supercronic. Analysis, audit,
-proposal, refine, spike, update-check, and check-workflows agents are **not** run at
+proposal, refine, spike, update-check, check-workflows, and plan agents are **not** run at
 startup — they wait for their own cron ticks so container restarts
 don't re-trigger token-heavy analysis passes.
 

--- a/cai.py
+++ b/cai.py
@@ -1267,6 +1267,59 @@ def _select_fix_target():
     return max(candidates.values(), key=_score)
 
 
+def _select_plan_target(issue_number: int | None = None):
+    """Return the oldest open :refined issue eligible for planning, or None.
+
+    If *issue_number* is given, fetch that issue directly (validating it is
+    open and not locked).  Otherwise query for the oldest :refined issue
+    that is not :in-progress or :pr-open.
+    """
+    if issue_number is not None:
+        try:
+            issue = _gh_json([
+                "issue", "view", str(issue_number),
+                "--repo", REPO,
+                "--json", "number,title,body,labels,state,createdAt,comments",
+            ])
+        except subprocess.CalledProcessError as e:
+            print(f"[cai plan] gh issue view #{issue_number} failed:\n{e.stderr}",
+                  file=sys.stderr)
+            return None
+        if issue.get("state", "").upper() != "OPEN":
+            print(f"[cai plan] issue #{issue_number} is not open; nothing to do",
+                  flush=True)
+            return None
+        label_names = {lbl["name"] for lbl in issue.get("labels", [])}
+        if LABEL_IN_PROGRESS in label_names or LABEL_PR_OPEN in label_names:
+            print(f"[cai plan] issue #{issue_number} is locked; skipping",
+                  flush=True)
+            return None
+        return issue
+
+    # Queue-based: oldest :refined issue not locked.
+    try:
+        candidates = _gh_json([
+            "issue", "list",
+            "--repo", REPO,
+            "--label", LABEL_REFINED,
+            "--state", "open",
+            "--json", "number,title,body,labels,createdAt,comments",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(f"[cai plan] gh issue list failed:\n{e.stderr}",
+              file=sys.stderr)
+        return None
+    candidates = [
+        c for c in candidates
+        if not {lbl["name"] for lbl in c.get("labels", [])}
+            & {LABEL_IN_PROGRESS, LABEL_PR_OPEN}
+    ]
+    if not candidates:
+        return None
+    return min(candidates, key=lambda c: c.get("createdAt", ""))
+
+
 def _set_labels(issue_number: int, *, add: list[str] = (), remove: list[str] = (), log_prefix: str = "cai fix") -> bool:
     """Add and/or remove labels on an issue. Returns True on success."""
     # Auto-add the base label for any state-prefixed label being added.
@@ -1525,6 +1578,136 @@ def _run_plan_select_pipeline(issue: dict, work_dir: Path, attempt_history_block
 
     print(f"[cai fix] select agent produced {len(selection)} chars", flush=True)
     return selection
+
+
+def _extract_stored_plan(issue_body: str) -> str | None:
+    """Extract the stored plan from an issue body, or None if not present."""
+    start_marker = "<!-- cai-plan-start -->"
+    end_marker = "<!-- cai-plan-end -->"
+    start = issue_body.find(start_marker)
+    end = issue_body.find(end_marker)
+    if start == -1 or end == -1 or end <= start:
+        return None
+    content = issue_body[start + len(start_marker):end].strip()
+    heading = "## Selected Implementation Plan"
+    if content.startswith(heading):
+        content = content[len(heading):].strip()
+    return content if content else None
+
+
+def _strip_stored_plan_block(issue_body: str) -> str:
+    """Remove an existing cai-plan block from the issue body, if present."""
+    start_marker = "<!-- cai-plan-start -->"
+    end_marker = "<!-- cai-plan-end -->"
+    start = issue_body.find(start_marker)
+    end = issue_body.find(end_marker)
+    if start == -1 or end == -1 or end <= start:
+        return issue_body
+    # Remove from start_marker through end_marker plus any trailing newlines.
+    after = end + len(end_marker)
+    while after < len(issue_body) and issue_body[after] == "\n":
+        after += 1
+    return issue_body[:start] + issue_body[after:]
+
+
+def cmd_plan(args) -> int:
+    """Run the plan-select pipeline on one :refined issue and store the result."""
+    t0 = time.monotonic()
+
+    # 1. Select target issue.
+    issue = _select_plan_target(getattr(args, "issue", None))
+    if issue is None:
+        print("[cai plan] no eligible :refined issues; nothing to do", flush=True)
+        log_run("plan", repo=REPO, result="no_eligible_issues", exit=0)
+        return 0
+
+    issue_number = issue["number"]
+    title = issue["title"]
+    print(f"[cai plan] picked #{issue_number}: {title}", flush=True)
+
+    # 2. Clone repo (plan agents need to read the codebase).
+    _uid = uuid.uuid4().hex[:8]
+    work_dir = Path(f"/tmp/cai-plan-{issue_number}-{_uid}")
+    try:
+        if work_dir.exists():
+            shutil.rmtree(work_dir)
+        clone = _run(
+            ["git", "clone", "--depth", "1",
+             f"https://github.com/{REPO}.git", str(work_dir)],
+            capture_output=True,
+        )
+        if clone.returncode != 0:
+            print(f"[cai plan] git clone failed:\n{clone.stderr}",
+                  file=sys.stderr)
+            log_run("plan", repo=REPO, issue=issue_number,
+                    result="clone_failed", exit=1)
+            return 1
+
+        # 3. Fetch previous fix attempts for context.
+        attempts = _fetch_previous_fix_attempts(issue_number)
+        attempt_history_block = _build_attempt_history_block(attempts)
+        if attempt_history_block:
+            print(
+                f"[cai plan] injecting {len(attempts)} previous fix "
+                f"attempt(s) for #{issue_number}",
+                flush=True,
+            )
+
+        # 4. Run plan-select pipeline.
+        selected_plan = _run_plan_select_pipeline(
+            issue, work_dir, attempt_history_block,
+        )
+        if selected_plan is None:
+            print(f"[cai plan] plan pipeline failed for #{issue_number}",
+                  file=sys.stderr)
+            dur = f"{int(time.monotonic() - t0)}s"
+            log_run("plan", repo=REPO, issue=issue_number,
+                    duration=dur, result="pipeline_failed", exit=1)
+            return 1
+
+        # 5. Store plan in issue body (strip any old plan block first).
+        current_body = _strip_stored_plan_block(issue.get("body", "") or "")
+        plan_block = (
+            "<!-- cai-plan-start -->\n"
+            "## Selected Implementation Plan\n\n"
+            f"{selected_plan}\n"
+            "<!-- cai-plan-end -->"
+        )
+        new_body = f"{plan_block}\n\n{current_body}"
+        update = _run(
+            ["gh", "issue", "edit", str(issue_number),
+             "--repo", REPO, "--body", new_body],
+            capture_output=True,
+        )
+        if update.returncode != 0:
+            print(f"[cai plan] gh issue edit failed:\n{update.stderr}",
+                  file=sys.stderr)
+            dur = f"{int(time.monotonic() - t0)}s"
+            log_run("plan", repo=REPO, issue=issue_number,
+                    duration=dur, result="edit_failed", exit=1)
+            return 1
+
+        # 6. Transition labels: :refined → :planned.
+        _set_labels(
+            issue_number,
+            add=[LABEL_PLANNED],
+            remove=[LABEL_REFINED],
+            log_prefix="cai plan",
+        )
+
+        dur = f"{int(time.monotonic() - t0)}s"
+        print(
+            f"[cai plan] #{issue_number} planned and transitioned to "
+            f":planned in {dur}",
+            flush=True,
+        )
+        log_run("plan", repo=REPO, issue=issue_number,
+                duration=dur, result="ok", exit=0)
+        return 0
+
+    finally:
+        if work_dir.exists():
+            shutil.rmtree(work_dir, ignore_errors=True)
 
 
 def _parse_suggested_issues(agent_output: str) -> list[dict]:
@@ -8065,6 +8248,12 @@ def cmd_cycle(args) -> int:
     if rc != 0:
         had_failure = True
 
+    # --- Phase 2.6: plan one :refined issue --------------------------------
+    rc = _run_step("plan", cmd_plan, args)
+    all_results["plan"] = rc
+    if rc != 0:
+        had_failure = True
+
     # --- Phase 3: fix loop — pick → fix → drain → refine → repeat ------
     # The loop also handles pr-open issues that need further
     # revise/review/merge passes, not just new fix targets.
@@ -8799,6 +8988,11 @@ def main() -> int:
         "--issue", type=int, default=None,
         help="Target a specific issue number instead of using queue-based selection",
     )
+    plan_parser = sub.add_parser("plan", help="Run plan-select pipeline on a :refined issue")
+    plan_parser.add_argument(
+        "--issue", type=int, default=None,
+        help="Target a specific issue number instead of using queue-based selection",
+    )
     spike_parser = sub.add_parser("spike", help="Run the spike agent on :needs-spike issues")
     spike_parser.add_argument(
         "--issue", type=int, default=None,
@@ -8868,6 +9062,7 @@ def main() -> int:
         "review-docs": cmd_review_docs,
         "merge": cmd_merge,
         "refine": cmd_refine,
+        "plan": cmd_plan,
         "spike": cmd_spike,
         "explore": cmd_explore,
         "cycle": cmd_cycle,

--- a/cai.py
+++ b/cai.py
@@ -8560,6 +8560,8 @@ def cmd_health_report(args) -> int:
     label_states = [
         ("raised", LABEL_RAISED),
         ("refined", LABEL_REFINED),
+        ("planned", LABEL_PLANNED),
+        ("plan-approved", LABEL_PLAN_APPROVED),
         ("in-progress", LABEL_IN_PROGRESS),
         ("pr-open", LABEL_PR_OPEN),
         ("merged", LABEL_MERGED),

--- a/cai.py
+++ b/cai.py
@@ -4016,7 +4016,7 @@ def cmd_verify(args) -> int:
         if LABEL_PR_OPEN in iss_labels:
             continue
         # Issue is open, has an open PR, but missing :pr-open — recover.
-        remove = [l for l in (LABEL_IN_PROGRESS, LABEL_REFINED, LABEL_PLANNED, LABEL_RAISED, LABEL_HUMAN_SUBMITTED, LABEL_AUDIT_RAISED) if l in iss_labels]
+        remove = [l for l in (LABEL_IN_PROGRESS, LABEL_REFINED, LABEL_PLANNED, LABEL_PLAN_APPROVED, LABEL_RAISED, LABEL_HUMAN_SUBMITTED, LABEL_AUDIT_RAISED) if l in iss_labels]
         if _set_labels(issue_num, add=[LABEL_PR_OPEN], remove=remove, log_prefix="cai verify"):
             print(
                 f"[cai verify] recovered #{issue_num}: added :pr-open "

--- a/cai.py
+++ b/cai.py
@@ -89,9 +89,6 @@ Subcommands:
                             `auto-improve:planned`. Runs on a cron
                             schedule (CAI_PLAN_SCHEDULE); not part
                             of the synchronous startup cycle.
-                            | Argument | Type | Description |
-                            |---|---|---|
-                            | `--issue INT` | optional | Target a specific issue |
 
     python cai.py spike     Pick the oldest issue labelled
                             `auto-improve:needs-spike`, clone the

--- a/cai.py
+++ b/cai.py
@@ -77,6 +77,22 @@ Subcommands:
                             issue body, and transition the label to
                             `auto-improve:refined`.
 
+    python cai.py plan      Run the plan-select pipeline on the
+                            oldest issue labelled `auto-improve:
+                            refined`. Clones the repo into /tmp,
+                            runs 2 serial plan agents followed by
+                            a select agent, stores the chosen plan
+                            in the issue body inside
+                            `<!-- cai-plan-start/end -->` markers,
+                            and transitions the label from
+                            `auto-improve:refined` to
+                            `auto-improve:planned`. Runs on a cron
+                            schedule (CAI_PLAN_SCHEDULE); not part
+                            of the synchronous startup cycle.
+                            | Argument | Type | Description |
+                            |---|---|---|
+                            | `--issue INT` | optional | Target a specific issue |
+
     python cai.py spike     Pick the oldest issue labelled
                             `auto-improve:needs-spike`, clone the
                             repo into /tmp, and run the cai-spike
@@ -131,6 +147,8 @@ Subcommands:
 The container runs `entrypoint.sh`, which executes `init`, `analyze`,
 `verify`, `refine`, `spike`, `fix`, `revise`, `review-pr`, `review-docs`, `merge`, `audit`, `code-audit`, `propose`, `update-check`, and `confirm` once synchronously at
 startup, then hands off to supercronic. Each cron tick is a fresh process.
+`plan` is not part of the synchronous startup cycle — it runs only on its
+cron schedule (CAI_PLAN_SCHEDULE, default 0 11 * * *).
 
 The gh auth check is done once per subcommand invocation. We want a
 clear error message in docker logs if credentials ever disappear from

--- a/cai.py
+++ b/cai.py
@@ -8230,6 +8230,7 @@ def cmd_cycle(args) -> int:
       1.5. recover stale locks (:in-progress / :revising)
       2. drain pending PRs (revise → review-pr → review-docs → merge)
       2.5. refine one :raised issue
+      2.6. plan one :refined issue (plan-select pipeline → store plan → :planned)
       3. loop: verify → fix/spike/explore → drain → refine → repeat
       4. final confirm
     """

--- a/cai.py
+++ b/cai.py
@@ -951,7 +951,9 @@ def cmd_analyze(args) -> int:
         LABEL_IN_PROGRESS: 0,
         LABEL_PR_OPEN: 1,
         LABEL_NEEDS_SPIKE: 2,
+        LABEL_PLAN_APPROVED: 3,
         LABEL_REFINED: 3,
+        LABEL_PLANNED: 3,
         LABEL_RAISED: 4,
         LABEL_HUMAN_SUBMITTED: 4,
         LABEL_MERGED: 5,
@@ -1191,6 +1193,12 @@ def _select_fix_target():
     `auto-improve:refined`) enter the fix pipeline.
     If no candidates are found, attempts to recover stale `:pr-open`
     issues whose linked PR was closed unmerged or that have no linked PR.
+
+    NOTE: `:planned` and `:plan-approved` issues are intentionally NOT
+    picked up here.  `:planned` issues are waiting for human approval;
+    `:plan-approved` issues will be wired into this function in Step 3 of
+    the plan-gate sub-issue chain (#481).  Until then, they sit in the
+    queue without being consumed by the fix agent.
     """
     candidates: dict[int, dict] = {}
     for label in (LABEL_REFINED, LABEL_REQUESTED):
@@ -4008,7 +4016,7 @@ def cmd_verify(args) -> int:
         if LABEL_PR_OPEN in iss_labels:
             continue
         # Issue is open, has an open PR, but missing :pr-open — recover.
-        remove = [l for l in (LABEL_IN_PROGRESS, LABEL_REFINED, LABEL_RAISED, LABEL_HUMAN_SUBMITTED, LABEL_AUDIT_RAISED) if l in iss_labels]
+        remove = [l for l in (LABEL_IN_PROGRESS, LABEL_REFINED, LABEL_PLANNED, LABEL_RAISED, LABEL_HUMAN_SUBMITTED, LABEL_AUDIT_RAISED) if l in iss_labels]
         if _set_labels(issue_num, add=[LABEL_PR_OPEN], remove=remove, log_prefix="cai verify"):
             print(
                 f"[cai verify] recovered #{issue_num}: added :pr-open "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly at :35 (auto-merge confident PRs)
       CAI_HEALTH_REPORT_SCHEDULE: "0 7 * * 1" # weekly Monday 07:00 UTC (pipeline health report)
       CAI_CHECK_WORKFLOWS_SCHEDULE: "0 */6 * * *" # every 6h (check for CI workflow failures)
+      CAI_PLAN_SCHEDULE: "0 11 * * *"        # daily 11:00 UTC (plan-select pipeline on :refined issues)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "50"        # read at most N recent transcript files (0 = no limit)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,11 +6,12 @@
 
 1. **Raise** — `cai analyze`, `cai propose`, `cai code-audit`, `cai audit`, or a human files an issue labeled `auto-improve:raised` or `human:submitted`.
 2. **Refine** — `cai refine` calls `cai-refine` to rewrite the issue into a structured plan with steps, verification, and scope guardrails. Label transitions to `auto-improve:refined`.
-3. **Fix** — `cai fix` calls `cai-fix` in a fresh git worktree. The wrapper commits, pushes, and opens a PR. Label transitions to `auto-improve:in-progress` → `auto-improve:pr-open`.
-4. **Review** — `cai review-pr` checks for ripple-effect inconsistencies and posts findings as PR comments. `cai review-docs` then (and only after review-pr completes) checks for stale documentation, directly fixes issues it can resolve, and commits/pushes those changes to the PR branch. Remaining unfixable issues are posted as `### Finding: stale_docs` comments. This ordering is enforced: review-docs skips PRs until review-pr has posted a review comment at the current HEAD SHA.
-5. **Revise** — `cai revise` calls `cai-revise` or `cai-rebase` to address review comments or rebase conflicts. Label transitions to `auto-improve:revising`.
-6. **Merge** — `cai merge` calls `cai-merge` to assess confidence and auto-merges PRs that meet the threshold. Label transitions to `auto-improve:merged`.
-7. **Confirm** — `cai confirm` calls `cai-confirm` to verify the merged fix actually resolved the original issue. Label transitions to `auto-improve:solved` or re-queues to `:refined`.
+3. **Plan** — `cai plan` runs plan-select agents to generate and select an implementation plan. The plan is stored in the issue body. Label transitions to `auto-improve:planned` (or `auto-improve:plan-approved` if human-reviewed).
+4. **Fix** — `cai fix` calls `cai-fix` in a fresh git worktree. The wrapper commits, pushes, and opens a PR. Label transitions to `auto-improve:in-progress` → `auto-improve:pr-open`.
+5. **Review** — `cai review-pr` checks for ripple-effect inconsistencies and posts findings as PR comments. `cai review-docs` then (and only after review-pr completes) checks for stale documentation, directly fixes issues it can resolve, and commits/pushes those changes to the PR branch. Remaining unfixable issues are posted as `### Finding: stale_docs` comments. This ordering is enforced: review-docs skips PRs until review-pr has posted a review comment at the current HEAD SHA.
+6. **Revise** — `cai revise` calls `cai-revise` or `cai-rebase` to address review comments or rebase conflicts. Label transitions to `auto-improve:revising`.
+7. **Merge** — `cai merge` calls `cai-merge` to assess confidence and auto-merges PRs that meet the threshold. Label transitions to `auto-improve:merged`.
+8. **Confirm** — `cai confirm` calls `cai-confirm` to verify the merged fix actually resolved the original issue. Label transitions to `auto-improve:solved` or re-queues to `:refined`.
 
 ## Lifecycle Labels
 
@@ -44,7 +45,7 @@
 2. **Recover stale locks** — roll back `:in-progress` and `:revising` issues past their timeout.
 3. **Ingest unlabeled** — attach `auto-improve` to any unlabeled issues that belong to the pipeline.
 4. **Drain PRs** — for each open auto-improve PR: revise → review-pr → review-docs → merge.
-5. **Refine one** — call `refine` on the oldest `:raised` issue.
+5. **Refine one + plan** — call `refine` on the oldest `:raised` issue, then `plan` on the oldest `:refined` issue to generate and store a selected plan.
 6. **Fix loop** — repeatedly call `fix`, `spike`, or `explore` until no eligible issues remain, draining PRs after each fix.
 7. **Final confirm** — one last confirm pass.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -112,6 +112,14 @@ Invoke `cai-refine` on the oldest `auto-improve:raised` or `human:submitted` iss
 |---|---|---|
 | `--issue INT` | optional | Target a specific issue number |
 
+## plan
+
+Run the plan-select pipeline on the oldest `auto-improve:refined` issue. Clones the repo, runs 2 serial plan agents followed by a select agent, stores the chosen plan in the issue body inside `<!-- cai-plan-start/end -->` markers, and transitions the label to `auto-improve:planned`. Runs on a cron schedule (CAI_PLAN_SCHEDULE); not part of the synchronous startup cycle.
+
+| Argument | Type | Description |
+|---|---|---|
+| `--issue INT` | optional | Target a specific issue number instead of queue-based selection |
+
 ## review-docs
 
 Review open PRs for stale documentation using `cai-review-docs`. Directly fixes stale documentation it finds and pushes commits to the PR branch. Posts `### Fixed: stale_docs` blocks for successfully fixed docs, and `### Finding: stale_docs` blocks for issues that cannot be fixed automatically.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,7 @@ All pipeline agents run on cron schedules configurable via environment variables
 | `CAI_UPDATE_CHECK_SCHEDULE` | `0 4 * * 1` | Weekly (Monday 04:00 UTC) — Claude Code release check |
 | `CAI_HEALTH_REPORT_SCHEDULE` | `0 7 * * 1` | Weekly (Monday 07:00 UTC) — pipeline health report |
 | `CAI_CHECK_WORKFLOWS_SCHEDULE` | `0 */6 * * *` | Every 6 hours — GitHub Actions workflow check |
+| `CAI_PLAN_SCHEDULE` | `0 11 * * *` | Daily (11:00 UTC) — plan-select pipeline on `:refined` issues |
 
 Schedule values use standard cron format: `minute hour day month weekday`. To disable a scheduled agent, set its variable to an empty string or a comment value.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,7 @@
 #      - health-report: automated pipeline health report with anomaly detection
 #      - cost-optimize: weekly cost-reduction proposal or evaluation
 #      - check-workflows: monitor GitHub Actions for failures
+#      - plan:            run plan-select pipeline on a :refined issue
 #    Each is its own crontab line so supercronic runs them as
 #    independent processes — natural concurrency, easy to add more.
 #
@@ -54,6 +55,7 @@ CAI_SPIKE_SCHEDULE="${CAI_SPIKE_SCHEDULE:-0 */2 * * *}"
 CAI_HEALTH_REPORT_SCHEDULE="${CAI_HEALTH_REPORT_SCHEDULE:-0 7 * * 1}"
 CAI_COST_OPTIMIZE_SCHEDULE="${CAI_COST_OPTIMIZE_SCHEDULE:-0 5 * * 0}"
 CAI_CHECK_WORKFLOWS_SCHEDULE="${CAI_CHECK_WORKFLOWS_SCHEDULE:-0 */6 * * *}"
+CAI_PLAN_SCHEDULE="${CAI_PLAN_SCHEDULE:-0 11 * * *}"
 
 CRONTAB_PATH=/tmp/crontab
 
@@ -77,6 +79,7 @@ $CAI_MERGE_SCHEDULE python /app/cai.py merge
 $CAI_HEALTH_REPORT_SCHEDULE python /app/cai.py health-report
 $CAI_COST_OPTIMIZE_SCHEDULE python /app/cai.py cost-optimize
 $CAI_CHECK_WORKFLOWS_SCHEDULE python /app/cai.py check-workflows
+$CAI_PLAN_SCHEDULE python /app/cai.py plan
 CRONTAB
 
 echo "[entrypoint] crontab:"

--- a/install.sh
+++ b/install.sh
@@ -148,6 +148,7 @@ services:
       CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly :35 (auto-merge confident PRs)
       CAI_HEALTH_REPORT_SCHEDULE: "0 7 * * 1" # weekly Monday 07:00 UTC (pipeline health report)
       CAI_CHECK_WORKFLOWS_SCHEDULE: "0 */6 * * *" # every 6h (check for CI workflow failures)
+      CAI_PLAN_SCHEDULE: "0 11 * * *"        # daily 11:00 UTC (plan-select pipeline on :refined issues)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "50"        # read at most N recent transcript files (0 = no limit)
@@ -217,6 +218,7 @@ services:
       CAI_MERGE_SCHEDULE: "35 * * * *"      # hourly :35 (auto-merge confident PRs)
       CAI_HEALTH_REPORT_SCHEDULE: "0 7 * * 1" # weekly Monday 07:00 UTC (pipeline health report)
       CAI_CHECK_WORKFLOWS_SCHEDULE: "0 */6 * * *" # every 6h (check for CI workflow failures)
+      CAI_PLAN_SCHEDULE: "0 11 * * *"        # daily 11:00 UTC (plan-select pipeline on :refined issues)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "50"        # read at most N recent transcript files (0 = no limit)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#518

**Issue:** #518 — [Step 2/3] `cmd_plan` standalone command

## PR Summary

### What this fixes
Issue #518 requests a standalone `cmd_plan` command that runs the plan-select pipeline on a `:refined` issue, stores the selected plan in the issue body (between HTML comment markers), and transitions the label from `auto-improve:refined` → `auto-improve:planned` — creating the human-validation gate between planning and implementation.

### What was changed
- **`cai.py:1263`** — Added `_select_plan_target(issue_number=None)` helper modelled after `_select_fix_target`, supporting both queue-based (oldest `:refined` not locked) and specific issue selection
- **`cai.py:1576`** — Added `_extract_stored_plan(issue_body)` helper that parses the `<!-- cai-plan-start -->` / `<!-- cai-plan-end -->` block from an issue body (to be consumed by `cmd_fix` in Step 3)
- **`cai.py:1591`** — Added `_strip_stored_plan_block(issue_body)` helper that removes any existing plan block before re-prepending (handles re-run on same issue)
- **`cai.py:1606`** — Added `cmd_plan(args)` that: selects a target issue, clones the repo, fetches prior fix attempts, runs `_run_plan_select_pipeline`, stores the result in the issue body with markers, and transitions labels `:refined` → `:planned`
- **`cai.py:8127`** — Added Phase 2.6 in `cmd_cycle` to call `cmd_plan` right after Phase 2.5 (refine)
- **`cai.py:8859`** — Registered `plan` subparser with `--issue` argument
- **`cai.py:8931`** — Added `"plan": cmd_plan` to the `handlers` dict

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
