### PR TITLE
auto-improve: some issues with an improved plan, are not picked by the agent that implements the solution

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,28 @@
+# PR Context Dossier
+Refs: damien-robotsix/robotsix-cai#594
+
+## Files touched
+- `cai.py:7454` — `cmd_refine` "Refined Issue" path: wrap `issue.get("body")` with `_strip_stored_plan_block`
+- `cai.py:7662` — spike `refine_and_retry` path: wrap `issue.get("body")` with `_strip_stored_plan_block`
+- `cai.py:7693` — spike "Refined Issue" path: wrap `issue.get("body")` with `_strip_stored_plan_block`
+- `cai.py:7922` — explore `refine_and_retry` path: wrap `issue.get("body")` with `_strip_stored_plan_block`
+- `cai.py:7953` — explore "Refined Issue" path: wrap `issue.get("body")` with `_strip_stored_plan_block`
+
+## Files read (not touched) that matter
+- `cai.py` (lines 1069 area) — `_strip_stored_plan_block` defined here, confirmed available at all call sites
+
+## Key symbols
+- `_strip_stored_plan_block` (`cai.py:~1069`) — strips `<!-- cai-plan-start/end -->` blocks from issue body before quoting
+- `original_body` (all five sites) — local variable holding the issue body to be quoted as `> ` prefix lines
+
+## Design decisions
+- Wrap at `original_body` assignment rather than at `quoted_original` construction — cleaner, avoids re-introducing stripped content
+- Rejected: changing `_extract_stored_plan` to handle quoted markers — would mask the root cause and accumulate corruption across re-refinements
+
+## Out of scope / known gaps
+- Did not change `_extract_stored_plan`, `_strip_stored_plan_block`, `cmd_plan`, or `_select_fix_target` per scope guardrails
+- Existing plan blocks in already-corrupted issues are not retroactively cleaned
+
+## Invariants this change relies on
+- `_strip_stored_plan_block` is idempotent: if no plan block exists, returns body unchanged (no regression)
+- All five `original_body` assignments are followed immediately by `quoted_original = "\n".join(...)` — the pattern is consistent

--- a/cai.py
+++ b/cai.py
@@ -7451,7 +7451,7 @@ def cmd_refine(args) -> int:
     refined_body = stdout[marker_pos:].strip()
 
     # 6. Build the new issue body: refined content + original text quoted.
-    original_body = issue.get("body") or "(no body)"
+    original_body = _strip_stored_plan_block(issue.get("body") or "(no body)")
     quoted_original = "\n".join(f"> {line}" for line in original_body.splitlines())
     new_body = (
         f"{refined_body}\n\n"
@@ -7659,7 +7659,7 @@ def cmd_spike(args) -> int:
 
             elif recommendation == "refine_and_retry":
                 # Update body with findings + original, relabel to :raised
-                original_body = issue.get("body") or "(no body)"
+                original_body = _strip_stored_plan_block(issue.get("body") or "(no body)")
                 quoted_original = "\n".join(f"> {line}" for line in original_body.splitlines())
                 new_body = (
                     f"{findings_block}\n\n"
@@ -7690,7 +7690,7 @@ def cmd_spike(args) -> int:
         refined_pos = stdout.find("## Refined Issue")
         if refined_pos != -1:
             refined_body = stdout[refined_pos:].strip()
-            original_body = issue.get("body") or "(no body)"
+            original_body = _strip_stored_plan_block(issue.get("body") or "(no body)")
             quoted_original = "\n".join(f"> {line}" for line in original_body.splitlines())
             new_body = (
                 f"{refined_body}\n\n"
@@ -7919,7 +7919,7 @@ def cmd_explore(args) -> int:
                 return 0
 
             elif recommendation == "refine_and_retry":
-                original_body = issue.get("body") or "(no body)"
+                original_body = _strip_stored_plan_block(issue.get("body") or "(no body)")
                 quoted_original = "\n".join(f"> {line}" for line in original_body.splitlines())
                 new_body = (
                     f"{findings_block}\n\n"
@@ -7950,7 +7950,7 @@ def cmd_explore(args) -> int:
         refined_pos = stdout.find("## Refined Issue")
         if refined_pos != -1:
             refined_body = stdout[refined_pos:].strip()
-            original_body = issue.get("body") or "(no body)"
+            original_body = _strip_stored_plan_block(issue.get("body") or "(no body)")
             quoted_original = "\n".join(f"> {line}" for line in original_body.splitlines())
             new_body = (
                 f"{refined_body}\n\n"


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#594

**Issue:** #594 — some issues with an improved plan, are not picked by the agent that implements the solution

## PR Summary

### What this fixes
When an issue already containing a `<!-- cai-plan-start/end -->` plan block was re-refined, `cmd_refine` quoted the entire original body (including the plan block) with `> ` prefixes. This caused `_extract_stored_plan()` to fail to find the plan marker in subsequent runs, breaking the implement pipeline for those issues.

### What was changed
- **`cai.py`** (5 sites: lines 7454, 7662, 7693, 7922, 7953): Replaced `issue.get("body") or "(no body)"` with `_strip_stored_plan_block(issue.get("body") or "(no body)")` at every `original_body` assignment that precedes a `quoted_original` construction, covering `cmd_refine`, spike `refine_and_retry`, spike "Refined Issue", explore `refine_and_retry`, and explore "Refined Issue" code paths.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
