### PR TITLE
auto-improve: cai-review-pr: include original issue content in review context

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,39 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#533
+
+## Files touched
+- `cai_lib/github.py`:3 — added `import re`
+- `cai_lib/github.py`:140-168 — added `_fetch_linked_issue_block(pr_body: str) -> str` helper
+- `cai.py`:194-197 — added `_fetch_linked_issue_block` to import
+- `cai.py`:5828,5842 — added `body` to `--json` fields in `cmd_review_pr()` both branches
+- `cai.py`:5926 — compute `issue_block` before user_message construction in `cmd_review_pr()`
+- `cai.py`:5934 — inject `issue_block` before `## PR diff` in `cmd_review_pr()` user message
+- `cai.py`:6079,6093 — added `body` to `--json` fields in `cmd_review_docs()` both branches
+- `cai.py`:6205 — compute `issue_block` before user_message construction in `cmd_review_docs()`
+- `cai.py`:6213 — inject `issue_block` before `## PR diff` in `cmd_review_docs()` user message
+- `.cai-staging/agents/cai-review-pr.md` — added item 3 (Original issue) to What you receive, added `issue_drift` category row, added step 2 in How to work, renumbered steps
+- `.cai-staging/agents/cai-review-docs.md` — added item 3 (Original issue) to What you receive, added step 2 in How to work, renumbered steps
+
+## Files read (not touched) that matter
+- `cai_lib/github.py` — confirmed `REPO` already imported; confirmed `subprocess`/`json` available
+- `cai.py` (offset 5820-5950) — exact structure of `cmd_review_pr()` user message construction
+- `cai.py` (offset 6068-6220) — exact structure of `cmd_review_docs()` user message construction
+
+## Key symbols
+- `_fetch_linked_issue_block` (`cai_lib/github.py`:140) — parses `Refs REPO#N` from PR body, fetches issue, returns formatted block or ""
+- `cmd_review_pr` (`cai.py`:5816) — PR review orchestration; now injects issue block into agent user message
+- `cmd_review_docs` (`cai.py`:6068) — docs review orchestration; now injects issue block into agent user message
+
+## Design decisions
+- Used `cai_lib/github.py` for helper — consistent with existing `_build_issue_block` / `_build_fix_user_message` placement
+- Parsed `Refs REPO#N` from PR body rather than branch name — more robust; canonical linking convention used throughout codebase
+- Graceful fallback (`try/except`, return `""`) — review proceeds normally when issue is missing/deleted/inaccessible
+- `body` is fetched but only the parsed issue number is forwarded to the agent (PR body itself is discarded)
+
+## Out of scope / known gaps
+- Did not change `cai-revise` agent — it already has the PR body context from its own flow
+- `issue_drift` findings by `cai-review-pr` will require the revise agent to address them like any other finding
+
+## Invariants this change relies on
+- Auto-improve PRs always embed `Refs robotsix/robotsix-cai#N` in their body (set by wrapper at PR creation time)
+- `_gh_json` raises `subprocess.CalledProcessError` on failure — the try/except handles this correctly

--- a/.claude/agents/cai-review-docs.md
+++ b/.claude/agents/cai-review-docs.md
@@ -57,7 +57,10 @@ In the user message, in order:
 
 1. **Work directory** — where the cloned PR branch lives
 2. **PR metadata** — number, title, author, base branch, head SHA
-3. **PR diff** — the full unified diff of the PR
+3. **Original issue** *(optional)* — if the PR references an issue,
+   the full issue body is included. Use this to verify documentation
+   changes align with the issue's stated scope.
+4. **PR diff** — the full unified diff of the PR
 
 ## What to check
 
@@ -90,14 +93,18 @@ Changes that **do NOT warrant documentation review**:
 
 1. Read the diff carefully. Note user-facing changes AND any renamed or
    removed symbols/labels/config keys.
-2. For every rename, `Grep` the full work directory for the old name across
+2. If an `## Original issue` section is present, read it and note
+   what user-facing changes the issue describes. Ensure the documentation
+   covers those changes (e.g., if the issue says "add CLI flag `--foo`",
+   verify `--foo` is documented).
+3. For every rename, `Grep` the full work directory for the old name across
    `.md`, `.py`, `.sh`, `.yml`, and `.yaml` — this catches stale README lines,
    docstrings, inline comments, help strings, and workflow comments.
-3. Use `Glob("docs/**/*.md", path="<work_dir>")` and read `README.md` to check
+4. Use `Glob("docs/**/*.md", path="<work_dir>")` and read `README.md` to check
    prose against the post-PR code.
-4. For each stale reference, **directly edit the file** using `Edit` or
+5. For each stale reference, **directly edit the file** using `Edit` or
    `Write` — update prose, docstrings, comments, and help strings in place.
-5. After fixing, emit a `### Fixed: stale_docs` block documenting each change.
+6. After fixing, emit a `### Fixed: stale_docs` block documenting each change.
 
 If the `docs/` directory does not exist:
 - Emit a single `### Finding: stale_docs` block with file `docs/ (missing)`,

--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -42,12 +42,15 @@ In the user message, in order:
 
 1. **Work directory** — where the cloned PR lives
 2. **PR metadata** — number, title, author, base branch, head SHA
-3. **PR diff** — the full unified diff of the PR
+3. **Original issue** *(optional)* — if the PR references an issue
+   via a `Refs` link in its body, the full issue body is included.
+   Use this to verify the diff addresses the issue's stated requirements.
+4. **PR diff** — the full unified diff of the PR
 
 ## What to look for
 
 Walk the diff, then use your tools to search the broader codebase for
-ripple effects in these five categories:
+ripple effects in these six categories:
 
 | Category | What it means |
 |---|---|
@@ -56,6 +59,7 @@ ripple effects in these five categories:
 | `contradictory_rules` | The PR introduces a pattern that contradicts an existing convention in the codebase |
 | `cross_cutting_ref` | The PR changes a function, constant, label, or path that is referenced elsewhere but doesn't update all references (code references only — see below on docs) |
 | `missing_co_change` | The PR changes one side of a paired change (e.g., adds a subcommand but doesn't register it, adds an env var but doesn't document it in code-level config) |
+| `issue_drift` | The PR diff does not address a stated requirement from the original issue, or introduces behavior the issue explicitly excludes |
 
 **Documentation is out of scope.** A separate `cai-review-docs` agent
 owns all documentation concerns — README, `docs/**`, code docstrings,
@@ -69,13 +73,17 @@ comments, the correct output is "No ripple effects found."
 
 ## How to work
 
-1. Read the diff carefully
-2. For each changed file/function/constant, use `Grep` and `Glob` to
+1. Read the diff carefully.
+2. If an `## Original issue` section is present, read it and note
+   the key requirements. As you walk the diff, verify each
+   requirement is addressed. Flag any that are missing or
+   contradicted as `issue_drift`.
+3. For each changed file/function/constant, use `Grep` and `Glob` to
    find other references in the codebase.
-3. Check if the PR's changes are consistent with those references
-4. Only report findings where you are confident there is a real
-   inconsistency — not hypothetical or stylistic concerns
-5. **Be exhaustive in a single pass.** Before returning, walk
+4. Check if the PR's changes are consistent with those references.
+5. Only report findings where you are confident there is a real
+   inconsistency — not hypothetical or stylistic concerns.
+6. **Be exhaustive in a single pass.** Before returning, walk
    through the diff one more time and, for each of the six
    categories in the table above, ask "did I actually search the
    codebase for this kind of ripple effect?". Do not stop at the

--- a/cai.py
+++ b/cai.py
@@ -194,6 +194,7 @@ from cai_lib.subprocess_utils import _run, _run_claude_p  # noqa: E402
 from cai_lib.github import (  # noqa: E402
     _gh_json, check_gh_auth, check_claude_auth, _transcript_dir_is_empty,
     _set_labels, _issue_has_label, _build_issue_block, _build_fix_user_message,
+    _fetch_linked_issue_block,
 )
 from cai_lib.cmd_lifecycle import _rollback_stale_in_progress  # noqa: E402
 from cai_lib.cmd_fix import _parse_decomposition  # noqa: E402
@@ -5824,7 +5825,7 @@ def cmd_review_pr(args) -> int:
             target_pr = _gh_json([
                 "pr", "view", str(args.pr),
                 "--repo", REPO,
-                "--json", "number,title,author,headRefOid,comments",
+                "--json", "number,title,author,headRefOid,body,comments",
             ])
         except subprocess.CalledProcessError as e:
             print(f"[cai review-pr] gh pr view #{args.pr} failed:\n{e.stderr}", file=sys.stderr)
@@ -5838,7 +5839,7 @@ def cmd_review_pr(args) -> int:
                 "--repo", REPO,
                 "--state", "open",
                 "--base", "main",
-                "--json", "number,title,author,headRefOid,comments",
+                "--json", "number,title,author,headRefOid,body,comments",
                 "--limit", "50",
             ]) or []
         except subprocess.CalledProcessError as e:
@@ -5923,6 +5924,7 @@ def cmd_review_pr(args) -> int:
             # where the cloned PR is) plus the dynamic per-run
             # context via stdin (#342).
             author_login = pr.get("author", {}).get("login", "unknown")
+            issue_block = _fetch_linked_issue_block(pr.get("body", ""))
             user_message = (
                 _work_directory_block(work_dir)
                 + "\n"
@@ -5932,6 +5934,7 @@ def cmd_review_pr(args) -> int:
                 + f"- **Author:** @{author_login}\n"
                 + f"- **Base:** main\n"
                 + f"- **HEAD SHA:** {head_sha}\n\n"
+                + issue_block
                 + f"## PR diff\n\n"
                 + f"```diff\n{pr_diff}\n```\n"
             )
@@ -6076,7 +6079,7 @@ def cmd_review_docs(args) -> int:
             target_pr = _gh_json([
                 "pr", "view", str(args.pr),
                 "--repo", REPO,
-                "--json", "number,title,author,headRefOid,headRefName,comments",
+                "--json", "number,title,author,headRefOid,headRefName,body,comments",
             ])
         except subprocess.CalledProcessError as e:
             print(f"[cai review-docs] gh pr view #{args.pr} failed:\n{e.stderr}", file=sys.stderr)
@@ -6090,7 +6093,7 @@ def cmd_review_docs(args) -> int:
                 "--repo", REPO,
                 "--state", "open",
                 "--base", "main",
-                "--json", "number,title,author,headRefOid,headRefName,comments",
+                "--json", "number,title,author,headRefOid,headRefName,body,comments",
                 "--limit", "50",
             ]) or []
         except subprocess.CalledProcessError as e:
@@ -6202,6 +6205,7 @@ def cmd_review_docs(args) -> int:
             _git(work_dir, "config", "user.email", email)
 
             author_login = pr.get("author", {}).get("login", "unknown")
+            issue_block = _fetch_linked_issue_block(pr.get("body", ""))
             user_message = (
                 _work_directory_block(work_dir)
                 + "\n"
@@ -6211,6 +6215,7 @@ def cmd_review_docs(args) -> int:
                 + f"- **Author:** @{author_login}\n"
                 + f"- **Base:** main\n"
                 + f"- **HEAD SHA:** {head_sha}\n\n"
+                + issue_block
                 + f"## PR diff\n\n"
                 + f"```diff\n{pr_diff}\n```\n"
             )

--- a/cai_lib/github.py
+++ b/cai_lib/github.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import subprocess
 import sys
 
@@ -135,6 +136,36 @@ def _build_issue_block(issue: dict) -> str:
             body = c.get("body", "")
             block += f"**{author}:**\n{body}\n\n"
     return block
+
+
+def _fetch_linked_issue_block(pr_body: str) -> str:
+    """Return an '## Original issue' block if the PR body contains a Refs link.
+
+    Auto-improve PRs include a ``Refs <REPO>#<N>`` line in their body.
+    Parse it, fetch the issue, and format the block. Returns "" on any
+    failure (missing link, deleted issue, network error).
+    """
+    if not pr_body:
+        return ""
+    m = re.search(rf"Refs\s+{re.escape(REPO)}#(\d+)", pr_body)
+    if not m:
+        return ""
+    issue_num = int(m.group(1))
+    try:
+        issue_data = _gh_json([
+            "issue", "view", str(issue_num),
+            "--repo", REPO,
+            "--json", "number,title,body",
+        ])
+    except subprocess.CalledProcessError:
+        return ""
+    if not issue_data:
+        return ""
+    return (
+        f"## Original issue\n\n"
+        f"### #{issue_data['number']} — {issue_data.get('title', '')}\n\n"
+        f"{issue_data.get('body') or '(no body)'}\n\n"
+    )
 
 
 def _build_fix_user_message(issue: dict, attempt_history_block: str = "") -> str:


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#533

**Issue:** #533 — cai-review-pr: include original issue content in review context

## PR Summary

### What this fixes
`cai-review-pr` and `cai-review-docs` reviewed PRs without knowing the original issue the PR was implementing, so they could only verify code consistency — not whether the PR actually addresses the issue's requirements.

### What was changed
- **`cai_lib/github.py`**: Added `import re` and a new `_fetch_linked_issue_block(pr_body: str) -> str` helper that parses the `Refs <REPO>#<N>` link from a PR body, fetches the linked issue via `gh issue view`, and returns a formatted `## Original issue` block (or `""` on any failure).
- **`cai.py`**: Added `_fetch_linked_issue_block` to the import from `cai_lib.github`; added `body` to the `--json` fields in both the direct-PR and list branches of `cmd_review_pr()` and `cmd_review_docs()`; injected the returned issue block into the agent user message (between PR metadata and the diff) in both functions.
- **`.cai-staging/agents/cai-review-pr.md`**: Added item 3 ("Original issue") to "What you receive", added `issue_drift` category to the finding table, and added step 2 instructing the agent to read the issue requirements and flag unaddressed ones as `issue_drift`.
- **`.cai-staging/agents/cai-review-docs.md`**: Added item 3 ("Original issue") to "What you receive" and added step 2 instructing the agent to verify documentation covers the user-facing changes described in the issue.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
