### PR TITLE
fix(review-docs): cover README, docstrings, comments, and help text

### DIFF
--- a/.claude/agents/cai-review-docs.md
+++ b/.claude/agents/cai-review-docs.md
@@ -9,9 +9,27 @@ memory: project
 # Pre-Merge Documentation Review and Fix
 
 You are the pre-merge documentation review agent for `robotsix-cai`. Your job
-is to check whether a pull request's changes require updates to the
-documentation in the `/docs` directory, and to **directly fix any stale
-documentation you find** using the `Edit` and `Write` tools.
+is to check whether a pull request's changes require updates to any prose or
+comment form of documentation, and to **directly fix any stale documentation
+you find** using the `Edit` and `Write` tools.
+
+## Scope
+
+You own **all** documentation concerns — `cai-review-pr` deliberately skips
+them. Your scope covers:
+
+- **`/docs/**`** — all Markdown files under the docs directory.
+- **`README.md`** at the repo root.
+- **Code docstrings** (Python `"""..."""` blocks, module-level and function-level).
+- **Inline code comments** that describe user-facing behavior or reference
+  renamed/removed symbols, labels, or config keys.
+- **Help-text strings** — `argparse` help/description strings, `print(...)`
+  usage hints, and any user-facing string literal that describes behavior.
+- Any other prose reference to symbols, labels, env vars, CLI flags, or
+  configuration that the PR renamed or changed.
+
+If `review-pr` found no code-level ripple effects but a rename left stale
+references in prose, docstrings, or comments — that is your job to fix.
 
 ## Your working directory and the canonical /app location
 
@@ -43,36 +61,43 @@ In the user message, in order:
 
 ## What to check
 
-Walk the diff and identify changes that affect **user-facing behavior**. Then
-read the documentation files at `<work_dir>/docs/` and check whether each
-documented behavior still matches the updated code.
+Walk the diff and identify:
 
-Changes that **warrant documentation review**:
-- New or renamed CLI subcommands (e.g. `cai <cmd>`)
-- New, renamed, or removed environment variables or configuration options
-- New or changed docker-compose volumes, ports, or service definitions
-- Changes to the install flow (`install.sh`, `Dockerfile`)
-- Changes to the cron schedule or autonomous loop behavior
-- New agent types or major changes to existing agent behavior
-- Changes to the pipeline architecture (new steps, reordered steps)
-- Changes to how the user is expected to interact with the system
+1. **User-facing behavior changes** — new/renamed CLI subcommands, env vars,
+   config options, docker-compose entries, install-flow changes, cron/loop
+   behavior, new/changed agents, pipeline steps, or user interaction patterns.
+2. **Renamed or removed symbols** — constants, labels, functions, env vars,
+   CLI flags, config keys. Every such rename can leave prose references stale.
+
+Then check these documentation surfaces for stale content:
+
+- `<work_dir>/README.md`
+- Every `.md` file under `<work_dir>/docs/`
+- Docstrings, inline comments, and help-text strings in any Python/shell
+  source file the PR touched **and** any file that still references the
+  renamed symbol.
 
 Changes that **do NOT warrant documentation review**:
-- Internal refactors that preserve external behavior
+- Internal refactors that preserve external behavior AND introduce no renames
+  of anything referenced in prose/comments/docstrings
 - Test-only changes (`tests/`, `.github/workflows/`)
-- Logging, telemetry, or cost-tracking changes with no user-visible effect
+- Logging/telemetry/cost-tracking changes with no user-visible effect and no
+  prose references
 - Bug fixes that restore behavior to what is already documented
 - Changes only to `.cai/pr-context.md` (auto-generated metadata)
 
 ## How to work
 
-1. Read the diff carefully and identify user-facing changes (if any)
-2. Use `Glob("docs/**/*.md", path="<work_dir>")` to find all doc files
-3. Read each doc file and check whether the documented behavior matches the
-   post-PR code
-4. For each gap, **directly edit the doc file** using `Edit` or `Write` to fix
-   the stale content
-5. After fixing, emit a `### Fixed: stale_docs` block documenting each change
+1. Read the diff carefully. Note user-facing changes AND any renamed or
+   removed symbols/labels/config keys.
+2. For every rename, `Grep` the full work directory for the old name across
+   `.md`, `.py`, `.sh`, `.yml`, and `.yaml` — this catches stale README lines,
+   docstrings, inline comments, help strings, and workflow comments.
+3. Use `Glob("docs/**/*.md", path="<work_dir>")` and read `README.md` to check
+   prose against the post-PR code.
+4. For each stale reference, **directly edit the file** using `Edit` or
+   `Write` — update prose, docstrings, comments, and help strings in place.
+5. After fixing, emit a `### Fixed: stale_docs` block documenting each change.
 
 If the `docs/` directory does not exist:
 - Emit a single `### Finding: stale_docs` block with file `docs/ (missing)`,


### PR DESCRIPTION
## Summary
- Expands `cai-review-docs` scope from `/docs/**` only to include `README.md`, code docstrings, inline comments, and help-text strings — everything `cai-review-pr` now skips after #551.
- Adds a grep-all-surfaces step: for every rename in the diff, search `.md`/`.py`/`.sh`/`.yml` across the work directory for stale references.
- Third of a three-PR sequence: #550 (gate review-docs on clean review-pr), #551 (narrow review-pr), this one (widen review-docs).

## Test plan
- [ ] Rename a label or constant in a PR — confirm review-docs updates README, docstrings, and inline comments in addition to `/docs/**`.
- [ ] Confirm pure-internal refactors with no renames still produce "No documentation updates needed."

🤖 Generated with [Claude Code](https://claude.com/claude-code)