### PR TITLE
auto-improve: In audit, we should analyze old issues to see how they were solved.

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -46,6 +46,20 @@ Refs: robotsix/robotsix-cai#529
 ### New gaps / deferred
 - None
 
+## Revision 3 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `.claude/agents/cai-audit.md` (via staging) — swapped items 5 and 6 in "What you receive" list so Outcome statistics is #5 and Recently closed issues is #6, matching the actual delivery order in cai.py
+
+### Decisions this revision
+- Chose reviewer option (b): update docs to match code order, since outcome stats logically pair with the cost summary as current-loop performance metrics, before historical closed-issue data
+
+### New gaps / deferred
+- None
+
 ## Out of scope / known gaps
 - `cmd_analyze` is not touched — outcome section is audit-only per scope guardrails
 - `_load_outcome_counts` internals not changed

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -18,6 +18,20 @@ Refs: robotsix/robotsix-cai#529
 - `sorted(outcome_counts.items())` — deterministic table order
 - Rejected: computing avg fix_attempt_count — would require additional log parsing; plan explicitly excluded it
 
+## Revision 1 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `publish.py`:55 — added `"workflow_efficiency"` to `AUDIT_CATEGORIES` set so the publish script accepts findings in the new category
+
+### Decisions this revision
+- Added single line to `AUDIT_CATEGORIES`; no other changes needed — category was already defined in `cai-audit.md` by the original fix
+
+### New gaps / deferred
+- None
+
 ## Out of scope / known gaps
 - `cmd_analyze` is not touched — outcome section is audit-only per scope guardrails
 - `_load_outcome_counts` internals not changed

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,27 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#529
+
+## Files touched
+- `cai.py`:4333 — added `outcome_section` build using `_load_outcome_counts(days=90)` after `cost_section`
+- `cai.py`:4335 — added `outcome_section` to `user_message` f-string in `cmd_audit`
+- `.claude/agents/cai-audit.md` (via staging) — added bullet 6 to "What you receive", new `workflow_efficiency` check row, new `workflow_efficiency` category row, updated "9 categories" → "10 categories" in two places
+
+## Files read (not touched) that matter
+- `cai_lib/logging_utils.py` — confirmed `_load_outcome_counts` returns `{cat: {"total": N, "solved": N}}` dict
+
+## Key symbols
+- `_load_outcome_counts` (`cai_lib/logging_utils.py:92`) — already imported in `cai.py:182`, returns per-category total/solved counts
+- `cmd_audit` (`cai.py:4183`) — the audit orchestrator where outcome_section is built and injected
+
+## Design decisions
+- `total >= 3` guard on the ⚠ flag — prevents spurious warnings on categories with too few data points
+- `sorted(outcome_counts.items())` — deterministic table order
+- Rejected: computing avg fix_attempt_count — would require additional log parsing; plan explicitly excluded it
+
+## Out of scope / known gaps
+- `cmd_analyze` is not touched — outcome section is audit-only per scope guardrails
+- `_load_outcome_counts` internals not changed
+
+## Invariants this change relies on
+- `_load_outcome_counts` returns a dict with `"total"` and `"solved"` keys per category bucket
+- `_load_outcome_counts` returns `{}` when log is absent (graceful fallback handled)

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -60,6 +60,23 @@ Refs: robotsix/robotsix-cai#529
 ### New gaps / deferred
 - None
 
+## Revision 4 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `publish.py`:55 — renamed `"workflow_efficiency"` → `"fix_loop_efficiency"` in `AUDIT_CATEGORIES`
+- `publish.py`:127 — renamed `("category:workflow_efficiency", ...)` → `("category:fix_loop_efficiency", ...)` in `AUDIT_LABELS`
+- `cai.py`:4335 — updated inline comment to reference `fix_loop_efficiency`
+- `.claude/agents/cai-audit.md` (via staging) — renamed `workflow_efficiency` → `fix_loop_efficiency` in check table (line 86) and categories table (line 156)
+
+### Decisions this revision
+- Chose reviewer option (rename) over consolidation — the two labels have distinct semantics (analyzer: "unnecessary workflow steps/config"; audit: "low fix success rate") and should not share a single GitHub label definition
+
+### New gaps / deferred
+- None
+
 ## Out of scope / known gaps
 - `cmd_analyze` is not touched — outcome section is audit-only per scope guardrails
 - `_load_outcome_counts` internals not changed

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -32,6 +32,20 @@ Refs: robotsix/robotsix-cai#529
 ### New gaps / deferred
 - None
 
+## Revision 2 (2026-04-13)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `publish.py`:127 — added `("category:workflow_efficiency", ...)` entry to `AUDIT_LABELS` so audit findings in this category get the audit-specific label description rather than the analyzer's label
+
+### Decisions this revision
+- Used reviewer's suggested color (`e4e669`) and description verbatim; consistent with adjacent `workflow_anomaly` entry
+
+### New gaps / deferred
+- None
+
 ## Out of scope / known gaps
 - `cmd_analyze` is not touched — outcome section is audit-only per scope guardrails
 - `_load_outcome_counts` internals not changed

--- a/.claude/agents/cai-audit.md
+++ b/.claude/agents/cai-audit.md
@@ -36,12 +36,12 @@ The user message contains:
    `claude -p --output-format json`'s `total_cost_usd` field, so
    they reflect what Anthropic actually billed. Use this section to
    spot `cost_outlier` patterns (see categories below).
-5. **Recently closed auto-improve issues** — number, title, labels at
+5. **Outcome statistics** — per-category success rate and total attempt count over the last 90 days, sourced from `cai-outcome.jsonl`. Rows flagged with ⚠ have a success rate below 40% with at least 3 recorded outcomes.
+6. **Recently closed auto-improve issues** — number, title, labels at
    close time, close date, and the last human rationale comment (if any).
    Use this to verify that issues transitioned through the expected
    lifecycle states before closing, and that PRs linked to closed issues
    were actually merged.
-6. **Outcome statistics** — per-category success rate and total attempt count over the last 90 days, sourced from `cai-outcome.jsonl`. Rows flagged with ⚠ have a success rate below 40% with at least 3 recorded outcomes.
 
 ## Lifecycle states — tracking vs active
 

--- a/.claude/agents/cai-audit.md
+++ b/.claude/agents/cai-audit.md
@@ -41,6 +41,7 @@ The user message contains:
    Use this to verify that issues transitioned through the expected
    lifecycle states before closing, and that PRs linked to closed issues
    were actually merged.
+6. **Outcome statistics** — per-category success rate and total attempt count over the last 90 days, sourced from `cai-outcome.jsonl`. Rows flagged with ⚠ have a success rate below 40% with at least 3 recorded outcomes.
 
 ## Lifecycle states — tracking vs active
 
@@ -82,6 +83,7 @@ stale `:merged` issues are flagged with `needs-human-review`.)
 | Closed issue whose labels don't include a terminal state (`auto-improve:merged` or `auto-improve:no-action`) — may indicate manual close without proper resolution | `workflow_anomaly` |
 | Merged PR whose linked `auto-improve` issue is still open (check recent PRs for matching branch/title against open issues) | `workflow_anomaly` |
 | Closed-unmerged PR whose linked issue is not rolled back to `:refined` | `workflow_anomaly` |
+| A category in the outcome statistics table flagged ⚠ (success rate <40% with ≥3 outcomes in 90 days) | `workflow_efficiency` |
 
 ### Log-level patterns
 
@@ -151,6 +153,7 @@ already been rolled back before your context is assembled.
 | `forgotten_backlog` | Tracking-only issue (no state label) older than 30 days with no human activity |
 | `cost_outlier` | A `claude -p` invocation (or category aggregate) in the cost summary that dominates token spend disproportionately to its functional value |
 | `workflow_anomaly` | Issue or PR whose lifecycle transitions don't match expected workflow (e.g., closed without terminal label, merged PR with open issue) |
+| `workflow_efficiency` | A fix category where the loop is structurally struggling — success rate below 40% over the last 90 days (with ≥3 outcomes), suggesting a prompt, scope, or tooling problem rather than a one-off failure |
 
 ## Output format
 
@@ -159,7 +162,7 @@ For each anomaly, output a markdown block:
 ```markdown
 ### Finding: <short imperative title>
 
-- **Category:** <one of the 9 categories above>
+- **Category:** <one of the 10 categories above>
 - **Key:** <stable-slug-for-deduplication>
 - **Confidence:** low | medium | high
 - **Evidence:**
@@ -177,7 +180,7 @@ No findings.
 
 - Every finding must be grounded in the data you received — no
   speculation about issues you can't see.
-- Stick to the 9 categories above; do not invent new ones.
+- Stick to the 10 categories above; do not invent new ones.
 - Keep titles short and imperative.
 - These findings are **report-only** — they go to humans for triage.
   Do not suggest automated fixes beyond what the deterministic

--- a/.claude/agents/cai-audit.md
+++ b/.claude/agents/cai-audit.md
@@ -83,7 +83,7 @@ stale `:merged` issues are flagged with `needs-human-review`.)
 | Closed issue whose labels don't include a terminal state (`auto-improve:merged` or `auto-improve:no-action`) — may indicate manual close without proper resolution | `workflow_anomaly` |
 | Merged PR whose linked `auto-improve` issue is still open (check recent PRs for matching branch/title against open issues) | `workflow_anomaly` |
 | Closed-unmerged PR whose linked issue is not rolled back to `:refined` | `workflow_anomaly` |
-| A category in the outcome statistics table flagged ⚠ (success rate <40% with ≥3 outcomes in 90 days) | `workflow_efficiency` |
+| A category in the outcome statistics table flagged ⚠ (success rate <40% with ≥3 outcomes in 90 days) | `fix_loop_efficiency` |
 
 ### Log-level patterns
 
@@ -153,7 +153,7 @@ already been rolled back before your context is assembled.
 | `forgotten_backlog` | Tracking-only issue (no state label) older than 30 days with no human activity |
 | `cost_outlier` | A `claude -p` invocation (or category aggregate) in the cost summary that dominates token spend disproportionately to its functional value |
 | `workflow_anomaly` | Issue or PR whose lifecycle transitions don't match expected workflow (e.g., closed without terminal label, merged PR with open issue) |
-| `workflow_efficiency` | A fix category where the loop is structurally struggling — success rate below 40% over the last 90 days (with ≥3 outcomes), suggesting a prompt, scope, or tooling problem rather than a one-off failure |
+| `fix_loop_efficiency` | A fix category where the loop is structurally struggling — success rate below 40% over the last 90 days (with ≥3 outcomes), suggesting a prompt, scope, or tooling problem rather than a one-off failure |
 
 ## Output format
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,8 @@ before the implement subagent picks them up.
 | `audit:needs-human` | Finding requires human judgement and cannot be resolved autonomously |
 
 Audit categories: `stale_lifecycle`, `lock_corruption`, `loop_stuck`,
-`prompt_contradiction`, `topic_duplicate`, `silent_failure`.
+`prompt_contradiction`, `topic_duplicate`, `silent_failure`, `forgotten_backlog`,
+`cost_outlier`, `workflow_anomaly`, `fix_loop_efficiency`.
 
 There are five exceptions to "report-only": stale lock rollback,
 stale `:no-action` rollback, stale `:merged` flagging,

--- a/cai.py
+++ b/cai.py
@@ -4332,7 +4332,7 @@ def cmd_audit(args) -> int:
     if not cost_section:
         cost_section = "## Cost summary\n\n(no cost-log entries yet)\n"
 
-    # Outcome statistics for the audit agent to spot workflow_efficiency issues.
+    # Outcome statistics for the audit agent to spot fix_loop_efficiency issues.
     outcome_counts = _load_outcome_counts(days=90)
     if outcome_counts:
         outcome_lines = ["## Outcome statistics (last 90 days)\n",

--- a/cai.py
+++ b/cai.py
@@ -4332,11 +4332,28 @@ def cmd_audit(args) -> int:
     if not cost_section:
         cost_section = "## Cost summary\n\n(no cost-log entries yet)\n"
 
+    # Outcome statistics for the audit agent to spot workflow_efficiency issues.
+    outcome_counts = _load_outcome_counts(days=90)
+    if outcome_counts:
+        outcome_lines = ["## Outcome statistics (last 90 days)\n",
+                         "| Category | Total | Solved | Rate |",
+                         "|---|---|---|---|"]
+        for cat, bucket in sorted(outcome_counts.items()):
+            total = bucket["total"]
+            solved = bucket["solved"]
+            rate = solved / total if total else 0.0
+            flag = " ⚠" if rate < 0.4 and total >= 3 else ""
+            outcome_lines.append(f"| {cat} | {total} | {solved} | {rate:.0%}{flag} |")
+        outcome_section = "\n".join(outcome_lines) + "\n"
+    else:
+        outcome_section = "## Outcome statistics (last 90 days)\n\n(no outcome-log entries yet)\n"
+
     user_message = (
         f"{issues_section}\n"
         f"{prs_section}\n"
         f"{log_section}\n"
         f"{cost_section}\n"
+        f"{outcome_section}\n"
         f"{closed_section}\n"
         f"{deterministic_section}"
     )

--- a/publish.py
+++ b/publish.py
@@ -52,7 +52,7 @@ AUDIT_CATEGORIES = {
     "forgotten_backlog",
     "cost_outlier",
     "workflow_anomaly",
-    "workflow_efficiency",
+    "fix_loop_efficiency",
 }
 
 CODE_AUDIT_CATEGORIES = {
@@ -124,7 +124,7 @@ AUDIT_LABELS = [
     ("category:forgotten_backlog", "c2e0c6", "Tracking-only issue with no state label idle >30 days"),
     ("category:cost_outlier", "fbca04", "A claude -p invocation or category aggregate that dominates token spend"),
     ("category:workflow_anomaly", "e4e669", "Issue or PR lifecycle transition doesn't match expected workflow"),
-    ("category:workflow_efficiency", "e4e669", "A fix category where the loop is structurally struggling — success rate below 40% with ≥3 outcomes in 90 days"),
+    ("category:fix_loop_efficiency", "e4e669", "A fix category where the loop is structurally struggling — success rate below 40% with ≥3 outcomes in 90 days"),
 ]
 
 CODE_AUDIT_LABELS = [

--- a/publish.py
+++ b/publish.py
@@ -52,6 +52,7 @@ AUDIT_CATEGORIES = {
     "forgotten_backlog",
     "cost_outlier",
     "workflow_anomaly",
+    "workflow_efficiency",
 }
 
 CODE_AUDIT_CATEGORIES = {

--- a/publish.py
+++ b/publish.py
@@ -124,6 +124,7 @@ AUDIT_LABELS = [
     ("category:forgotten_backlog", "c2e0c6", "Tracking-only issue with no state label idle >30 days"),
     ("category:cost_outlier", "fbca04", "A claude -p invocation or category aggregate that dominates token spend"),
     ("category:workflow_anomaly", "e4e669", "Issue or PR lifecycle transition doesn't match expected workflow"),
+    ("category:workflow_efficiency", "e4e669", "A fix category where the loop is structurally struggling — success rate below 40% with ≥3 outcomes in 90 days"),
 ]
 
 CODE_AUDIT_LABELS = [


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#529

**Issue:** #529 — In audit, we should analyze old issues to see how they were solved.

## PR Summary

### What this fixes
The audit agent had no visibility into per-category success rates from `cai-outcome.jsonl`, so it could not detect categories where the fix loop chronically fails. This adds an `## Outcome statistics` section to the audit user message and a new `workflow_efficiency` category to `cai-audit.md` so the agent can flag struggling categories.

### What was changed
- **`cai.py`** (`cmd_audit`): After building `cost_section`, builds an `outcome_section` using the existing `_load_outcome_counts(days=90)` function, formatting results as a 4-column markdown table with ⚠ flags for categories with `rate < 40%` and ≥3 outcomes; appends it to the `user_message` f-string.
- **`.claude/agents/cai-audit.md`** (via staging): Added bullet 6 ("Outcome statistics") to "What you receive"; added a `workflow_efficiency` check row to the "What to check" table; added `workflow_efficiency` to the Categories table; updated "9 categories" → "10 categories" in two places in the output format and guardrails sections.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
