### PR TITLE
auto-improve: cai: automatically handle failing CI checks on open PRs

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,47 @@
+# PR Context Dossier
+Refs: damien-robotsix/robotsix-cai#532
+
+## Files touched
+- cai.py:2502 — added `"## CI-fix subagent:"` to `_BOT_COMMENT_MARKERS`
+- cai.py:2578 — added `_CI_FIX_ATTEMPT_MARKER` constant after `_REBASE_FAILED_MARKER`
+- cai.py:2876 — added `_select_ci_fix_targets()` function
+- cai.py:3009 — added `_fetch_ci_failure_log()` helper
+- cai.py:8089 — added `cmd_fix_ci()` function
+- cai.py:8372 — updated `_drain_pending_prs` to include `fix-ci` step
+- cai.py:9327 — added `fix-ci` argparse subcommand with `--pr` argument
+- cai.py:9401 — added `"fix-ci": cmd_fix_ci` to handlers dict
+- entrypoint.sh:54 — added `CAI_FIX_CI_SCHEDULE` env var (default `50 * * * *`)
+- entrypoint.sh:73 — added crontab entry for `cai.py fix-ci`
+- docs/architecture.md:12 — added step 7.5 CI Fix, updated step 4 drain description
+- .cai-staging/agents/cai-fix-ci.md — new subagent definition (copied to .claude/agents/ by wrapper)
+
+## Files read (not touched) that matter
+- cai.py (cmd_revise, _select_revise_targets) — primary pattern reference for the new command
+- .claude/agents/cai-revise.md — agent definition pattern reference
+
+## Key symbols
+- `_CI_FIX_ATTEMPT_MARKER` (cai.py:2583) — per-SHA loop guard marker constant
+- `_select_ci_fix_targets` (cai.py:2876) — queue selection: open PRs with failing CI, no unaddressed comments, no prior fix attempt on current SHA
+- `_fetch_ci_failure_log` (cai.py:3009) — fetches last 200 lines of `gh run view --log-failed` output
+- `cmd_fix_ci` (cai.py:8089) — main command: clones, rebases, invokes cai-fix-ci, commits, pushes, posts marker
+- `_drain_pending_prs` (cai.py:8372) — updated to run fix-ci between revise and review-pr
+
+## Design decisions
+- Reuses `LABEL_REVISING` as the lock label — same as revise, avoids new label, race prevented by skipping if :revising in `_select_ci_fix_targets`
+- Always posts `_CI_FIX_ATTEMPT_MARKER` comment whether fix succeeded or not — guarantees loop guard fires
+- Skips PRs with unaddressed review comments — leaves them for `cai revise`
+- Aborts and skips on rebase conflicts — leaves conflict resolution for `cai revise`/`cai-rebase`
+- Runs after revise and before review-pr in `_drain_pending_prs` — correct ordering: revise first (may clear unaddressed comments), then fix-ci, then review
+- Default cron schedule `50 * * * *` — runs after revise at :30 and merge/cycle at :00
+- Limits CI log to last 200 lines and at most 2 failing checks — token budget
+- Rejected: modifying `cmd_revise` or `_select_revise_targets` — scope guardrail
+
+## Out of scope / known gaps
+- No flake detection — if failure is infrastructure/flaky, agent should output "cannot fix" and bail
+- No auto-rerun of failed jobs — investigating the log is the whole point
+- No new GitHub labels — the per-SHA marker comment is sufficient state
+
+## Invariants this change relies on
+- `_drain_pending_prs` runs revise before fix-ci, so revise has already released the lock by the time fix-ci checks for :revising
+- `_BOT_COMMENT_MARKERS` prefix `"## CI-fix subagent:"` matches both `_CI_FIX_ATTEMPT_MARKER` (`"## CI-fix subagent: fix attempt"`) and any "cannot fix" message — ensures these comments don't appear as unaddressed review comments
+- `gh pr list --json comments` returns issue-level comments (not line comments); `_fetch_review_comments` fetches line comments separately — both are needed for the unaddressed-comment check

--- a/.claude/agents/cai-fix-ci.md
+++ b/.claude/agents/cai-fix-ci.md
@@ -1,0 +1,151 @@
+---
+name: cai-fix-ci
+description: Diagnose and fix failing CI checks on an open auto-improve PR. Receives a CI failure log section in the user message, identifies the root cause (test, lint, build, or type error), locates the relevant source in the clone, and makes the minimal targeted fix. Leaves edits uncommitted for the wrapper to commit and push.
+tools: Read, Edit, Write, Grep, Glob, Agent
+model: claude-sonnet-4-6
+memory: project
+---
+
+# CI Fix Subagent
+
+You are the CI fix subagent for `robotsix-cai`. The wrapper script
+(`cai.py fix-ci`) has cloned the PR branch, configured your git
+identity, and run a non-conflicting `git rebase origin/main`. Your
+job is to **diagnose the failing CI check(s) shown in the user
+message and make the minimal targeted fix** so the PR can pass CI
+and proceed to merge.
+
+## Working directory
+
+**Your `cwd` is `/app` (read-only).** All file operations must use
+absolute paths under the work directory from the user message.
+
+  - GOOD: `Read("<work_dir>/cai.py")` / `Edit("<work_dir>/parse.py", ...)`
+  - BAD:  `Read("cai.py")` / `Edit("parse.py", ...)`  (hits /app, not the clone)
+
+`cai.py` is ~63 k tokens — use `Grep` + `Read(..., offset=N, limit=200)`
+for targeted reads. Git operations go through `cai-git` if needed — you
+have no Bash.
+
+## Self-modifying agent files (staging directory)
+
+Claude-code blocks `Edit`/`Write` on `.claude/agents/*.md` paths.
+Use the staging directory the wrapper pre-creates:
+
+- **Agent files:** Write the FULL new file to
+  `<work_dir>/.cai-staging/agents/<basename>.md`. The wrapper copies
+  it over `.claude/agents/<basename>.md` after you exit.
+- **Plugin files:** Write to
+  `<work_dir>/.cai-staging/plugins/<same-relative-path>`.
+
+Rules: write the FULL file (unconditional overwrite), use exact
+basename, never try `Edit`/`Write` on the protected paths.
+
+## Hard rules — remote and git
+
+1. **Never push.** The wrapper pushes after you exit.
+2. **Never use `gh`.** The wrapper handles all PR and comment state.
+3. **Do not commit your changes.** Leave edits uncommitted; the
+   wrapper commits them with an appropriate message.
+4. **Do not modify `.github/workflows/`** unless the failure log
+   explicitly shows a workflow bug (not a test/code bug).
+
+## Hard rules — editing and efficiency
+
+1. **Read immediately before Edit.** If more than 2 tool calls have
+   occurred since you last read a file, re-read it. Use 3+ lines of
+   surrounding context in `old_string`.
+2. **Verify `old_string` uniqueness.** In repetitive files, expand
+   to 5–7 lines with a distinctive anchor.
+3. **Minimal changes only.** Fix only what CI is failing on. No
+   reformatting, renaming, docstrings, or refactors outside the fix.
+4. **Update failing tests if your fix changes behavior.** If the fix
+   is in source code and an existing test now fails, update the test.
+5. **Stay inside the worktree.** Don't touch files outside the work
+   directory.
+6. **Fail fast.** Two consecutive failures on the same call →
+   diagnose root cause, re-read the file.
+7. **Grep before Read; batch independent reads** in parallel;
+   minimize Write calls.
+
+## Step-by-step approach
+
+### 1. Read the CI failure log
+
+The user message contains a `## CI failure log` section with one or
+more failing check logs. Read them carefully to identify:
+
+- **What kind of failure?** Test failure, lint error, type error,
+  build/import error.
+- **Which file and line?** Locate the exact file path and line
+  number from the traceback or error message.
+- **What is the expected vs. actual behavior?** For test failures:
+  what did the test expect and what did it get?
+
+### 2. Locate the relevant source
+
+Use Grep/Glob to find the failing file(s) in the clone. For test
+failures, read both the test file and the source file it exercises.
+Use the PR stat summary in the user message to understand what this
+PR changed — the failure is almost always caused by the PR's own
+changes.
+
+### 3. Make the minimal fix
+
+Fix exactly the root cause identified in step 1. Do not touch
+unrelated code. Common cases:
+
+- **Test assertion fails on new output**: update the test expectation
+  to match the new correct behavior introduced by the PR.
+- **Import error / NameError**: add the missing import or fix the
+  reference.
+- **Lint error (unused import, line too long, etc.)**: remove the
+  unused import or wrap the long line.
+- **Type error**: fix the type annotation or cast.
+- **AttributeError / KeyError on the new code**: fix the incorrect
+  attribute access in the PR's new code.
+
+### 4. Verify the fix
+
+After editing, re-read the changed section to confirm the fix looks
+correct. If the change is non-trivial, check for related tests that
+might also need updating.
+
+## When to bail out
+
+If the failure is NOT caused by the PR's code changes — for example:
+
+- A flaky network call, a timeout, or an infrastructure outage
+- A workflow runner misconfiguration
+- A test for unrelated code that was already broken before this PR
+- The root cause is genuinely ambiguous or would require a large
+  architectural change
+
+…then output:
+
+```
+## CI-fix subagent: cannot fix — <one-line reason>
+```
+
+and exit without making any changes. The wrapper will post this
+message as the marker comment, and the per-SHA loop guard will
+prevent retrying on the same SHA.
+
+## Final output
+
+Print a concise summary describing:
+- What the CI failure was
+- Which file(s) you edited and what you changed
+- Or why you bailed out (if you did)
+
+The wrapper includes this in the PR marker comment.
+
+## Context provided below
+
+The user message provides:
+1. `## Work directory` — the absolute path to the clone
+2. `## Original issue` — the issue that prompted this PR (context only)
+3. `## Current PR state` — `git diff origin/main..HEAD --stat` summary
+4. `## CI failure log` — the failing check output (last 200 lines per check)
+
+Read them in order before doing anything else.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The individual pipeline subcommands (`implement`, `refine`, `plan`,
 
 | Subcommand | Default schedule | What it does |
 |---|---|---|
-| `cai.py cycle` | `0 * * * *` (hourly, startup, manual) | Implement pipeline on `human:plan-approved` issues: verify → confirm → drain pending PRs (revise → review-pr → review-docs → merge) → loop(implement/spike/explore → drain) → plan-all → confirm. A flock serializes overlapping runs; the entrypoint also runs this once synchronously at `docker compose up -d` so startup logs are immediate |
+| `cai.py cycle` | `0 * * * *` (hourly, startup, manual) | Implement pipeline on `human:plan-approved` issues: verify → confirm → drain pending PRs (revise → fix-ci → review-pr → review-docs → merge) → loop(implement/spike/explore → drain) → plan-all → confirm. A flock serializes overlapping runs; the entrypoint also runs this once synchronously at `docker compose up -d` so startup logs are immediate |
 | `cai.py plan-all` | `30 * * * *` (hourly, offset 30) | Drains every open `:raised` / `:refined` issue through refine → plan → `:planned` so humans have a queue to review. Also runs at the end of each `cycle`; the cron line provides a mid-cycle catch-up pass |
 | `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` (6-hour TTL) and `:revising` (1-hour TTL) locks and stale `:no-action` issues, flags stale `:merged` issues for human review, recovers `:pr-open` issues whose linked PR was closed (rolls back to `:refined`), deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |
@@ -79,7 +79,7 @@ The individual pipeline subcommands (`implement`, `refine`, `plan`,
 | `cai.py health-report` | `0 7 * * 1` (weekly Monday 07:00 UTC) | Automated pipeline health report with anomaly detection. Aggregates cost trends (last 7d vs prior 7d WoW delta), issue queue counts per label state, pipeline stalls, and fix quality metrics. Posts a GitHub-flavored markdown report with 🔴/🟡/🟢 traffic-light indicators as a `health-report` labelled issue. Use `--dry-run` to print to stdout without posting. |
 | `cai.py cost-optimize` | `0 5 * * 0` (weekly Sunday 05:00 UTC) | Weekly cost-reduction agent — loads 14 days of cost data, computes per-agent WoW deltas and cache hit rates, and proposes one concrete optimization targeting the most expensive agent or workflow. Alternates with evaluating previous proposals to track effectiveness. Files proposals as `auto-improve:raised` issues. |
 | `cai.py check-workflows` | `0 */6 * * *` (every 6 hours) | GitHub Actions failure monitor — fetches recent failed workflow runs (last 24 h), filters out bot branches, and runs a Haiku agent to group related failures and identify root causes; findings are published as `check-workflows` namespace issues. |
-| `cai.py refine` / `plan` / `spike` / `implement` / `revise` / `review-pr` / `merge` / `verify` / `confirm` | _(invoked by `cycle`; also manual/on-demand)_ | Individual pipeline stages. See the lifecycle below for how `cycle` chains them. |
+| `cai.py refine` / `plan` / `spike` / `implement` / `revise` / `fix-ci` / `review-pr` / `review-docs` / `merge` / `verify` / `confirm` | _(invoked by `cycle`; also manual/on-demand)_ | Individual pipeline stages. See the lifecycle below for how `cycle` chains them. |
 | `cai.py test` | _(manual/on-demand)_ | Runs the project test suite (`python -m unittest discover` under `tests/`) |
 
 On `docker compose up -d` the entrypoint templates the crontab from
@@ -87,7 +87,7 @@ the env vars (`CAI_CYCLE_SCHEDULE`, `CAI_ANALYZER_SCHEDULE`,
 `CAI_AUDIT_SCHEDULE`, `CAI_AUDIT_TRIAGE_SCHEDULE`,
 `CAI_CODE_AUDIT_SCHEDULE`, `CAI_PROPOSE_SCHEDULE`,
 `CAI_UPDATE_CHECK_SCHEDULE`, `CAI_HEALTH_REPORT_SCHEDULE`,
-`CAI_COST_OPTIMIZE_SCHEDULE`, `CAI_CHECK_WORKFLOWS_SCHEDULE`),
+`CAI_COST_OPTIMIZE_SCHEDULE`, `CAI_CHECK_WORKFLOWS_SCHEDULE`, `CAI_FIX_CI_SCHEDULE`),
 runs `cai.py cycle` once synchronously so the issue-solving pipeline
 produces immediate logs, then execs supercronic. Orthogonal tasks
 (analyze, audit, propose, update-check, health-report, cost-optimize,

--- a/cai.py
+++ b/cai.py
@@ -2503,6 +2503,7 @@ _BOT_COMMENT_MARKERS = (
     "## Fix subagent:",  # compat: pre-rename bot comments
     "## Revise subagent:",
     "## Revision summary",
+    "## CI-fix subagent:",
     "## cai pre-merge review (clean)",
     "## cai docs review (clean)",
     "## cai docs review (applied)",
@@ -2574,6 +2575,12 @@ _NO_ADDITIONAL_CHANGES_MARKER = "## Revise subagent: no additional changes"
 # under the pre-resolver code path get exactly one fresh attempt
 # with the new resolver before being skipped again.
 _REBASE_FAILED_MARKER = "## Revise subagent: rebase resolution failed"
+
+# Marker posted on a PR after each CI-fix subagent attempt. The per-SHA loop
+# guard in _select_ci_fix_targets checks whether any comment starting with
+# this prefix was posted AFTER the current HEAD commit — if so, one attempt
+# has already been made on this SHA and we skip until the SHA advances.
+_CI_FIX_ATTEMPT_MARKER = "## CI-fix subagent: fix attempt"
 
 
 def _parse_iso_ts(value):
@@ -2864,6 +2871,160 @@ def _select_revise_targets() -> list[dict]:
         })
 
     return targets
+
+
+def _select_ci_fix_targets() -> list[dict]:
+    """Return PRs with failing CI checks that are eligible for auto-fix.
+
+    Eligible = branch matches auto-improve/<N>-* AND linked issue has
+    label auto-improve:pr-open AND does NOT have :needs-human-review or
+    :merge-blocked AND does NOT have :revising (avoid contention) AND
+    the PR has at least one failing check AND the PR has no unaddressed
+    review comments (those belong to cai revise) AND no prior CI fix
+    attempt was posted after the current HEAD commit.
+
+    Returns a list of dicts with keys: pr_number, issue_number, branch,
+    head_sha, failing_checks (list of {name, detailsUrl}).
+    """
+    try:
+        prs = _gh_json([
+            "pr", "list",
+            "--repo", REPO,
+            "--state", "open",
+            "--json", "number,headRefName,comments,labels",
+            "--limit", "50",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(f"[cai fix-ci] gh pr list failed:\n{e.stderr}", file=sys.stderr)
+        return []
+
+    targets = []
+    for pr in prs:
+        branch = pr.get("headRefName", "")
+        m = re.match(r"^auto-improve/(\d+)-", branch)
+        if not m:
+            continue
+        issue_number = int(m.group(1))
+
+        # Check issue eligibility.
+        try:
+            issue = _gh_json([
+                "issue", "view", str(issue_number),
+                "--repo", REPO,
+                "--json", "labels,state",
+            ])
+        except subprocess.CalledProcessError:
+            continue
+        if not issue or issue.get("state", "").upper() != "OPEN":
+            continue
+        label_names = {lbl["name"] for lbl in issue.get("labels", [])}
+        if LABEL_PR_OPEN not in label_names:
+            continue
+        if LABEL_REVISING in label_names:
+            print(
+                f"[cai fix-ci] PR #{pr['number']}: skipping — "
+                f"issue has :{LABEL_REVISING} (revise in progress)",
+                flush=True,
+            )
+            continue
+        if LABEL_PR_NEEDS_HUMAN in label_names or LABEL_MERGE_BLOCKED in label_names:
+            continue
+
+        # Fetch PR detail: CI status, commits, per-PR labels.
+        try:
+            pr_detail = _gh_json([
+                "pr", "view", str(pr["number"]),
+                "--repo", REPO,
+                "--json", "statusCheckRollup,commits,labels",
+            ])
+        except subprocess.CalledProcessError:
+            continue
+
+        # Secondary per-PR label check (stale list data).
+        detail_label_names = {lbl["name"] for lbl in pr_detail.get("labels", [])}
+        if LABEL_PR_NEEDS_HUMAN in detail_label_names:
+            continue
+
+        # Collect failing checks.
+        checks = pr_detail.get("statusCheckRollup") or []
+        failing = [
+            {"name": c.get("name", ""), "detailsUrl": c.get("detailsUrl") or c.get("url", "")}
+            for c in checks
+            if (c.get("conclusion") or c.get("status") or "").upper() == "FAILURE"
+        ]
+        if not failing:
+            continue
+
+        # Get latest commit date and SHA for the loop guard.
+        commits = pr_detail.get("commits") or []
+        if not commits:
+            continue
+        last_commit = commits[-1]
+        last_commit_date = last_commit.get("committedDate", "")
+        head_sha = last_commit.get("oid", "")
+        commit_ts = _parse_iso_ts(last_commit_date)
+        if commit_ts is None:
+            continue
+
+        # Skip if there are unaddressed review comments — leave for cai revise.
+        issue_comments = pr.get("comments", [])
+        line_comments = _fetch_review_comments(pr["number"])
+        all_comments = issue_comments + line_comments
+        unaddressed = _filter_unaddressed_comments(all_comments, commit_ts)
+        if unaddressed:
+            print(
+                f"[cai fix-ci] PR #{pr['number']}: skipping — "
+                f"{len(unaddressed)} unaddressed review comment(s) "
+                "(leaving for cai revise)",
+                flush=True,
+            )
+            continue
+
+        # Per-SHA loop guard: skip if a CI-fix attempt was already posted
+        # after the current HEAD commit.
+        already_attempted = any(
+            (c.get("body") or "").lstrip().startswith(_CI_FIX_ATTEMPT_MARKER)
+            and (_parse_iso_ts(c.get("createdAt")) or commit_ts) > commit_ts
+            for c in all_comments
+        )
+        if already_attempted:
+            print(
+                f"[cai fix-ci] PR #{pr['number']}: prior CI fix attempt "
+                "since last commit; skipping",
+                flush=True,
+            )
+            continue
+
+        targets.append({
+            "pr_number": pr["number"],
+            "issue_number": issue_number,
+            "branch": branch,
+            "head_sha": head_sha,
+            "failing_checks": failing,
+        })
+
+    return targets
+
+
+def _fetch_ci_failure_log(detail_url: str) -> str:
+    """Fetch the failed job log tail from a GitHub Actions check run.
+
+    Extracts run_id from detailsUrl (format: .../runs/<run_id>/...)
+    and calls `gh run view <run_id> --log-failed --repo REPO`.
+    Returns the last 200 lines to stay within token limits.
+    """
+    m = re.search(r"/runs/(\d+)", detail_url)
+    if not m:
+        return f"(could not extract run ID from URL: {detail_url})"
+    run_id = m.group(1)
+    result = _run(
+        ["gh", "run", "view", run_id, "--log-failed", "--repo", REPO],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return f"(failed to fetch log: {result.stderr})"
+    lines = (result.stdout or "").splitlines()
+    return "\n".join(lines[-200:])
 
 
 def _recover_stuck_rebase_prs() -> int:
@@ -7922,6 +8083,281 @@ def cmd_explore(args) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Fix-CI (auto-diagnose and fix failing CI on open auto-improve PRs)
+# ---------------------------------------------------------------------------
+
+def cmd_fix_ci(args) -> int:
+    """Auto-diagnose and fix CI failures on open auto-improve PRs."""
+    print("[cai fix-ci] checking for PRs with failing CI", flush=True)
+
+    if getattr(args, "pr", None) is not None:
+        # Direct targeting: build a single-item target from the specified PR.
+        try:
+            pr_detail = _gh_json([
+                "pr", "view", str(args.pr),
+                "--repo", REPO,
+                "--json", "number,headRefName,comments,statusCheckRollup,commits,labels",
+            ])
+        except subprocess.CalledProcessError as e:
+            print(f"[cai fix-ci] gh pr view #{args.pr} failed:\n{e.stderr}", file=sys.stderr)
+            log_run("fix-ci", repo=REPO, pr=args.pr, result="pr_lookup_failed", exit=1)
+            return 1
+        branch = pr_detail.get("headRefName", "")
+        m = re.match(r"^auto-improve/(\d+)-", branch)
+        if not m:
+            print(
+                f"[cai fix-ci] PR #{args.pr} branch '{branch}' "
+                "is not an auto-improve branch",
+                file=sys.stderr,
+            )
+            log_run("fix-ci", repo=REPO, pr=args.pr, result="not_auto_improve", exit=1)
+            return 1
+        issue_number = int(m.group(1))
+        checks = pr_detail.get("statusCheckRollup") or []
+        failing = [
+            {"name": c.get("name", ""), "detailsUrl": c.get("detailsUrl") or c.get("url", "")}
+            for c in checks
+            if (c.get("conclusion") or c.get("status") or "").upper() == "FAILURE"
+        ]
+        commits = pr_detail.get("commits") or []
+        head_sha = commits[-1].get("oid", "") if commits else ""
+        targets = [{
+            "pr_number": pr_detail["number"],
+            "issue_number": issue_number,
+            "branch": branch,
+            "head_sha": head_sha,
+            "failing_checks": failing,
+        }]
+    else:
+        targets = _select_ci_fix_targets()
+
+    if not targets:
+        print("[cai fix-ci] no PRs need CI fixes; nothing to do", flush=True)
+        log_run("fix-ci", repo=REPO, result="no_targets", exit=0)
+        return 0
+
+    print(f"[cai fix-ci] found {len(targets)} PR(s) with failing CI", flush=True)
+
+    had_failure = False
+    for target in targets:
+        pr_number = target["pr_number"]
+        issue_number = target["issue_number"]
+        branch = target["branch"]
+        failing_checks = target["failing_checks"]
+
+        print(
+            f"[cai fix-ci] fixing PR #{pr_number} (issue #{issue_number}, "
+            f"{len(failing_checks)} failing check(s))",
+            flush=True,
+        )
+
+        # 1. Lock — add :revising label.
+        if not _set_labels(issue_number, add=[LABEL_REVISING], log_prefix="cai fix-ci"):
+            print(f"[cai fix-ci] could not lock #{issue_number}", file=sys.stderr)
+            log_run("fix-ci", repo=REPO, pr=pr_number, result="lock_failed", exit=1)
+            had_failure = True
+            continue
+
+        _run(["gh", "auth", "setup-git"], capture_output=True)
+        _write_active_job("fix-ci", "issue", issue_number)
+
+        _uid = uuid.uuid4().hex[:8]
+        work_dir = Path(f"/tmp/cai-fix-ci-{issue_number}-{_uid}")
+
+        try:
+            if work_dir.exists():
+                shutil.rmtree(work_dir)
+
+            # 2. Clone and check out the PR branch.
+            clone = _run(
+                ["gh", "repo", "clone", REPO, str(work_dir)],
+                capture_output=True,
+            )
+            if clone.returncode != 0:
+                print(f"[cai fix-ci] clone failed:\n{clone.stderr}", file=sys.stderr)
+                _set_labels(issue_number, remove=[LABEL_REVISING], log_prefix="cai fix-ci")
+                log_run("fix-ci", repo=REPO, pr=pr_number, result="clone_failed", exit=1)
+                had_failure = True
+                continue
+
+            _git(work_dir, "fetch", "origin", branch)
+            _git(work_dir, "checkout", branch)
+
+            # 3. Configure git identity.
+            name, email = _gh_user_identity()
+            _git(work_dir, "config", "user.name", name)
+            _git(work_dir, "config", "user.email", email)
+
+            # 4. Freshen-up rebase onto main (non-conflicting only).
+            _git(work_dir, "fetch", "origin", "main")
+            pre_agent_head = _git(
+                work_dir, "rev-parse", "HEAD", check=False,
+            ).stdout.strip()
+            _git(work_dir, "rebase", "origin/main", check=False)
+
+            rebase_merge_dir = work_dir / ".git" / "rebase-merge"
+            rebase_apply_dir = work_dir / ".git" / "rebase-apply"
+            rebase_in_progress = (
+                rebase_merge_dir.exists() or rebase_apply_dir.exists()
+            )
+
+            if rebase_in_progress:
+                # Abort and skip — let cai revise handle conflicts.
+                _git(work_dir, "rebase", "--abort", check=False)
+                print(
+                    f"[cai fix-ci] PR #{pr_number}: rebase conflicts; "
+                    "skipping (leave for cai revise)",
+                    flush=True,
+                )
+                _set_labels(issue_number, remove=[LABEL_REVISING], log_prefix="cai fix-ci")
+                log_run("fix-ci", repo=REPO, pr=pr_number, result="rebase_conflict", exit=0)
+                continue
+
+            # 5. Fetch CI failure logs (first two failing checks).
+            ci_log_section = "## CI failure log\n\n"
+            for check in failing_checks[:2]:
+                log_text = _fetch_ci_failure_log(check.get("detailsUrl", ""))
+                ci_log_section += (
+                    f"### Check: {check.get('name', 'unknown')}\n\n"
+                    f"```\n{log_text}\n```\n\n"
+                )
+
+            # 6. Fetch original issue body.
+            try:
+                issue_data = _gh_json([
+                    "issue", "view", str(issue_number),
+                    "--repo", REPO,
+                    "--json", "number,title,body",
+                ])
+            except subprocess.CalledProcessError:
+                issue_data = {"number": issue_number, "title": "(unknown)", "body": ""}
+
+            # 7. Build PR state block.
+            stat_result = _git(
+                work_dir, "diff", "origin/main..HEAD", "--stat", check=False,
+            )
+            pr_stat = (stat_result.stdout or "").strip() or "(no changes vs origin/main)"
+            pr_state_block = (
+                f"## Current PR state\n\n"
+                f"```\n{pr_stat}\n```\n\n"
+            )
+
+            # 8. Build the user message.
+            _issue_num = issue_data["number"]
+            user_message = (
+                _work_directory_block(work_dir)
+                + "\n"
+                + "## Original issue\n\n"
+                + f"### #{_issue_num} — {issue_data.get('title', '')}\n\n"
+                + f"{issue_data.get('body') or '(no body)'}\n\n"
+                + pr_state_block
+                + ci_log_section
+            )
+
+            # 9. Pre-create the staging directory for agent self-edits.
+            _setup_agent_edit_staging(work_dir)
+
+            # 10. Invoke the cai-fix-ci subagent.
+            print(
+                f"[cai fix-ci] running cai-fix-ci subagent for {work_dir}",
+                flush=True,
+            )
+            agent = _run_claude_p(
+                ["claude", "-p", "--agent", "cai-fix-ci",
+                 "--dangerously-skip-permissions",
+                 "--add-dir", str(work_dir)],
+                category="fix-ci",
+                agent="cai-fix-ci",
+                input=user_message,
+                cwd="/app",
+            )
+            if agent.stdout:
+                print(agent.stdout, flush=True)
+
+            # 10b. Apply any staged .claude/agents/*.md updates.
+            applied = _apply_agent_edit_staging(work_dir)
+            if applied:
+                print(
+                    f"[cai fix-ci] applied {applied} staged "
+                    f".claude/agents/*.md update(s)",
+                    flush=True,
+                )
+
+            agent_summary = (agent.stdout or "").strip()[:4000]
+
+            # 11. Commit any uncommitted changes the agent left behind.
+            status = _git(work_dir, "status", "--porcelain", check=False)
+            has_uncommitted = bool(status.stdout.strip())
+            post_agent_head = _git(
+                work_dir, "rev-parse", "HEAD", check=False,
+            ).stdout.strip()
+            head_changed = pre_agent_head != post_agent_head
+
+            if has_uncommitted:
+                _git(work_dir, "add", "-A")
+                _git(work_dir, "commit", "-m",
+                     "fix: address CI failure\n\n"
+                     f"Refs {REPO}#{issue_number}\n\n"
+                     "Co-Authored-By: Claude <noreply@anthropic.com>",
+                     check=False)
+                post_agent_head = _git(
+                    work_dir, "rev-parse", "HEAD", check=False,
+                ).stdout.strip()
+                head_changed = True
+
+            if head_changed:
+                push = _run(
+                    ["git", "-C", str(work_dir), "push",
+                     "--force-with-lease", "origin", branch],
+                    capture_output=True,
+                )
+                if push.returncode != 0:
+                    print(
+                        f"[cai fix-ci] push failed:\n{push.stderr}",
+                        file=sys.stderr,
+                    )
+                else:
+                    print(f"[cai fix-ci] pushed fix for PR #{pr_number}", flush=True)
+            else:
+                print(
+                    f"[cai fix-ci] no changes produced by agent for PR #{pr_number}",
+                    flush=True,
+                )
+
+            # 12. Post marker comment (always — prevents retry on same SHA).
+            marker_body = (
+                f"{_CI_FIX_ATTEMPT_MARKER} — "
+                f"{post_agent_head or pre_agent_head}"
+            )
+            if agent_summary:
+                marker_body += f"\n\n{agent_summary}"
+            _run(
+                ["gh", "pr", "comment", str(pr_number),
+                 "--repo", REPO, "--body", marker_body],
+                capture_output=True,
+            )
+
+            _set_labels(issue_number, remove=[LABEL_REVISING], log_prefix="cai fix-ci")
+            log_run(
+                "fix-ci", repo=REPO, pr=pr_number,
+                result="fix_pushed" if head_changed else "no_changes",
+                exit=0,
+            )
+
+        except Exception as exc:
+            print(f"[cai fix-ci] unexpected failure: {exc!r}", file=sys.stderr)
+            _set_labels(issue_number, remove=[LABEL_REVISING], log_prefix="cai fix-ci")
+            log_run("fix-ci", repo=REPO, pr=pr_number, result="unexpected_error", exit=1)
+            had_failure = True
+        finally:
+            _clear_active_job()
+            if work_dir.exists():
+                shutil.rmtree(work_dir, ignore_errors=True)
+
+    return 1 if had_failure else 0
+
+
+# ---------------------------------------------------------------------------
 # Cycle (full pipeline without analyze)
 # ---------------------------------------------------------------------------
 
@@ -7936,9 +8372,10 @@ def _run_step(name: str, handler, args) -> int:
 
 
 def _drain_pending_prs(args) -> dict:
-    """Revise → review-pr → review-docs → merge all pending PRs. Returns step results."""
+    """Revise → fix-ci → review-pr → review-docs → merge all pending PRs. Returns step results."""
     results: dict[str, int] = {}
     results["revise"] = _run_step("revise", cmd_revise, args)
+    results["fix-ci"] = _run_step("fix-ci", cmd_fix_ci, args)
     results["review-pr"] = _run_step("review-pr", cmd_review_pr, args)
     results["review-docs"] = _run_step("review-docs", cmd_review_docs, args)
     results["merge"] = _run_step("merge", cmd_merge, args)
@@ -8887,6 +9324,14 @@ def main() -> int:
     )
     sub.add_parser("cost-optimize", help="Weekly cost-reduction proposal or evaluation")
     sub.add_parser("check-workflows", help="Check GitHub Actions for recent workflow failures and raise findings")
+    fix_ci_parser = sub.add_parser(
+        "fix-ci",
+        help="Auto-diagnose and fix CI failures on open auto-improve PRs",
+    )
+    fix_ci_parser.add_argument(
+        "--pr", type=int, default=None,
+        help="Target a specific PR number instead of using queue-based selection",
+    )
     sub.add_parser("cycle", help="Full cycle: verify, fix, revise, review-pr, review-docs, merge, confirm")
     sub.add_parser("test", help="Run the project test suite")
 
@@ -8953,6 +9398,7 @@ def main() -> int:
         "health-report": cmd_health_report,
         "cost-optimize": cmd_cost_optimize,
         "check-workflows": cmd_check_workflows,
+        "fix-ci": cmd_fix_ci,
         "test": cmd_test,
     }
     return handlers[args.command](args)

--- a/cai.py
+++ b/cai.py
@@ -8481,7 +8481,7 @@ def cmd_cycle(args) -> int:
     Flow:
       1. verify + confirm  (sync label state)
       1.5. recover stale locks (:in-progress / :revising)
-      2. drain pending PRs (revise → review-pr → review-docs → merge)
+      2. drain pending PRs (revise → fix-ci → review-pr → review-docs → merge)
       3. loop: verify → fix/spike/explore → drain → repeat
          (fix picks only human:plan-approved / human:requested — nothing raised
          or refined is auto-consumed here; an issue whose fix fails
@@ -9332,7 +9332,7 @@ def main() -> int:
         "--pr", type=int, default=None,
         help="Target a specific PR number instead of using queue-based selection",
     )
-    sub.add_parser("cycle", help="Full cycle: verify, fix, revise, review-pr, review-docs, merge, confirm")
+    sub.add_parser("cycle", help="Full cycle: verify, fix, revise, fix-ci, review-pr, review-docs, merge, confirm")
     sub.add_parser("test", help="Run the project test suite")
 
     cost_parser = sub.add_parser(

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -11,6 +11,7 @@ Agents are defined in `.claude/agents/*.md` with YAML frontmatter (`name`, `desc
 | `cai-confirm` | Verify each `auto-improve:merged` issue is actually resolved | Read, Grep, Glob | sonnet | Read-only |
 | `cai-cost-optimize` | Weekly cost-reduction agent — analyzes spending trends, proposes one optimization | Read, Grep, Glob | sonnet | Read-only |
 | `cai-explore` | Autonomous exploration and benchmarking of `:needs-exploration` issues | Read, Grep, Glob, Bash, Agent, Write, Edit | opus | Clone |
+| `cai-fix-ci` | Diagnose and fix failing GitHub Actions checks on open PRs | Read, Edit, Write, Grep, Glob, Agent | sonnet | Worktree |
 | `cai-implement` | Autonomous code-editing subagent — makes the smallest targeted change for an issue | Read, Edit, Write, Grep, Glob, TodoWrite | sonnet | Worktree |
 | `cai-git` | Lightweight subagent that executes git operations on behalf of other agents | Bash | haiku | Worktree |
 | `cai-merge` | Assess whether a PR correctly implements its linked issue and emit a merge verdict | Read | opus | Inline-only |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,7 @@
 5. **Fix** — `cai implement` calls `cai-implement` on `human:plan-approved` issues in a fresh git worktree. The wrapper commits, pushes, and opens a PR. Label transitions to `auto-improve:in-progress` → `auto-improve:pr-open`.
 6. **Review** — `cai review-pr` checks for ripple-effect inconsistencies and posts findings as PR comments. `cai review-docs` then (and only after review-pr completes) checks for stale documentation, directly fixes issues it can resolve, and commits/pushes those changes to the PR branch. Remaining unfixable issues are posted as `### Finding: stale_docs` comments. This ordering is enforced: review-docs skips PRs until review-pr has posted a review comment at the current HEAD SHA.
 7. **Revise** — `cai revise` calls `cai-revise` or `cai-rebase` to address review comments or rebase conflicts. Label transitions to `auto-improve:revising`.
+7.5. **CI Fix** — `cai fix-ci` calls `cai-fix-ci` to diagnose and fix failing GitHub Actions checks on open PRs. The subagent reads the failure log (last 200 lines, up to 2 failing checks), locates the root cause in the clone, and makes the minimal fix. A per-SHA marker comment (`## CI-fix subagent: fix attempt`) is always posted after each run — whether or not a fix was produced — so the loop guard fires on the next tick if CI is still red. PRs with unaddressed review comments are skipped (left for `cai revise`); PRs with `:needs-human-review` or `:merge-blocked` are always skipped.
 8. **Merge** — `cai merge` calls `cai-merge` to assess confidence and auto-merges PRs that meet the threshold. Label transitions to `auto-improve:merged`.
 9. **Confirm** — `cai confirm` calls `cai-confirm` to verify the merged fix actually resolved the original issue. Label transitions to `auto-improve:solved` or re-queues to `:refined`.
 
@@ -45,7 +46,7 @@
 1. **Verify + confirm** — sync label state with actual PR/issue state.
 2. **Recover stale locks** — roll back `:in-progress` and `:revising` issues past their timeout.
 3. **Ingest unlabeled** — attach `auto-improve` to any unlabeled issues that belong to the pipeline.
-4. **Drain PRs** — for each open auto-improve PR: revise → review-pr → review-docs → merge.
+4. **Drain PRs** — for each open auto-improve PR: revise → fix-ci → review-pr → review-docs → merge.
 5. **Implement loop** — repeatedly call `implement`, `spike`, or `explore` on `human:plan-approved` / `human:requested` issues until no eligible work remains, draining PRs after each implementation. `:raised`, `:refined`, and `:planned` issues are not consumed here — they wait on the human:plan-approved gate.
 6. **Plan-all** — run `plan-all` to drain every open `:raised` / `:refined` issue through refine → plan → `:planned` so humans have a backlog to review before the next cycle.
 7. **Final confirm** — one last confirm pass.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,7 +56,7 @@ Print a human-readable cost report from `/var/log/cai/cai-cost.jsonl`.
 
 ## cycle
 
-Continuously run the full pipeline until nothing is left to do: verify + confirm → recover stale locks → drain pending PRs (revise → review-pr → review-docs → merge) → refine one `:raised` or `human:submitted` issue → fix/spike/explore loop → final confirm.
+Continuously run the full pipeline until nothing is left to do: verify + confirm → recover stale locks → drain pending PRs (revise → fix-ci → review-pr → review-docs → merge) → refine one `:raised` or `human:submitted` issue → fix/spike/explore loop → final confirm.
 
 No arguments.
 
@@ -67,6 +67,14 @@ Run `cai-explore` on the oldest `auto-improve:needs-exploration` issue. Outcomes
 | Argument | Type | Description |
 |---|---|---|
 | `--issue INT` | optional | Target a specific issue number |
+
+## fix-ci
+
+Diagnose and fix failing GitHub Actions checks on open auto-improve PRs. Invokes `cai-fix-ci` to read the failure log, identify the root cause (test, lint, build, or type error), and make a minimal targeted fix. Skips PRs with unaddressed review comments (left for `cai revise`), PRs marked `:needs-human-review`, or `:merge-blocked`. Posts a per-SHA marker comment after each run to prevent retry loops on the same commit.
+
+| Argument | Type | Description |
+|---|---|---|
+| `--pr INT` | optional | Target a specific PR number instead of using queue-based selection |
 
 ## implement
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@
 
 Cron schedules are configurable via environment variables. Default values are set in `entrypoint.sh`; most are also explicitly configured in `docker-compose.yml`.
 
-The issue-solving pipeline is split in two. `CAI_CYCLE_SCHEDULE` drives implement → revise → review-pr → merge → confirm on `human:plan-approved` issues (flock-serialized, one issue at a time). `CAI_PLAN_ALL_SCHEDULE` drives every `:raised` / `:refined` issue through refine → plan → `:planned` so humans have a backlog to approve; `plan-all` also runs at the end of each `cycle`. `:raised`, `:refined`, and `:planned` issues are never auto-fixed — a human must promote `:planned` → `human:plan-approved` before the implement loop touches them. Individual pipeline subcommands (`implement`, `refine`, `plan`, `plan-all`, `spike`, `revise`, `review-pr`, `merge`, `verify`, `confirm`) remain callable manually or from GitHub Actions.
+The issue-solving pipeline is split in two. `CAI_CYCLE_SCHEDULE` drives implement → revise → fix-ci → review-pr → review-docs → merge → confirm on `human:plan-approved` issues (flock-serialized, one issue at a time). `CAI_PLAN_ALL_SCHEDULE` drives every `:raised` / `:refined` issue through refine → plan → `:planned` so humans have a backlog to approve; `plan-all` also runs at the end of each `cycle`. `:raised`, `:refined`, and `:planned` issues are never auto-fixed — a human must promote `:planned` → `human:plan-approved` before the implement loop touches them. Individual pipeline subcommands (`implement`, `refine`, `plan`, `plan-all`, `spike`, `revise`, `fix-ci`, `review-pr`, `review-docs`, `merge`, `verify`, `confirm`) remain callable manually or from GitHub Actions.
 
 | Variable | Default | Description |
 |---|---|---|
@@ -31,6 +31,7 @@ The issue-solving pipeline is split in two. `CAI_CYCLE_SCHEDULE` drives implemen
 | `CAI_UPDATE_CHECK_SCHEDULE` | `0 4 * * 1` | Weekly (Monday 04:00 UTC) — Claude Code release check |
 | `CAI_HEALTH_REPORT_SCHEDULE` | `0 7 * * 1` | Weekly (Monday 07:00 UTC) — pipeline health report |
 | `CAI_CHECK_WORKFLOWS_SCHEDULE` | `0 */6 * * *` | Every 6 hours — GitHub Actions workflow check |
+| `CAI_FIX_CI_SCHEDULE` | `50 * * * *` | Hourly (offset 50) — diagnose and fix failing CI checks |
 
 Schedule values use standard cron format: `minute hour day month weekday`. To disable a scheduled agent, set its variable to an empty string or a comment value.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,6 +51,7 @@ CAI_UPDATE_CHECK_SCHEDULE="${CAI_UPDATE_CHECK_SCHEDULE:-0 4 * * 1}"
 CAI_HEALTH_REPORT_SCHEDULE="${CAI_HEALTH_REPORT_SCHEDULE:-0 7 * * 1}"
 CAI_COST_OPTIMIZE_SCHEDULE="${CAI_COST_OPTIMIZE_SCHEDULE:-0 5 * * 0}"
 CAI_CHECK_WORKFLOWS_SCHEDULE="${CAI_CHECK_WORKFLOWS_SCHEDULE:-0 */6 * * *}"
+CAI_FIX_CI_SCHEDULE="${CAI_FIX_CI_SCHEDULE:-50 * * * *}"
 
 CRONTAB_PATH=/tmp/crontab
 
@@ -69,6 +70,7 @@ $CAI_UPDATE_CHECK_SCHEDULE python /app/cai.py update-check
 $CAI_HEALTH_REPORT_SCHEDULE python /app/cai.py health-report
 $CAI_COST_OPTIMIZE_SCHEDULE python /app/cai.py cost-optimize
 $CAI_CHECK_WORKFLOWS_SCHEDULE python /app/cai.py check-workflows
+$CAI_FIX_CI_SCHEDULE python /app/cai.py fix-ci
 CRONTAB
 
 echo "[entrypoint] crontab:"


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#532

**Issue:** #532 — cai: automatically handle failing CI checks on open PRs

## PR Summary

### What this fixes
When `cai merge` encounters an open auto-improve PR with failing CI checks, it skips the PR indefinitely because neither `cai revise` (comment-driven) nor `cai merge` (CI gate) advances it. This adds a new `cai fix-ci` lifecycle step that autonomously diagnoses and fixes failing CI checks.

### What was changed
- **`cai.py`**: Added `"## CI-fix subagent:"` to `_BOT_COMMENT_MARKERS`; added `_CI_FIX_ATTEMPT_MARKER` constant; added `_select_ci_fix_targets()` to select eligible PRs (open, no unaddressed comments, no prior fix attempt on current SHA, has failing checks); added `_fetch_ci_failure_log()` to fetch last 200 lines of failing job output; added `cmd_fix_ci()` function (clones PR branch, rebases, invokes `cai-fix-ci` subagent, commits, pushes, posts per-SHA marker comment); inserted `fix-ci` into `_drain_pending_prs` between revise and review-pr; registered `fix-ci` argparse subcommand with `--pr` targeting; added to handlers dispatch
- **`.cai-staging/agents/cai-fix-ci.md`**: New subagent definition — diagnoses CI failure log, makes minimal fix, bails with structured "cannot fix" message for infrastructure/flaky failures
- **`entrypoint.sh`**: Added `CAI_FIX_CI_SCHEDULE` env var (default `50 * * * *`) and crontab entry
- **`docs/architecture.md`**: Documented the new CI Fix step (7.5) and updated the Drain PRs description

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
