### PR TITLE
auto-improve: Phase 2: complete cai_lib migration — remove duplicates from cai.py

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,30 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#534
+
+## Files touched
+- `cai.py:194` — expanded inline github import into multi-symbol form, added cmd_lifecycle and cmd_fix imports
+- `cai.py:808` — deleted inline `from cai_lib.github import _set_labels, ...` (was between two functions)
+- `cai.py:1320` — deleted inline `from cai_lib.cmd_fix import _parse_decomposition` (was inside Multi-step section)
+- `cai.py:3755` — deleted inline `from cai_lib.cmd_lifecycle import _rollback_stale_in_progress` (was between two functions)
+
+## Files read (not touched) that matter
+- `cai_lib/cmd_lifecycle.py` — verified no circular import back into `cai`
+- `cai_lib/cmd_fix.py` — verified no circular import back into `cai`
+
+## Key symbols
+- `_set_labels`, `_issue_has_label`, `_build_issue_block`, `_build_fix_user_message` (`cai_lib/github.py`) — moved from inline import at old line 808 to top-level
+- `_parse_decomposition` (`cai_lib/cmd_fix.py`) — moved from inline import at old line 1320 to top-level
+- `_rollback_stale_in_progress` (`cai_lib/cmd_lifecycle.py`) — moved from inline import at old line 3755 to top-level
+
+## Design decisions
+- Edits applied bottom-to-top to avoid line-number drift between changes
+- Used multi-line parenthesized import for the github block to keep line length reasonable
+- Rejected: restructuring all cai_lib imports into a single block — out of scope per plan selection
+
+## Out of scope / known gaps
+- Removing duplicate symbol *definitions* from cai.py (constants, functions like `_run`, `log_run`, etc.) — that is a separate follow-on
+- Moving `cmd_*` functions into `cai_lib` submodules — step 3 follow-on
+
+## Invariants this change relies on
+- `cai_lib.cmd_lifecycle` and `cai_lib.cmd_fix` do not import from the top-level `cai` module (verified)
+- All three symbols were already imported via these same `from cai_lib.X import Y` statements; this is a pure location move with no semantic change

--- a/cai.py
+++ b/cai.py
@@ -191,7 +191,12 @@ from cai_lib.logging_utils import (  # noqa: E402
 from cai_lib.subprocess_utils import _run, _run_claude_p  # noqa: E402
 
 
-from cai_lib.github import _gh_json, check_gh_auth, check_claude_auth, _transcript_dir_is_empty  # noqa: E402
+from cai_lib.github import (  # noqa: E402
+    _gh_json, check_gh_auth, check_claude_auth, _transcript_dir_is_empty,
+    _set_labels, _issue_has_label, _build_issue_block, _build_fix_user_message,
+)
+from cai_lib.cmd_lifecycle import _rollback_stale_in_progress  # noqa: E402
+from cai_lib.cmd_fix import _parse_decomposition  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -805,9 +810,6 @@ def _select_plan_target(issue_number: int | None = None):
     return min(candidates, key=lambda c: c.get("createdAt", ""))
 
 
-from cai_lib.github import _set_labels, _issue_has_label, _build_issue_block, _build_fix_user_message  # noqa: E402
-
-
 def _fetch_previous_fix_attempts(issue_number: int) -> list[dict]:
     """Retrieve closed, unmerged PRs for this issue and extract merge verdicts.
 
@@ -1315,10 +1317,6 @@ def _create_suggested_issues(
 # ---------------------------------------------------------------------------
 # Multi-step issue helpers
 # ---------------------------------------------------------------------------
-
-
-from cai_lib.cmd_fix import _parse_decomposition  # noqa: E402
-
 
 def _find_sub_issue(parent_number: int, step: int) -> int | None:
     """Return the issue number of an existing sub-issue for *parent_number*
@@ -3750,9 +3748,6 @@ def _cleanup_orphaned_branches() -> list[str]:
             print(f"[cai audit] deleted orphaned branch: {branch}", flush=True)
 
     return deleted
-
-
-from cai_lib.cmd_lifecycle import _rollback_stale_in_progress  # noqa: E402
 
 
 def _unstuck_stale_no_action() -> list[dict]:


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#534

**Issue:** #534 — Phase 2: complete cai_lib migration — remove duplicates from cai.py

## PR Summary

### What this fixes
Three `from cai_lib` import statements were scattered inline throughout `cai.py` (after function definitions at ~lines 808, 1320, and 3755) instead of being consolidated at the top-level import block. This is the Phase 2 cleanup completing the `cai_lib` migration started in PR #486.

### What was changed
- **`cai.py` lines 194–199**: Expanded the `from cai_lib.github import` statement into a multi-line parenthesized form that includes all eight symbols (`_gh_json`, `check_gh_auth`, `check_claude_auth`, `_transcript_dir_is_empty`, `_set_labels`, `_issue_has_label`, `_build_issue_block`, `_build_fix_user_message`); added `from cai_lib.cmd_lifecycle import _rollback_stale_in_progress` and `from cai_lib.cmd_fix import _parse_decomposition` immediately after.
- **`cai.py` ~line 808**: Deleted the inline `from cai_lib.github import _set_labels, _issue_has_label, _build_issue_block, _build_fix_user_message` statement and its surrounding blank lines.
- **`cai.py` ~line 1320**: Deleted the inline `from cai_lib.cmd_fix import _parse_decomposition` statement and its surrounding blank lines.
- **`cai.py` ~line 3755**: Deleted the inline `from cai_lib.cmd_lifecycle import _rollback_stale_in_progress` statement and its surrounding blank lines.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
