### PR TITLE
auto-improve: doc review should only happen once the review is completed

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,26 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#522
+
+## Files touched
+- `cai.py:6419` — added gate in `cmd_review_docs` to skip PRs whose HEAD SHA has not yet been reviewed by `cai review-pr`
+
+## Files read (not touched) that matter
+- `cai.py:6827–6847` — `cmd_merge` filter 7 uses the identical `startswith(_REVIEW_COMMENT_HEADING_FINDINGS) and head_sha in first_line` pattern; this fix mirrors it exactly
+
+## Key symbols
+- `_REVIEW_COMMENT_HEADING_FINDINGS` (`cai.py:6115`) — prefix `"## cai pre-merge review"`, matches both findings and clean variants (clean starts with same prefix)
+- `cmd_review_docs` (`cai.py:6355`) — function where the gate was added
+- `skipped` counter — incremented for both the already-reviewed skip and the new gate skip so summary log stays accurate
+
+## Design decisions
+- Reuse existing `startswith(_REVIEW_COMMENT_HEADING_FINDINGS) and head_sha in first_line` pattern — mirrors `cmd_merge` filter 7 exactly, no new logic
+- Gate applies even for `--pr N` direct targeting — consistent with review-pr's own behavior; explicit bypass not provided
+- Rejected: adding a new label to track review-pr completion — more moving parts for no correctness benefit over comment-SHA check
+
+## Out of scope / known gaps
+- No label state machine changes — the gate is purely comment-presence based
+- No bypass flag added — if needed in future, would be a separate issue
+
+## Invariants this change relies on
+- `cai review-pr` always posts a comment whose first line starts with `_REVIEW_COMMENT_HEADING_FINDINGS` and contains the head SHA
+- PR comments are fetched with sufficient depth in `cmd_review_docs` to include review-pr comments

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -24,3 +24,18 @@ Refs: robotsix-cai/robotsix-cai#522
 ## Invariants this change relies on
 - `cai review-pr` always posts a comment whose first line starts with `_REVIEW_COMMENT_HEADING_FINDINGS` and contains the head SHA
 - PR comments are fetched with sufficient depth in `cmd_review_docs` to include review-pr comments
+
+## Revision 1 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `docs/cli.md:115` — added Note block explaining review-pr → review-docs ordering enforcement
+- `docs/architecture.md:10` — expanded Review step description to document ordering constraint and enforcement mechanism
+
+### Decisions this revision
+- Verbatim wording from reviewer suggestion used for both doc sites — accurate and consistent
+
+### New gaps / deferred
+- None

--- a/cai.py
+++ b/cai.py
@@ -6417,6 +6417,28 @@ def cmd_review_docs(args) -> int:
             skipped += 1
             continue
 
+        # Gate: only review docs after review-pr has reviewed this SHA.
+        # This enforces the review-pr → review-docs → merge ordering.
+        has_code_review_at_sha = False
+        for comment in pr.get("comments", []):
+            body = (comment.get("body") or "")
+            first_line = body.split("\n", 1)[0]
+            if (
+                first_line.startswith(_REVIEW_COMMENT_HEADING_FINDINGS)
+                and head_sha in first_line
+            ):
+                has_code_review_at_sha = True
+                break
+
+        if not has_code_review_at_sha:
+            print(
+                f"[cai review-docs] PR #{pr_number}: review-pr has not reviewed "
+                f"{head_sha[:8]} yet; waiting",
+                flush=True,
+            )
+            skipped += 1
+            continue
+
         print(f"[cai review-docs] reviewing PR #{pr_number}: {title}", flush=True)
 
         # Get the diff.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@
 1. **Raise** — `cai analyze`, `cai propose`, `cai code-audit`, `cai audit`, or a human files an issue labeled `auto-improve:raised` or `human:submitted`.
 2. **Refine** — `cai refine` calls `cai-refine` to rewrite the issue into a structured plan with steps, verification, and scope guardrails. Label transitions to `auto-improve:refined`.
 3. **Fix** — `cai fix` calls `cai-fix` in a fresh git worktree. The wrapper commits, pushes, and opens a PR. Label transitions to `auto-improve:in-progress` → `auto-improve:pr-open`.
-4. **Review** — `cai review-pr` checks for ripple-effect inconsistencies; `cai review-docs` checks for stale documentation. Findings are posted as PR comments.
+4. **Review** — `cai review-pr` checks for ripple-effect inconsistencies and posts findings as PR comments. `cai review-docs` then (and only after review-pr completes) checks for stale documentation, also posting findings as comments. This ordering is enforced: review-docs skips PRs until review-pr has posted a review comment at the current HEAD SHA.
 5. **Revise** — `cai revise` calls `cai-revise` or `cai-rebase` to address review comments or rebase conflicts. Label transitions to `auto-improve:revising`.
 6. **Merge** — `cai merge` calls `cai-merge` to assess confidence and auto-merges PRs that meet the threshold. Label transitions to `auto-improve:merged`.
 7. **Confirm** — `cai confirm` calls `cai-confirm` to verify the merged fix actually resolved the original issue. Label transitions to `auto-improve:solved` or re-queues to `:refined`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -116,6 +116,8 @@ Invoke `cai-refine` on the oldest `auto-improve:raised` or `human:submitted` iss
 
 Review open PRs for stale documentation using `cai-review-docs`. Posts `### Finding: stale_docs` blocks as PR comments.
 
+**Note:** `review-docs` skips PRs until `cai review-pr` has reviewed the current HEAD SHA. This enforces the `review-pr` → `review-docs` → `merge` ordering.
+
 | Argument | Type | Description |
 |---|---|---|
 | `--pr INT` | optional | Target a specific PR number |


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#522

**Issue:** #522 — doc review should only happen once the review is completed

## PR Summary

### What this fixes
`cmd_review_docs` was running independently of `cmd_review_pr`, so docs reviews could be posted before (or without) a code review, breaking the intended `review-pr → review-docs → merge` ordering.

### What was changed
- **`cai.py`** (`cmd_review_docs`, after the "already reviewed" skip block): Added a gate that checks whether a `## cai pre-merge review … <head_sha>` comment already exists for the PR's current HEAD SHA. If no such comment exists, the PR is skipped with a "waiting" log message and `skipped += 1` is incremented. This mirrors the identical pattern used in `cmd_merge`'s safety filter 7, using `_REVIEW_COMMENT_HEADING_FINDINGS` which correctly matches both findings and clean review variants.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
