### PR TITLE
auto-improve: We should avoid to have so many MR opened in parallel

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,34 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#524
+
+## Files touched
+- `cai.py:8031-8043` — removed `if not has_fix_target:` guard so `has_pending_prs` is checked unconditionally every cycle
+- `cai.py:8111` — changed `if not has_fix_target and has_pending_prs:` to `if has_pending_prs:` so drain counter tracks all pending-PR situations
+- `cai.py:8126` — updated drain reset comment to "reset when no pending PRs"
+- `cai.py:8128` — changed `if has_fix_target:` to `if has_fix_target and not has_pending_prs:` to gate new PRs on drain state
+- `cai.py:8138-8142` — added `elif has_fix_target and has_pending_prs:` log message when fix is skipped
+
+## Files read (not touched) that matter
+- `cai.py:8025-8165` — `cmd_cycle` main loop body; understood full control flow
+
+## Key symbols
+- `has_pending_prs` (`cai.py:8031`) — boolean flag, now set unconditionally each iteration
+- `drain_only_passes` (`cai.py:8018`) — counter, now increments whenever pending PRs exist (not just when no fix target)
+- `_MAX_DRAIN_ONLY_PASSES` (`cai.py:8019`) — unchanged limit of 3
+
+## Design decisions
+- Made `has_pending_prs` unconditional rather than moving the entire block — minimal change, existing structure preserved
+- Updated drain counter to trigger on any `has_pending_prs=True` (not just when no fix target) — ensures counter tracks all stuck-PR situations
+- Avoided referencing `len(pending)` in log message since `pending` may not be defined if exception was raised
+- Rejected: restructuring the loop body order (Plan 2 approach) — unnecessary complexity
+
+## Out of scope / known gaps
+- `_select_fix_target()` unchanged — already excludes `:pr-open` issues from candidates
+- `_drain_pending_prs()` unchanged — works correctly
+- `has_spike` and `has_exploration` checks still gated on `not has_fix_target` — not related to this issue
+- Loop exit condition at line 8106 unchanged — still correctly exits when nothing to do
+
+## Invariants this change relies on
+- One extra `gh issue list` call per cycle is acceptable overhead
+- `_drain_pending_prs()` is idempotent if there are no pending PRs to drain
+- `_MAX_DRAIN_ONLY_PASSES=3` guard prevents infinite loops when PRs get stuck

--- a/cai.py
+++ b/cai.py
@@ -8029,19 +8029,18 @@ def cmd_cycle(args) -> int:
 
         # Check for pr-open issues that still need drain passes.
         has_pending_prs = False
-        if not has_fix_target:
-            try:
-                pending = _gh_json([
-                    "issue", "list",
-                    "--repo", REPO,
-                    "--label", LABEL_PR_OPEN,
-                    "--state", "open",
-                    "--json", "number",
-                    "--limit", "1",
-                ]) or []
-                has_pending_prs = len(pending) > 0
-            except subprocess.CalledProcessError:
-                pass
+        try:
+            pending = _gh_json([
+                "issue", "list",
+                "--repo", REPO,
+                "--label", LABEL_PR_OPEN,
+                "--state", "open",
+                "--json", "number",
+                "--limit", "1",
+            ]) or []
+            has_pending_prs = len(pending) > 0
+        except subprocess.CalledProcessError:
+            pass
 
         # Check for :needs-spike issues.
         has_spike = False
@@ -8109,7 +8108,7 @@ def cmd_cycle(args) -> int:
                   flush=True)
             break
 
-        if not has_fix_target and has_pending_prs:
+        if has_pending_prs:
             drain_only_passes += 1
             if drain_only_passes > _MAX_DRAIN_ONLY_PASSES:
                 print(
@@ -8119,14 +8118,14 @@ def cmd_cycle(args) -> int:
                 )
                 break
             print(
-                f"[cai cycle] no fix targets but {len(pending)} PR(s) still open; "
+                f"[cai cycle] pending PR(s) still open; "
                 f"draining (pass {drain_only_passes}/{_MAX_DRAIN_ONLY_PASSES})",
                 flush=True,
             )
         else:
-            drain_only_passes = 0  # reset when we have fix work
+            drain_only_passes = 0  # reset when no pending PRs
 
-        if has_fix_target:
+        if has_fix_target and not has_pending_prs:
             rc = _run_step("fix", cmd_fix, args)
             key = f"fix.{iteration}"
             all_results[key] = rc
@@ -8136,6 +8135,11 @@ def cmd_cycle(args) -> int:
                 # fix failed (error) — stop looping.
                 print("[cai cycle] fix step failed; stopping loop", flush=True)
                 break
+        elif has_fix_target and has_pending_prs:
+            print(
+                "[cai cycle] fix target available but skipping — draining pending PR(s) first",
+                flush=True,
+            )
 
         # Run spike if no fix target but :needs-spike issues exist.
         # Spike outcomes feed back: refine_and_retry → :raised,


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#524

**Issue:** #524 — We should avoid to have so many MR opened in parallel

## PR Summary

### What this fixes
`cmd_cycle` was opening new PRs via `cmd_fix` even when there were already pending PRs (with the `auto-improve:pr-open` label) waiting to be merged. This was because `has_pending_prs` was only checked when there was no fix target, so it never blocked the fix step from running.

### What was changed
- **`cai.py` (~line 8031)**: Removed the `if not has_fix_target:` guard around the `has_pending_prs` check, so pending PRs are always detected each cycle regardless of whether a fix target exists
- **`cai.py` (~line 8111)**: Changed `if not has_fix_target and has_pending_prs:` to `if has_pending_prs:` so the drain-only pass counter and its exit guard fire whenever any pending PRs are present
- **`cai.py` (~line 8128)**: Changed `if has_fix_target:` to `if has_fix_target and not has_pending_prs:` so `cmd_fix` is skipped when pending PRs exist
- **`cai.py` (~line 8138)**: Added an `elif has_fix_target and has_pending_prs:` branch that logs a message when a fix target is available but skipped due to pending PRs

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
