### PR TITLE
auto-improve: Detail of why choosing a plan over another posted in the issue is useless noise

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,23 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#538
+
+## Files touched
+- .claude/agents/cai-select.md:57-79 — replaced `## Output format` section to emit only raw plan text, removing `## Selection`, `### Chosen plan`, `### Reasoning`, and `### Plan to implement` wrapper
+
+## Files read (not touched) that matter
+- .claude/agents/cai-select.md — the only file changed; lines 1-56 unchanged
+
+## Key symbols
+- `## Output format` (.claude/agents/cai-select.md:57) — section replaced entirely
+
+## Design decisions
+- Output bare plan text with no wrapper headings — cleanest result after wrapper prepends `## Selected Implementation Plan\n\n`
+- Added optional `> **Note:** …` blockquote escape hatch for edge-case commentary
+- Rejected: keeping a `## Selected Plan` heading — unnecessary nesting noise
+
+## Out of scope / known gaps
+- `cai.py` untouched — wrapper's `_extract_stored_plan` and `selection.strip()` guard both work correctly with bare plan output
+- `cai-implement.md` untouched — it looks for `## Selected Implementation Plan` injected by the wrapper, not the select agent's output
+
+## Invariants this change relies on
+- The wrapper prepends `## Selected Implementation Plan\n\n` before storing; `_extract_stored_plan` strips exactly that heading — bare plan output starts with plan's own `## Plan` heading after stripping

--- a/.claude/agents/cai-select.md
+++ b/.claude/agents/cai-select.md
@@ -56,23 +56,13 @@ Assess each plan on these criteria, in order of importance:
 
 ## Output format
 
-Produce your selection in exactly this structure:
-
-```
-## Selection
-
-### Chosen plan
-Plan <N>
-
-### Reasoning
-<2-3 sentences explaining why this plan is best and why the others
-were not chosen>
-
-### Plan to implement
-<paste the full chosen plan here, exactly as provided — do not
-modify it>
-```
+Output **only** the chosen plan — paste it exactly as provided with
+no modifications. Do not emit any selection metadata, plan numbers,
+reasoning, or wrapper headings. Your entire response should be the
+plan text and nothing else.
 
 If all plans are equally bad or none correctly addresses the issue,
-say so in your reasoning and pick the least-bad option, noting its
-weaknesses so the fix agent can compensate.
+pick the least-bad option. You may insert a single `> **Note:** …`
+blockquote at the very top of the output (before the plan content)
+to flag critical weaknesses for the fix agent, but keep it to one
+sentence.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#538

**Issue:** #538 — Detail of why choosing a plan over another posted in the issue is useless noise

## PR Summary

### What this fixes
The `cai-select` agent's output included `## Selection`, `### Chosen plan`, `### Reasoning`, and `### Plan to implement` wrapper sections that became noise once stored in the issue body — the reasoning compared rejected alternatives that are no longer relevant, and the structural metadata added no value for human readers or downstream agents.

### What was changed
- `.claude/agents/cai-select.md` (lines 57–79): Replaced the `## Output format` section to require the agent to output **only the raw chosen plan text** with no selection metadata, plan numbers, reasoning, or wrapper headings. Added an optional single-line `> **Note:** …` blockquote escape hatch for flagging critical weaknesses in the least-bad-option case.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
