### PR TITLE
auto-improve: Sub issues should mention parent issue

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,24 @@
+# PR Context Dossier
+Refs: damien-robotsix/robotsix-cai#590
+
+## Files touched
+- `cai.py:1450` — changed sub-issue title format from `[Step X/Y]` to `[#parent_number Step X/Y]`
+
+## Files read (not touched) that matter
+- `cai.py` — contains `_create_sub_issues` function where the change was made
+
+## Key symbols
+- `_create_sub_issues` (`cai.py:~1440`) — function that creates GitHub sub-issues for multi-step decomposition
+- `parent_number` (`cai.py:~1447`) — already in scope at line 1450, used in body template
+
+## Design decisions
+- Added `#{parent_number}` at the leading position in the title bracket: `[#123 Step 1/3]`
+- Rejected: Unicode middle-dot separator — unnecessary complexity, deviates from spec
+
+## Out of scope / known gaps
+- Body template already links correctly via `_Sub-issue of #{parent_number}` — not changed
+- `_find_sub_issue`, `_update_parent_checklist`, checklist/label logic — not touched
+- `<!-- parent: #N -->` HTML comment markers — not touched (relied on by `_find_sub_issue` for deduplication)
+
+## Invariants this change relies on
+- `parent_number` variable is in scope at line 1450 (confirmed by reading the function)

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ approach and this guidance does not apply.
 
 If the refine subagent detects that work requires multiple independent steps, it produces a `## Multi-Step Decomposition` output. The wrapper then:
 1. Labels the parent issue `auto-improve:parent`
-2. Creates one sub-issue per step (each sub-issue body includes a back-reference to the parent)
+2. Creates one sub-issue per step, with titles formatted as `[#{parent} Step X/Y] <title>` (e.g. `[#123 Step 1/3] Add schema migration`) so you can identify the parent from a list view. Each sub-issue body includes a back-reference to the parent.
 3. Adds a checklist to the parent issue to track sub-issue completion
 
 You can watch the parent issue's checklist to monitor progress. Note: if an issue already has a structured `### Plan` section when filed, the refine subagent will skip refinement, and no sub-issues will be created — the implement subagent will execute the steps directly from the issue body.

--- a/cai.py
+++ b/cai.py
@@ -1447,7 +1447,7 @@ def _create_sub_issues(
             f"_Sub-issue of #{parent_number} ({parent_title}). "
             f"Step {s['step']} of {total}._\n"
         )
-        title = f"[Step {s['step']}/{total}] {s['title']}"
+        title = f"[#{parent_number} Step {s['step']}/{total}] {s['title']}"
         labels = ",".join(["auto-improve", LABEL_RAISED])
         result = _run(
             [

--- a/cai.py
+++ b/cai.py
@@ -1416,8 +1416,12 @@ def _create_sub_issues(
 ) -> list[int]:
     """Create GitHub sub-issues for a multi-step decomposition.
 
-    Each sub-issue gets HTML-comment markers for parent and step number,
-    enabling the ordering gate in ``_select_fix_target``.
+    Each sub-issue gets:
+    - A title formatted as `[#{parent_number} Step {step}/{total}] {title}`
+      (e.g. `[#123 Step 1/3] Add schema migration`)
+    - HTML-comment markers for parent and step number,
+      enabling the ordering gate in ``_select_fix_target``
+    - A body with a back-reference to the parent issue
 
     Returns list of created issue numbers (may be shorter than *steps*
     if some creations fail).


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#590

**Issue:** #590 — Sub issues should mention parent issue

## PR Summary

### What this fixes
Sub-issues created by `_create_sub_issues` had titles like `[Step 1/3] <title>` with no reference to the parent issue, making it hard to identify which parent a sub-issue belongs to when browsing a list of issues.

### What was changed
- `cai.py:1450` — changed the sub-issue title format string from `f"[Step {s['step']}/{total}] {s['title']}"` to `f"[#{parent_number} Step {s['step']}/{total}] {s['title']}"`, so sub-issue titles now read e.g. `[#123 Step 1/3] Add schema migration`

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
