### PR TITLE
auto-improve: cai-revise: strip review-pr preamble/footer from inlined review comments

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,28 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#575
+
+## Files touched
+- cai.py:2481-2508 — Added `_REVIEW_PR_FOOTER_SENTINEL`, `_REVIEW_PR_PREAMBLE` constants and `_strip_review_pr_boilerplate()` helper
+- cai.py:3353-3361 — Applied stripping in the `comments_section` loop for review-pr findings comments
+
+## Files read (not touched) that matter
+- cai.py:6022-6043 — Shows exact footer text added by `cmd_review_pr` to findings comments
+- cai.py:2463-2472 — `_BOT_COMMENT_MARKERS` explains why clean comments are already filtered; findings comments flow through
+
+## Key symbols
+- `_strip_review_pr_boilerplate` (cai.py:2491) — strips footer (via `\n---\n` sentinel) and preamble from review-pr comment bodies
+- `_REVIEW_COMMENT_HEADING_FINDINGS` (cai.py:5859) — used to detect review-pr findings comments in the loop
+- `_REVIEW_COMMENT_HEADING_CLEAN` (cai.py:5860) — guard: clean comments are already filtered by `_BOT_COMMENT_MARKERS` but double-checked
+
+## Design decisions
+- Sentinel-string detection, not author login — the bot uses the human operator's gh token, so login-based filtering is unreliable (see comment at line 2450-2453)
+- `rfind("\n---\n")` for footer — matches the last separator to avoid false positives if finding bodies contain `---` themselves
+- `replace()` for preamble — the preamble appears once at most; `replace` + `strip` is simpler than index-based removal
+
+## Out of scope / known gaps
+- Other agent preambles (not "Now I have enough information...") are not stripped; only the specific string from issue #575 is targeted
+- Docs review comments (`## cai docs review`) are not stripped; they're already filtered by `_BOT_COMMENT_MARKERS` (clean/applied variants) or don't have this boilerplate
+
+## Invariants this change relies on
+- Clean review-pr comments (`## cai pre-merge review (clean)`) are always in `_BOT_COMMENT_MARKERS` and filtered before reaching `comments_section`
+- The footer always follows the `\n---\n` pattern as constructed in `cmd_review_pr` at line ~6029-6032

--- a/cai.py
+++ b/cai.py
@@ -2478,6 +2478,36 @@ def _is_bot_comment(comment: dict) -> bool:
     return any(body.startswith(m) for m in _BOT_COMMENT_MARKERS)
 
 
+# Sentinel strings for the fixed boilerplate that cai review-pr wraps around
+# agent output. We strip these when inlining review-pr findings into the
+# revise user message — they are inert for the revise agent and just waste
+# tokens.
+_REVIEW_PR_FOOTER_SENTINEL = (
+    "_Pre-merge consistency review by `cai review-pr`."
+)
+_REVIEW_PR_PREAMBLE = "Now I have enough information to report findings."
+
+
+def _strip_review_pr_boilerplate(body: str) -> str:
+    """Strip known preamble/footer from a cai review-pr findings comment body.
+
+    The footer is the ``---`` separator line plus the attribution sentence
+    added by ``cmd_review_pr``.  The preamble is a fixed phrase the
+    ``cai-review-pr`` agent emits before its ``### Finding:`` blocks.
+    Both are inert for the revise agent.
+    """
+    # Strip trailing footer: find the last "---" separator whose following
+    # content is the review-pr attribution line.
+    footer_idx = body.rfind("\n---\n")
+    if footer_idx != -1:
+        after_sep = body[footer_idx + 5:].lstrip()
+        if after_sep.startswith(_REVIEW_PR_FOOTER_SENTINEL):
+            body = body[:footer_idx].rstrip()
+    # Strip the fixed agent preamble if present anywhere in the body.
+    body = body.replace(_REVIEW_PR_PREAMBLE, "").strip()
+    return body
+
+
 # Marker that revise/cmd_implement uses when its subagent decides no code
 # changes are needed in response to a comment. The presence of this
 # marker AFTER all human comments means the bot has acknowledged the
@@ -3320,6 +3350,15 @@ def cmd_revise(args) -> int:
                     author = c.get("author", {}).get("login", "unknown")
                     body = c.get("body", "")
                     created = c.get("createdAt", "")
+                    # Strip boilerplate from review-pr findings comments so
+                    # the revise agent only sees the actionable ### Finding:
+                    # blocks, not the fixed preamble/footer.
+                    stripped = body.lstrip()
+                    if (
+                        stripped.startswith(_REVIEW_COMMENT_HEADING_FINDINGS)
+                        and not stripped.startswith(_REVIEW_COMMENT_HEADING_CLEAN)
+                    ):
+                        body = _strip_review_pr_boilerplate(body)
                     comments_section += (
                         f"### Comment by @{author} ({created})\n\n"
                         f"{body}\n\n"


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#575

**Issue:** #575 — cai-revise: strip review-pr preamble/footer from inlined review comments

## PR Summary

### What this fixes
`cai revise` was inlining raw review-pr comment bodies into its user message, including a fixed preamble ("Now I have enough information to report findings.") and a footer (`---` + attribution line) that `cmd_review_pr` appends to every findings comment. These are inert for the revise agent but consumed tokens on every revise run.

### What was changed
- **`cai.py:2481-2508`** — Added two sentinel constants (`_REVIEW_PR_FOOTER_SENTINEL`, `_REVIEW_PR_PREAMBLE`) and a helper `_strip_review_pr_boilerplate(body)` that strips the `\n---\n` + attribution footer and the fixed preamble phrase from comment bodies.
- **`cai.py:3353-3361`** — In the `comments_section` loop in `cmd_revise`, detect review-pr findings comments (start with `## cai pre-merge review` but not `(clean)`) and apply `_strip_review_pr_boilerplate` before inlining. Human comments are passed through verbatim.

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
