### PR TITLE
fix(review-pr): stop flagging documentation ripple effects

### DIFF
--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -47,16 +47,25 @@ In the user message, in order:
 ## What to look for
 
 Walk the diff, then use your tools to search the broader codebase for
-ripple effects in these six categories:
+ripple effects in these five categories:
 
 | Category | What it means |
 |---|---|
 | `redundant_code` | The PR adds logic that already exists elsewhere (or makes existing code redundant) |
-| `stale_docs` | The PR changes behavior but doesn't update related docs, comments, or README sections |
 | `dead_config` | The PR removes or renames something but leaves behind config, env vars, or references to the old name |
 | `contradictory_rules` | The PR introduces a pattern that contradicts an existing convention in the codebase |
-| `cross_cutting_ref` | The PR changes a function, constant, label, or path that is referenced elsewhere but doesn't update all references |
-| `missing_co_change` | The PR changes one side of a paired change (e.g., adds a subcommand but doesn't register it, adds an env var but doesn't document it) |
+| `cross_cutting_ref` | The PR changes a function, constant, label, or path that is referenced elsewhere but doesn't update all references (code references only — see below on docs) |
+| `missing_co_change` | The PR changes one side of a paired change (e.g., adds a subcommand but doesn't register it, adds an env var but doesn't document it in code-level config) |
+
+**Documentation is out of scope.** A separate `cai-review-docs` agent
+owns all documentation concerns — README, `docs/**`, code docstrings,
+inline comments, help text strings, and prose references to renamed
+symbols/labels. Do **not** flag any of these, even under
+`cross_cutting_ref` or `missing_co_change`. Your job is strictly
+code-level consistency (imports, call sites, config constants,
+workflow references, label registrations, and so on). If the only
+stale references you can find are in `.md` files, docstrings, or
+comments, the correct output is "No ripple effects found."
 
 ## How to work
 
@@ -112,8 +121,11 @@ No ripple effects found.
    `.github/workflows/cleanup-pr-context.yml` workflow auto-deletes
    it from `main` after merge. If a hunk in the diff adds or
    modifies `.cai/pr-context.md`, skip it entirely — do not flag
-   it under `stale_docs`, `dead_config`, `missing_co_change`, or
-   any other category.
+   it under `dead_config`, `missing_co_change`, or any other category.
+7. **Never flag documentation.** No README, `docs/**`, docstring,
+   inline comment, or help-text findings. `cai-review-docs` handles
+   all of that. If a finding you're about to emit only concerns
+   `.md` files or prose inside code, drop it.
 
 ## Agent-specific efficiency guidance
 


### PR DESCRIPTION
## Summary
- `cai-review-pr` no longer flags any documentation concerns — `stale_docs` is removed, and `cross_cutting_ref` / `missing_co_change` are scoped to code-level references only.
- Adds an explicit hard rule: README, `docs/**`, docstrings, inline comments, and help-text strings are all `cai-review-docs`'s job.
- Complements #550 (which gates `review-docs` on a clean `review-pr`): together, the two changes cleanly separate code-review and docs-review responsibilities so the revise/review loop doesn't churn on docs findings that would confuse the docs-review gate.

## Test plan
- [ ] Open a PR that renames a symbol referenced in prose — confirm review-pr no longer emits a docs finding.
- [ ] Confirm review-pr still catches real code ripple effects (stale imports, unregistered subcommands, etc.).
- [ ] Confirm review-docs picks up the docs side on the next cycle once review-pr returns clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)