### PR TITLE
revise: auto-clear :merge-blocked on new human comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,13 +244,16 @@ identity as the operator.
 If the bot can't address a comment (unclear or out of scope), it
 posts a reply explaining why and exits without changes.
 
-**Skip conditions:** `cai revise` skips (logging a `[cai revise] … skipping` message) a PR when its linked
-issue carries the `merge-blocked` label **or** the PR itself carries
-the `needs-human-review` label. Revising code cannot unblock a PR
-that is waiting on a human decision, so the bot leaves it alone to
-avoid infinite revision loops. A human must clear those labels
-(and, for `merge-blocked` issues, resolve the underlying blocker)
-to re-enable automatic comment-driven iteration.
+**Skip conditions:** `cai revise` skips (logging a `[cai revise] … skipping` message) a PR when the
+PR carries the `needs-human-review` label, or when the linked issue
+carries `merge-blocked` **and no new human comment has been posted
+since the last commit**. Revising code cannot unblock a PR that is
+waiting on a human decision, so the bot leaves it alone to avoid
+infinite revision loops. A human can re-enable the revise loop on
+a `merge-blocked` PR simply by posting a comment: `cai revise` treats
+a fresh non-bot comment as the human decision to resume and
+automatically clears the `merge-blocked` label on its next tick.
+`needs-human-review` must still be cleared manually.
 
 ### Pre-merge consistency review
 

--- a/cai.py
+++ b/cai.py
@@ -2917,16 +2917,15 @@ def _select_revise_targets() -> list[dict]:
         # Skip PRs that are blocked on a human decision — revising
         # code won't unblock them and causes an infinite loop.
         # Issue #399.
+        #
+        # NOTE: :merge-blocked is handled below, *after* we've parsed
+        # comments, so a fresh human comment can auto-clear it and
+        # resume the revise loop (no more manual label toggling).
         pr_label_names = {lbl["name"] for lbl in pr.get("labels", [])}
-        if LABEL_MERGE_BLOCKED in label_names or LABEL_PR_NEEDS_HUMAN in pr_label_names:
-            skip_reason = []
-            if LABEL_MERGE_BLOCKED in label_names:
-                skip_reason.append(f"issue has :{LABEL_MERGE_BLOCKED}")
-            if LABEL_PR_NEEDS_HUMAN in pr_label_names:
-                skip_reason.append(f"PR has :{LABEL_PR_NEEDS_HUMAN}")
+        if LABEL_PR_NEEDS_HUMAN in pr_label_names:
             print(
                 f"[cai revise] PR #{pr['number']}: skipping — "
-                f"{', '.join(skip_reason)} (needs human decision)",
+                f"PR has :{LABEL_PR_NEEDS_HUMAN} (needs human decision)",
                 flush=True,
             )
             continue
@@ -2980,6 +2979,41 @@ def _select_revise_targets() -> list[dict]:
         # Filter: createdAt > commit_ts AND not bot AND not already
         # acknowledged by a "no additional changes" reply (loop guard).
         unaddressed = _filter_unaddressed_comments(comments, commit_ts)
+
+        # :merge-blocked auto-clear. If the issue carries :merge-blocked
+        # AND a human has posted an unaddressed comment since the last
+        # commit, treat the comment as the human decision to resume and
+        # strip the label so revise can act on it. If there are no new
+        # human comments, keep skipping — the PR is still waiting on a
+        # human. Previously humans had to remove the label by hand,
+        # which was easy to forget (see chicken-and-egg with cmd_merge
+        # holding the PR back on unaddressed review-pr comments that
+        # only revise can address).
+        if LABEL_MERGE_BLOCKED in label_names:
+            if not unaddressed:
+                print(
+                    f"[cai revise] PR #{pr['number']}: skipping — "
+                    f"issue has :{LABEL_MERGE_BLOCKED} (needs human decision)",
+                    flush=True,
+                )
+                continue
+            if not _set_labels(
+                issue_number,
+                remove=[LABEL_MERGE_BLOCKED],
+                log_prefix="cai revise",
+            ):
+                print(
+                    f"[cai revise] PR #{pr['number']}: failed to clear "
+                    f":{LABEL_MERGE_BLOCKED} on issue #{issue_number}; skipping",
+                    file=sys.stderr, flush=True,
+                )
+                continue
+            print(
+                f"[cai revise] PR #{pr['number']}: cleared "
+                f":{LABEL_MERGE_BLOCKED} on issue #{issue_number} — "
+                f"{len(unaddressed)} new human comment(s) since last commit",
+                flush=True,
+            )
 
         # Determine if the PR needs a rebase (unmergeable).
         needs_rebase = pr_detail.get("mergeable") == "CONFLICTING" or \


### PR DESCRIPTION
## Summary
- `cai revise` now auto-clears `:merge-blocked` from the linked issue when a fresh non-bot comment has landed since the last commit, so a human can resume the loop by simply replying on the PR.
- Keeps the skip when there is no new human comment, and leaves `:needs-human-review` handling unchanged.
- README skip-conditions updated.

## Test plan
- [ ] Manual: post a comment on a `:merge-blocked` PR; next `cai revise` tick clears the label and addresses the comment.
- [ ] Manual: `:merge-blocked` PR with no new human comment still gets skipped.