### PR TITLE
auto-improve: [Step 2/3] Wire label transitions into commands and replace SHA-based gates

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,39 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#566
+
+## Files touched
+- `cai.py:3788` — added `_pr_set_pipeline_state(pr_number, LABEL_PR_EDITED)` in `cmd_revise` after push success
+- `cai.py:6336-6338` — added `_pr_set_pipeline_state` calls (reject/accept) in `cmd_review_pr` after posting review comment
+- `cai.py:6462-6470` — replaced SHA-scan gate in `cmd_review_docs` with `pr_labels` label check for `LABEL_PR_REVIEWED_ACCEPT`
+- `cai.py:6602-6609` — added `_pr_set_pipeline_state` calls (edited/documented) in `cmd_review_docs` after posting comment
+- `cai.py:6896` — extracted `pr_labels` to top of per-PR loop in `cmd_merge`
+- `cai.py:6946-6955` — replaced entire SHA-scan filter 7 block in `cmd_merge` with label check (reviewed-accept OR documented)
+- `cai.py:6958-6963` — replaced SHA-scan filter 7b in `cmd_merge` with label check (documented)
+- `cai.py:6392-6396` — removed `_REVIEW_DOCS_COMMIT_SUBJECT` constant definition (5 lines)
+- `cai.py:6564-6566` — inlined the constant string into the `_git commit -m` call in `cmd_review_docs`
+
+## Files read (not touched) that matter
+- `cai.py` — `_pr_set_pipeline_state` function (line 6688), label constants (lines 6680-6683), `_DOCS_REVIEW_COMMENT_HEADING_PREFIX` (line 6390, still live in idempotency check at ~6434)
+
+## Key symbols
+- `_pr_set_pipeline_state` (`cai.py:6688`) — removes all existing pr:* labels and sets the new one atomically
+- `LABEL_PR_EDITED` (`cai.py:6680`) — "pr:edited", set after push in cmd_revise and docs-fix push in cmd_review_docs
+- `LABEL_PR_REVIEWED_ACCEPT` (`cai.py:6682`) — "pr:reviewed-accept", gate for cmd_review_docs and filter 7 in cmd_merge
+- `LABEL_PR_REVIEWED_REJECT` (`cai.py:6681`) — "pr:reviewed-reject", set when review-pr finds issues
+- `LABEL_PR_DOCUMENTED` (`cai.py:6683`) — "pr:documented", gate for filter 7b in cmd_merge, set by cmd_review_docs clean
+- `pr_labels` (`cai.py:6896`) — set computed once per loop iteration in cmd_merge, shared by filters 7 and 7b
+
+## Design decisions
+- `pr_labels` computed at top of cmd_merge loop (before filter 1) — harmless for non-bot PRs since they continue immediately; avoids re-scoping inside filter 7
+- Label set in cmd_revise immediately after push (before comment) — reflects branch state change, not comment posting
+- `_DOCS_REVIEW_COMMENT_HEADING_PREFIX` NOT removed — still used in cmd_review_docs idempotency check (~line 6434)
+- Bootstrap: PRs with no pr:* label skip cmd_review_docs and cmd_merge until next cmd_review_pr run sets label
+
+## Out of scope / known gaps
+- `_pr_label_sweep` changes deferred to step 3 (#557)
+- Safety filters 1-6 and 3 (unaddressed review comments) not touched
+- `needs-human-review` and `merge-blocked` logic not touched
+
+## Invariants this change relies on
+- `_pr_set_pipeline_state` is idempotent — calling it multiple times with same label is safe
+- Label constants (`LABEL_PR_*`) defined at module level (line 6674+); Python resolves in function bodies at call-time, so cmd_review_docs using them is fine despite being defined before the constants in the file

--- a/cai.py
+++ b/cai.py
@@ -3784,6 +3784,9 @@ def cmd_revise(args) -> int:
                 flush=True,
             )
 
+            # 11a. Advance pipeline state: branch now has new commits.
+            _pr_set_pipeline_state(pr_number, LABEL_PR_EDITED)
+
             # 11. Post a summary comment describing what happened.
             if head_changed and has_uncommitted:
                 summary_suffix = (
@@ -6328,6 +6331,12 @@ def cmd_review_pr(args) -> int:
                 capture_output=True,
             )
 
+            # Advance pipeline state based on review outcome.
+            if has_findings:
+                _pr_set_pipeline_state(pr_number, LABEL_PR_REVIEWED_REJECT)
+            else:
+                _pr_set_pipeline_state(pr_number, LABEL_PR_REVIEWED_ACCEPT)
+
             _log_review_pr_findings(pr_number, head_sha, agent_output)
 
             finding_word = "with findings" if has_findings else "clean"
@@ -6379,13 +6388,6 @@ def cmd_review_pr(args) -> int:
 _DOCS_REVIEW_COMMENT_HEADING_PREFIX = "## cai docs review"
 _DOCS_REVIEW_COMMENT_HEADING_CLEAN = "## cai docs review (clean)"
 _DOCS_REVIEW_COMMENT_HEADING_APPLIED = "## cai docs review (applied)"
-
-# Commit-message subject used by `cmd_review_docs` when it pushes
-# automated documentation fixes. Recognized by the merge gate so a
-# docs-only follow-up commit doesn't force another full review-pr
-# pass (which would cascade into another review-docs pass, etc.).
-_REVIEW_DOCS_COMMIT_SUBJECT = "docs: update documentation per review-docs"
-
 
 def cmd_review_docs(args) -> int:
     """Fix stale documentation on open PRs and post findings for issues that cannot be fixed automatically."""
@@ -6453,28 +6455,14 @@ def cmd_review_docs(args) -> int:
             skipped += 1
             continue
 
-        # Gate: only review docs after review-pr has posted a CLEAN
-        # review at this SHA. Running review-docs while review-pr
-        # still has open findings lets the docs commit advance HEAD
-        # past an unresolved finding, which confuses revise's
-        # "comment already addressed" logic (the docs self-summary
-        # gets conflated with the real review-pr finding). Wait until
-        # the revise/review loop has converged before touching docs.
-        has_clean_code_review_at_sha = False
-        for comment in pr.get("comments", []):
-            body = (comment.get("body") or "")
-            first_line = body.split("\n", 1)[0]
-            if (
-                first_line.startswith(_REVIEW_COMMENT_HEADING_CLEAN)
-                and head_sha in first_line
-            ):
-                has_clean_code_review_at_sha = True
-                break
-
-        if not has_clean_code_review_at_sha:
+        # Gate: only review docs after `pr:reviewed-accept` label is set,
+        # meaning cmd_review_pr has posted a clean verdict for this PR.
+        # Bootstrap note: PRs already in flight with no pr:* label will be
+        # skipped here until the next natural cmd_review_pr run sets the label.
+        pr_labels = {l["name"] for l in pr.get("labels", [])}
+        if LABEL_PR_REVIEWED_ACCEPT not in pr_labels:
             print(
-                f"[cai review-docs] PR #{pr_number}: review-pr has not posted "
-                f"a clean review for {head_sha[:8]} yet; waiting for revise/review loop",
+                f"[cai review-docs] PR #{pr_number}: label `pr:reviewed-accept` not present; waiting",
                 flush=True,
             )
             skipped += 1
@@ -6574,7 +6562,7 @@ def cmd_review_docs(args) -> int:
                 # Commit and push the doc fixes.
                 _git(work_dir, "add", "-A")
                 _git(work_dir, "commit", "-m",
-                     f"{_REVIEW_DOCS_COMMIT_SUBJECT}\n\n"
+                     "docs: update documentation per review-docs\n\n"
                      "Applied by cai review-docs.")
                 push = _run(
                     ["git", "-C", str(work_dir), "push", "origin", branch],
@@ -6611,6 +6599,14 @@ def cmd_review_docs(args) -> int:
                  "--repo", REPO, "--body", comment_body],
                 capture_output=True,
             )
+
+            # Advance pipeline state based on docs review outcome.
+            if has_doc_changes:
+                # Docs fix was pushed — branch updated, re-enter revise/review cycle.
+                _pr_set_pipeline_state(pr_number, LABEL_PR_EDITED)
+            else:
+                # No doc changes needed — docs confirmed current.
+                _pr_set_pipeline_state(pr_number, LABEL_PR_DOCUMENTED)
 
             result_word = "fixes pushed" if has_doc_changes else "clean"
             print(
@@ -6896,6 +6892,8 @@ def cmd_merge(args) -> int:
         head_sha = pr["headRefOid"]
         branch = pr.get("headRefName", "")
         title = pr["title"]
+        # Collect PR label names once per iteration; used by filters 7 and 7b.
+        pr_labels = {l["name"] for l in pr.get("labels", [])}
 
         # Safety filter 1: only bot PRs.
         m = re.match(r"^auto-improve/(\d+)-", branch)
@@ -6943,105 +6941,24 @@ def cmd_merge(args) -> int:
         # `merge-blocked` label (and any `needs-human-review` label)
         # to restart the merge-evaluation cycle for those PRs.
 
-        # Safety filter 7: require `cai review-pr` to have reviewed
-        # the current head SHA before we run a merge verdict on it.
-        #
-        # Without this gate, `cmd_merge` runs on every new commit — in
-        # particular, every commit that `cmd_revise` pushes in response
-        # to a prior review's findings — BEFORE the reviewer has had a
-        # chance to walk the new diff. That produces a verdict on an
-        # un-reviewed SHA (uninformed by the ripple-effect scan) and,
-        # via `_pr_label_sweep`, flips the PR to `needs-human-review`
-        # while the fix/review/revise loop is still actively making
-        # progress. The PR then flaps through the label on every cycle
-        # until the reviewer finally reports clean. Refs #351
-        # post-mortem: 5+ premature verdicts, each one flagging the PR
-        # for human triage even though revise was still addressing
-        # ripple findings one round at a time.
-        #
-        # Matches either heading variant (findings or clean) because
-        # both start with `_REVIEW_COMMENT_HEADING_FINDINGS` and both
-        # include the head SHA on the heading line. Mirrors the
-        # already-reviewed check in `cmd_review_pr`.
-        #
-        # Exception: when `cai review-docs` fixes documentation it
-        # pushes a new commit with subject
-        # `_REVIEW_DOCS_COMMIT_SUBJECT`, advancing HEAD past the last
-        # review-pr SHA. Treat such follow-up commits as "already
-        # reviewed" — otherwise every docs push forces another
-        # review-pr pass, which in turn triggers another review-docs
-        # pass at the new SHA, cascading indefinitely for any tweak.
-        reviewed_shas = set()
-        for comment in pr.get("comments", []):
-            body = (comment.get("body") or "")
-            first_line = body.split("\n", 1)[0]
-            if not first_line.startswith(_REVIEW_COMMENT_HEADING_FINDINGS):
-                continue
-            m_sha = re.search(r"\u2014\s+([0-9a-f]{7,40})", first_line)
-            if m_sha:
-                reviewed_shas.add(m_sha.group(1))
-
-        has_review_at_sha = head_sha in reviewed_shas
-
-        if not has_review_at_sha and reviewed_shas:
-            # Accept an earlier review-pr SHA if every intervening
-            # commit up to HEAD is a review-docs self-commit.
-            try:
-                _commits_data = _gh_json([
-                    "pr", "view", str(pr_number),
-                    "--repo", REPO,
-                    "--json", "commits",
-                ])
-                _commit_list = _commits_data.get("commits", [])
-            except subprocess.CalledProcessError:
-                _commit_list = []
-
-            latest_reviewed_idx = -1
-            for idx, c in enumerate(_commit_list):
-                if c.get("oid") in reviewed_shas:
-                    latest_reviewed_idx = idx
-
-            if latest_reviewed_idx >= 0:
-                tail = _commit_list[latest_reviewed_idx + 1:]
-                if tail and all(
-                    (c.get("messageHeadline") or "").startswith(
-                        _REVIEW_DOCS_COMMIT_SUBJECT
-                    )
-                    for c in tail
-                ):
-                    has_review_at_sha = True
-                    print(
-                        f"[cai merge] PR #{pr_number}: accepting review-pr "
-                        f"at earlier SHA; {len(tail)} intervening "
-                        f"commit(s) are review-docs follow-ups",
-                        flush=True,
-                    )
-
-        if not has_review_at_sha:
+        # Safety filter 7: require a clean code review (`pr:reviewed-accept`)
+        # OR a completed docs review (`pr:documented`) before merging.
+        # pr_labels was computed once at the top of this loop.
+        # Bootstrap note: PRs already in flight with no pr:* label will be
+        # skipped here until the next natural cmd_review_pr run sets the label.
+        if LABEL_PR_REVIEWED_ACCEPT not in pr_labels and LABEL_PR_DOCUMENTED not in pr_labels:
             print(
-                f"[cai merge] PR #{pr_number}: review-pr has not reviewed "
-                f"{head_sha[:8]} yet; waiting",
+                f"[cai merge] PR #{pr_number}: neither `pr:reviewed-accept` nor "
+                f"`pr:documented` present; waiting",
                 flush=True,
             )
             continue
 
-        # Safety filter 7b: require `cai review-docs` to have reviewed
-        # the current head SHA before running a merge verdict.
-        has_docs_review_at_sha = False
-        for comment in pr.get("comments", []):
-            body = (comment.get("body") or "")
-            first_line = body.split("\n", 1)[0]
-            if (
-                first_line.startswith(_DOCS_REVIEW_COMMENT_HEADING_PREFIX)
-                and head_sha in first_line
-            ):
-                has_docs_review_at_sha = True
-                break
-
-        if not has_docs_review_at_sha:
+        # Safety filter 7b: require docs review sign-off (`pr:documented`).
+        # pr_labels was computed once at the top of this loop.
+        if LABEL_PR_DOCUMENTED not in pr_labels:
             print(
-                f"[cai merge] PR #{pr_number}: review-docs has not reviewed "
-                f"{head_sha[:8]} yet; waiting",
+                f"[cai merge] PR #{pr_number}: label `pr:documented` not present; waiting",
                 flush=True,
             )
             continue

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@
 3. **Plan** — `cai plan` runs plan-select agents to generate and select an implementation plan. The plan is stored in the issue body. Label transitions to `auto-improve:planned`, awaiting human approval.
 4. **Human Approval** — A human reviews the generated plan and applies `human:plan-approved` label to approve the issue for fixing.
 5. **Fix** — `cai implement` calls `cai-implement` on `human:plan-approved` issues in a fresh git worktree. The wrapper commits, pushes, and opens a PR. Label transitions to `auto-improve:in-progress` → `auto-improve:pr-open`.
-6. **Review** — `cai review-pr` checks for ripple-effect inconsistencies and posts findings as PR comments. `cai review-docs` then (and only after review-pr completes) checks for stale documentation, directly fixes issues it can resolve, and commits/pushes those changes to the PR branch. Remaining unfixable issues are posted as `### Finding: stale_docs` comments. This ordering is enforced: review-docs skips PRs until review-pr has posted a review comment at the current HEAD SHA.
+6. **Review** — `cai review-pr` checks for ripple-effect inconsistencies, posts findings as PR comments, and sets the `pr:reviewed-accept` or `pr:reviewed-reject` label. `cai review-docs` then (and only after review-pr has set `pr:reviewed-accept`) checks for stale documentation, directly fixes issues it can resolve, and commits/pushes those changes to the PR branch. Remaining unfixable issues are posted as `### Finding: stale_docs` comments. This ordering is enforced: review-docs skips PRs until the `pr:reviewed-accept` label is present.
 7. **Revise** — `cai revise` calls `cai-revise` or `cai-rebase` to address review comments or rebase conflicts. Label transitions to `auto-improve:revising`.
 7.5. **CI Fix** — `cai fix-ci` calls `cai-fix-ci` to diagnose and fix failing GitHub Actions checks on open PRs. The subagent reads the failure log (last 200 lines, up to 2 failing checks), locates the root cause in the clone, and makes the minimal fix. A per-SHA marker comment (`## CI-fix subagent: fix attempt`) is always posted after each run — whether or not a fix was produced — so the loop guard fires on the next tick if CI is still red. PRs with unaddressed review comments are skipped (left for `cai revise`); PRs with `:needs-human-review` or `:merge-blocked` are always skipped.
 8. **Merge** — `cai merge` calls `cai-merge` to assess confidence and auto-merges PRs that meet the threshold. Label transitions to `auto-improve:merged`.
@@ -38,6 +38,10 @@
 | `human:submitted` | Human-submitted issue awaiting refinement |
 | `merge-blocked` | PR has a blocking review finding; will not auto-merge |
 | `needs-human-review` | Issue or PR requires human attention |
+| `pr:edited` | PR branch has been updated by `cai revise` or `cai review-docs` |
+| `pr:reviewed-accept` | `cai review-pr` completed and posted a clean verdict (no findings) |
+| `pr:reviewed-reject` | `cai review-pr` completed and posted findings (changes needed) |
+| `pr:documented` | `cai review-docs` completed (documentation is current) |
 
 ## The Cycle Command
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -132,7 +132,7 @@ Run the plan-select pipeline on the oldest `auto-improve:refined` issue. Clones 
 
 Review open PRs for stale documentation using `cai-review-docs`. Directly fixes stale documentation it finds and pushes commits to the PR branch. Posts `### Fixed: stale_docs` blocks for successfully fixed docs, and `### Finding: stale_docs` blocks for issues that cannot be fixed automatically.
 
-**Note:** `review-docs` skips PRs until `cai review-pr` has reviewed the current HEAD SHA. This enforces the `review-pr` → `review-docs` → `merge` ordering.
+**Note:** `review-docs` skips PRs until the `pr:reviewed-accept` label is set (set by `cai review-pr`). This enforces the `review-pr` → `review-docs` → `merge` ordering.
 
 | Argument | Type | Description |
 |---|---|---|


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#566

**Issue:** #566 — [Step 2/3] Wire label transitions into commands and replace SHA-based gates

## PR Summary

### What this fixes
Pipeline-state labels (`pr:edited`, `pr:reviewed-accept`, `pr:reviewed-reject`, `pr:documented`) were created in step 1 but nothing set or read them. `cmd_review_docs` and `cmd_merge` used fragile SHA-scan loops over PR comments to determine readiness, which failed for docs-fix commits that advanced HEAD past the last review SHA.

### What was changed
- **`cai.py` — `cmd_revise`**: Added `_pr_set_pipeline_state(pr_number, LABEL_PR_EDITED)` immediately after a successful force-push.
- **`cai.py` — `cmd_review_pr`**: Added conditional `_pr_set_pipeline_state` calls after posting the review comment — `LABEL_PR_REVIEWED_REJECT` when findings exist, `LABEL_PR_REVIEWED_ACCEPT` when clean.
- **`cai.py` — `cmd_review_docs` (gate)**: Replaced the `has_clean_code_review_at_sha` SHA-scan loop with a `pr_labels` set check for `LABEL_PR_REVIEWED_ACCEPT`.
- **`cai.py` — `cmd_review_docs` (exit)**: Added conditional `_pr_set_pipeline_state` calls after posting the docs comment — `LABEL_PR_EDITED` when doc changes were pushed, `LABEL_PR_DOCUMENTED` when no changes were needed.
- **`cai.py` — `cmd_merge` loop top**: Extracted `pr_labels = {l["name"] for l in pr.get("labels", [])}` once per iteration before all safety filters.
- **`cai.py` — `cmd_merge` filter 7**: Replaced the 84-line SHA-scan block (including the `_REVIEW_DOCS_COMMIT_SUBJECT` exception logic) with a simple label check requiring `pr:reviewed-accept` OR `pr:documented`.
- **`cai.py` — `cmd_merge` filter 7b**: Replaced the `has_docs_review_at_sha` SHA-scan loop with a single `LABEL_PR_DOCUMENTED not in pr_labels` check.
- **`cai.py` — `_REVIEW_DOCS_COMMIT_SUBJECT`**: Removed the constant definition (now dead code) and inlined its string value into the `_git commit -m` call in `cmd_review_docs`.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
