### PR TITLE
ci: auto-commit regenerated CODEBASE_INDEX.md on same-repo PRs

### DIFF
--- a/.github/workflows/check-index.yml
+++ b/.github/workflows/check-index.yml
@@ -4,16 +4,36 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   check-index:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Regenerate index
         run: bash scripts/generate-index.sh
-      - name: Check for drift
+      - name: Commit regenerated index if drifted
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
-          if ! git diff --exit-code CODEBASE_INDEX.md; then
-            echo "::error::CODEBASE_INDEX.md is stale. Run 'bash scripts/generate-index.sh' and commit."
+          if git diff --quiet CODEBASE_INDEX.md; then
+            echo "CODEBASE_INDEX.md already up to date."
+            exit 0
+          fi
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::CODEBASE_INDEX.md is stale and PR is from a fork; cannot auto-commit. Run 'bash scripts/generate-index.sh' and push."
+            git --no-pager diff CODEBASE_INDEX.md
             exit 1
           fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CODEBASE_INDEX.md
+          git commit -m "chore: auto-regenerate CODEBASE_INDEX.md"
+          git push

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,7 +5,6 @@
 
 | File | Purpose |
 |------|---------|
-| `.cai/pr-context.md` | Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `audit:raised` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |


### PR DESCRIPTION
## Summary
- Upgrades `.github/workflows/check-index.yml` to regenerate `CODEBASE_INDEX.md` and push the update back to the PR branch when it drifts, instead of only failing the check.
- Fork PRs keep the previous fail-with-diff behavior since `GITHUB_TOKEN` can't push to forks.
- Motivated by PR #602, where `cai-fix-ci` looped on stale-index failures because the subagent can't run `scripts/generate-index.sh`.

## Test plan
- [ ] Trigger a same-repo PR that edits a tracked file without updating CODEBASE_INDEX.md and confirm the workflow auto-commits the regenerated index.
- [ ] Confirm a PR with an already-up-to-date index passes without a new commit.