### PR TITLE
auto-improve: [Step 1/2] Define the FSM data structures in `cai_lib/fsm.py`

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,36 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#592
+
+## Files touched
+- cai_lib/config.py:68 — Added 3 new label constants: LABEL_IN_PR, LABEL_HUMAN_NEEDED, LABEL_PR_HUMAN_NEEDED
+- cai_lib/fsm.py — New file: IssueState (10-state), PRState (6-state), Transition dataclass, ISSUE_TRANSITIONS (12), PR_TRANSITIONS (7), get_issue_state, get_pr_state, render_fsm_mermaid
+- cai_lib/__init__.py:48 — Added 3 new config constants to import block; added fsm import block after cmd_implement import; extended __all__
+- tests/test_fsm.py — New file: 5 unit tests for the FSM module
+
+## Files read (not touched) that matter
+- cai_lib/__init__.py — Source of truth for import structure and __all__ ordering
+
+## Key symbols
+- `IssueState` (cai_lib/fsm.py:21) — 10-state enum replacing the old PR_OPEN+REVISING pair with a single PR state
+- `PRState` (cai_lib/fsm.py:34) — 6-state PR submachine enum using "pr:*" descriptor strings (not GitHub labels)
+- `Transition` (cai_lib/fsm.py:43) — dataclass representing a labelled FSM edge with confidence gate
+- `ISSUE_TRANSITIONS` (cai_lib/fsm.py:53) — 12 transitions covering the full issue lifecycle
+- `PR_TRANSITIONS` (cai_lib/fsm.py:79) — 7 transitions for the PR submachine
+- `LABEL_IN_PR` (cai_lib/config.py:69) — "auto-improve:in-pr", the label backing IssueState.PR
+
+## Design decisions
+- Single IssueState.PR instead of PR_OPEN+REVISING — per project owner revision; PR-internal states belong to PRState only
+- PRState uses "pr:*" descriptor strings, not GitHub labels — no new labels needed; pure data model
+- LABEL_PR_OPEN, LABEL_REVISING remain in config.py untouched — still used by cai.py's _set_labels calls
+- typing.Optional used instead of X | None union — avoids Python 3.9 syntax issues in older containers
+- Rejected: adding transitions PR_OPEN→REVISING and REVISING→PR_OPEN to ISSUE_TRANSITIONS — project owner moved these to PRState submachine exclusively
+
+## Out of scope / known gaps
+- No behaviour change in cai.py — FSM is pure data model; wiring ISSUE_TRANSITIONS into _set_labels is a future step
+- No Python FSM library adopted — dataclasses sufficient for step 1; library adoption deferred
+- LABEL_NO_ACTION, LABEL_NEEDS_SPIKE not in IssueState — backward-compatible constants stay in config.py
+
+## Invariants this change relies on
+- LABEL_IN_PROGRESS already exists in config.py (for IssueState.IN_PROGRESS enum value)
+- LABEL_NEEDS_EXPLORATION already exists in config.py (for IssueState.NEEDS_EXPLORATION enum value)
+- All LABEL_* constants imported by fsm.py must exist in config.py before fsm.py is imported

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -48,6 +48,7 @@
 | `cai_lib/cmd_implement.py` | Helpers for the implement-subagent pipeline |
 | `cai_lib/cmd_lifecycle.py` | Pipeline state-transition helpers |
 | `cai_lib/config.py` | Shared constants and path definitions |
+| `cai_lib/fsm.py` | FSM data structures for the auto-improve lifecycle (IssueState, PRState, transitions) |
 | `cai_lib/github.py` | GitHub/gh CLI helpers and shared label utilities |
 | `cai_lib/logging_utils.py` | Logging utilities extracted from cai.py |
 | `cai_lib/subprocess_utils.py` | Subprocess helpers extracted from cai.py |
@@ -65,6 +66,7 @@
 | `pyproject.toml` | Python project configuration (ruff lint settings) |
 | `scripts/generate-index.sh` | Generator script for CODEBASE_INDEX.md |
 | `tests/__init__.py` | Test package init |
+| `tests/test_fsm.py` | Tests for FSM data structures (IssueState, PRState, transitions, render) |
 | `tests/test_lint.py` | Lint check: ruff must report zero violations |
 | `tests/test_multistep.py` | Tests for multi-step plan support |
 | `tests/test_parse.py` | Tests for parse.py signal extraction |

--- a/cai_lib/__init__.py
+++ b/cai_lib/__init__.py
@@ -45,6 +45,9 @@ from cai_lib.config import (
     LABEL_HUMAN_SUBMITTED,
     LABEL_PLANNED,
     LABEL_PLAN_APPROVED,
+    LABEL_IN_PR,
+    LABEL_HUMAN_NEEDED,
+    LABEL_PR_HUMAN_NEEDED,
     _STALE_IN_PROGRESS_HOURS,
     _STALE_REVISING_HOURS,
     _STALE_NO_ACTION_DAYS,
@@ -82,6 +85,12 @@ from cai_lib.cmd_lifecycle import _rollback_stale_in_progress, _reconcile_interr
 
 from cai_lib.cmd_implement import _parse_decomposition
 
+from cai_lib.fsm import (
+    IssueState, PRState, Transition,
+    ISSUE_TRANSITIONS, PR_TRANSITIONS,
+    get_issue_state, get_pr_state, render_fsm_mermaid,
+)
+
 __all__ = [
     # config
     "REPO", "SMOKE_PROMPT", "TRANSCRIPT_DIR", "PARSE_SCRIPT", "PUBLISH_SCRIPT",
@@ -94,6 +103,7 @@ __all__ = [
     "LABEL_NEEDS_EXPLORATION", "LABEL_REFINED", "LABEL_REVISING", "LABEL_PARENT",
     "LABEL_MERGE_BLOCKED", "LABEL_AUDIT_RAISED", "LABEL_AUDIT_NEEDS_HUMAN",
     "LABEL_PR_NEEDS_HUMAN", "LABEL_HUMAN_SUBMITTED", "LABEL_PLANNED", "LABEL_PLAN_APPROVED",
+    "LABEL_IN_PR", "LABEL_HUMAN_NEEDED", "LABEL_PR_HUMAN_NEEDED",
     "_STALE_IN_PROGRESS_HOURS", "_STALE_REVISING_HOURS",
     "_STALE_NO_ACTION_DAYS", "_STALE_MERGED_DAYS",
     # logging
@@ -110,4 +120,8 @@ __all__ = [
     "_reconcile_interrupted",
     # cmd_implement
     "_parse_decomposition",
+    # fsm
+    "IssueState", "PRState", "Transition",
+    "ISSUE_TRANSITIONS", "PR_TRANSITIONS",
+    "get_issue_state", "get_pr_state", "render_fsm_mermaid",
 ]

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -65,6 +65,9 @@ LABEL_AUDIT_NEEDS_HUMAN = "audit:needs-human"
 LABEL_HUMAN_SUBMITTED = "human:submitted"
 LABEL_PLANNED = "auto-improve:planned"
 LABEL_PLAN_APPROVED = "human:plan-approved"
+LABEL_IN_PR           = "auto-improve:in-pr"           # IssueState.PR — issue has an active PR
+LABEL_HUMAN_NEEDED    = "auto-improve:human-needed"    # IssueState.HUMAN_NEEDED
+LABEL_PR_HUMAN_NEEDED = "auto-improve:pr-human-needed" # PRState.PR_HUMAN_NEEDED
 
 # PR-level label applied by `cai merge` when the verdict is below the
 # auto-merge threshold. Lets a human filter open PRs that are waiting

--- a/cai_lib/fsm.py
+++ b/cai_lib/fsm.py
@@ -1,0 +1,138 @@
+"""FSM data structures for the auto-improve lifecycle.
+
+This module defines the explicit state machine that the auto-improve
+pipeline follows. It is a pure data-structure module — no behaviour
+in cai.py is changed by importing it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+from cai_lib.config import (
+    LABEL_RAISED, LABEL_REFINED, LABEL_PLANNED, LABEL_PLAN_APPROVED,
+    LABEL_IN_PROGRESS, LABEL_IN_PR, LABEL_MERGED, LABEL_SOLVED,
+    LABEL_NEEDS_EXPLORATION, LABEL_HUMAN_NEEDED, LABEL_PR_HUMAN_NEEDED,
+)
+
+
+class IssueState(str, Enum):
+    RAISED            = LABEL_RAISED
+    REFINED           = LABEL_REFINED
+    PLANNED           = LABEL_PLANNED
+    PLAN_APPROVED     = LABEL_PLAN_APPROVED
+    IN_PROGRESS       = LABEL_IN_PROGRESS
+    PR                = LABEL_IN_PR        # currently in the PR submachine
+    MERGED            = LABEL_MERGED
+    SOLVED            = LABEL_SOLVED
+    NEEDS_EXPLORATION = LABEL_NEEDS_EXPLORATION
+    HUMAN_NEEDED      = LABEL_HUMAN_NEEDED
+
+
+class PRState(str, Enum):
+    OPEN              = "pr:open"
+    REVIEWING         = "pr:reviewing"
+    REVISION_PENDING  = "pr:revision_pending"
+    APPROVED          = "pr:approved"
+    MERGED            = "pr:merged"
+    PR_HUMAN_NEEDED   = "pr:human_needed"
+
+
+@dataclass
+class Transition:
+    name: str
+    from_state: IssueState | PRState
+    to_state:   IssueState | PRState
+    labels_add:    list[str] = field(default_factory=list)
+    labels_remove: list[str] = field(default_factory=list)
+    min_confidence: float = 0.0
+    human_label_if_below: str = LABEL_HUMAN_NEEDED
+
+
+ISSUE_TRANSITIONS: list[Transition] = [
+    Transition("raise_to_refine",         IssueState.RAISED,            IssueState.REFINED,
+               labels_remove=[LABEL_RAISED],            labels_add=[LABEL_REFINED],           min_confidence=0.6),
+    Transition("raise_to_exploration",    IssueState.RAISED,            IssueState.NEEDS_EXPLORATION,
+               labels_remove=[LABEL_RAISED],            labels_add=[LABEL_NEEDS_EXPLORATION]),
+    Transition("raise_to_human",          IssueState.RAISED,            IssueState.HUMAN_NEEDED,
+               labels_remove=[LABEL_RAISED],            labels_add=[LABEL_HUMAN_NEEDED]),
+    Transition("refine_to_plan",          IssueState.REFINED,           IssueState.PLANNED,
+               labels_remove=[LABEL_REFINED],           labels_add=[LABEL_PLANNED]),
+    Transition("plan_to_approved",        IssueState.PLANNED,           IssueState.PLAN_APPROVED,
+               labels_remove=[LABEL_PLANNED],           labels_add=[LABEL_PLAN_APPROVED]),
+    Transition("approved_to_in_progress", IssueState.PLAN_APPROVED,     IssueState.IN_PROGRESS,
+               labels_remove=[LABEL_PLAN_APPROVED],     labels_add=[LABEL_IN_PROGRESS]),
+    Transition("refine_to_in_progress",   IssueState.REFINED,           IssueState.IN_PROGRESS,
+               labels_remove=[LABEL_REFINED],           labels_add=[LABEL_IN_PROGRESS]),
+    Transition("in_progress_to_pr",       IssueState.IN_PROGRESS,       IssueState.PR,
+               labels_remove=[LABEL_IN_PROGRESS],       labels_add=[LABEL_IN_PR]),
+    Transition("pr_to_merged",            IssueState.PR,                IssueState.MERGED,
+               labels_remove=[LABEL_IN_PR],             labels_add=[LABEL_MERGED],            min_confidence=0.8),
+    Transition("merged_to_solved",        IssueState.MERGED,            IssueState.SOLVED,
+               labels_remove=[LABEL_MERGED],            labels_add=[LABEL_SOLVED],            min_confidence=0.7),
+    Transition("exploration_to_refine",   IssueState.NEEDS_EXPLORATION, IssueState.REFINED,
+               labels_remove=[LABEL_NEEDS_EXPLORATION], labels_add=[LABEL_REFINED]),
+    Transition("human_to_raised",         IssueState.HUMAN_NEEDED,      IssueState.RAISED,
+               labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_RAISED]),
+]
+
+
+PR_TRANSITIONS: list[Transition] = [
+    Transition("pr_open_to_reviewing",          PRState.OPEN,             PRState.REVIEWING,
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    Transition("reviewing_to_revision_pending", PRState.REVIEWING,        PRState.REVISION_PENDING,
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    Transition("revision_pending_to_reviewing", PRState.REVISION_PENDING, PRState.REVIEWING,
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    Transition("reviewing_to_approved",         PRState.REVIEWING,        PRState.APPROVED,
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    Transition("approved_to_merged",            PRState.APPROVED,         PRState.MERGED,
+               min_confidence=0.8, human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    Transition("pr_to_human",                   PRState.REVIEWING,        PRState.PR_HUMAN_NEEDED,
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    Transition("pr_human_to_reviewing",         PRState.PR_HUMAN_NEEDED,  PRState.REVIEWING,
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+]
+
+
+def get_issue_state(labels: list[str]) -> Optional[IssueState]:
+    """Return the first IssueState whose label value appears in *labels*."""
+    label_set = set(labels)
+    for state in IssueState:
+        if state.value in label_set:
+            return state
+    return None
+
+
+def get_pr_state(pr: dict) -> PRState:
+    """Derive the current PRState from a GitHub PR JSON dict."""
+    if pr.get("merged") or pr.get("mergedAt") or pr.get("state") == "MERGED":
+        return PRState.MERGED
+    review_decision = pr.get("reviewDecision") or ""
+    if review_decision == "APPROVED":
+        return PRState.APPROVED
+    if review_decision == "CHANGES_REQUESTED":
+        return PRState.REVISION_PENDING
+    reviews = pr.get("reviews", {})
+    total_count = 0
+    if isinstance(reviews, dict):
+        total_count = reviews.get("totalCount", 0)
+    elif isinstance(reviews, list):
+        total_count = len(reviews)
+    if total_count > 0:
+        return PRState.REVIEWING
+    return PRState.OPEN
+
+
+def render_fsm_mermaid(transitions: list[Transition], title: str = "FSM") -> str:
+    """Render *transitions* as a Mermaid stateDiagram-v2 block."""
+    lines = ["stateDiagram-v2"]
+    for t in transitions:
+        from_name = t.from_state.name if hasattr(t.from_state, "name") else str(t.from_state)
+        to_name   = t.to_state.name   if hasattr(t.to_state,   "name") else str(t.to_state)
+        label = t.name
+        if t.min_confidence > 0.0:
+            label = f"{t.name} [≥{t.min_confidence}]"
+        lines.append(f"    {from_name} --> {to_name} : {label}")
+    return "\n".join(lines)

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -1,0 +1,80 @@
+"""Tests for cai_lib.fsm — FSM data structures."""
+import sys
+import os
+import unittest
+from collections import deque
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.fsm import (
+    IssueState, PRState, Transition,
+    ISSUE_TRANSITIONS, PR_TRANSITIONS,
+    get_issue_state, render_fsm_mermaid,
+)
+from cai_lib.config import LABEL_IN_PROGRESS
+
+
+class TestFsm(unittest.TestCase):
+
+    def test_get_issue_state_in_progress(self):
+        result = get_issue_state([LABEL_IN_PROGRESS])
+        self.assertEqual(result, IssueState.IN_PROGRESS)
+
+    def test_no_orphan_states(self):
+        """BFS from RAISED must reach every non-terminal IssueState."""
+        terminal = {IssueState.SOLVED, IssueState.HUMAN_NEEDED}
+        adj: dict = {}
+        for t in ISSUE_TRANSITIONS:
+            adj.setdefault(t.from_state, []).append(t.to_state)
+
+        visited = set()
+        queue = deque([IssueState.RAISED])
+        while queue:
+            state = queue.popleft()
+            if state in visited:
+                continue
+            visited.add(state)
+            for nxt in adj.get(state, []):
+                if nxt not in visited:
+                    queue.append(nxt)
+
+        non_terminal = {s for s in IssueState if s not in terminal}
+        unreachable = non_terminal - visited
+        self.assertFalse(
+            unreachable,
+            f"States unreachable from RAISED via BFS: {unreachable}",
+        )
+
+    def test_no_pr_open_in_issue_state(self):
+        names = [s.name for s in IssueState]
+        self.assertNotIn("PR_OPEN", names,
+            "PR_OPEN must not appear in IssueState — it belongs in PRState")
+        self.assertNotIn("REVISING", names,
+            "REVISING must not appear in IssueState — it belongs in PRState")
+        self.assertIn("PR", names,
+            "IssueState must have a PR state representing the PR submachine")
+
+    def test_render_fsm_mermaid_contains_all_transitions(self):
+        result = render_fsm_mermaid(ISSUE_TRANSITIONS)
+        self.assertIn("stateDiagram-v2", result)
+        for t in ISSUE_TRANSITIONS:
+            self.assertIn(t.name, result,
+                f"Transition {t.name!r} missing from mermaid output")
+        for t in ISSUE_TRANSITIONS:
+            if t.min_confidence > 0.0:
+                self.assertIn(f"[≥{t.min_confidence}]", result,
+                    f"Confidence annotation missing for {t.name!r}")
+
+    def test_pr_transitions_are_transition_objects(self):
+        self.assertTrue(len(PR_TRANSITIONS) > 0)
+        for t in PR_TRANSITIONS:
+            self.assertIsInstance(t, Transition,
+                f"{t!r} is not a Transition instance")
+            self.assertIsInstance(t.from_state, PRState,
+                f"from_state {t.from_state!r} is not a PRState member")
+            self.assertIsInstance(t.to_state, PRState,
+                f"to_state {t.to_state!r} is not a PRState member")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#592

**Issue:** #592 — [Step 1/2] Define the FSM data structures in `cai_lib/fsm.py`

## PR Summary

### What this fixes
Issue #592 requires creating an explicit FSM data structure for the auto-improve lifecycle. The pipeline's state machine was previously implicit — state lived in GitHub labels and transitions were ad-hoc `_set_labels()` calls scattered through `cai.py`. The project owner revised the design to collapse `PR_OPEN`+`REVISING` into a single `PR` state in `IssueState`, with the PR-internal lifecycle living entirely in a `PRState` submachine.

### What was changed
- **`cai_lib/config.py`**: Added 3 new label constants after `LABEL_PLAN_APPROVED` — `LABEL_IN_PR` (`"auto-improve:in-pr"`), `LABEL_HUMAN_NEEDED` (`"auto-improve:human-needed"`), `LABEL_PR_HUMAN_NEEDED` (`"auto-improve:pr-human-needed"`)
- **`cai_lib/fsm.py`** (new): Full FSM module with `IssueState` (10-state enum), `PRState` (6-state PR submachine enum), `Transition` dataclass, `ISSUE_TRANSITIONS` (12 transitions), `PR_TRANSITIONS` (7 transitions), and helper functions `get_issue_state`, `get_pr_state`, `render_fsm_mermaid`
- **`cai_lib/__init__.py`**: Added the 3 new config constants to the import block and `__all__`; added `from cai_lib.fsm import (...)` block after `cmd_implement`; added all 8 FSM symbols to `__all__`
- **`tests/test_fsm.py`** (new): 5 unit tests — state lookup, BFS reachability, PR_OPEN/REVISING exclusion from IssueState, Mermaid render completeness, PR_TRANSITIONS type check

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
