### PR TITLE
cycle: split into fix-only loop + standalone plan-all drainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,29 @@ The container is long-lived. It runs as a **scheduler**
 fires tasks on configurable cron schedules. `cai.py` is a subcommand
 dispatcher so each task is its own subprocess with no shared state.
 
-The issue-solving pipeline is driven by a single `cai.py cycle`
-cron line. A flock in `cmd_cycle` serializes overlapping runs, so
-issues are processed one at a time: each cycle refines, fixes,
-drains pending PRs, and only advances to the next issue when the
-current one is solved or has reached a blocking point (human review,
-`:merge-blocked`, etc.). The individual pipeline subcommands
-(`fix`, `refine`, `plan`, `spike`, `revise`, `review-pr`, `merge`,
-`verify`, `confirm`) remain available for manual/on-demand use but
-no longer have their own cron lines.
+The issue-solving pipeline is split across two cron lines:
+
+- `cai.py cycle` drains pending PRs and fixes `:plan-approved`
+  issues only. `:raised`, `:refined`, and `:planned` issues are
+  invisible to the fix loop — a human approves a plan into
+  `:plan-approved` before the cycle will act on it.
+- `cai.py plan-all` drives every `:raised` / `:refined` issue
+  through refine → plan → `:planned`, producing the backlog humans
+  review. It also runs at the end of each `cycle` so the next
+  approval pass has a fresh queue.
+
+A flock in `cmd_cycle` serializes overlapping runs, so issues are
+processed one at a time: each cycle fixes, drains pending PRs, and
+only advances to the next issue when the current one is solved or
+has reached a blocking point (human review, `:merge-blocked`, etc.).
+The individual pipeline subcommands (`fix`, `refine`, `plan`,
+`plan-all`, `spike`, `revise`, `review-pr`, `merge`, `verify`,
+`confirm`) remain available for manual/on-demand use.
 
 | Subcommand | Default schedule | What it does |
 |---|---|---|
-| `cai.py cycle` | `0 * * * *` (hourly, startup, manual) | Full issue-solving pipeline: verify → confirm → drain pending PRs (revise → review-pr → review-docs → merge) → refine → loop(fix/spike/explore → drain → refine). A flock serializes overlapping runs; the entrypoint also runs this once synchronously at `docker compose up -d` so startup logs are immediate |
+| `cai.py cycle` | `0 * * * *` (hourly, startup, manual) | Fix pipeline on `:plan-approved` issues: verify → confirm → drain pending PRs (revise → review-pr → review-docs → merge) → loop(fix/spike/explore → drain) → plan-all → confirm. A flock serializes overlapping runs; the entrypoint also runs this once synchronously at `docker compose up -d` so startup logs are immediate |
+| `cai.py plan-all` | `30 * * * *` (hourly, offset 30) | Drains every open `:raised` / `:refined` issue through refine → plan → `:planned` so humans have a queue to review. Also runs at the end of each `cycle`; the cron line provides a mid-cycle catch-up pass |
 | `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` (6-hour TTL) and `:revising` (1-hour TTL) locks and stale `:no-action` issues, flags stale `:merged` issues for human review, recovers `:pr-open` issues whose linked PR was closed (rolls back to `:refined`), deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |
 | `cai.py audit-triage` | `10 */6 * * *` (every 6 hours) | Triages `audit:raised` findings and emits close/passthrough/escalate verdicts |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dispatcher so each task is its own subprocess with no shared state.
 
 The issue-solving pipeline is driven by a single `cai.py cycle`
 cron line. A flock in `cmd_cycle` serializes overlapping runs, so
-issues are processed one at a time: each cycle refines, plans, fixes,
+issues are processed one at a time: each cycle refines, fixes,
 drains pending PRs, and only advances to the next issue when the
 current one is solved or has reached a blocking point (human review,
 `:merge-blocked`, etc.). The individual pipeline subcommands
@@ -59,7 +59,7 @@ no longer have their own cron lines.
 
 | Subcommand | Default schedule | What it does |
 |---|---|---|
-| `cai.py cycle` | `0 * * * *` (hourly, startup, manual) | Full issue-solving pipeline: verify → confirm → drain pending PRs (revise → review-pr → review-docs → merge) → refine → plan → loop(fix/spike/explore → drain → refine). A flock serializes overlapping runs; the entrypoint also runs this once synchronously at `docker compose up -d` so startup logs are immediate |
+| `cai.py cycle` | `0 * * * *` (hourly, startup, manual) | Full issue-solving pipeline: verify → confirm → drain pending PRs (revise → review-pr → review-docs → merge) → refine → loop(fix/spike/explore → drain → refine). A flock serializes overlapping runs; the entrypoint also runs this once synchronously at `docker compose up -d` so startup logs are immediate |
 | `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` (6-hour TTL) and `:revising` (1-hour TTL) locks and stale `:no-action` issues, flags stale `:merged` issues for human review, recovers `:pr-open` issues whose linked PR was closed (rolls back to `:refined`), deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |
 | `cai.py audit-triage` | `10 */6 * * *` (every 6 hours) | Triages `audit:raised` findings and emits close/passthrough/escalate verdicts |

--- a/cai.py
+++ b/cai.py
@@ -638,22 +638,25 @@ def _select_fix_target():
     Categories with fewer than 3 observations get a neutral prior of 0.60.
     This replaces the previous FIFO (oldest-first) selection.
 
-    Eligible = labelled `:refined` or `:requested`, NOT labelled
-    `:in-progress` or `:pr-open`.  `audit:raised` issues are handled
-    exclusively by the audit-triage agent — only issues that triage
-    re-labels to `auto-improve:raised` (and subsequently refine to
-    `auto-improve:refined`) enter the fix pipeline.
+    Eligible = labelled `:plan-approved` or `:requested`, NOT labelled
+    `:in-progress` or `:pr-open`.  `:plan-approved` is the primary gate:
+    the `plan-all` step drives every :raised / :refined issue to
+    :planned, and a human then promotes :planned → :plan-approved when
+    the plan looks good.  `:requested` is an explicit human shortcut
+    that bypasses the plan gate (treat as "I've already validated this,
+    just fix it").  `:refined` and `:planned` issues sit outside the
+    fix pipeline until a human approves.
+
+    `audit:raised` issues are handled exclusively by the audit-triage
+    agent — only issues that triage re-labels to `auto-improve:raised`
+    (and subsequently refine → plan → plan-approved) enter the fix
+    pipeline.
+
     If no candidates are found, attempts to recover stale `:pr-open`
     issues whose linked PR was closed unmerged or that have no linked PR.
-
-    NOTE: `:planned` and `:plan-approved` issues are intentionally NOT
-    picked up here.  `:planned` issues are waiting for human approval;
-    `:plan-approved` issues will be wired into this function in Step 3 of
-    the plan-gate sub-issue chain (#481).  Until then, they sit in the
-    queue without being consumed by the fix agent.
     """
     candidates: dict[int, dict] = {}
-    for label in (LABEL_REFINED, LABEL_REQUESTED):
+    for label in (LABEL_PLAN_APPROVED, LABEL_REQUESTED):
         try:
             issues = _gh_json([
                 "issue", "list",
@@ -1118,6 +1121,118 @@ def cmd_plan(args) -> int:
     finally:
         if work_dir.exists():
             shutil.rmtree(work_dir, ignore_errors=True)
+
+
+def _count_open_by_label(label: str) -> int:
+    """Return the number of open issues carrying *label*, or 0 on query failure."""
+    try:
+        issues = _gh_json([
+            "issue", "list",
+            "--repo", REPO,
+            "--label", label,
+            "--state", "open",
+            "--json", "number",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError:
+        return 0
+    return len(issues)
+
+
+def cmd_plan_all(args) -> int:
+    """Drive every :raised / :human:submitted / :refined issue to :planned.
+
+    Each iteration runs one `refine` (if any :raised or
+    :human:submitted remain) or one `plan` (otherwise, if any
+    :refined remain). The loop exits when both queues are empty, an
+    iteration cap is reached, or two consecutive iterations make no
+    progress (to avoid spinning on a perpetually-failing issue).
+
+    This step produces the :planned backlog that humans review and
+    promote to :plan-approved. The fix loop in `cycle` only consumes
+    :plan-approved work, so without this step nothing new would ever
+    reach a state a human can approve.
+    """
+    t0 = time.monotonic()
+    print("[cai plan-all] draining :raised and :refined queues", flush=True)
+
+    refined_ct = 0
+    planned_ct = 0
+    refine_err = 0
+    plan_err = 0
+    had_failure = False
+
+    MAX_ITER = 50
+    last_state: tuple[int, int] | None = None
+    stuck_strikes = 0
+
+    for iteration in range(1, MAX_ITER + 1):
+        raised = (
+            _count_open_by_label(LABEL_RAISED)
+            + _count_open_by_label(LABEL_HUMAN_SUBMITTED)
+        )
+        refined = _count_open_by_label(LABEL_REFINED)
+
+        if raised == 0 and refined == 0:
+            print("[cai plan-all] queue drained; done", flush=True)
+            break
+
+        if last_state == (raised, refined):
+            stuck_strikes += 1
+            if stuck_strikes >= 2:
+                print(
+                    f"[cai plan-all] no progress for 2 iterations "
+                    f"(raised={raised} refined={refined}); bailing",
+                    flush=True,
+                )
+                had_failure = True
+                break
+        else:
+            stuck_strikes = 0
+        last_state = (raised, refined)
+
+        print(
+            f"[cai plan-all] iteration {iteration}: raised={raised} refined={refined}",
+            flush=True,
+        )
+
+        if raised > 0:
+            rc = cmd_refine(args)
+            if rc == 0:
+                refined_ct += 1
+            else:
+                refine_err += 1
+                had_failure = True
+        else:
+            rc = cmd_plan(args)
+            if rc == 0:
+                planned_ct += 1
+            else:
+                plan_err += 1
+                had_failure = True
+    else:
+        print(
+            f"[cai plan-all] hit iteration cap ({MAX_ITER}); stopping",
+            flush=True,
+        )
+
+    dur = f"{time.monotonic() - t0:.1f}s"
+    print(
+        f"[cai plan-all] done in {dur} — refined={refined_ct} "
+        f"planned={planned_ct} refine_err={refine_err} plan_err={plan_err}",
+        flush=True,
+    )
+    log_run(
+        "plan-all",
+        repo=REPO,
+        refined=refined_ct,
+        planned=planned_ct,
+        refine_err=refine_err,
+        plan_err=plan_err,
+        duration=dur,
+        exit=1 if had_failure else 0,
+    )
+    return 1 if had_failure else 0
 
 
 def _parse_suggested_issues(agent_output: str) -> list[dict]:
@@ -7674,8 +7789,11 @@ def cmd_cycle(args) -> int:
       1. verify + confirm  (sync label state)
       1.5. recover stale locks (:in-progress / :revising)
       2. drain pending PRs (revise → review-pr → review-docs → merge)
-      2.5. refine one :raised issue
-      3. loop: verify → fix/spike/explore → drain → refine → repeat
+      3. loop: verify → fix/spike/explore → drain → repeat
+         (fix picks only :plan-approved / :requested — nothing raised
+         or refined is auto-consumed here)
+      3.5. plan-all — drive every remaining :raised / :refined issue
+         to :planned so humans have a queue to approve against
       4. final confirm
 
     A non-blocking flock on `_CYCLE_LOCK_PATH` ensures at most one
@@ -7738,13 +7856,10 @@ def _cmd_cycle_inner(args) -> int:
     if any(v != 0 for v in pr_results.values()):
         had_failure = True
 
-    # --- Phase 2.5: refine one :raised issue ------------------------------
-    rc = _run_step("refine", cmd_refine, args)
-    all_results["refine"] = rc
-    if rc != 0:
-        had_failure = True
-
-    # --- Phase 3: fix loop — pick → fix → drain → refine → repeat ------
+    # --- Phase 3: fix loop — pick → fix → drain → repeat ----------------
+    # Refining and planning are no longer interleaved in this loop; the
+    # dedicated `plan-all` phase below drives :raised/:refined through
+    # the refine → plan pipeline after the fix loop exits.
     # The loop also handles pr-open issues that need further
     # revise/review/merge passes, not just new fix targets.
     drain_only_passes = 0
@@ -7799,36 +7914,7 @@ def _cmd_cycle_inner(args) -> int:
             except subprocess.CalledProcessError:
                 pass
 
-        # Check for :raised or human:submitted issues that still need refining.
-        has_raised = False
         if not has_fix_target and not has_pending_prs and not has_spike and not has_exploration:
-            try:
-                raised = _gh_json([
-                    "issue", "list",
-                    "--repo", REPO,
-                    "--label", LABEL_RAISED,
-                    "--state", "open",
-                    "--json", "number",
-                    "--limit", "1",
-                ]) or []
-                has_raised = len(raised) > 0
-            except subprocess.CalledProcessError:
-                pass
-            if not has_raised:
-                try:
-                    human_submitted = _gh_json([
-                        "issue", "list",
-                        "--repo", REPO,
-                        "--label", LABEL_HUMAN_SUBMITTED,
-                        "--state", "open",
-                        "--json", "number",
-                        "--limit", "1",
-                    ]) or []
-                    has_raised = len(human_submitted) > 0
-                except subprocess.CalledProcessError:
-                    pass
-
-        if not has_fix_target and not has_pending_prs and not has_spike and not has_exploration and not has_raised:
             print("[cai cycle] no eligible issues and no pending PRs; exiting loop",
                   flush=True)
             break
@@ -7891,10 +7977,15 @@ def _cmd_cycle_inner(args) -> int:
             if step_rc != 0:
                 had_failure = True
 
-        # Refine one more :raised issue so the next iteration has
-        # something to fix.
-        rc = _run_step("refine", cmd_refine, args)
-        all_results[f"refine.{iteration}"] = rc
+    # --- Phase 3.5: plan-all — drive :raised/:refined to :planned -------
+    # The fix loop only acts on :plan-approved (or :requested) issues,
+    # so any :raised or :refined work would sit idle without this step.
+    # plan-all loops refine → plan until the queue is exhausted; humans
+    # then approve :planned → :plan-approved on their own schedule.
+    rc = _run_step("plan-all", cmd_plan_all, args)
+    all_results["plan-all"] = rc
+    if rc != 0:
+        had_failure = True
 
     # --- Phase 4: final confirm -----------------------------------------
     rc = _run_step("confirm-final", cmd_confirm, args)
@@ -8478,6 +8569,10 @@ def main() -> int:
         "--issue", type=int, default=None,
         help="Target a specific issue number instead of using queue-based selection",
     )
+    sub.add_parser(
+        "plan-all",
+        help="Drive every :raised/:refined issue to :planned (refine → plan loop)",
+    )
     spike_parser = sub.add_parser("spike", help="Run the spike agent on :needs-spike issues")
     spike_parser.add_argument(
         "--issue", type=int, default=None,
@@ -8548,6 +8643,7 @@ def main() -> int:
         "merge": cmd_merge,
         "refine": cmd_refine,
         "plan": cmd_plan,
+        "plan-all": cmd_plan_all,
         "spike": cmd_spike,
         "explore": cmd_explore,
         "cycle": cmd_cycle,

--- a/cai.py
+++ b/cai.py
@@ -7588,7 +7588,7 @@ def _has_actionable_pending_prs() -> bool:
         it's in-flight or already red — is not something cai can
         advance by itself, so we don't block fix work on it.
 
-    When every open PR is stuck, the cycle should proceed to :planned
+    When every open PR is stuck, the cycle should proceed to :refined
     issues rather than idle draining — CI and humans will unblock the
     stuck PRs on their own schedule, and draining still runs every
     iteration to pick them back up once unblocked.
@@ -7675,7 +7675,6 @@ def cmd_cycle(args) -> int:
       1.5. recover stale locks (:in-progress / :revising)
       2. drain pending PRs (revise → review-pr → review-docs → merge)
       2.5. refine one :raised issue
-      2.6. plan one :refined issue (plan-select pipeline → store plan → :planned)
       3. loop: verify → fix/spike/explore → drain → refine → repeat
       4. final confirm
 
@@ -7742,12 +7741,6 @@ def _cmd_cycle_inner(args) -> int:
     # --- Phase 2.5: refine one :raised issue ------------------------------
     rc = _run_step("refine", cmd_refine, args)
     all_results["refine"] = rc
-    if rc != 0:
-        had_failure = True
-
-    # --- Phase 2.6: plan one :refined issue --------------------------------
-    rc = _run_step("plan", cmd_plan, args)
-    all_results["plan"] = rc
     if rc != 0:
         had_failure = True
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,12 +28,15 @@ services:
       # 5-field cron line works — see https://crontab.guru/ —
       # supercronic also supports @hourly, @daily, etc.
       #
-      # CAI_CYCLE_SCHEDULE drives the full issue-solving pipeline
-      # (refine → plan → fix → revise → review-pr → merge → confirm).
-      # A flock in cmd_cycle serializes overlapping runs so issues
-      # are processed one at a time. The remaining schedules are
-      # for orthogonal tasks that run independently.
-      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — full issue-solving pipeline
+      # CAI_CYCLE_SCHEDULE drives the fix pipeline on :plan-approved
+      # issues (fix → revise → review-pr → merge → confirm). A flock
+      # in cmd_cycle serializes overlapping runs so issues are
+      # processed one at a time. CAI_PLAN_ALL_SCHEDULE drives the
+      # upstream refine → plan flow that turns :raised/:refined
+      # issues into :planned for humans to approve. The remaining
+      # schedules are for orthogonal tasks that run independently.
+      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on :plan-approved
+      CAI_PLAN_ALL_SCHEDULE: "30 * * * *"   # hourly @30 — drain :raised/:refined into :planned
       CAI_ANALYZER_SCHEDULE: "0 0 * * *"   # daily at 00:00 UTC (LLM call)
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet: LLM audit + deterministic cleanup; see README)
       CAI_AUDIT_TRIAGE_SCHEDULE: "10 */6 * * *" # every 6h at :10 (triage raised findings)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,9 +45,11 @@
 2. **Recover stale locks** — roll back `:in-progress` and `:revising` issues past their timeout.
 3. **Ingest unlabeled** — attach `auto-improve` to any unlabeled issues that belong to the pipeline.
 4. **Drain PRs** — for each open auto-improve PR: revise → review-pr → review-docs → merge.
-5. **Refine one** — call `refine` on the oldest `:raised` issue to transition it to `:refined` so the fix loop has a candidate.
-6. **Fix loop** — repeatedly call `fix`, `spike`, or `explore` until no eligible issues remain, draining PRs after each fix.
+5. **Fix loop** — repeatedly call `fix`, `spike`, or `explore` on `:plan-approved` / `:requested` issues until no eligible work remains, draining PRs after each fix. `:raised`, `:refined`, and `:planned` issues are not consumed here — they wait on the plan-approved gate.
+6. **Plan-all** — run `plan-all` to drain every open `:raised` / `:refined` issue through refine → plan → `:planned` so humans have a backlog to review before the next cycle.
 7. **Final confirm** — one last confirm pass.
+
+`plan-all` also runs on its own cron line (default `30 * * * *`) so the `:planned` queue stays current between cycles.
 
 ## Agent Execution Modes
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@
 2. **Recover stale locks** — roll back `:in-progress` and `:revising` issues past their timeout.
 3. **Ingest unlabeled** — attach `auto-improve` to any unlabeled issues that belong to the pipeline.
 4. **Drain PRs** — for each open auto-improve PR: revise → review-pr → review-docs → merge.
-5. **Refine one + plan** — call `refine` on the oldest `:raised` issue, then `plan` on the oldest `:refined` issue to generate and store a selected plan.
+5. **Refine one** — call `refine` on the oldest `:raised` issue to transition it to `:refined` so the fix loop has a candidate.
 6. **Fix loop** — repeatedly call `fix`, `spike`, or `explore` until no eligible issues remain, draining PRs after each fix.
 7. **Final confirm** — one last confirm pass.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -114,7 +114,7 @@ Invoke `cai-refine` on the oldest `auto-improve:raised` or `human:submitted` iss
 
 ## plan
 
-Run the plan-select pipeline on the oldest `auto-improve:refined` issue. Clones the repo, runs 2 serial plan agents followed by a select agent, stores the chosen plan in the issue body inside `<!-- cai-plan-start/end -->` markers, and transitions the label to `auto-improve:planned`. Invoked as part of `cai.py cycle`; also runnable manually on-demand.
+Run the plan-select pipeline on the oldest `auto-improve:refined` issue. Clones the repo, runs 2 serial plan agents followed by a select agent, stores the chosen plan in the issue body inside `<!-- cai-plan-start/end -->` markers, and transitions the label to `auto-improve:planned`. Runnable manually on-demand; no longer invoked automatically by `cai.py cycle`.
 
 | Argument | Type | Description |
 |---|---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@
 
 Cron schedules are configurable via environment variables. Default values are set in `entrypoint.sh`; most are also explicitly configured in `docker-compose.yml`.
 
-The issue-solving pipeline (refine → plan → fix → revise → review-pr → merge → confirm) is driven by a single `CAI_CYCLE_SCHEDULE` line. A flock in `cmd_cycle` serializes overlapping runs, so issues are processed one at a time — each cycle refines, plans, fixes, drains PRs, and only moves to the next issue when the current one is solved or has reached a blocking point (human review requested, `:merge-blocked`, etc.). Individual pipeline subcommands (`fix`, `refine`, `plan`, `spike`, `revise`, `review-pr`, `merge`, `verify`, `confirm`) remain callable manually or from GitHub Actions but no longer have their own cron lines.
+The issue-solving pipeline (refine → fix → revise → review-pr → merge → confirm) is driven by a single `CAI_CYCLE_SCHEDULE` line. A flock in `cmd_cycle` serializes overlapping runs, so issues are processed one at a time — each cycle refines, fixes, drains PRs, and only moves to the next issue when the current one is solved or has reached a blocking point (human review requested, `:merge-blocked`, etc.). Individual pipeline subcommands (`fix`, `refine`, `plan`, `spike`, `revise`, `review-pr`, `merge`, `verify`, `confirm`) remain callable manually or from GitHub Actions but no longer have their own cron lines.
 
 | Variable | Default | Description |
 |---|---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,11 +16,12 @@
 
 Cron schedules are configurable via environment variables. Default values are set in `entrypoint.sh`; most are also explicitly configured in `docker-compose.yml`.
 
-The issue-solving pipeline (refine → fix → revise → review-pr → merge → confirm) is driven by a single `CAI_CYCLE_SCHEDULE` line. A flock in `cmd_cycle` serializes overlapping runs, so issues are processed one at a time — each cycle refines, fixes, drains PRs, and only moves to the next issue when the current one is solved or has reached a blocking point (human review requested, `:merge-blocked`, etc.). Individual pipeline subcommands (`fix`, `refine`, `plan`, `spike`, `revise`, `review-pr`, `merge`, `verify`, `confirm`) remain callable manually or from GitHub Actions but no longer have their own cron lines.
+The issue-solving pipeline is split in two. `CAI_CYCLE_SCHEDULE` drives fix → revise → review-pr → merge → confirm on `:plan-approved` issues (flock-serialized, one issue at a time). `CAI_PLAN_ALL_SCHEDULE` drives every `:raised` / `:refined` issue through refine → plan → `:planned` so humans have a backlog to approve; `plan-all` also runs at the end of each `cycle`. `:raised`, `:refined`, and `:planned` issues are never auto-fixed — a human must promote `:planned` → `:plan-approved` before the fix loop touches them. Individual pipeline subcommands (`fix`, `refine`, `plan`, `plan-all`, `spike`, `revise`, `review-pr`, `merge`, `verify`, `confirm`) remain callable manually or from GitHub Actions.
 
 | Variable | Default | Description |
 |---|---|---|
-| `CAI_CYCLE_SCHEDULE` | `0 * * * *` | Hourly full issue-solving pipeline (flock-serialized) |
+| `CAI_CYCLE_SCHEDULE` | `0 * * * *` | Hourly fix pipeline on `:plan-approved` issues (flock-serialized) |
+| `CAI_PLAN_ALL_SCHEDULE` | `30 * * * *` | Hourly (offset 30) — drain `:raised`/`:refined` into `:planned` |
 | `CAI_ANALYZER_SCHEDULE` | `0 0 * * *` | Daily transcript analysis and issue raising |
 | `CAI_AUDIT_SCHEDULE` | `0 */6 * * *` | Every 6 hours — queue/PR lifecycle audit |
 | `CAI_AUDIT_TRIAGE_SCHEDULE` | `10 */6 * * *` | Every 6 hours — resolve `audit:raised` findings |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,14 +5,16 @@
 #
 # 1. Template the crontab from env vars. Tasks fall into two groups:
 #
-#    Pipeline (issue-solving) — a single `cai.py cycle` line drives
-#    the full refine → plan → fix → revise → review-pr → merge → confirm
-#    flow. A flock in cmd_cycle guarantees at most one cycle runs
-#    at a time, so issues are processed serially (one full cycle
-#    per issue from refine through merge). This replaces the older
-#    per-stage cron lines (fix, refine, plan, spike, revise,
-#    review-pr, merge, verify, confirm) which could interleave
-#    stages across different issues.
+#    Pipeline (issue-solving) — a `cai.py cycle` line drives the
+#    fix → revise → review-pr → merge → confirm flow on
+#    :plan-approved issues, while a separate `cai.py plan-all` line
+#    drives :raised and :refined issues through refine → plan → :planned
+#    so humans can review and approve plans out-of-band. A flock in
+#    cmd_cycle guarantees at most one cycle runs at a time, so issues
+#    are processed serially (one full cycle per issue from fix through
+#    merge). This replaces the older per-stage cron lines (fix, refine,
+#    plan, spike, revise, review-pr, merge, verify, confirm) which
+#    could interleave stages across different issues.
 #
 #    Orthogonal (independent) tasks — not part of the fix pipeline,
 #    so they keep their own schedules:
@@ -39,6 +41,7 @@
 set -euo pipefail
 
 CAI_CYCLE_SCHEDULE="${CAI_CYCLE_SCHEDULE:-0 * * * *}"
+CAI_PLAN_ALL_SCHEDULE="${CAI_PLAN_ALL_SCHEDULE:-30 * * * *}"
 CAI_ANALYZER_SCHEDULE="${CAI_ANALYZER_SCHEDULE:-0 0 * * *}"
 CAI_AUDIT_SCHEDULE="${CAI_AUDIT_SCHEDULE:-0 */6 * * *}"
 CAI_AUDIT_TRIAGE_SCHEDULE="${CAI_AUDIT_TRIAGE_SCHEDULE:-10 */6 * * *}"
@@ -56,6 +59,7 @@ cat > "$CRONTAB_PATH" <<CRONTAB
 # The single cycle line drives the full issue-solving pipeline;
 # other lines are orthogonal tasks with their own cadence.
 $CAI_CYCLE_SCHEDULE python /app/cai.py cycle
+$CAI_PLAN_ALL_SCHEDULE python /app/cai.py plan-all
 $CAI_ANALYZER_SCHEDULE python /app/cai.py analyze
 $CAI_AUDIT_SCHEDULE python /app/cai.py audit
 $CAI_AUDIT_TRIAGE_SCHEDULE python /app/cai.py audit-triage

--- a/install.sh
+++ b/install.sh
@@ -133,12 +133,15 @@ services:
       # Crontab expressions for the scheduled tasks (any valid
       # 5-field cron line — see https://crontab.guru/).
       #
-      # CAI_CYCLE_SCHEDULE drives the full issue-solving pipeline
-      # (refine → plan → fix → revise → review-pr → merge → confirm).
-      # A flock in cmd_cycle serializes overlapping runs so issues
-      # are processed one at a time. The remaining schedules are
-      # for orthogonal tasks that run independently.
-      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — full issue-solving pipeline
+      # CAI_CYCLE_SCHEDULE drives the fix pipeline on :plan-approved
+      # issues (fix → revise → review-pr → merge → confirm). A flock
+      # in cmd_cycle serializes overlapping runs so issues are
+      # processed one at a time. CAI_PLAN_ALL_SCHEDULE drives the
+      # upstream refine → plan flow that turns :raised/:refined
+      # issues into :planned for humans to approve. The remaining
+      # schedules are for orthogonal tasks that run independently.
+      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on :plan-approved
+      CAI_PLAN_ALL_SCHEDULE: "30 * * * *"   # hourly @30 — drain :raised/:refined into :planned
       CAI_ANALYZER_SCHEDULE: "0 0 * * *"   # daily 00:00 UTC (LLM call)
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet: LLM audit + deterministic cleanup; see README)
       CAI_AUDIT_TRIAGE_SCHEDULE: "10 */6 * * *" # every 6h at :10 (triage raised findings)
@@ -202,12 +205,15 @@ services:
       # Crontab expressions for the scheduled tasks (any valid
       # 5-field cron line — see https://crontab.guru/).
       #
-      # CAI_CYCLE_SCHEDULE drives the full issue-solving pipeline
-      # (refine → plan → fix → revise → review-pr → merge → confirm).
-      # A flock in cmd_cycle serializes overlapping runs so issues
-      # are processed one at a time. The remaining schedules are
-      # for orthogonal tasks that run independently.
-      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — full issue-solving pipeline
+      # CAI_CYCLE_SCHEDULE drives the fix pipeline on :plan-approved
+      # issues (fix → revise → review-pr → merge → confirm). A flock
+      # in cmd_cycle serializes overlapping runs so issues are
+      # processed one at a time. CAI_PLAN_ALL_SCHEDULE drives the
+      # upstream refine → plan flow that turns :raised/:refined
+      # issues into :planned for humans to approve. The remaining
+      # schedules are for orthogonal tasks that run independently.
+      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on :plan-approved
+      CAI_PLAN_ALL_SCHEDULE: "30 * * * *"   # hourly @30 — drain :raised/:refined into :planned
       CAI_ANALYZER_SCHEDULE: "0 0 * * *"   # daily 00:00 UTC (LLM call)
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet: LLM audit + deterministic cleanup; see README)
       CAI_AUDIT_TRIAGE_SCHEDULE: "10 */6 * * *" # every 6h at :10 (triage raised findings)


### PR DESCRIPTION
## Summary
Splits `cmd_cycle` into two distinct concerns and wires an explicit human-approval gate on the fix path.

- **`cai cycle`** drains pending PRs and runs the fix loop on `:plan-approved` / `:requested` issues only. `:raised`, `:refined`, and `:planned` issues are never auto-fixed — a human must promote `:planned` → `:plan-approved` first.
- **`cai plan-all`** (new) drives every `:raised` / `:refined` issue through refine → plan → `:planned`. It runs at the end of every `cycle` and on its own cron line (`CAI_PLAN_ALL_SCHEDULE`, default `30 * * * *`).
- `_select_fix_target` now queries `:plan-approved` + `:requested` (was `:refined` + `:requested`), enforcing the gate at the selection layer.

## Why
The previous cycle auto-fixed `:refined` issues with no human review, while also running `plan` as a side effect that sidelined candidates into `:planned` — a state nothing downstream consumed (see #481 note in cai.py:649-653). The net effect was contradictory: cycle both planned and bypassed planning. This PR makes the gate real: plans are produced continuously, but fix only acts once a human has approved.

## Test plan
- [ ] `python cai.py --help` lists `plan-all`.
- [ ] `python cai.py plan-all` iterates over `:raised` / `:refined` and exits cleanly when the queue is empty.
- [ ] `python cai.py cycle` skips :refined issues (they remain `:refined`/`:planned` without being fixed), and the final `plan-all` phase promotes them to `:planned`.
- [ ] The new cron line appears in `/tmp/crontab` after `docker compose up`.
- [ ] A `:plan-approved` issue is still picked up by the fix loop.

## Compat note
Existing `:refined` issues will no longer be auto-fixed on cycle; they will be moved to `:planned` by plan-all and wait for a human to promote them to `:plan-approved`. That is the intended behavior, matching #481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)