### PR TITLE
auto-improve: cai-revise: truncate '## Original issue' block in user message

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,26 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#574
+
+## Files touched
+- cai.py:2480 — added `_REVISE_ISSUE_BODY_MAX_CHARS = 1500` constant
+- cai.py:3379-3397 — truncate issue body before inlining into revise user message
+
+## Files read (not touched) that matter
+- cai.py (lines 2440–2490, 3320–3400) — revise section: constant placement and user_message construction
+
+## Key symbols
+- `_REVISE_ISSUE_BODY_MAX_CHARS` (cai.py:2480) — cap for issue body chars in revise user message
+- `cmd_revise` (cai.py:3023) — function that builds the user message for cai-revise agent
+- `_issue_body_raw` / `_issue_body` (cai.py:3379-3387) — local vars for truncated body
+
+## Design decisions
+- Truncate at char boundary (not token boundary) — simple, deterministic, no tokenizer dependency
+- Append `… (truncated — see #N for full body)` so agent knows truncation happened and where to find more
+- Constant placed in revise section near other revise-specific constants, not at top of file
+
+## Out of scope / known gaps
+- No change to the `cai-implement` or `cai-fix` pipelines — they inline full issue bodies but are not addressed by this issue
+
+## Invariants this change relies on
+- `issue_data["number"]` is always present (fetched from GitHub API before this code runs)
+- `_REVISE_ISSUE_BODY_MAX_CHARS` is module-level, so it can be patched in tests if needed

--- a/cai.py
+++ b/cai.py
@@ -2472,6 +2472,14 @@ _BOT_COMMENT_MARKERS = (
 )
 
 
+# Maximum number of characters of the original issue body to inline into the
+# revise agent's user message.  The full body is redundant once a PR exists —
+# the agent needs intent and acceptance criteria, not the full proposal.  When
+# the body exceeds this limit it is truncated and a pointer to the GitHub issue
+# is appended so the agent can fetch the rest if needed.
+_REVISE_ISSUE_BODY_MAX_CHARS = 1500
+
+
 def _is_bot_comment(comment: dict) -> bool:
     """Return True if a comment body looks like it was posted by a cai subagent."""
     body = (comment.get("body") or "").lstrip()
@@ -3368,13 +3376,23 @@ def cmd_revise(args) -> int:
                     "(none — only the rebase needed attention)\n"
                 )
 
+            _issue_body_raw = issue_data.get("body") or "(no body)"
+            _issue_num = issue_data["number"]
+            if len(_issue_body_raw) > _REVISE_ISSUE_BODY_MAX_CHARS:
+                _issue_body = (
+                    _issue_body_raw[:_REVISE_ISSUE_BODY_MAX_CHARS]
+                    + f"\n\n… (truncated — see #{_issue_num} for full body)"
+                )
+            else:
+                _issue_body = _issue_body_raw
+
             user_message = (
                 _work_directory_block(work_dir)
                 + "\n"
                 + f"{rebase_state_block}\n"
                 + "## Original issue\n\n"
-                + f"### #{issue_data['number']} — {issue_data.get('title', '')}\n\n"
-                + f"{issue_data.get('body') or '(no body)'}\n\n"
+                + f"### #{_issue_num} — {issue_data.get('title', '')}\n\n"
+                + f"{_issue_body}\n\n"
                 + pr_state_block
                 + comments_section
             )


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#574

**Issue:** #574 — cai-revise: truncate '## Original issue' block in user message

## PR Summary

### What this fixes
`cmd_revise` was inlining the full issue body (2–4 k tokens) into the revise agent's user message on every cycle, even though most of it is redundant once a PR exists. This wastes tokens on large issues.

### What was changed
- **`cai.py:2480`** — Added `_REVISE_ISSUE_BODY_MAX_CHARS = 1500` constant in the revise section
- **`cai.py:3379–3397`** — Before building the user message, truncate the issue body to `_REVISE_ISSUE_BODY_MAX_CHARS` chars and append `… (truncated — see #N for full body)` when truncation occurs; issue number is factored into a local `_issue_num` variable (used in both the truncation marker and the heading)

---
_Auto-generated by `cai fix`. The fix subagent runs autonomously with full tool permissions — please review the diff carefully._
