### PR TITLE
auto-improve: [Step 3/3] Auto-reset to `pr:edited` on new non-bot commits (polling sweep)

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -30,3 +30,17 @@ Refs: robotsix/robotsix-cai#567
 - `gh pr list --json commits` returns `authors` list with `login` field per commit
 - Bot pipeline comments use `createdAt` ISO 8601 UTC; commit `committedDate` is same format
 - `_is_bot_comment` matches bot comments by body prefix (not author), so it correctly identifies pipeline summary comments
+
+## Revision 1 (2026-04-14)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:6895-6908` — replaced `_is_bot_comment(c)` with specific pipeline-state heading check using `_REVIEW_COMMENT_HEADING_CLEAN`, `_DOCS_REVIEW_COMMENT_HEADING_CLEAN`, `_DOCS_REVIEW_COMMENT_HEADING_APPLIED`
+
+### Decisions this revision
+- Used a local `_pipeline_comment_markers` tuple rather than a new module-level constant — keeps the change minimal and co-located with the comment that describes the intent
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,32 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#567
+
+## Files touched
+- `cai.py:2499` — added `BOT_USERNAME = "github-actions[bot]"` constant before `_BOT_COMMENT_MARKERS`
+- `cai.py:6897-6927` — added pipeline-reset block in `_pr_label_sweep` after DIRTY-check, before `needs` label sync
+
+## Files read (not touched) that matter
+- `cai.py` — `_pr_label_sweep` (lines 6799–6936), `_BOT_COMMENT_MARKERS` area (lines 2497–2520)
+
+## Key symbols
+- `BOT_USERNAME` (`cai.py:2499`) — new constant identifying the GitHub Actions bot login
+- `_pr_label_sweep` (`cai.py:6799`) — sweep function where reset block was inserted
+- `_pr_set_pipeline_state` (`cai.py:6755`) — called to reset label to `pr:edited`
+- `_is_bot_comment` (`cai.py:2573`) — checks comment body prefix to identify bot comments
+- `_parse_iso_ts` (`cai.py:2637`) — parses ISO timestamps for comparison
+- `LABEL_PR_REVIEWED_ACCEPT`, `LABEL_PR_DOCUMENTED` (`cai.py:6736-6737`) — stale labels that trigger reset
+
+## Design decisions
+- Used `commits[-1].get("authors", [])` fallback to `[]` when field absent → treat as bot (false-negative preference)
+- Only reset when `latest_bot_comment_ts is not None and commit_ts is not None` — no-op if ordering can't be established
+- `LABEL_PR_REVIEWED_REJECT` excluded — rejection stands regardless of new pushes
+- Rejected: resetting unconditionally on new commits — would cause spurious resets for bot self-pushes
+
+## Out of scope / known gaps
+- Multiple co-authors: only first author checked; human second author won't trigger reset (acceptable false-negative)
+- No new `gh` API fields added — reuses existing `commits` field already in `--json` query
+
+## Invariants this change relies on
+- `gh pr list --json commits` returns `authors` list with `login` field per commit
+- Bot pipeline comments use `createdAt` ISO 8601 UTC; commit `committedDate` is same format
+- `_is_bot_comment` matches bot comments by body prefix (not author), so it correctly identifies pipeline summary comments

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -44,3 +44,17 @@ Refs: robotsix/robotsix-cai#567
 
 ### New gaps / deferred
 - None
+
+## Revision 2 (2026-04-14)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:6928-6932` — added `or last_author_login == "github-actions"` to `is_bot_commit` guard to align with existing bot-detection pattern at line 265
+
+### Decisions this revision
+- Added the bare `"github-actions"` check to match the existing `author == "github-actions"` guard used elsewhere; keeps both detection sites consistent
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -58,3 +58,17 @@ Refs: robotsix/robotsix-cai#567
 
 ### New gaps / deferred
 - None
+
+## Revision 3 (2026-04-14)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:6898` — corrected typo `#557` → `#567` in inline comment
+
+### Decisions this revision
+- Typo fix: the inline comment referenced the wrong issue number (#557 instead of #567)
+
+### New gaps / deferred
+- None

--- a/cai.py
+++ b/cai.py
@@ -6928,6 +6928,7 @@ def _pr_label_sweep() -> tuple[int, int]:
                 is_bot_commit = (
                     not last_author_login                   # unknown → treat as bot
                     or last_author_login == BOT_USERNAME    # github-actions[bot]
+                    or last_author_login == "github-actions"  # bare name variant
                     or last_author_login.endswith("[bot]")  # any other bot account
                 )
                 if not is_bot_commit and commit_ts > latest_bot_comment_ts:

--- a/cai.py
+++ b/cai.py
@@ -6895,7 +6895,7 @@ def _pr_label_sweep() -> tuple[int, int]:
         if not needs and merge_state == "DIRTY":
             needs = True
 
-        # Step 3/3 (#557): If the PR carries a stale pipeline label
+        # Step 3/3 (#567): If the PR carries a stale pipeline label
         # (pr:reviewed-accept or pr:documented) and a non-bot commit was
         # pushed AFTER the most recent bot pipeline comment, reset the
         # label to pr:edited so the pipeline re-enters review.

--- a/cai.py
+++ b/cai.py
@@ -2484,6 +2484,10 @@ def cmd_implement(args) -> int:
 # so the bot's "identity" is the same as the user's. Content-based
 # marker matching is the robust alternative.
 #
+# Login used by the GitHub Actions bot when it pushes commits.  Used in
+# _pr_label_sweep to distinguish bot pushes from human pushes.
+BOT_USERNAME = "github-actions[bot]"
+
 # IMPORTANT: only "no-action" / "summary" bot comments belong here.
 # Comments that contain ACTIONABLE content for the revise subagent
 # (most notably review-pr findings) must NOT be in this list — they
@@ -6879,6 +6883,38 @@ def _pr_label_sweep() -> tuple[int, int]:
         # Signal: PR has unresolved merge conflict against main.
         if not needs and merge_state == "DIRTY":
             needs = True
+
+        # Step 3/3 (#557): If the PR carries a stale pipeline label
+        # (pr:reviewed-accept or pr:documented) and a non-bot commit was
+        # pushed AFTER the most recent bot pipeline comment, reset the
+        # label to pr:edited so the pipeline re-enters review.
+        stale_pipeline_labels = {LABEL_PR_REVIEWED_ACCEPT, LABEL_PR_DOCUMENTED}
+        if labels & stale_pipeline_labels and commits:
+            # Proxy for "when was the pipeline label last applied":
+            # find the most recent bot pipeline comment timestamp.
+            latest_bot_comment_ts = None
+            for c in comments:
+                if not _is_bot_comment(c):
+                    continue
+                ts = _parse_iso_ts(c.get("createdAt"))
+                if ts is not None and (latest_bot_comment_ts is None
+                                       or ts > latest_bot_comment_ts):
+                    latest_bot_comment_ts = ts
+            # Only reset when we can establish a reliable ordering.
+            # Prefer false-negative (no reset) over false-positive (spurious
+            # reset) when information is missing.
+            if latest_bot_comment_ts is not None and commit_ts is not None:
+                last_authors = commits[-1].get("authors", [])
+                last_author_login = (
+                    last_authors[0].get("login", "") if last_authors else ""
+                )
+                is_bot_commit = (
+                    not last_author_login                   # unknown → treat as bot
+                    or last_author_login == BOT_USERNAME    # github-actions[bot]
+                    or last_author_login.endswith("[bot]")  # any other bot account
+                )
+                if not is_bot_commit and commit_ts > latest_bot_comment_ts:
+                    _pr_set_pipeline_state(pr_number, LABEL_PR_EDITED)
 
         if needs and not currently_labeled:
             _pr_set_needs_human(pr_number, True)

--- a/cai.py
+++ b/cai.py
@@ -6893,8 +6893,14 @@ def _pr_label_sweep() -> tuple[int, int]:
             # Proxy for "when was the pipeline label last applied":
             # find the most recent bot pipeline comment timestamp.
             latest_bot_comment_ts = None
+            _pipeline_comment_markers = (
+                _REVIEW_COMMENT_HEADING_CLEAN,
+                _DOCS_REVIEW_COMMENT_HEADING_CLEAN,
+                _DOCS_REVIEW_COMMENT_HEADING_APPLIED,
+            )
             for c in comments:
-                if not _is_bot_comment(c):
+                body = (c.get("body") or "").lstrip()
+                if not any(body.startswith(h) for h in _pipeline_comment_markers):
                     continue
                 ts = _parse_iso_ts(c.get("createdAt"))
                 if ts is not None and (latest_bot_comment_ts is None

--- a/cai.py
+++ b/cai.py
@@ -6791,7 +6791,7 @@ def _pr_set_pipeline_state(pr_number: int, label: str) -> None:
 
 
 def _pr_label_sweep() -> tuple[int, int]:
-    """Sync `needs-human-review` across every open bot PR.
+    """Sync `needs-human-review` across every open bot PR and reset stale pipeline labels.
 
     Run after the merge loop so that PRs the merge step did NOT
     process this tick (e.g., idempotency-skipped because no human
@@ -6801,6 +6801,13 @@ def _pr_label_sweep() -> tuple[int, int]:
     `rebase resolution failed` once would never be labelled, since
     that failure path doesn't go through the merge agent. Refs #223.
 
+    Also detects when a non-bot commit was pushed after a stale
+    pipeline label (pr:reviewed-accept or pr:documented) and resets
+    the label to pr:edited to re-enter the review pipeline. This
+    ensures that human or external bot commits on auto-improve
+    branches trigger a re-review, even if no review comments are
+    posted. Refs #567.
+
     Signals (each scoped to comments AFTER the latest commit so a
     fresh push naturally clears them):
 
@@ -6809,8 +6816,12 @@ def _pr_label_sweep() -> tuple[int, int]:
     - any `## Revise subagent: rebase resolution failed` comment
     - any `## Revise subagent: no additional changes` comment
     - mergeStateStatus is DIRTY (unresolved conflict against main)
+    - a non-bot commit pushed after the most recent bot pipeline
+      comment while PR carries pr:reviewed-accept or pr:documented
 
-    Returns (added, removed) for the run summary.
+    Returns (added, removed) for the run summary (counts of
+    `needs-human-review` labels added/removed; pipeline-state resets
+    are side-effects not included in the count).
     """
     try:
         prs = _gh_json([

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,7 @@
 | `human:submitted` | Human-submitted issue awaiting refinement |
 | `merge-blocked` | PR has a blocking review finding; will not auto-merge |
 | `needs-human-review` | Issue or PR requires human attention |
-| `pr:edited` | PR branch has been updated by `cai revise` or `cai review-docs` |
+| `pr:edited` | PR branch has been updated by `cai revise`, `cai review-docs`, or polling sweep (when non-bot commits are detected after a stale pipeline label) |
 | `pr:reviewed-accept` | `cai review-pr` completed and posted a clean verdict (no findings) |
 | `pr:reviewed-reject` | `cai review-pr` completed and posted findings (changes needed) |
 | `pr:documented` | `cai review-docs` completed (documentation is current) |


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#567

**Issue:** #567 — [Step 3/3] Auto-reset to `pr:edited` on new non-bot commits (polling sweep)

## PR Summary

### What this fixes
After a PR receives `pr:reviewed-accept` or `pr:documented`, a subsequent non-bot commit leaves those labels stale — the pipeline won't re-enter review because `cmd_revise` only triggers on unaddressed review comments, not raw pushes. This adds detection in the polling sweep to auto-reset the label to `pr:edited` whenever a human commit lands after the most recent bot pipeline comment.

### What was changed
- **`cai.py:2499`** — Added `BOT_USERNAME = "github-actions[bot]"` constant before `_BOT_COMMENT_MARKERS`, naming the GitHub Actions bot login for use in commit-author detection.
- **`cai.py:6897–6927`** — Inserted a pipeline-reset block in `_pr_label_sweep` after the DIRTY-check signal. If the PR carries `pr:reviewed-accept` or `pr:documented`, it finds the most recent bot pipeline comment timestamp, checks whether the latest commit was pushed after that timestamp by a non-bot author, and calls `_pr_set_pipeline_state(pr_number, LABEL_PR_EDITED)` when both conditions hold. Prefers false-negative (no reset) over false-positive (spurious reset) when author or timestamp information is missing.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
