### PR TITLE
auto-improve: explore cai-plan cost reduction?

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -40,3 +40,19 @@ Refs: robotsix/robotsix-cai#377
 
 ### New gaps / deferred
 - review-docs comment (opus→sonnet in docs/agents.md) was already applied before this revision; this revision undoes that since the model is reverting to opus
+
+## Revision 2 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `.claude/agents/cai-plan.md`:5 — changed `model: claude-opus-4-6` to `model: claude-sonnet-4-6` (via staging dir)
+- `docs/agents.md`:17 — updated cai-plan model column from `opus` to `sonnet`
+
+### Decisions this revision
+- Switched model to sonnet per reviewer explicit override ("now we MUST switch to sonnet") — overrides the prior "keep opus" decision from Revision 1
+- Both files updated for consistency: agent definition frontmatter + docs table
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,25 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#377
+
+## Files touched
+- `.claude/agents/cai-plan.md`:5 — changed `model: claude-opus-4-6` to `model: claude-sonnet-4-6`
+
+## Files read (not touched) that matter
+- `.claude/agents/cai-plan.md` — the agent definition being changed
+
+## Key symbols
+- `model` frontmatter field (`.claude/agents/cai-plan.md`:5) — controls which Claude model the cai-plan agent uses
+
+## Design decisions
+- Used staging directory (`/.cai-staging/agents/cai-plan.md`) because `.claude/agents/*.md` files are write-blocked in headless `-p` mode
+- Haiku delegation guidance (lines 71–80) was already present and correct — no changes needed there
+- Rejected: modifying `cai.py` budget cap — explicitly out of scope per issue guardrails
+
+## Out of scope / known gaps
+- `--max-budget-usd 1.00` cap in `cai.py` left unchanged (independent safety rail)
+- `cai-select.md` model unchanged — separate agent, separate issue
+- Single-plan architecture (run 1 plan instead of 2) — medium risk, explicitly out of scope
+
+## Invariants this change relies on
+- The wrapper copies `.cai-staging/agents/*.md` to `.claude/agents/` by basename after the session exits
+- The `cai-select` agent (still on Opus) provides a quality safety net when comparing two Sonnet-generated plans

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -23,3 +23,20 @@ Refs: robotsix/robotsix-cai#377
 ## Invariants this change relies on
 - The wrapper copies `.cai-staging/agents/*.md` to `.claude/agents/` by basename after the session exits
 - The `cai-select` agent (still on Opus) provides a quality safety net when comparing two Sonnet-generated plans
+
+## Revision 1 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `.claude/agents/cai-plan.md`:5 — reverted `model: claude-sonnet-4-6` back to `model: claude-opus-4-6` (via staging dir)
+- `docs/agents.md`:17 — reverted cai-plan model column from `sonnet` back to `opus`
+
+### Decisions this revision
+- Reverted model from sonnet to opus per documented reviewer decision (memory line 110: "we should keep opus for planning the solution")
+- Haiku delegation guidance (lines 71–80) and "3 or fewer files" boundary retained — reviewer had accepted those changes
+- The review-docs agent comment was already addressed in the branch (docs/agents.md model sonnet), but since model is reverting to opus, the docs must also revert
+
+### New gaps / deferred
+- review-docs comment (opus→sonnet in docs/agents.md) was already applied before this revision; this revision undoes that since the model is reverting to opus

--- a/.claude/agents/cai-plan.md
+++ b/.claude/agents/cai-plan.md
@@ -2,7 +2,7 @@
 name: cai-plan
 description: Generate a detailed fix plan for an auto-improve issue. Read-only — examines the codebase and produces a structured plan that the fix agent will implement. First of two serial planners — the second receives this plan and proposes an alternative. Output is evaluated by cai-select.
 tools: Read, Grep, Glob, Agent
-model: claude-sonnet-4-6
+model: claude-opus-4-6
 ---
 
 # Plan Generator

--- a/.claude/agents/cai-plan.md
+++ b/.claude/agents/cai-plan.md
@@ -2,7 +2,7 @@
 name: cai-plan
 description: Generate a detailed fix plan for an auto-improve issue. Read-only — examines the codebase and produces a structured plan that the fix agent will implement. First of two serial planners — the second receives this plan and proposes an alternative. Output is evaluated by cai-select.
 tools: Read, Grep, Glob, Agent
-model: claude-opus-4-6
+model: claude-sonnet-4-6
 ---
 
 # Plan Generator

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -14,7 +14,7 @@ Agents are defined in `.claude/agents/*.md` with YAML frontmatter (`name`, `desc
 | `cai-fix` | Autonomous code-editing subagent — makes the smallest targeted change for an issue | Read, Edit, Write, Grep, Glob, TodoWrite | sonnet | Worktree |
 | `cai-git` | Lightweight subagent that executes git operations on behalf of other agents | Bash | haiku | Worktree |
 | `cai-merge` | Assess whether a PR correctly implements its linked issue and emit a merge verdict | Read | opus | Inline-only |
-| `cai-plan` | Generate a detailed fix plan for an issue (first of two serial planners) | Read, Grep, Glob, Agent | sonnet | Worktree |
+| `cai-plan` | Generate a detailed fix plan for an issue (first of two serial planners) | Read, Grep, Glob, Agent | opus | Worktree |
 | `cai-propose` | Weekly creative agent that proposes ambitious improvements | Read, Grep, Glob | sonnet | Worktree |
 | `cai-propose-review` | Evaluate creative proposals for feasibility and value before filing issues | Read, Grep, Glob | sonnet | Worktree |
 | `cai-rebase` | Lightweight rebase conflict resolution for PRs with no unaddressed review comments | Read, Edit, Write, Grep, Glob, Agent | haiku | Worktree |

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -14,7 +14,7 @@ Agents are defined in `.claude/agents/*.md` with YAML frontmatter (`name`, `desc
 | `cai-fix` | Autonomous code-editing subagent — makes the smallest targeted change for an issue | Read, Edit, Write, Grep, Glob, TodoWrite | sonnet | Worktree |
 | `cai-git` | Lightweight subagent that executes git operations on behalf of other agents | Bash | haiku | Worktree |
 | `cai-merge` | Assess whether a PR correctly implements its linked issue and emit a merge verdict | Read | opus | Inline-only |
-| `cai-plan` | Generate a detailed fix plan for an issue (first of two serial planners) | Read, Grep, Glob, Agent | opus | Worktree |
+| `cai-plan` | Generate a detailed fix plan for an issue (first of two serial planners) | Read, Grep, Glob, Agent | sonnet | Worktree |
 | `cai-propose` | Weekly creative agent that proposes ambitious improvements | Read, Grep, Glob | sonnet | Worktree |
 | `cai-propose-review` | Evaluate creative proposals for feasibility and value before filing issues | Read, Grep, Glob | sonnet | Worktree |
 | `cai-rebase` | Lightweight rebase conflict resolution for PRs with no unaddressed review comments | Read, Edit, Write, Grep, Glob, Agent | haiku | Worktree |


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#377

**Issue:** #377 — explore cai-plan cost reduction?

## PR Summary

### What this fixes
`cai-plan` was configured with `model: claude-opus-4-6` despite no documented rationale, while comparable agents (cai-fix, cai-refine, cai-revise) all use `claude-sonnet-4-6`. This caused the plan-select pipeline to cost ~$1.20–1.50 per fix attempt when Sonnet would deliver equivalent quality at ~80% lower cost.

### What was changed
- **`.claude/agents/cai-plan.md`** (via staging at `.cai-staging/agents/cai-plan.md`): Changed frontmatter line 5 from `model: claude-opus-4-6` to `model: claude-sonnet-4-6`. The haiku delegation guidance (lines 71–80) was already present and correct, so no further edits were needed.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
