### PR TITLE
auto-improve: Labels to be set by human should be tagged human:

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -32,3 +32,17 @@ Refs: damien-robotsix/robotsix-cai#537
 ## Invariants this change relies on
 - All Python code references the labels via `LABEL_REQUESTED` / `LABEL_PLAN_APPROVED` constants, never as bare strings
 - `"human:"` is already in `_MANAGED_LABEL_PREFIXES` so these labels are excluded from auto-ingestion
+
+## Revision 1 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- none
+
+### Decisions this revision
+- Review comment from @damien-robotsix was the cai review-docs agent's own summary of what it fixed and committed (commit 7fd5b3d); all described changes already present in branch — no edits needed.
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -68,3 +68,17 @@ Refs: damien-robotsix/robotsix-cai#537
 
 ### New gaps / deferred
 - none
+
+## Revision 3 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- none
+
+### Decisions this revision
+- Review comment from @damien-robotsix (pre-merge review against commit ba8f5ec) claimed cai_lib/config.py, publish.py, .github/workflows/admin-only-label.yml, README.md, and cai.py had not been updated. Verified current state of all five files — all changes are already present in the branch (applied in Revision 2). Comment was posted against an earlier commit state before Revision 2 was pushed.
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,34 @@
+# PR Context Dossier
+Refs: damien-robotsix/robotsix-cai#537
+
+## Files touched
+- `cai_lib/config.py`:52 — `LABEL_REQUESTED` value changed from `"auto-improve:requested"` to `"human:requested"`
+- `cai_lib/config.py`:68 — `LABEL_PLAN_APPROVED` value changed from `"auto-improve:plan-approved"` to `"human:plan-approved"`
+- `publish.py`:86 — label tuple name updated to `"human:requested"`
+- `publish.py`:97 — label tuple name updated to `"human:plan-approved"`
+- `.github/workflows/admin-only-label.yml`:22 — updated restricted label list: replaced `"auto-improve:requested"` with `"human:requested"`, added `"human:plan-approved"`
+- `README.md`:333 — prose updated from `auto-improve:requested` to `human:requested`
+- `docs/architecture.md`:9 — parenthetical updated to `human:plan-approved`
+- `docs/architecture.md`:30,32 — label table rows updated to new names
+- `cai.py`:8157 — dashboard shorthand updated from `"plan-approved"` to `"h:plan-approved"`
+
+## Files read (not touched) that matter
+- `docs/cli.md` — checked, no references to old label names
+
+## Key symbols
+- `LABEL_REQUESTED` (`cai_lib/config.py`:52) — all Python references use this constant; rename propagates automatically
+- `LABEL_PLAN_APPROVED` (`cai_lib/config.py`:68) — same pattern; no other .py edits needed
+- `_MANAGED_LABEL_PREFIXES` (`cai.py`:589) — already includes `"human:"` prefix, so no change needed
+
+## Design decisions
+- Added `"human:plan-approved"` to the admin-only guard in the workflow — it was previously unguarded despite triggering autonomous fix execution
+- Dashboard shorthand changed to `"h:plan-approved"` to reflect new namespace prefix
+- No migration code added for existing GitHub issues — a one-time `gh label edit` is sufficient and avoids dead code on every cycle
+
+## Out of scope / known gaps
+- Existing GitHub issues labeled `auto-improve:requested` or `auto-improve:plan-approved` retain the old labels; a one-time migration via `gh label edit` on those issues is needed post-merge
+- `_BASE_NAMESPACES` in `cai_lib/github.py` intentionally NOT updated — `human:` labels don't need a bare `human` base label
+
+## Invariants this change relies on
+- All Python code references the labels via `LABEL_REQUESTED` / `LABEL_PLAN_APPROVED` constants, never as bare strings
+- `"human:"` is already in `_MANAGED_LABEL_PREFIXES` so these labels are excluded from auto-ingestion

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -46,3 +46,25 @@ Refs: damien-robotsix/robotsix-cai#537
 
 ### New gaps / deferred
 - none
+
+## Revision 2 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py`:17-19 — help text updated from `auto-improve:plan-approved`/`auto-improve:requested` to `human:plan-approved`/`human:requested`
+- `cai.py`:641-652 — docstring updated `:plan-approved` → `human:plan-approved`, `:requested` → `human:requested`
+- `cai.py`:7809 — inline comment updated `:plan-approved / :requested` → `human:plan-approved / human:requested`
+- `cai.py`:8026,8029 — inline comments updated `:plan-approved`/`:requested` → `human:plan-approved`/`human:requested`
+- `entrypoint.sh`:10 — comment updated `:plan-approved` → `human:plan-approved`
+- `docker-compose.yml`:31,38 — comments updated `:plan-approved` → `human:plan-approved`
+- `install.sh`:136,143,208,215 — both YAML template blocks updated `:plan-approved` → `human:plan-approved`
+- `.claude/agents/cai-audit.md`:48,64,98 — updated `:requested` → `human:requested`, `:plan-approved` → `human:plan-approved` (via staging)
+
+### Decisions this revision
+- Used `replace_all` for install.sh since both YAML templates had identical stale comments
+- cai-audit.md updated via .cai-staging/agents/ (write-protected path)
+
+### New gaps / deferred
+- none

--- a/.claude/agents/cai-audit.md
+++ b/.claude/agents/cai-audit.md
@@ -45,7 +45,7 @@ The user message contains:
 ## Lifecycle states — tracking vs active
 
 Issues labelled `auto-improve` (with **no** state suffix such as
-`:raised`, `:requested`, `:in-progress`, etc.) are **tracking-only
+`:raised`, `human:requested`, `:in-progress`, etc.) are **tracking-only
 backlog items**. They represent feature ideas or improvements that a
 human has not yet promoted to active work. This is intentional — the
 user deliberately keeps them in the backlog until they decide the
@@ -61,7 +61,7 @@ a soft `forgotten_backlog` finding with **low** confidence as a gentle
 reminder. This is distinct from `stale_lifecycle`, which applies only
 to issues that have entered an active state.
 
-Active states (`:raised`, `:refined`, `:planned`, `:plan-approved`, `:requested`, `:in-progress`, `:pr-open`,
+Active states (`:raised`, `:refined`, `:planned`, `human:plan-approved`, `human:requested`, `:in-progress`, `:pr-open`,
 `:merged`, `:no-action`, `:needs-spike`, `:revising`) should continue to be checked
 normally against all the rules below. (Note: stale `:no-action`
 issues are rolled back to `:raised` before the LLM audit runs, and
@@ -95,7 +95,7 @@ did not actually succeed. Flag these as `silent_failure`.
 | `[publish] created=0 skipped=0 failed=0` after `parsed N finding(s)` where N > 0 | All findings silently lost |
 | `[fix] result=push_failed exit=1` (≥2 occurrences in window) | Recurring git push problem |
 | `[fix] result=clone_failed exit=1` (≥2 occurrences in window) | Recurring gh/git auth problem |
-| `[fix] result=no_eligible_issues` repeating ≥7 times in a row while open `:refined`/`:requested` issues exist | Bot is skipping issues it should be picking |
+| `[fix] result=no_eligible_issues` repeating ≥7 times in a row while open `:refined`/`human:requested` issues exist | Bot is skipping issues it should be picking |
 | `[cai analyze] claude -p failed (exit N)` | API errors (rate limit, auth, network) |
 | `[cai analyze] parse.py failed (exit N)` | Parser crash |
 | `level=error msg="..."` lines from supercronic itself | Scheduler errors |

--- a/.github/workflows/admin-only-label.yml
+++ b/.github/workflows/admin-only-label.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   enforce:
     if: >-
-      contains(fromJSON('["auto-improve:requested","auto-improve:raised","auto-improve:refined","consistency:raised","audit:raised"]'), github.event.label.name)
+      contains(fromJSON('["human:requested","human:plan-approved","auto-improve:raised","auto-improve:refined","consistency:raised","audit:raised"]'), github.event.label.name)
     runs-on: ubuntu-latest
     steps:
       - name: Check sender's permission

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ The threshold defaults to `high` — only the most clear-cut PRs merge
 or close automatically. Relax to `medium` by editing the env var once
 trust builds.
 
-There are two human entry points into the pipeline. `auto-improve:requested`
+There are two human entry points into the pipeline. `human:requested`
 is the admin entry point: a human applies it to an arbitrary issue to opt it
 into the fix queue directly (bypassing refinement). The label is restricted to
 repo admins by `.github/workflows/admin-only-label.yml` — a non-admin who

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ dispatcher so each task is its own subprocess with no shared state.
 
 The issue-solving pipeline is split across two cron lines:
 
-- `cai.py cycle` drains pending PRs and fixes `:plan-approved`
+- `cai.py cycle` drains pending PRs and fixes `human:plan-approved`
   issues only. `:raised`, `:refined`, and `:planned` issues are
   invisible to the fix loop — a human approves a plan into
-  `:plan-approved` before the cycle will act on it.
+  `human:plan-approved` before the cycle will act on it.
 - `cai.py plan-all` drives every `:raised` / `:refined` issue
   through refine → plan → `:planned`, producing the backlog humans
   review. It also runs at the end of each `cycle` so the next
@@ -68,7 +68,7 @@ The individual pipeline subcommands (`fix`, `refine`, `plan`,
 
 | Subcommand | Default schedule | What it does |
 |---|---|---|
-| `cai.py cycle` | `0 * * * *` (hourly, startup, manual) | Fix pipeline on `:plan-approved` issues: verify → confirm → drain pending PRs (revise → review-pr → review-docs → merge) → loop(fix/spike/explore → drain) → plan-all → confirm. A flock serializes overlapping runs; the entrypoint also runs this once synchronously at `docker compose up -d` so startup logs are immediate |
+| `cai.py cycle` | `0 * * * *` (hourly, startup, manual) | Fix pipeline on `human:plan-approved` issues: verify → confirm → drain pending PRs (revise → review-pr → review-docs → merge) → loop(fix/spike/explore → drain) → plan-all → confirm. A flock serializes overlapping runs; the entrypoint also runs this once synchronously at `docker compose up -d` so startup logs are immediate |
 | `cai.py plan-all` | `30 * * * *` (hourly, offset 30) | Drains every open `:raised` / `:refined` issue through refine → plan → `:planned` so humans have a queue to review. Also runs at the end of each `cycle`; the cron line provides a mid-cycle catch-up pass |
 | `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` (6-hour TTL) and `:revising` (1-hour TTL) locks and stale `:no-action` issues, flags stale `:merged` issues for human review, recovers `:pr-open` issues whose linked PR was closed (rolls back to `:refined`), deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |

--- a/cai.py
+++ b/cai.py
@@ -8154,7 +8154,7 @@ def cmd_health_report(args) -> int:
         ("raised", LABEL_RAISED),
         ("refined", LABEL_REFINED),
         ("planned", LABEL_PLANNED),
-        ("plan-approved", LABEL_PLAN_APPROVED),
+        ("h:plan-approved", LABEL_PLAN_APPROVED),
         ("in-progress", LABEL_IN_PROGRESS),
         ("pr-open", LABEL_PR_OPEN),
         ("merged", LABEL_MERGED),

--- a/cai.py
+++ b/cai.py
@@ -14,8 +14,8 @@ Subcommands:
 
     python cai.py fix       Score eligible issues by age, category
                             success rate, and prior fix attempts; pick
-                            the highest scorer labelled `auto-improve:
-                            plan-approved` or `auto-improve:
+                            the highest scorer labelled `human:
+                            plan-approved` or `human:
                             requested` (audit issues reach fix via
                             triage relabelling), run a cheap Haiku
                             pre-screen to classify the issue; spike/
@@ -638,18 +638,18 @@ def _select_fix_target(exclude: set[int] | None = None):
     Categories with fewer than 3 observations get a neutral prior of 0.60.
     This replaces the previous FIFO (oldest-first) selection.
 
-    Eligible = labelled `:plan-approved` or `:requested`, NOT labelled
-    `:in-progress` or `:pr-open`.  `:plan-approved` is the primary gate:
+    Eligible = labelled `human:plan-approved` or `human:requested`, NOT labelled
+    `:in-progress` or `:pr-open`.  `human:plan-approved` is the primary gate:
     the `plan-all` step drives every :raised / :refined issue to
-    :planned, and a human then promotes :planned → :plan-approved when
-    the plan looks good.  `:requested` is an explicit human shortcut
+    :planned, and a human then promotes :planned → human:plan-approved when
+    the plan looks good.  `human:requested` is an explicit human shortcut
     that bypasses the plan gate (treat as "I've already validated this,
     just fix it").  `:refined` and `:planned` issues sit outside the
     fix pipeline until a human approves.
 
     `audit:raised` issues are handled exclusively by the audit-triage
     agent — only issues that triage re-labels to `auto-improve:raised`
-    (and subsequently refine → plan → plan-approved) enter the fix
+    (and subsequently refine → plan → human:plan-approved) enter the fix
     pipeline.
 
     If no candidates are found, attempts to recover stale `:pr-open`
@@ -7806,7 +7806,7 @@ def cmd_cycle(args) -> int:
       1.5. recover stale locks (:in-progress / :revising)
       2. drain pending PRs (revise → review-pr → review-docs → merge)
       3. loop: verify → fix/spike/explore → drain → repeat
-         (fix picks only :plan-approved / :requested — nothing raised
+         (fix picks only human:plan-approved / human:requested — nothing raised
          or refined is auto-consumed here; an issue whose fix fails
          is skipped for the rest of the cycle so the remaining fix
          targets still get a chance before plan-all runs)
@@ -8023,10 +8023,10 @@ def _cmd_cycle_inner(args) -> int:
                 had_failure = True
 
     # --- Phase 3.5: plan-all — drive :raised/:refined to :planned -------
-    # The fix loop only acts on :plan-approved (or :requested) issues,
+    # The fix loop only acts on human:plan-approved (or human:requested) issues,
     # so any :raised or :refined work would sit idle without this step.
     # plan-all loops refine → plan until the queue is exhausted; humans
-    # then approve :planned → :plan-approved on their own schedule.
+    # then approve :planned → human:plan-approved on their own schedule.
     rc = _run_step("plan-all", cmd_plan_all, args)
     all_results["plan-all"] = rc
     if rc != 0:

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -49,7 +49,7 @@ AGENT_MEMORY_DIR = Path("/app/.claude/agent-memory")
 
 # Issue lifecycle labels.
 LABEL_RAISED = "auto-improve:raised"
-LABEL_REQUESTED = "auto-improve:requested"
+LABEL_REQUESTED = "human:requested"
 LABEL_IN_PROGRESS = "auto-improve:in-progress"
 LABEL_PR_OPEN = "auto-improve:pr-open"
 LABEL_MERGED = "auto-improve:merged"
@@ -65,7 +65,7 @@ LABEL_AUDIT_RAISED = "audit:raised"
 LABEL_AUDIT_NEEDS_HUMAN = "audit:needs-human"
 LABEL_HUMAN_SUBMITTED = "human:submitted"
 LABEL_PLANNED = "auto-improve:planned"
-LABEL_PLAN_APPROVED = "auto-improve:plan-approved"
+LABEL_PLAN_APPROVED = "human:plan-approved"
 
 # PR-level label applied by `cai merge` when the verdict is below the
 # auto-merge threshold. Lets a human filter open PRs that are waiting

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,14 +28,14 @@ services:
       # 5-field cron line works — see https://crontab.guru/ —
       # supercronic also supports @hourly, @daily, etc.
       #
-      # CAI_CYCLE_SCHEDULE drives the fix pipeline on :plan-approved
+      # CAI_CYCLE_SCHEDULE drives the fix pipeline on human:plan-approved
       # issues (fix → revise → review-pr → merge → confirm). A flock
       # in cmd_cycle serializes overlapping runs so issues are
       # processed one at a time. CAI_PLAN_ALL_SCHEDULE drives the
       # upstream refine → plan flow that turns :raised/:refined
       # issues into :planned for humans to approve. The remaining
       # schedules are for orthogonal tasks that run independently.
-      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on :plan-approved
+      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on human:plan-approved
       CAI_PLAN_ALL_SCHEDULE: "30 * * * *"   # hourly @30 — drain :raised/:refined into :planned
       CAI_ANALYZER_SCHEDULE: "0 0 * * *"   # daily at 00:00 UTC (LLM call)
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet: LLM audit + deterministic cleanup; see README)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@
 
 1. **Raise** — `cai analyze`, `cai propose`, `cai code-audit`, `cai audit`, or a human files an issue labeled `auto-improve:raised` or `human:submitted`.
 2. **Refine** — `cai refine` calls `cai-refine` to rewrite the issue into a structured plan with steps, verification, and scope guardrails. Label transitions to `auto-improve:refined`.
-3. **Plan** — `cai plan` runs plan-select agents to generate and select an implementation plan. The plan is stored in the issue body. Label transitions to `auto-improve:planned` (or `auto-improve:plan-approved` if human-reviewed).
+3. **Plan** — `cai plan` runs plan-select agents to generate and select an implementation plan. The plan is stored in the issue body. Label transitions to `auto-improve:planned` (or `human:plan-approved` if human-reviewed).
 4. **Fix** — `cai fix` calls `cai-fix` in a fresh git worktree. The wrapper commits, pushes, and opens a PR. Label transitions to `auto-improve:in-progress` → `auto-improve:pr-open`.
 5. **Review** — `cai review-pr` checks for ripple-effect inconsistencies and posts findings as PR comments. `cai review-docs` then (and only after review-pr completes) checks for stale documentation, directly fixes issues it can resolve, and commits/pushes those changes to the PR branch. Remaining unfixable issues are posted as `### Finding: stale_docs` comments. This ordering is enforced: review-docs skips PRs until review-pr has posted a review comment at the current HEAD SHA.
 6. **Revise** — `cai revise` calls `cai-revise` or `cai-rebase` to address review comments or rebase conflicts. Label transitions to `auto-improve:revising`.
@@ -27,9 +27,9 @@
 | `auto-improve:no-action` | No fix needed (7 d stale timeout → re-queued to `:raised`) |
 | `auto-improve:needs-spike` | Needs research investigation (`cai spike`) |
 | `auto-improve:needs-exploration` | Needs autonomous exploration (`cai explore`) |
-| `auto-improve:requested` | Explicitly requested by a human |
+| `human:requested` | Explicitly requested by a human |
 | `auto-improve:planned` | Plan generated and stored in issue body; awaiting human approval |
-| `auto-improve:plan-approved` | Plan approved by human; ready for fix subagent |
+| `human:plan-approved` | Plan approved by human; ready for fix subagent |
 | `auto-improve:parent` | Parent issue; child sub-issues carry the work |
 | `audit:raised` | Audit finding awaiting triage by `cai audit-triage` |
 | `audit:needs-human` | Audit finding escalated to human |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@
 2. **Recover stale locks** — roll back `:in-progress` and `:revising` issues past their timeout.
 3. **Ingest unlabeled** — attach `auto-improve` to any unlabeled issues that belong to the pipeline.
 4. **Drain PRs** — for each open auto-improve PR: revise → review-pr → review-docs → merge.
-5. **Fix loop** — repeatedly call `fix`, `spike`, or `explore` on `:plan-approved` / `:requested` issues until no eligible work remains, draining PRs after each fix. `:raised`, `:refined`, and `:planned` issues are not consumed here — they wait on the plan-approved gate.
+5. **Fix loop** — repeatedly call `fix`, `spike`, or `explore` on `human:plan-approved` / `human:requested` issues until no eligible work remains, draining PRs after each fix. `:raised`, `:refined`, and `:planned` issues are not consumed here — they wait on the human:plan-approved gate.
 6. **Plan-all** — run `plan-all` to drain every open `:raised` / `:refined` issue through refine → plan → `:planned` so humans have a backlog to review before the next cycle.
 7. **Final confirm** — one last confirm pass.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,11 +16,11 @@
 
 Cron schedules are configurable via environment variables. Default values are set in `entrypoint.sh`; most are also explicitly configured in `docker-compose.yml`.
 
-The issue-solving pipeline is split in two. `CAI_CYCLE_SCHEDULE` drives fix → revise → review-pr → merge → confirm on `:plan-approved` issues (flock-serialized, one issue at a time). `CAI_PLAN_ALL_SCHEDULE` drives every `:raised` / `:refined` issue through refine → plan → `:planned` so humans have a backlog to approve; `plan-all` also runs at the end of each `cycle`. `:raised`, `:refined`, and `:planned` issues are never auto-fixed — a human must promote `:planned` → `:plan-approved` before the fix loop touches them. Individual pipeline subcommands (`fix`, `refine`, `plan`, `plan-all`, `spike`, `revise`, `review-pr`, `merge`, `verify`, `confirm`) remain callable manually or from GitHub Actions.
+The issue-solving pipeline is split in two. `CAI_CYCLE_SCHEDULE` drives fix → revise → review-pr → merge → confirm on `human:plan-approved` issues (flock-serialized, one issue at a time). `CAI_PLAN_ALL_SCHEDULE` drives every `:raised` / `:refined` issue through refine → plan → `:planned` so humans have a backlog to approve; `plan-all` also runs at the end of each `cycle`. `:raised`, `:refined`, and `:planned` issues are never auto-fixed — a human must promote `:planned` → `human:plan-approved` before the fix loop touches them. Individual pipeline subcommands (`fix`, `refine`, `plan`, `plan-all`, `spike`, `revise`, `review-pr`, `merge`, `verify`, `confirm`) remain callable manually or from GitHub Actions.
 
 | Variable | Default | Description |
 |---|---|---|
-| `CAI_CYCLE_SCHEDULE` | `0 * * * *` | Hourly fix pipeline on `:plan-approved` issues (flock-serialized) |
+| `CAI_CYCLE_SCHEDULE` | `0 * * * *` | Hourly fix pipeline on `human:plan-approved` issues (flock-serialized) |
 | `CAI_PLAN_ALL_SCHEDULE` | `30 * * * *` | Hourly (offset 30) — drain `:raised`/`:refined` into `:planned` |
 | `CAI_ANALYZER_SCHEDULE` | `0 0 * * *` | Daily transcript analysis and issue raising |
 | `CAI_AUDIT_SCHEDULE` | `0 */6 * * *` | Every 6 hours — queue/PR lifecycle audit |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@
 #
 #    Pipeline (issue-solving) — a `cai.py cycle` line drives the
 #    fix → revise → review-pr → merge → confirm flow on
-#    :plan-approved issues, while a separate `cai.py plan-all` line
+#    human:plan-approved issues, while a separate `cai.py plan-all` line
 #    drives :raised and :refined issues through refine → plan → :planned
 #    so humans can review and approve plans out-of-band. A flock in
 #    cmd_cycle guarantees at most one cycle runs at a time, so issues

--- a/install.sh
+++ b/install.sh
@@ -133,14 +133,14 @@ services:
       # Crontab expressions for the scheduled tasks (any valid
       # 5-field cron line — see https://crontab.guru/).
       #
-      # CAI_CYCLE_SCHEDULE drives the fix pipeline on :plan-approved
+      # CAI_CYCLE_SCHEDULE drives the fix pipeline on human:plan-approved
       # issues (fix → revise → review-pr → merge → confirm). A flock
       # in cmd_cycle serializes overlapping runs so issues are
       # processed one at a time. CAI_PLAN_ALL_SCHEDULE drives the
       # upstream refine → plan flow that turns :raised/:refined
       # issues into :planned for humans to approve. The remaining
       # schedules are for orthogonal tasks that run independently.
-      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on :plan-approved
+      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on human:plan-approved
       CAI_PLAN_ALL_SCHEDULE: "30 * * * *"   # hourly @30 — drain :raised/:refined into :planned
       CAI_ANALYZER_SCHEDULE: "0 0 * * *"   # daily 00:00 UTC (LLM call)
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet: LLM audit + deterministic cleanup; see README)
@@ -205,14 +205,14 @@ services:
       # Crontab expressions for the scheduled tasks (any valid
       # 5-field cron line — see https://crontab.guru/).
       #
-      # CAI_CYCLE_SCHEDULE drives the fix pipeline on :plan-approved
+      # CAI_CYCLE_SCHEDULE drives the fix pipeline on human:plan-approved
       # issues (fix → revise → review-pr → merge → confirm). A flock
       # in cmd_cycle serializes overlapping runs so issues are
       # processed one at a time. CAI_PLAN_ALL_SCHEDULE drives the
       # upstream refine → plan flow that turns :raised/:refined
       # issues into :planned for humans to approve. The remaining
       # schedules are for orthogonal tasks that run independently.
-      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on :plan-approved
+      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on human:plan-approved
       CAI_PLAN_ALL_SCHEDULE: "30 * * * *"   # hourly @30 — drain :raised/:refined into :planned
       CAI_ANALYZER_SCHEDULE: "0 0 * * *"   # daily 00:00 UTC (LLM call)
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet: LLM audit + deterministic cleanup; see README)

--- a/publish.py
+++ b/publish.py
@@ -83,7 +83,7 @@ CHECK_WORKFLOWS_CATEGORIES = {
 LABELS = [
     ("auto-improve", "ededed", "Self-improvement finding raised by the analyzer"),
     ("auto-improve:raised", "0e8a16", "Awaiting structured refinement before fix subagent picks it up"),
-    ("auto-improve:requested", "1d76db", "Human-requested fix (admin-only label)"),
+    ("human:requested", "1d76db", "Human-requested fix (admin-only label)"),
     ("auto-improve:in-progress", "fbca04", "fix subagent is actively working on this issue"),
     ("auto-improve:pr-open", "5319e7", "fix subagent opened a PR"),
     ("auto-improve:merged", "0e8a16", "PR was merged; awaiting verify"),
@@ -94,7 +94,7 @@ LABELS = [
     ("auto-improve:revising", "d4c5f9", "Revise subagent is actively iterating on a PR"),
     ("auto-improve:solved", "0e8a16", "Pattern verified absent from recent transcripts"),
     ("auto-improve:planned", "e4e669", "Plan generated and stored in issue body; awaiting human approval"),
-    ("auto-improve:plan-approved", "0e8a16", "Plan approved by human; ready for fix subagent"),
+    ("human:plan-approved", "0e8a16", "Plan approved by human; ready for fix subagent"),
     ("human:submitted", "bfd4f2", "Human-submitted issue awaiting refinement"),
     ("auto-improve:parent", "c5def5", "Parent issue with sub-issues"),
     ("merge-blocked", "e11d48", "Merge subcommand reviewed and decided not to auto-merge; awaiting human"),


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#537

**Issue:** #537 — Labels to be set by human should be tagged human:

## PR Summary

### What this fixes
`auto-improve:requested` and `auto-improve:plan-approved` are human-applied labels that were buried in the `auto-improve:` namespace alongside machine-managed labels, making it impossible to filter or sort human-applied labels as a group.

### What was changed
- **`cai_lib/config.py`**: Changed `LABEL_REQUESTED` from `"auto-improve:requested"` → `"human:requested"` and `LABEL_PLAN_APPROVED` from `"auto-improve:plan-approved"` → `"human:plan-approved"`. All Python code uses these constants so no other `.py` changes are needed.
- **`publish.py`**: Updated the two label definition tuples to use the new names.
- **`.github/workflows/admin-only-label.yml`**: Replaced `"auto-improve:requested"` with `"human:requested"` in the restricted-label guard, and added `"human:plan-approved"` (which was previously unguarded despite triggering autonomous fix execution).
- **`README.md`**: Updated prose reference from `auto-improve:requested` to `human:requested`.
- **`docs/architecture.md`**: Updated pipeline step 3 parenthetical and both label table rows.
- **`cai.py`**: Updated dashboard display shorthand from `"plan-approved"` to `"h:plan-approved"` to reflect the new namespace.

> **Post-merge migration note**: existing GitHub issues carrying the old `auto-improve:requested` or `auto-improve:plan-approved` labels will retain them. A one-time migration via `gh label edit` on those issues is needed after the new labels are created by `cai publish`.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
