### PR TITLE
auto-improve: use structured template for plan output

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,34 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#579
+
+## Files touched
+- `cai.py:2519` — updated comment on `_REVISE_ISSUE_BODY_MAX_CHARS` to note it's now the fallback for old-format issues
+- `cai.py:2521` — added `_REVISE_CONTEXT_HEADINGS` tuple constant
+- `cai.py:2530` — added `_extract_revise_context()` function (splits on `\n### `, extracts relevant sections, falls back to char truncation)
+- `cai.py:3580` — replaced 6-line truncation block with single call to `_extract_revise_context(_issue_body_raw)`
+- `.claude/agents/cai-refine.md` (via staging) — renamed `### Problem` → `### Description` and `### Files likely to touch` → `### Files to change` in output template and Multi-Step Decomposition block
+- `.claude/agents/cai-plan.md` (via staging) — appended `### Scope guardrails` section to Output format template
+
+## Files read (not touched) that matter
+- `cai.py:3570-3597` — `cmd_revise` context around the truncation block; `_issue_num` is still used on line 3593
+
+## Key symbols
+- `_REVISE_ISSUE_BODY_MAX_CHARS` (`cai.py:2519`) — kept; now used only as fallback truncation length in `_extract_revise_context`
+- `_REVISE_CONTEXT_HEADINGS` (`cai.py:2521`) — new constant; ordered section heading aliases for extraction
+- `_extract_revise_context` (`cai.py:2530`) — new function; replaces blunt char truncation with section-aware extraction
+
+## Design decisions
+- Kept `_extract_revise_context` in `cai.py` (not `cai_lib/github.py`) — single call site, co-located with the constant it supersedes
+- Used `alias.lstrip("# ").lower()` for normalised key lookup — handles `### ` prefix in aliases cleanly
+- Fallback to `body[:_REVISE_ISSUE_BODY_MAX_CHARS]` for old-format issues with no `\n### ` headings
+- Rejected: moving function to shared library (Plan 1) — unnecessary for single call site
+
+## Out of scope / known gaps
+- Did NOT change early-exit detection in cai-refine.md (still checks for `### Problem`) — that scans incoming issue bodies, not refine's own output
+- Did NOT touch `_build_implement_user_message` or `_build_issue_block` — implement agent gets full body
+- Did NOT change cai-select, cai-merge, or any other agent
+
+## Invariants this change relies on
+- `_issue_num` is still assigned at line 3579 before the (now replaced) truncation block; line 3593 references it safely
+- `body.split("\n### ")` avoids splitting on `###` inside code fences or inline text
+- First element of `parts` (preamble) is intentionally discarded

--- a/.claude/agents/cai-plan.md
+++ b/.claude/agents/cai-plan.md
@@ -100,6 +100,9 @@ Produce your plan in exactly this structure:
 
 ### Risks and edge cases
 - <anything the fix agent should watch out for>
+
+### Scope guardrails
+- <what the fix agent must NOT touch; boundaries of the change>
 ```
 
 Be concrete and specific. Name functions, variables, and line

--- a/.claude/agents/cai-refine.md
+++ b/.claude/agents/cai-refine.md
@@ -58,7 +58,7 @@ Produce exactly one fenced block in this format:
 ~~~
 ## Refined Issue
 
-### Problem
+### Description
 <concrete problem statement derived from the human's text — what is
 wrong or missing, and why it matters>
 
@@ -74,7 +74,7 @@ file Z looks like ...">
 ### Scope guardrails
 <what NOT to touch; what is out of scope for this change>
 
-### Files likely to touch
+### Files to change
 <best-guess list of files based on the repo state>
 ~~~
 
@@ -96,7 +96,7 @@ Produce a `## Multi-Step Decomposition` block **instead of**
 
 ### Step 1: <title>
 
-### Problem
+### Description
 <what this step fixes or adds>
 
 ### Plan
@@ -109,12 +109,12 @@ Produce a `## Multi-Step Decomposition` block **instead of**
 ### Scope guardrails
 <what NOT to touch in this step>
 
-### Files likely to touch
+### Files to change
 <file list for this step>
 
 ### Step 2: <title>
 
-### Problem
+### Description
 <what this step fixes or adds>
 
 ### Plan
@@ -126,7 +126,7 @@ Produce a `## Multi-Step Decomposition` block **instead of**
 ### Scope guardrails
 ...
 
-### Files likely to touch
+### Files to change
 ...
 ~~~
 
@@ -152,6 +152,6 @@ Multi-step guidelines:
   addresses the human's intent. Do not add scope.
 - **Preserve intent.** If the human's request is ambiguous, pick
   the most likely interpretation and note the ambiguity in the
-  Problem section.
+  Description section.
 - **Keep it short.** The fix agent reads this plan as context. A
   wall of text is counterproductive.

--- a/cai.py
+++ b/cai.py
@@ -2512,11 +2512,58 @@ _BOT_COMMENT_MARKERS = (
 
 
 # Maximum number of characters of the original issue body to inline into the
-# revise agent's user message.  The full body is redundant once a PR exists —
-# the agent needs intent and acceptance criteria, not the full proposal.  When
-# the body exceeds this limit it is truncated and a pointer to the GitHub issue
-# is appended so the agent can fetch the rest if needed.
+# revise agent's user message when no recognisable section headings are found
+# (old-format issues).  Structured issues are handled by _extract_revise_context
+# which extracts only the relevant sections instead of truncating.
 _REVISE_ISSUE_BODY_MAX_CHARS = 1500
+
+# Ordered list of section headings to extract from an issue body for the
+# revise agent. Each entry is (preferred_heading, *fallback_headings).
+# The revise agent needs intent and scope, not detailed implementation steps.
+_REVISE_CONTEXT_HEADINGS: tuple[tuple[str, ...], ...] = (
+    ("### Description", "### Problem"),
+    ("### Summary",),
+    ("### Files to change", "### Files likely to touch"),
+    ("### Scope guardrails",),
+    ("### Review considerations",),
+)
+
+
+def _extract_revise_context(body: str) -> str:
+    """Return only the sections relevant to cai-revise from an issue body.
+
+    Splits on level-3 headings and keeps only the entries listed in
+    _REVISE_CONTEXT_HEADINGS (first matching alias wins).  Falls back to
+    the first _REVISE_ISSUE_BODY_MAX_CHARS characters when the body has
+    no recognisable headings (old-format issues).
+    """
+    parts = body.split("\n### ")
+    if len(parts) <= 1:
+        return body[:_REVISE_ISSUE_BODY_MAX_CHARS]
+
+    # Build {normalised_heading: full_section_text} from the split parts.
+    sections: dict[str, str] = {}
+    for part in parts[1:]:
+        nl = part.find("\n")
+        if nl == -1:
+            heading, content = part.strip(), ""
+        else:
+            heading, content = part[:nl].strip(), part[nl + 1:]
+        sections[heading.lower()] = f"### {heading}\n{content}"
+
+    extracted: list[str] = []
+    for aliases in _REVISE_CONTEXT_HEADINGS:
+        for alias in aliases:
+            key = alias.lstrip("# ").lower()
+            if key in sections:
+                extracted.append(sections[key].rstrip())
+                break
+
+    if not extracted:
+        # No target headings found — old-format issue, fall back.
+        return body[:_REVISE_ISSUE_BODY_MAX_CHARS]
+
+    return "\n\n".join(extracted)
 
 
 def _is_bot_comment(comment: dict) -> bool:
@@ -3577,13 +3624,7 @@ def cmd_revise(args) -> int:
 
             _issue_body_raw = issue_data.get("body") or "(no body)"
             _issue_num = issue_data["number"]
-            if len(_issue_body_raw) > _REVISE_ISSUE_BODY_MAX_CHARS:
-                _issue_body = (
-                    _issue_body_raw[:_REVISE_ISSUE_BODY_MAX_CHARS]
-                    + f"\n\n… (truncated — see #{_issue_num} for full body)"
-                )
-            else:
-                _issue_body = _issue_body_raw
+            _issue_body = _extract_revise_context(_issue_body_raw)
 
             user_message = (
                 _work_directory_block(work_dir)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#579

**Issue:** #579 — use structured template for plan output

## PR Summary

### What this fixes
Issue bodies passed to `cai-revise` were bluntly truncated at 1500 characters, which could drop critical sections (e.g., `### Scope guardrails`) while keeping irrelevant ones (e.g., `### Detailed steps`). Additionally, `cai-refine` used inconsistent section names (`### Problem`, `### Files likely to touch`) compared to `cai-plan`, making section-aware extraction unreliable.

### What was changed
- **`cai.py`**: Added `_REVISE_CONTEXT_HEADINGS` constant and `_extract_revise_context()` function after the `_REVISE_ISSUE_BODY_MAX_CHARS` constant. The new function splits on `\n### ` headings and extracts only the sections relevant to `cai-revise` (Description/Problem, Summary, Files to change, Scope guardrails, Review considerations), falling back to character truncation for old-format issues. Replaced the 6-line truncation block in `cmd_revise` with a single call to `_extract_revise_context(_issue_body_raw)`.
- **`.claude/agents/cai-refine.md`** (via staging): Renamed `### Problem` → `### Description` and `### Files likely to touch` → `### Files to change` in the output template and Multi-Step Decomposition block; updated inline prose reference accordingly.
- **`.claude/agents/cai-plan.md`** (via staging): Appended `### Scope guardrails` section to the Output format template after `### Risks and edge cases`.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
