### PR TITLE
auto-improve: python linter should be introduced

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,37 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#554
+
+## Files touched
+- `pyproject.toml` — new file: ruff config (line-length=120, select E+F, ignore E501/F403/F405)
+- `tests/test_lint.py` — new file: unittest that runs `ruff check .` and asserts exit 0; skips when ruff not installed
+- `cai.py:181` — added `# noqa: F401` for `log_cost` unused import
+- `cai.py:1731-1732` — removed spurious `f` prefix from two f-strings without placeholders
+- `cai.py:2432` — removed spurious `f` prefix from `f"unexpected_error"`
+- `cai.py:3336` — removed spurious `f` prefix from `f"## Original issue\n\n"`
+- `cai.py:5977,5981,5984,6251,6255,6258` — removed spurious `f` prefix from 6 literal f-strings in two PR metadata blocks
+- `cai.py:3677,3681,6440,6604,8225` — added `# noqa: E741` on lines using `l` as iterator var
+- `cai.py:6901` — removed unused `reasoning = verdict["reasoning"]` assignment (F841)
+- `cai.py:8277` — changed `except Exception as exc:` to `except Exception:` (F841, exc never used)
+- `cai_lib/github.py:121` — added `# noqa: E741` for `l` iterator variable
+- `tests/test_publish.py:10` — added `# noqa: F401` for `VALID_CATEGORIES` unused import
+
+## Files read (not touched) that matter
+- `cai.py` — scanned for F541/F401/F841/E741 violations
+- `cai_lib/github.py` — E741 violation at line 121
+- `tests/test_publish.py` — F401 violation at line 10
+
+## Key symbols
+- `TestLint.test_lint_passes` (tests/test_lint.py:12) — the new lint gate test
+
+## Design decisions
+- F403/F405 ignored globally — cai.py uses `from X import *` extensively (~540 usage sites), per-line suppression is impractical
+- E501 ignored globally — issue explicitly says "don't be picky on line length"
+- E741 suppressed with `# noqa` rather than renaming `l` — minimal change, renaming would affect readability of set/list comprehensions
+
+## Out of scope / known gaps
+- ruff not added to Dockerfile/image — issue says this is a deployment concern handled separately
+- No CI/CD workflow changes — no workflows exist in this repo
+
+## Invariants this change relies on
+- `python -m unittest discover -s tests -v` already discovers `test_lint.py` automatically via `tests/__init__.py`
+- ruff skips gracefully when not installed (`@unittest.skipUnless(shutil.which("ruff"), ...)`)

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -13,7 +13,7 @@ Refs: robotsix/robotsix-cai#554
 - `cai.py:6901` — removed unused `reasoning = verdict["reasoning"]` assignment (F841)
 - `cai.py:8277` — changed `except Exception as exc:` to `except Exception:` (F841, exc never used)
 - `cai_lib/github.py:121` — added `# noqa: E741` for `l` iterator variable
-- `tests/test_publish.py:10` — added `# noqa: F401` for `VALID_CATEGORIES` unused import
+- `tests/test_publish.py:10` — removed genuinely unused `VALID_CATEGORIES` import; restored `# noqa: E402` for post-sys.path import
 
 ## Files read (not touched) that matter
 - `cai.py` — scanned for F541/F401/F841/E741 violations
@@ -35,3 +35,17 @@ Refs: robotsix/robotsix-cai#554
 ## Invariants this change relies on
 - `python -m unittest discover -s tests -v` already discovers `test_lint.py` automatically via `tests/__init__.py`
 - ruff skips gracefully when not installed (`@unittest.skipUnless(shutil.which("ruff"), ...)`)
+
+## Revision 1 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `tests/test_publish.py:10` — removed genuinely unused `VALID_CATEGORIES` from import; replaced `# noqa: F401` with `# noqa: E402`
+
+### Decisions this revision
+- Removed `VALID_CATEGORIES` rather than suppressing it — it has no re-export mechanism, no callers in the test file, and the issue scope guardrails say to fix genuine auto-fixable violations manually
+
+### New gaps / deferred
+- None

--- a/cai.py
+++ b/cai.py
@@ -178,7 +178,7 @@ from cai_lib.config import *  # noqa: E402,F403
 
 
 from cai_lib.logging_utils import (  # noqa: E402
-    _write_active_job, _clear_active_job, log_run, log_cost,
+    _write_active_job, _clear_active_job, log_run, log_cost,  # noqa: F401
     _get_issue_category, _log_outcome, _load_outcome_counts,
     _load_outcome_stats, _load_cost_log, _row_ts, _build_cost_summary,
 )
@@ -1728,8 +1728,8 @@ def _apply_agent_edit_staging(work_dir: Path) -> int:
             shutil.copytree(str(plugin_staging), str(plugin_target),
                             dirs_exist_ok=True)
             print(
-                f"[cai] applied staged plugin tree: .claude/plugins/ "
-                f"(merged from .cai-staging/plugins/)",
+                "[cai] applied staged plugin tree: .claude/plugins/ "
+                "(merged from .cai-staging/plugins/)",
                 flush=True,
             )
             applied += 1
@@ -2429,7 +2429,7 @@ def cmd_implement(args) -> int:
         print(f"[cai implement] unexpected failure: {e!r}", file=sys.stderr)
         rollback()
         log_run("implement", repo=REPO, issue=issue_number,
-                result=f"unexpected_error", exit=1)
+                result="unexpected_error", exit=1)
         return 1
     finally:
         _clear_active_job()
@@ -3333,7 +3333,7 @@ def cmd_revise(args) -> int:
                 _work_directory_block(work_dir)
                 + "\n"
                 + f"{rebase_state_block}\n"
-                + f"## Original issue\n\n"
+                + "## Original issue\n\n"
                 + f"### #{issue_data['number']} — {issue_data.get('title', '')}\n\n"
                 + f"{issue_data.get('body') or '(no body)'}\n\n"
                 + pr_state_block
@@ -3674,11 +3674,11 @@ def cmd_verify(args) -> int:
             continue
         if (iss.get("state") or "").upper() != "OPEN":
             continue
-        iss_labels = {l["name"] for l in iss.get("labels", [])}
+        iss_labels = {l["name"] for l in iss.get("labels", [])}  # noqa: E741
         if LABEL_PR_OPEN in iss_labels:
             continue
         # Issue is open, has an open PR, but missing :pr-open — recover.
-        remove = [l for l in (LABEL_IN_PROGRESS, LABEL_REFINED, LABEL_PLANNED, LABEL_PLAN_APPROVED, LABEL_RAISED, LABEL_HUMAN_SUBMITTED, LABEL_AUDIT_RAISED) if l in iss_labels]
+        remove = [l for l in (LABEL_IN_PROGRESS, LABEL_REFINED, LABEL_PLANNED, LABEL_PLAN_APPROVED, LABEL_RAISED, LABEL_HUMAN_SUBMITTED, LABEL_AUDIT_RAISED) if l in iss_labels]  # noqa: E741
         if _set_labels(issue_num, add=[LABEL_PR_OPEN], remove=remove, log_prefix="cai verify"):
             print(
                 f"[cai verify] recovered #{issue_num}: added :pr-open "
@@ -5974,14 +5974,14 @@ def cmd_review_pr(args) -> int:
             user_message = (
                 _work_directory_block(work_dir)
                 + "\n"
-                + f"## PR metadata\n\n"
+                + "## PR metadata\n\n"
                 + f"- **Number:** #{pr_number}\n"
                 + f"- **Title:** {title}\n"
                 + f"- **Author:** @{author_login}\n"
-                + f"- **Base:** main\n"
+                + "- **Base:** main\n"
                 + f"- **HEAD SHA:** {head_sha}\n\n"
                 + issue_block
-                + f"## PR diff\n\n"
+                + "## PR diff\n\n"
                 + f"```diff\n{pr_diff}\n```\n"
             )
 
@@ -6248,14 +6248,14 @@ def cmd_review_docs(args) -> int:
             user_message = (
                 _work_directory_block(work_dir)
                 + "\n"
-                + f"## PR metadata\n\n"
+                + "## PR metadata\n\n"
                 + f"- **Number:** #{pr_number}\n"
                 + f"- **Title:** {title}\n"
                 + f"- **Author:** @{author_login}\n"
-                + f"- **Base:** main\n"
+                + "- **Base:** main\n"
                 + f"- **HEAD SHA:** {head_sha}\n\n"
                 + issue_block
-                + f"## PR diff\n\n"
+                + "## PR diff\n\n"
                 + f"```diff\n{pr_diff}\n```\n"
             )
 
@@ -6437,7 +6437,7 @@ def _pr_label_sweep() -> tuple[int, int]:
         pr_number = pr["number"]
         comments = pr.get("comments", [])
         merge_state = pr.get("mergeStateStatus", "")
-        labels = {l.get("name", "") for l in pr.get("labels", [])}
+        labels = {l.get("name", "") for l in pr.get("labels", [])}  # noqa: E741
         currently_labeled = LABEL_PR_NEEDS_HUMAN in labels
 
         # Scope signals to comments newer than the latest commit so
@@ -6601,7 +6601,7 @@ def cmd_merge(args) -> int:
             )
             continue
 
-        issue_labels = [l["name"] for l in issue.get("labels", [])]
+        issue_labels = [l["name"] for l in issue.get("labels", [])]  # noqa: E741
         if LABEL_PR_OPEN not in issue_labels:
             continue
         # NOTE: do NOT skip on `merge-blocked`. The label
@@ -6899,7 +6899,6 @@ def cmd_merge(args) -> int:
 
         confidence = verdict["confidence"]
         action = verdict["action"]
-        reasoning = verdict["reasoning"]
         evaluated += 1
 
         # Post the verdict as a PR comment.
@@ -8222,7 +8221,7 @@ def cmd_health_report(args) -> int:
 
             rows_md = []
             for agent in all_agents:
-                l = last_by_agent.get(agent, 0.0)
+                l = last_by_agent.get(agent, 0.0)  # noqa: E741
                 p = prior_by_agent.get(agent, 0.0)
                 delta = ((l - p) / p * 100) if p > 0 else float("nan")
                 delta_str = f"{delta:+.1f}%" if p > 0 else "n/a"
@@ -8274,7 +8273,7 @@ def cmd_health_report(args) -> int:
                  "--json", "number", "--limit", "200"]
             )
             counts[name] = len(items) if items else 0
-    except Exception as exc:
+    except Exception:
         throughput_status = "🟡"
         counts = {name: -1 for name, _ in label_states}
 

--- a/cai_lib/github.py
+++ b/cai_lib/github.py
@@ -118,7 +118,7 @@ def _issue_has_label(issue_number: int, label: str) -> bool:
         ])
     except subprocess.CalledProcessError:
         return False
-    return label in [l["name"] for l in (issue or {}).get("labels", [])]
+    return label in [l["name"] for l in (issue or {}).get("labels", [])]  # noqa: E741
 
 
 def _build_issue_block(issue: dict) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F"]
+ignore = ["E501", "F403", "F405"]

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,0 +1,28 @@
+"""Lint check: ruff must report zero violations across the whole repo."""
+import os
+import shutil
+import subprocess
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class TestLint(unittest.TestCase):
+
+    @unittest.skipUnless(shutil.which("ruff"), "ruff not installed")
+    def test_lint_passes(self):
+        result = subprocess.run(
+            ["ruff", "check", "."],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"ruff reported violations:\n{result.stdout}\n{result.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -7,7 +7,7 @@ import unittest
 # regardless of how the test runner is invoked.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from publish import parse_findings, Finding, VALID_CATEGORIES
+from publish import parse_findings, Finding, VALID_CATEGORIES  # noqa: F401
 
 
 def _finding_block(title, category, key, confidence, evidence, remediation):

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -7,7 +7,7 @@ import unittest
 # regardless of how the test runner is invoked.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from publish import parse_findings, Finding, VALID_CATEGORIES  # noqa: F401
+from publish import parse_findings, Finding  # noqa: E402
 
 
 def _finding_block(title, category, key, confidence, evidence, remediation):


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#554

**Issue:** #554 — python linter should be introduced

## PR Summary

### What this fixes
The Python codebase had no linting configuration or lint step, allowing style regressions, unused imports, and undefined-name bugs to slip through the automated fix → PR flow undetected.

### What was changed
- **`pyproject.toml`** (new) — ruff config: `line-length = 120`, `select = ["E", "F"]`, `ignore = ["E501", "F403", "F405"]`; F403/F405 ignored globally because `cai.py` uses star imports extensively (~540 usage sites), making per-line suppression impractical
- **`tests/test_lint.py`** (new) — `unittest.TestCase` that runs `ruff check .` and asserts exit code 0; gracefully skips when ruff is not installed
- **`cai.py`** — fixed 10 F541 violations (removed spurious `f` prefix from literal strings with no `{...}` placeholders); added `# noqa: F401` for `log_cost` unused import; added `# noqa: E741` on 5 lines using `l` as iterator variable; removed unused `reasoning` assignment (F841); changed `except Exception as exc:` → `except Exception:` where `exc` was unused
- **`cai_lib/github.py`** — added `# noqa: E741` on line using `l` as iterator variable
- **`tests/test_publish.py`** — added `# noqa: F401` for `VALID_CATEGORIES` unused import

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
