### PR TITLE
fix(cai fix/merge): stop no-action issues from looping forever

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -681,6 +681,19 @@ def _select_fix_target(exclude: set[int] | None = None):
             label_names = {lbl["name"] for lbl in issue.get("labels", [])}
             if LABEL_IN_PROGRESS in label_names or LABEL_PR_OPEN in label_names:
                 continue
+            # Skip issues that already reached a terminal lifecycle state.
+            # An issue can carry both `human:plan-approved` and a terminal
+            # label (e.g. `:no-action`, `:merged`, `:needs-spike`) when an
+            # earlier transition forgot to strip the human approval. Without
+            # this guard, the fix loop keeps re-selecting the same issue and
+            # the cai-fix subagent correctly reports "no action needed" every
+            # run — wasting cycles forever.
+            if (
+                LABEL_NO_ACTION in label_names
+                or LABEL_MERGED in label_names
+                or LABEL_NEEDS_SPIKE in label_names
+            ):
+                continue
             if exclude and issue["number"] in exclude:
                 continue
             candidates[issue["number"]] = issue
@@ -2215,11 +2228,20 @@ def cmd_fix(args) -> int:
                  "--body", comment_body],
                 capture_output=True,
             )
-            # Transition: in-progress -> target_label (NOT back to :raised)
+            # Transition: in-progress -> target_label (NOT back to :raised).
+            # Strip the human approval labels as well — if we leave
+            # `human:plan-approved` / `human:requested` in place, the fix
+            # selector will keep re-picking this issue forever because it
+            # only gates on those two labels.
+            terminal_remove = [
+                LABEL_IN_PROGRESS,
+                LABEL_PLAN_APPROVED,
+                LABEL_REQUESTED,
+            ]
             if not _set_labels(
                 issue_number,
                 add=[target_label],
-                remove=[LABEL_IN_PROGRESS],
+                remove=terminal_remove,
             ):
                 print(
                     f"[cai fix] WARNING: label transition to {log_label} "
@@ -2229,7 +2251,7 @@ def cmd_fix(args) -> int:
                 if not _set_labels(
                     issue_number,
                     add=[target_label],
-                    remove=[LABEL_IN_PROGRESS],
+                    remove=terminal_remove,
                 ):
                     print(
                         f"[cai fix] WARNING: label transition to "
@@ -6857,13 +6879,13 @@ def cmd_merge(args) -> int:
             )
             if close_result.returncode == 0:
                 print(f"[cai merge] PR #{pr_number}: closed successfully", flush=True)
-                if not _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED, LABEL_REVISING], log_prefix="cai merge"):
+                if not _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED, LABEL_REVISING, LABEL_PLAN_APPROVED, LABEL_REQUESTED], log_prefix="cai merge"):
                     print(
                         f"[cai merge] WARNING: label transition to :no-action failed for "
                         f"#{issue_number} after closing PR #{pr_number}; retrying",
                         flush=True,
                     )
-                    if not _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED, LABEL_REVISING], log_prefix="cai merge"):
+                    if not _set_labels(issue_number, add=[LABEL_NO_ACTION], remove=[LABEL_PR_OPEN, LABEL_MERGE_BLOCKED, LABEL_REVISING, LABEL_PLAN_APPROVED, LABEL_REQUESTED], log_prefix="cai merge"):
                         print(
                             f"[cai merge] WARNING: label transition to :no-action failed twice for "
                             f"#{issue_number} — issue may be stuck without a lifecycle label",


### PR DESCRIPTION
## Summary
- `_select_fix_target` now excludes issues carrying terminal labels (`:no-action`, `:merged`, `:needs-spike`), so they cannot be re-picked by the fix loop.
- The no-action / needs-spike transition in `cmd_fix` and the reject transition in `cai merge` now also strip `human:plan-approved` and `human:requested`, keeping the lifecycle state machine self-consistent.

## Motivation
Issue #534 had been merged (`:merged`) and marked `:no-action`, but still carried `human:plan-approved`. The fix loop kept re-selecting it and cai-fix kept correctly reporting \"no action needed\" — infinite wasted cycles. Root cause was that the transition sites removed `:in-progress` but left the human approval label in place, and the selector didn't defensively skip terminal labels.

## Test plan
- [ ] `python -m unittest discover -s tests -v`
- [ ] Verify `cai fix` no longer selects #534 (or any issue with both `human:plan-approved` and `:no-action`).

Refs #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)