### PR TITLE
auto-improve: [Step 3/3] Wire `cmd_fix` to `plan-approved` and remove inline planning

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,34 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#519
+
+## Files touched
+- `cai.py:1955` — `origin_raised_label` fallback changed from `LABEL_REFINED` to `LABEL_PLAN_APPROVED`
+- `cai.py:1958-1962` — lock step comment + `remove=` list updated from `LABEL_REFINED` to `LABEL_PLAN_APPROVED`
+- `cai.py:1031-1047` — new `_get_plan_for_fix` helper added after `_extract_stored_plan`
+- `cai.py:2072-2075` — inline plan extraction block replaced with `_get_plan_for_fix(issue, origin_raised_label)` call
+- `cai.py:2113-2115` — plan header text updated from "produced by `cai plan` and stored on the issue" to "pre-computed by `cai plan` and approved by a human reviewer"
+
+## Files read (not touched) that matter
+- `cai.py:640-665` — `_select_fix_target` already uses `LABEL_PLAN_APPROVED` and updated docstring (steps 1-2 already done)
+- `cai.py:1016-1028` — `_extract_stored_plan` (called by new `_get_plan_for_fix` helper)
+- `cai.py:982-979` — `_run_plan_select_pipeline` definition (intentionally NOT removed per scope guardrails)
+
+## Key symbols
+- `_get_plan_for_fix` (`cai.py:1031`) — new helper that distinguishes `:requested` (no plan expected) from `:plan-approved` with missing plan (WARNING)
+- `origin_raised_label` (`cai.py:1955`) — used throughout cmd_fix for label rollback; now defaults to `LABEL_PLAN_APPROVED`
+- `LABEL_PLAN_APPROVED` — already imported via `from cai_lib.config import *`
+
+## Design decisions
+- Added `_get_plan_for_fix` wrapper instead of inlining — improves diagnosability (WARNING vs. info log) and keeps cmd_fix body clean
+- `_run_plan_select_pipeline` function definition kept intact — only the call site in cmd_fix was replaced; function is still used in `cmd_plan`
+- Rejected: deleting `_run_plan_select_pipeline` — still needed by `cmd_plan`
+
+## Out of scope / known gaps
+- `LABEL_REFINED` constant untouched — still used as intermediate state by `cmd_plan`
+- `LABEL_REQUESTED` behavior unchanged — admin bypass still works
+- `_select_fix_target` docstring/query already updated in a prior change; not touched here
+
+## Invariants this change relies on
+- `LABEL_PLAN_APPROVED` is already defined and imported via `cai_lib.config`
+- `_extract_stored_plan` is defined before `_get_plan_for_fix` in the file
+- Issues reaching `cmd_fix` with `:plan-approved` label have a stored plan block in their body (best-effort; WARNING logged if missing)

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -46,3 +46,17 @@ Refs: robotsix-cai/robotsix-cai#519
 
 ### New gaps / deferred
 - none
+
+## Revision 2 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- none
+
+### Decisions this revision
+- No edits made — review comment from @damien-robotsix (cai-review-pr pre-merge review) was already_addressed: all five claimed missing changes were verified present in the file — `_select_fix_target` uses `LABEL_PLAN_APPROVED` (line 665), `_get_plan_for_fix` helper exists (lines 1031-1046), `origin_raised_label` defaults to `LABEL_PLAN_APPROVED` (line 1955), lock step removes `LABEL_PLAN_APPROVED` (lines 1958-1962), plan header text updated (lines 2108-2115). Reviewer was reviewing an earlier commit state.
+
+### New gaps / deferred
+- none

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -32,3 +32,17 @@ Refs: robotsix-cai/robotsix-cai#519
 - `LABEL_PLAN_APPROVED` is already defined and imported via `cai_lib.config`
 - `_extract_stored_plan` is defined before `_get_plan_for_fix` in the file
 - Issues reaching `cmd_fix` with `:plan-approved` label have a stored plan block in their body (best-effort; WARNING logged if missing)
+
+## Revision 1 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- none — all documentation changes already committed at 241ad34
+
+### Decisions this revision
+- No edits made — review comment from @damien-robotsix (cai-review-docs) was already_addressed: the agent committed all described doc fixes at 241ad34 before posting the summary comment; wrapper incorrectly flagged the summary comment as unaddressed
+
+### New gaps / deferred
+- none

--- a/README.md
+++ b/README.md
@@ -106,14 +106,23 @@ action so two concurrent `fix` runs can't pick the same issue.
                                 │
                                 │ refine
                                 ▼
-                             refined  ◄──┐
+                             refined
+                                │
+                                │ plan
+                                ▼
+                             planned  ◄──┐
                                 │       │ (PR closed
-                                │ fix    │  unmerged, or
-                                ▼        │  pre-screen ambiguous
-                          in-progress    │  → rolled back to
-                                │        │    origin label)
-                          pre-screen     │
-                            (Haiku)      │
+                    (human approval)   │  unmerged, or
+                                │       │  pre-screen ambiguous
+                                ▼       │  → rolled back to
+                        plan-approved  │  origin label)
+                                │       │
+                                │ fix   │
+                                ▼       │
+                          in-progress   │
+                                │       │
+                          pre-screen    │
+                            (Haiku)     │
                   ┌─────────────┼───────┐│
                   │             │       ││
                (spike)   (actionable)   ││
@@ -147,8 +156,9 @@ action so two concurrent `fix` runs can't pick the same issue.
 `:no-action` means the fix subagent reviewed the issue and decided no
 code change was needed. The agent's reasoning is posted as a comment
 on the issue. A human can either close the issue (agreeing with the
-bot), re-label to `:refined` to retry the fix directly, or re-label to
-`:raised` to re-run through the refine step first.
+bot), re-label to `:refined` to re-run through refine → plan → `:plan-approved` 
+before the fix subagent retries, or re-label to `:raised` to re-run through 
+the refine step first.
 
 ### Filing issues with multi-step plans
 
@@ -192,7 +202,9 @@ Audit findings flag inconsistencies in the issue/PR lifecycle.
 Issues labelled `audit:raised` go through `cai.py audit-triage`
 first, which relabels eligible ones to `auto-improve:raised` so the
 `refine` subagent can structure them and transition them to
-`auto-improve:refined`, after which the fix subagent picks them up.
+`auto-improve:refined`. They then flow through `cai.py plan`
+to `:planned`, awaiting human approval to transition to `:plan-approved`
+before the fix subagent picks them up.
 
 | Label | Meaning |
 |---|---|
@@ -216,7 +228,8 @@ determine whether the fix worked. Additionally, remote `auto-improve/*`
 branches with no open PR — including branches for merged/closed PRs and
 branches pushed by the fix agent that never had a PR opened — are deleted
 automatically. Finally, `:pr-open` issues whose linked PR was closed without
-merging are rolled back to `:refined` so the fix agent can re-attempt.
+merging are rolled back to `:refined` to restart the refinement and planning
+cycle before a human can re-approve them for the fix subagent.
 
 ### Comment-driven PR iteration
 
@@ -437,8 +450,8 @@ Docker daemons (≥ API 1.44), causing watchtower to crash-loop with
 subagent is running, the in-flight fix is killed and the issue may be
 left stuck in `auto-improve:in-progress`. The audit subcommand handles
 automatic recovery (rolling back to `:refined`). For manual recovery,
-relabel back to `:refined` to re-enter the fix pipeline directly, or
-to `:raised` to re-run through the refine step first.
+relabel back to `:refined` to re-enter the refinement → plan → approval
+cycle, or to `:raised` to re-run through the refine step first.
 
 To change the polling interval, edit the `--interval` value (in
 seconds) in the `watchtower` service's `command:` block and run

--- a/cai.py
+++ b/cai.py
@@ -1998,9 +1998,13 @@ def cmd_fix(args) -> int:
         return 0
 
     if ps_verdict == "ambiguous":
+        # Bounce to :refined (not :plan-approved) so the issue re-flows
+        # through refine → plan → human approval. Returning to
+        # :plan-approved would make _select_fix_target pick it up again
+        # immediately and loop on the same pre-screen verdict.
         _set_labels(
             issue_number,
-            add=[origin_raised_label],
+            add=[LABEL_REFINED],
             remove=[LABEL_IN_PROGRESS],
         )
         _run(
@@ -2010,7 +2014,7 @@ def cmd_fix(args) -> int:
              f"## Pre-screen: ambiguous issue\n\n"
              f"{ps_reason}\n\n---\n"
              f"_Flagged by `cai fix` pre-screen (Haiku). The issue "
-             f"was returned to `{origin_raised_label}` for refinement._"],
+             f"was returned to `{LABEL_REFINED}` for refinement._"],
             capture_output=True,
         )
         log_run("fix", repo=REPO, issue=issue_number, result="pre_screen_ambiguous", exit=0)

--- a/cai.py
+++ b/cai.py
@@ -1028,6 +1028,24 @@ def _extract_stored_plan(issue_body: str) -> str | None:
     return content if content else None
 
 
+def _get_plan_for_fix(issue: dict, origin_label: str) -> str | None:
+    """Retrieve the implementation plan for a fix run.
+
+    For :plan-approved issues, the plan is extracted from the issue body
+    where `cai plan` stored it.  For :requested (admin bypass) issues,
+    no plan is expected — returns None for graceful degradation.
+    """
+    if origin_label == LABEL_REQUESTED:
+        print("[cai fix] :requested bypass — no stored plan expected", flush=True)
+        return None
+    plan = _extract_stored_plan(issue.get("body", ""))
+    if plan:
+        print(f"[cai fix] using stored plan from issue body ({len(plan)} chars)", flush=True)
+    else:
+        print("[cai fix] WARNING: :plan-approved issue has no stored plan in body — proceeding without plan", flush=True)
+    return plan
+
+
 def _strip_stored_plan_block(issue_body: str) -> str:
     """Remove an existing cai-plan block from the issue body, if present."""
     start_marker = "<!-- cai-plan-start -->"
@@ -1934,14 +1952,14 @@ def cmd_fix(args) -> int:
     issue_number = issue["number"]
     title = issue["title"]
     label_names = {lbl["name"] for lbl in issue.get("labels", [])}
-    origin_raised_label = LABEL_REQUESTED if LABEL_REQUESTED in label_names else LABEL_REFINED
+    origin_raised_label = LABEL_REQUESTED if LABEL_REQUESTED in label_names else LABEL_PLAN_APPROVED
     print(f"[cai fix] picked #{issue_number}: {title}", flush=True)
 
-    # 1. Lock — set :in-progress, drop :refined and :requested.
+    # 1. Lock — set :in-progress, drop :plan-approved and :requested.
     if not _set_labels(
         issue_number,
         add=[LABEL_IN_PROGRESS],
-        remove=[LABEL_REFINED, LABEL_REQUESTED],
+        remove=[LABEL_PLAN_APPROVED, LABEL_REQUESTED],
     ):
         print(f"[cai fix] could not lock #{issue_number}", file=sys.stderr)
         log_run("fix", repo=REPO, issue=issue_number, result="lock_failed", exit=1)
@@ -2050,26 +2068,11 @@ def cmd_fix(args) -> int:
                 flush=True,
             )
 
-        # 4c. Load the stored implementation plan from the issue body.
-        #     `cai plan` is an independent step that runs the plan-select
-        #     pipeline and writes the selected plan between
-        #     `<!-- cai-plan-start/end -->` markers. `cai fix` only
-        #     executes that stored plan — it never re-plans. For
-        #     `:requested` issues (human shortcut) there may be no
-        #     stored plan, and the fix agent runs without one.
-        selected_plan = _extract_stored_plan(issue.get("body", "") or "")
-        if selected_plan:
-            print(
-                f"[cai fix] using stored plan from issue body "
-                f"({len(selected_plan)} chars)",
-                flush=True,
-            )
-        else:
-            print(
-                "[cai fix] no stored plan found; running fix agent "
-                "without a plan (expected for :requested issues)",
-                flush=True,
-            )
+        # 4c. Retrieve the pre-computed plan from the issue body.
+        #     For :plan-approved issues, `cai plan` stored the plan
+        #     and a human approved it.  For :requested bypass issues,
+        #     no plan is expected.
+        selected_plan = _get_plan_for_fix(issue, origin_raised_label)
 
         # 4d. Pre-create the `.cai-staging/agents/` directory so the
         #     agent has somewhere to write proposed updates to its
@@ -2107,8 +2110,9 @@ def cmd_fix(args) -> int:
                 _work_directory_block(work_dir)
                 + "\n"
                 + "## Selected Implementation Plan\n\n"
-                + "The following plan was produced by `cai plan` and "
-                + "stored on the issue. Follow it to implement the fix.\n\n"
+                + "The following plan was pre-computed by `cai plan` and "
+                + "approved by a human reviewer. "
+                + "Follow this plan to implement the fix.\n\n"
                 + f"{selected_plan}\n\n"
                 + "---\n\n"
                 + _build_fix_user_message(issue, attempt_history_block)

--- a/cai.py
+++ b/cai.py
@@ -571,9 +571,9 @@ def _recover_stale_pr_open(issues: list[dict], *, log_prefix: str = "cai") -> li
                 comment = (
                     "## Auto-improve: rolling back to :refined\n\n"
                     f"Linked PR #{pr['number']} was closed without merging. "
-                    "Resetting this issue to `:refined` so the fix subagent can "
-                    "re-attempt on the next tick (bypassing the refine step since "
-                    "the issue was already structured before the previous fix attempt).\n\n"
+                    "Resetting this issue to `:refined` so it can flow through "
+                    "the refinement and planning cycle again before a human "
+                    "can re-approve it for the fix subagent.\n\n"
                     f"---\n_Rolled back automatically by `{log_prefix}`._"
                 )
                 _run(["gh", "issue", "comment", str(issue["number"]),
@@ -2772,8 +2772,9 @@ def _select_revise_targets() -> list[dict]:
 
 
 def _recover_stuck_rebase_prs() -> int:
-    """Close PRs the rebase resolver gave up on so the fix subagent
-    can re-attempt them from a fresh branch off current main.
+    """Close PRs the rebase resolver gave up on so the issue can flow
+    through the planning cycle and the fix subagent can re-attempt from
+    a fresh branch off current main.
 
     Trigger condition: an open `auto-improve/<N>-*` PR has a
     `## Revise subagent: rebase resolution failed` comment newer than
@@ -2781,8 +2782,8 @@ def _recover_stuck_rebase_prs() -> int:
     revise step from spamming retry comments — but without recovery
     the PR sits stuck forever, accumulating an ever-larger conflict
     surface every time main moves. Closing it and resetting the issue
-    to `:refined` lets the fix subagent open a fresh PR against the
-    current main on its next tick (#144 was the original symptom).
+    to `:refined` lets it re-flow through plan → approval → fix against
+    current main on a future cycle (#144 was the original symptom).
 
     Returns the number of PRs recovered.
     """

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,19 +6,20 @@
 
 1. **Raise** — `cai analyze`, `cai propose`, `cai code-audit`, `cai audit`, or a human files an issue labeled `auto-improve:raised` or `human:submitted`.
 2. **Refine** — `cai refine` calls `cai-refine` to rewrite the issue into a structured plan with steps, verification, and scope guardrails. Label transitions to `auto-improve:refined`.
-3. **Plan** — `cai plan` runs plan-select agents to generate and select an implementation plan. The plan is stored in the issue body. Label transitions to `auto-improve:planned` (or `human:plan-approved` if human-reviewed).
-4. **Fix** — `cai fix` calls `cai-fix` in a fresh git worktree. The wrapper commits, pushes, and opens a PR. Label transitions to `auto-improve:in-progress` → `auto-improve:pr-open`.
-5. **Review** — `cai review-pr` checks for ripple-effect inconsistencies and posts findings as PR comments. `cai review-docs` then (and only after review-pr completes) checks for stale documentation, directly fixes issues it can resolve, and commits/pushes those changes to the PR branch. Remaining unfixable issues are posted as `### Finding: stale_docs` comments. This ordering is enforced: review-docs skips PRs until review-pr has posted a review comment at the current HEAD SHA.
-6. **Revise** — `cai revise` calls `cai-revise` or `cai-rebase` to address review comments or rebase conflicts. Label transitions to `auto-improve:revising`.
-7. **Merge** — `cai merge` calls `cai-merge` to assess confidence and auto-merges PRs that meet the threshold. Label transitions to `auto-improve:merged`.
-8. **Confirm** — `cai confirm` calls `cai-confirm` to verify the merged fix actually resolved the original issue. Label transitions to `auto-improve:solved` or re-queues to `:refined`.
+3. **Plan** — `cai plan` runs plan-select agents to generate and select an implementation plan. The plan is stored in the issue body. Label transitions to `auto-improve:planned`, awaiting human approval.
+4. **Human Approval** — A human reviews the generated plan and applies `human:plan-approved` label to approve the issue for fixing.
+5. **Fix** — `cai fix` calls `cai-fix` on `human:plan-approved` issues in a fresh git worktree. The wrapper commits, pushes, and opens a PR. Label transitions to `auto-improve:in-progress` → `auto-improve:pr-open`.
+6. **Review** — `cai review-pr` checks for ripple-effect inconsistencies and posts findings as PR comments. `cai review-docs` then (and only after review-pr completes) checks for stale documentation, directly fixes issues it can resolve, and commits/pushes those changes to the PR branch. Remaining unfixable issues are posted as `### Finding: stale_docs` comments. This ordering is enforced: review-docs skips PRs until review-pr has posted a review comment at the current HEAD SHA.
+7. **Revise** — `cai revise` calls `cai-revise` or `cai-rebase` to address review comments or rebase conflicts. Label transitions to `auto-improve:revising`.
+8. **Merge** — `cai merge` calls `cai-merge` to assess confidence and auto-merges PRs that meet the threshold. Label transitions to `auto-improve:merged`.
+9. **Confirm** — `cai confirm` calls `cai-confirm` to verify the merged fix actually resolved the original issue. Label transitions to `auto-improve:solved` or re-queues to `:refined`.
 
 ## Lifecycle Labels
 
 | Label | Meaning |
 |---|---|
 | `auto-improve:raised` | Newly filed, awaiting refinement |
-| `auto-improve:refined` | Has a structured plan, ready for fix |
+| `auto-improve:refined` | Has a structured plan, ready for the planning pipeline |
 | `auto-improve:in-progress` | Fix agent is running (lock; 6 h stale timeout) |
 | `auto-improve:pr-open` | PR created, awaiting review and merge |
 | `auto-improve:revising` | Revise agent is running (lock; 1 h stale timeout) |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -70,7 +70,7 @@ Run `cai-explore` on the oldest `auto-improve:needs-exploration` issue. Outcomes
 
 ## fix
 
-Run the `cai-fix` agent against one eligible `auto-improve:refined` issue in a fresh git worktree. The wrapper handles commit, push, and PR creation.
+Run the `cai-fix` agent against one eligible `human:plan-approved` issue in a fresh git worktree. The wrapper handles commit, push, and PR creation. The issue must have a plan pre-computed by `cai plan` and approved by a human reviewer.
 
 | Argument | Type | Description |
 |---|---|---|


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#519

**Issue:** #519 — [Step 3/3] Wire `cmd_fix` to `plan-approved` and remove inline planning

## PR Summary

### What this fixes
`cmd_fix` was still falling back to `LABEL_REFINED` in `origin_raised_label` and the lock step, meaning issues that had been promoted to `:plan-approved` would have their label incorrectly rolled back to `:refined` on failure. The fix completes Step 3/3 of the plan-gate work by wiring `cmd_fix` to use `LABEL_PLAN_APPROVED` everywhere `LABEL_REFINED` appeared, and replaces the inline plan extraction with a new `_get_plan_for_fix` helper that properly distinguishes `:requested` bypass (no plan expected) from `:plan-approved` with a missing plan (logs a WARNING).

### What was changed
- `cai.py` — `origin_raised_label` fallback changed from `LABEL_REFINED` to `LABEL_PLAN_APPROVED` (line 1955)
- `cai.py` — lock step comment updated and `remove=[LABEL_REFINED, LABEL_REQUESTED]` changed to `remove=[LABEL_PLAN_APPROVED, LABEL_REQUESTED]` (lines 1958–1962)
- `cai.py` — new `_get_plan_for_fix(issue, origin_label)` helper added after `_extract_stored_plan` (line 1031); logs WARNING for `:plan-approved` issues missing a stored plan, and silently returns `None` for `:requested` bypass
- `cai.py` — inline plan extraction block in `cmd_fix` replaced with `_get_plan_for_fix(issue, origin_raised_label)` call (line 2075)
- `cai.py` — plan header text updated from "produced by `cai plan` and stored on the issue" to "pre-computed by `cai plan` and approved by a human reviewer" (lines 2113–2115)

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
