### PR TITLE
fix: gate review-docs on clean review-pr instead of any review

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -6118,23 +6118,28 @@ def cmd_review_docs(args) -> int:
             skipped += 1
             continue
 
-        # Gate: only review docs after review-pr has reviewed this SHA.
-        # This enforces the review-pr → review-docs → merge ordering.
-        has_code_review_at_sha = False
+        # Gate: only review docs after review-pr has posted a CLEAN
+        # review at this SHA. Running review-docs while review-pr
+        # still has open findings lets the docs commit advance HEAD
+        # past an unresolved finding, which confuses revise's
+        # "comment already addressed" logic (the docs self-summary
+        # gets conflated with the real review-pr finding). Wait until
+        # the revise/review loop has converged before touching docs.
+        has_clean_code_review_at_sha = False
         for comment in pr.get("comments", []):
             body = (comment.get("body") or "")
             first_line = body.split("\n", 1)[0]
             if (
-                first_line.startswith(_REVIEW_COMMENT_HEADING_FINDINGS)
+                first_line.startswith(_REVIEW_COMMENT_HEADING_CLEAN)
                 and head_sha in first_line
             ):
-                has_code_review_at_sha = True
+                has_clean_code_review_at_sha = True
                 break
 
-        if not has_code_review_at_sha:
+        if not has_clean_code_review_at_sha:
             print(
-                f"[cai review-docs] PR #{pr_number}: review-pr has not reviewed "
-                f"{head_sha[:8]} yet; waiting",
+                f"[cai review-docs] PR #{pr_number}: review-pr has not posted "
+                f"a clean review for {head_sha[:8]} yet; waiting for revise/review loop",
                 flush=True,
             )
             skipped += 1


### PR DESCRIPTION
## Summary
- `cmd_review_docs` now requires a clean `review-pr` comment at the current SHA before running, instead of accepting any review (including findings).
- Prevents the docs-review commit from advancing HEAD past unresolved `review-pr` findings, which was conflating the docs self-summary with the real finding and causing `revise` to skip it as "already addressed" (observed on PR #549, cycle A).

## Test plan
- [ ] Open a PR, let `review-pr` post findings, confirm `review-docs` now skips with "waiting for revise/review loop" instead of committing doc edits.
- [ ] After `revise` addresses findings and `review-pr` posts a clean review, confirm `review-docs` proceeds normally.
- [ ] Confirm `cai merge` behavior is unchanged (its gate still matches any review; downstream filter 3 handles unaddressed comments).

Generated with [Claude Code](https://claude.com/claude-code)