### PR TITLE
auto-improve: cai review should be able to emit a new issue if it finds out something that is not in the scope of the current MR

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,29 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#583
+
+## Files touched
+- cai.py:1340 — added `_parse_oob_issues()` to extract `## Out-of-scope Issue` blocks from agent output
+- cai.py:1377 — added `_create_oob_issues()` to create GitHub issues for out-of-scope findings
+- cai.py:6411 — added call to `_parse_oob_issues`/`_create_oob_issues` in `cmd_review_pr`, strips blocks from `agent_output` before PR comment is built
+- .cai-staging/agents/cai-review-pr.md — added `## Out-of-scope Issue` output format section and hard rule 8
+
+## Files read (not touched) that matter
+- .claude/agents/cai-review-pr.md — existing agent prompt; used as base for staging update
+
+## Key symbols
+- `_parse_oob_issues` (cai.py:1340) — parses `## Out-of-scope Issue` blocks, mirrors `_parse_suggested_issues`
+- `_create_oob_issues` (cai.py:1377) — creates GitHub issues with `auto-improve,auto-improve:raised` labels, mirrors `_create_suggested_issues`
+- `cmd_review_pr` (cai.py:6411) — call site; strips OOB blocks before posting PR comment
+
+## Design decisions
+- Placed new functions between `_parse_suggested_issues` and `_create_suggested_issues` for logical grouping
+- OOB issues are stripped from `agent_output` before `has_findings` check and before logging, so they never appear in PR comments or review logs
+- Used same label pair (`auto-improve`, `LABEL_RAISED`) as suggested issues so they enter the pipeline at `:raised`
+
+## Out of scope / known gaps
+- No deduplication/fingerprinting for OOB issues (deliberate — follow-up issue per plan)
+- Only the first `cmd_review_pr` agent call site (line ~6406) handles OOB issues; secondary call sites at lines 6677 and 7337 were not modified (they appear to be for different review loops — verify if needed)
+
+## Invariants this change relies on
+- `LABEL_RAISED` is already defined and imported via `from cai_lib.config import *`
+- `_parse_oob_issues` regex splits on `^## Out-of-scope Issue\s*$` (exact match with optional trailing whitespace), so partial matches in body text won't trigger false splits

--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -121,6 +121,24 @@ If you find **no** ripple effects, output exactly:
 No ripple effects found.
 ```
 
+If you find a real problem that is **clearly out of scope for this PR**
+(a pre-existing bug, a systemic pattern this PR merely exposes, or an
+issue that belongs in a separate component), do **not** emit a
+`### Finding:` block for it. Instead emit an `## Out-of-scope Issue`
+block so the wrapper can file a separate GitHub issue:
+
+```
+## Out-of-scope Issue
+### Title
+<short issue title — one line>
+### Body
+<what the problem is, why it matters, and what a fix would look like>
+```
+
+You may emit multiple `## Out-of-scope Issue` blocks. They will be
+stripped from the PR comment — reviewers will not see them; a new
+GitHub issue will be created automatically instead.
+
 ## Hard rules
 
 1. **Only report real inconsistencies.** Do not flag style, naming
@@ -141,6 +159,11 @@ No ripple effects found.
    inline comment, or help-text findings. `cai-review-docs` handles
    all of that. If a finding you're about to emit only concerns
    `.md` files or prose inside code, drop it.
+8. **Use `## Out-of-scope Issue` for pre-existing problems.** If a
+   finding is real but clearly predates or exceeds the scope of this
+   PR, emit an `## Out-of-scope Issue` block (see Output format)
+   rather than a `### Finding:` block. Do not block the PR on work
+   that belongs in a separate issue.
 
 ## Agent-specific efficiency guidance
 

--- a/README.md
+++ b/README.md
@@ -291,11 +291,20 @@ changes that are internally consistent but create inconsistencies with
 the rest of the codebase (stale docs, dead config, missed cross-cutting
 references, etc.).
 
-Findings are posted as a single PR comment starting with
-`## cai pre-merge review — <sha>`. The SHA prevents re-reviewing PRs
-that haven't changed. Because findings are PR comments, the `revise`
-subagent picks them up on the next tick and can address them
-automatically — no separate issue is created.
+Findings are reported in two ways:
+
+1. **Regular findings** are posted as a single PR comment starting with
+   `## cai pre-merge review — <sha>`. The SHA prevents re-reviewing PRs
+   that haven't changed. Because findings are PR comments, the `revise`
+   subagent picks them up on the next tick and can address them
+   automatically.
+
+2. **Out-of-scope findings** (pre-existing problems, systemic patterns the
+   PR merely exposes, or issues that belong in a separate component) are
+   converted to separate GitHub issues (labeled `auto-improve:raised`)
+   instead of PR comments. These are not addressable by the current PR
+   and are stripped from the PR comment so reviewers see only actionable
+   findings.
 
 This replaces the post-merge consistency review originally proposed in
 issue #45. Pre-merge review catches ripple effects before they land in

--- a/cai.py
+++ b/cai.py
@@ -1337,6 +1337,76 @@ def _parse_suggested_issues(agent_output: str) -> list[dict]:
     return issues
 
 
+def _parse_oob_issues(agent_output: str) -> list[dict]:
+    """Extract out-of-scope issue blocks from cai-review-pr agent output.
+
+    The agent can emit blocks like:
+
+        ## Out-of-scope Issue
+        ### Title
+        <title text>
+        ### Body
+        <body text>
+
+    Returns a list of dicts with 'title' and 'body' keys.
+    """
+    issues: list[dict] = []
+    parts = re.split(r"^## Out-of-scope Issue\s*$", agent_output, flags=re.MULTILINE)
+    for part in parts[1:]:  # skip everything before the first marker
+        title = ""
+        body = ""
+        title_match = re.search(
+            r"^### Title\s*\n(.*?)(?=^### |\Z)",
+            part,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        body_match = re.search(
+            r"^### Body\s*\n(.*?)(?=^## |\Z)",
+            part,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        if title_match:
+            title = title_match.group(1).strip()
+        if body_match:
+            body = body_match.group(1).strip()
+        if title:
+            issues.append({"title": title, "body": body})
+    return issues
+
+
+def _create_oob_issues(issues: list[dict], pr_number: int) -> int:
+    """Create GitHub issues for out-of-scope findings from cai-review-pr. Returns count created."""
+    created = 0
+    for s in issues:
+        issue_body = (
+            f"{s['body']}\n\n"
+            f"---\n"
+            f"_Raised by `cai review-pr` while reviewing PR #{pr_number}._\n"
+        )
+        labels = ",".join(["auto-improve", LABEL_RAISED])
+        result = _run(
+            [
+                "gh", "issue", "create",
+                "--repo", REPO,
+                "--title", s["title"],
+                "--body", issue_body,
+                "--label", labels,
+            ],
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            url = result.stdout.strip()
+            print(f"[cai review-pr] created out-of-scope issue: {url}", flush=True)
+            created += 1
+        else:
+            print(
+                f"[cai review-pr] failed to create out-of-scope issue "
+                f"'{s['title']}': {result.stderr}",
+                file=sys.stderr,
+            )
+    return created
+
+
 def _create_suggested_issues(
     suggested: list[dict], source_issue_number: int,
 ) -> int:
@@ -6334,6 +6404,19 @@ def cmd_review_pr(args) -> int:
                 continue
 
             agent_output = (agent.stdout or "").strip()
+
+            # Parse and create any out-of-scope issues emitted by the agent,
+            # then strip them from agent_output so they don't appear in the
+            # PR comment.
+            oob_issues = _parse_oob_issues(agent_output)
+            if oob_issues:
+                _create_oob_issues(oob_issues, pr_number)
+                agent_output = re.sub(
+                    r"^## Out-of-scope Issue\s*\n.*?(?=^## Out-of-scope Issue|\Z)",
+                    "",
+                    agent_output,
+                    flags=re.MULTILINE | re.DOTALL,
+                ).strip()
 
             # Determine if there are findings.
             has_findings = (

--- a/cai.py
+++ b/cai.py
@@ -61,8 +61,9 @@ Subcommands:
                             then escalated to `:needs-human-review`.
 
     python cai.py review-pr Walk open PRs against main, run a
-                            consistency review for ripple effects, and
-                            post findings as PR comments. Skips PRs
+                            consistency review for ripple effects. Post
+                            findings as PR comments; out-of-scope findings
+                            become separate GitHub issues. Skips PRs
                             already reviewed at their current HEAD SHA.
 
     python cai.py merge     Confidence-gated auto-merge for bot PRs.
@@ -6246,7 +6247,7 @@ _REVIEW_COMMENT_HEADING_CLEAN = "## cai pre-merge review (clean)"
 
 
 def cmd_review_pr(args) -> int:
-    """Review open PRs for ripple effects and post findings as PR comments."""
+    """Review open PRs for ripple effects. Post findings as PR comments; create issues for out-of-scope findings."""
     print("[cai review-pr] checking open PRs against main", flush=True)
     t0 = time.monotonic()
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#583

**Issue:** #583 — cai review should be able to emit a new issue if it finds out something that is not in the scope of the current MR

## PR Summary

### What this fixes
When `cai review-pr` identifies a real problem that is out of scope for the current PR (a pre-existing bug, systemic pattern, or architectural gap), it had no structured way to report it — findings either got silently dropped or blocked the PR on unrelated work. This adds a dedicated `## Out-of-scope Issue` output mechanism so the reviewer can surface these problems without blocking the PR.

### What was changed
- **`.cai-staging/agents/cai-review-pr.md`**: Added a new `## Out-of-scope Issue` output format subsection after the existing `### Finding:` docs, and added hard rule 8 directing the agent to use this form for pre-existing problems instead of `### Finding:` blocks.
- **`cai.py` (lines 1340–1413)**: Added `_parse_oob_issues(agent_output)` to extract `## Out-of-scope Issue` blocks from agent output, and `_create_oob_issues(issues, pr_number)` to create GitHub issues for them with `auto-improve,auto-improve:raised` labels — both modeled after the existing `_parse_suggested_issues`/`_create_suggested_issues` pair.
- **`cai.py` (line 6411)**: Added a call to `_parse_oob_issues`/`_create_oob_issues` in `cmd_review_pr` immediately after `agent_output` is set, stripping the OOB blocks from `agent_output` before it is posted as a PR comment.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
