### PR TITLE
fix(cai-fix): force-push the fix branch to overwrite stale remote

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -2280,8 +2280,20 @@ def cmd_fix(args) -> int:
             return 1
 
         # 8. Push.
+        #    The branch name is scoped to the issue
+        #    (`auto-improve/<num>-<slug>`) and each fix cycle
+        #    rewrites it from scratch off the current main, so any
+        #    pre-existing remote branch with that name is a stale
+        #    artefact from a previous attempt. The shallow clone at
+        #    depth 1 is single-branch by default, so we have no
+        #    remote-tracking ref to compare against and
+        #    `--force-with-lease` cannot be used meaningfully here.
+        #    Plain `--force` is the right call: we own the branch
+        #    namespace and the fresh commit off current main is
+        #    authoritative.
         push = _run(
-            ["git", "-C", str(work_dir), "push", "-u", "origin", branch],
+            ["git", "-C", str(work_dir), "push",
+             "--force", "-u", "origin", branch],
             capture_output=True,
         )
         if push.returncode != 0:


### PR DESCRIPTION
## Summary

When `cai fix` creates a shallow single-branch clone, the local repo lacks a remote-tracking ref for the per-issue branch. If a stale branch exists on the remote from a prior cycle, a plain push fails with "fetch first". Since each cycle rewrites the branch from scratch off current main, the fresh commit is authoritative — switching to `git push --force` allows the push to succeed.

## Test plan

- [ ] Verify that subsequent cycles of `cai fix` on the same issue successfully push the fix branch without "fetch first" errors
- [ ] Confirm that the force-push does not affect other branches or workflows
- [ ] Check that `cai revise` continues to use `--force-with-lease` as intended