### PR TITLE
refactor(fsm): add apply_transition and migrate 3 call sites

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -47,7 +47,7 @@
 | `cai_lib/cmd_implement.py` | Helpers for the implement-subagent pipeline |
 | `cai_lib/cmd_lifecycle.py` | Pipeline state-transition helpers |
 | `cai_lib/config.py` | Shared constants and path definitions |
-| `cai_lib/fsm.py` | FSM data structures for the auto-improve lifecycle (IssueState, PRState, transitions) |
+| `cai_lib/fsm.py` | TODO: add description |
 | `cai_lib/github.py` | GitHub/gh CLI helpers and shared label utilities |
 | `cai_lib/logging_utils.py` | Logging utilities extracted from cai.py |
 | `cai_lib/subprocess_utils.py` | Subprocess helpers extracted from cai.py |
@@ -65,7 +65,7 @@
 | `pyproject.toml` | Python project configuration (ruff lint settings) |
 | `scripts/generate-index.sh` | Generator script for CODEBASE_INDEX.md |
 | `tests/__init__.py` | Test package init |
-| `tests/test_fsm.py` | Tests for FSM data structures (IssueState, PRState, transitions, render) |
+| `tests/test_fsm.py` | TODO: add description |
 | `tests/test_lint.py` | Lint check: ruff must report zero violations |
 | `tests/test_multistep.py` | Tests for multi-step plan support |
 | `tests/test_parse.py` | Tests for parse.py signal extraction |

--- a/cai.py
+++ b/cai.py
@@ -198,6 +198,7 @@ from cai_lib.github import (  # noqa: E402
     _fetch_linked_issue_block,
 )
 from cai_lib.cmd_lifecycle import _rollback_stale_in_progress, _reconcile_interrupted  # noqa: E402
+from cai_lib.fsm import apply_transition  # noqa: E402
 from cai_lib.cmd_implement import _parse_decomposition  # noqa: E402
 
 
@@ -1157,10 +1158,9 @@ def cmd_plan(args) -> int:
             return 1
 
         # 6. Transition labels: :refined → :planned.
-        _set_labels(
-            issue_number,
-            add=[LABEL_PLANNED],
-            remove=[LABEL_REFINED],
+        apply_transition(
+            issue_number, "refine_to_plan",
+            current_labels=[l["name"] for l in issue.get("labels", [])],  # noqa: E741
             log_prefix="cai plan",
         )
 
@@ -7594,6 +7594,7 @@ def cmd_refine(args) -> int:
         return result.returncode
 
     stdout = result.stdout
+    issue_label_names = [l["name"] for l in issue.get("labels", [])]  # noqa: E741
 
     # 4. Check for early-exit (already structured).
     if "## No Refinement Needed" in stdout:
@@ -7602,10 +7603,10 @@ def cmd_refine(args) -> int:
             f"transitioning to :refined",
             flush=True,
         )
-        _set_labels(
-            issue_number,
-            add=[LABEL_REFINED],
-            remove=[LABEL_RAISED, LABEL_HUMAN_SUBMITTED],
+        apply_transition(
+            issue_number, "raise_to_refine",
+            current_labels=issue_label_names,
+            extra_remove=[LABEL_HUMAN_SUBMITTED],
             log_prefix="cai refine",
         )
         dur = f"{int(time.monotonic() - t0)}s"
@@ -7689,10 +7690,10 @@ def cmd_refine(args) -> int:
         return 1
 
     # 8. Transition labels: :raised / human:submitted → :refined.
-    _set_labels(
-        issue_number,
-        add=[LABEL_REFINED],
-        remove=[LABEL_RAISED, LABEL_HUMAN_SUBMITTED],
+    apply_transition(
+        issue_number, "raise_to_refine",
+        current_labels=issue_label_names,
+        extra_remove=[LABEL_HUMAN_SUBMITTED],
         log_prefix="cai refine",
     )
 

--- a/cai_lib/fsm.py
+++ b/cai_lib/fsm.py
@@ -6,9 +6,10 @@ in cai.py is changed by importing it.
 """
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
+from typing import Optional, Sequence
 
 from cai_lib.config import (
     LABEL_RAISED, LABEL_REFINED, LABEL_PLANNED, LABEL_PLAN_APPROVED,
@@ -123,6 +124,63 @@ def get_pr_state(pr: dict) -> PRState:
     if total_count > 0:
         return PRState.REVIEWING
     return PRState.OPEN
+
+
+_ALL_TRANSITIONS: list[Transition] = ISSUE_TRANSITIONS + PR_TRANSITIONS
+
+
+def find_transition(name: str, transitions: Sequence[Transition] = _ALL_TRANSITIONS) -> Transition:
+    """Return the Transition with the given *name*. Raises KeyError if unknown."""
+    for t in transitions:
+        if t.name == name:
+            return t
+    raise KeyError(f"unknown transition: {name!r}")
+
+
+def apply_transition(
+    issue_number: int,
+    transition_name: str,
+    *,
+    current_labels: Optional[list[str]] = None,
+    extra_remove: Sequence[str] = (),
+    log_prefix: str = "cai",
+    set_labels=None,
+) -> bool:
+    """Apply a named issue FSM transition via ``_set_labels``.
+
+    When *current_labels* is provided, the current IssueState is derived and
+    compared to ``transition.from_state``. A mismatch is refused (logs and
+    returns False) so drift cannot silently compound.
+
+    *extra_remove* is appended to the transition's own ``labels_remove`` —
+    used for auxiliary labels (e.g. ``human:submitted``) that aren't part
+    of the canonical FSM but must be cleared alongside the state change.
+
+    *set_labels* is injectable for tests; defaults to
+    ``cai_lib.github._set_labels``.
+    """
+    transition = find_transition(transition_name, ISSUE_TRANSITIONS)
+
+    if current_labels is not None:
+        current = get_issue_state(current_labels)
+        if current != transition.from_state:
+            print(
+                f"[{log_prefix}] refusing transition {transition_name!r} on "
+                f"#{issue_number}: current state {current} does not match "
+                f"expected {transition.from_state}",
+                file=sys.stderr,
+            )
+            return False
+
+    if set_labels is None:
+        from cai_lib.github import _set_labels as set_labels  # local import — avoids cycle at module load
+
+    return set_labels(
+        issue_number,
+        add=list(transition.labels_add),
+        remove=list(transition.labels_remove) + list(extra_remove),
+        log_prefix=log_prefix,
+    )
 
 
 def render_fsm_mermaid(transitions: list[Transition], title: str = "FSM") -> str:

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -10,8 +10,11 @@ from cai_lib.fsm import (
     IssueState, PRState, Transition,
     ISSUE_TRANSITIONS, PR_TRANSITIONS,
     get_issue_state, render_fsm_mermaid,
+    apply_transition, find_transition,
 )
-from cai_lib.config import LABEL_IN_PROGRESS
+from cai_lib.config import (
+    LABEL_IN_PROGRESS, LABEL_RAISED, LABEL_REFINED, LABEL_HUMAN_SUBMITTED,
+)
 
 
 class TestFsm(unittest.TestCase):
@@ -74,6 +77,70 @@ class TestFsm(unittest.TestCase):
                 f"from_state {t.from_state!r} is not a PRState member")
             self.assertIsInstance(t.to_state, PRState,
                 f"to_state {t.to_state!r} is not a PRState member")
+
+
+class TestApplyTransition(unittest.TestCase):
+
+    def _recording_set_labels(self):
+        calls = []
+        def _fake(issue_number, *, add=(), remove=(), log_prefix="cai"):
+            calls.append({
+                "issue_number": issue_number,
+                "add": list(add),
+                "remove": list(remove),
+                "log_prefix": log_prefix,
+            })
+            return True
+        return calls, _fake
+
+    def test_happy_path_applies_labels(self):
+        calls, fake = self._recording_set_labels()
+        ok = apply_transition(
+            42, "raise_to_refine",
+            current_labels=[LABEL_RAISED],
+            set_labels=fake,
+        )
+        self.assertTrue(ok)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["issue_number"], 42)
+        self.assertIn(LABEL_REFINED, calls[0]["add"])
+        self.assertIn(LABEL_RAISED, calls[0]["remove"])
+
+    def test_extra_remove_is_forwarded(self):
+        calls, fake = self._recording_set_labels()
+        apply_transition(
+            7, "raise_to_refine",
+            current_labels=[LABEL_RAISED],
+            extra_remove=[LABEL_HUMAN_SUBMITTED],
+            set_labels=fake,
+        )
+        self.assertIn(LABEL_HUMAN_SUBMITTED, calls[0]["remove"])
+        self.assertIn(LABEL_RAISED, calls[0]["remove"])
+
+    def test_state_mismatch_refuses(self):
+        calls, fake = self._recording_set_labels()
+        ok = apply_transition(
+            9, "raise_to_refine",
+            current_labels=[LABEL_REFINED],  # wrong from_state
+            set_labels=fake,
+        )
+        self.assertFalse(ok)
+        self.assertEqual(calls, [])
+
+    def test_unknown_transition_raises(self):
+        with self.assertRaises(KeyError):
+            apply_transition(1, "not_a_real_transition", current_labels=[LABEL_RAISED])
+
+    def test_skip_validation_when_no_current_labels(self):
+        calls, fake = self._recording_set_labels()
+        ok = apply_transition(1, "raise_to_refine", set_labels=fake)
+        self.assertTrue(ok)
+        self.assertEqual(len(calls), 1)
+
+    def test_find_transition_roundtrip(self):
+        t = find_transition("raise_to_refine")
+        self.assertEqual(t.from_state, IssueState.RAISED)
+        self.assertEqual(t.to_state, IssueState.REFINED)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `apply_transition` + `find_transition` to `cai_lib/fsm.py`, making the FSM executable instead of purely declarative
- Validates `from_state` when `current_labels` is supplied — illegal transitions are refused loudly instead of silently corrupting labels
- Migrate 3 POC call sites in `cai.py` (two `raise_to_refine`, one `refine_to_plan`) to the new helper

## Test plan
- [x] `python -m unittest discover tests` — 50 passed, 1 skipped (ruff not installed locally)
- [x] `python -c "import cai"` smoke check
- [ ] CI runs the same suite on merge

Phase 1 of a larger cleanup that makes `cai_lib/fsm.py` the single source of truth for label transitions. Remaining `_set_labels` sites will be migrated in follow-up PRs; sites that touch the PR submachine need the `LABEL_IN_PR` vs `LABEL_PR_OPEN` mismatch resolved first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)