### PR TITLE
fix: fetch labels in review-docs and merge PR queries

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -6400,7 +6400,7 @@ def cmd_review_docs(args) -> int:
             target_pr = _gh_json([
                 "pr", "view", str(args.pr),
                 "--repo", REPO,
-                "--json", "number,title,author,headRefOid,headRefName,body,comments",
+                "--json", "number,title,author,headRefOid,headRefName,body,comments,labels",
             ])
         except subprocess.CalledProcessError as e:
             print(f"[cai review-docs] gh pr view #{args.pr} failed:\n{e.stderr}", file=sys.stderr)
@@ -6414,7 +6414,7 @@ def cmd_review_docs(args) -> int:
                 "--repo", REPO,
                 "--state", "open",
                 "--base", "main",
-                "--json", "number,title,author,headRefOid,headRefName,body,comments",
+                "--json", "number,title,author,headRefOid,headRefName,body,comments,labels",
                 "--limit", "50",
             ]) or []
         except subprocess.CalledProcessError as e:
@@ -6855,7 +6855,7 @@ def cmd_merge(args) -> int:
             target_pr = _gh_json([
                 "pr", "view", str(args.pr),
                 "--repo", REPO,
-                "--json", "number,title,headRefName,headRefOid,comments,mergeable",
+                "--json", "number,title,headRefName,headRefOid,comments,mergeable,labels",
             ])
         except subprocess.CalledProcessError as e:
             print(f"[cai merge] gh pr view #{args.pr} failed:\n{e.stderr}", file=sys.stderr)
@@ -6869,7 +6869,7 @@ def cmd_merge(args) -> int:
                 "--repo", REPO,
                 "--state", "open",
                 "--base", "main",
-                "--json", "number,title,headRefName,headRefOid,comments,mergeable",
+                "--json", "number,title,headRefName,headRefOid,comments,mergeable,labels",
                 "--limit", "50",
             ]) or []
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary

`cmd_review_docs` and `cmd_merge` were not requesting `labels` in their `gh pr list/view` queries, causing the `pr:reviewed-accept` and `pr:documented` gates to always see empty label sets. This caused these gates to skip every PR, draining the cycle forever on stuck PRs and never running the implement command.

## Affected functions

- `cmd_review_docs` (lines 6400 and 6414 in cai.py)
- `cmd_merge` (lines 6855 and 6869 in cai.py)

The fix adds `,labels` to the `--json` selectors in all four `gh pr` query invocations.

Generated with Claude Code