### PR TITLE
feat(fsm): Confidence enum + divert-to-human helpers

### DIFF
--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -1,5 +1,6 @@
 """cai_lib.config — shared constants and path definitions."""
 
+import os
 from pathlib import Path
 
 
@@ -94,3 +95,24 @@ _STALE_IN_PROGRESS_HOURS = 6
 _STALE_REVISING_HOURS = 1
 _STALE_NO_ACTION_DAYS = 7
 _STALE_MERGED_DAYS = 14
+
+
+# ---------------------------------------------------------------------------
+# Admin identity
+#
+# Comma-separated list of GitHub logins whose comments on :human-needed
+# issues/PRs are allowed to wake the FSM resume loop. Parsed once at
+# import time; empty / unset means no one can unblock via comments (safe
+# default).
+# ---------------------------------------------------------------------------
+
+ADMIN_LOGINS: frozenset[str] = frozenset(
+    login.strip()
+    for login in os.environ.get("CAI_ADMIN_LOGINS", "").split(",")
+    if login.strip()
+)
+
+
+def is_admin_login(login: str) -> bool:
+    """True if *login* is configured as an admin via ``CAI_ADMIN_LOGINS``."""
+    return bool(login) and login in ADMIN_LOGINS

--- a/cai_lib/fsm.py
+++ b/cai_lib/fsm.py
@@ -1,11 +1,13 @@
 """FSM data structures for the auto-improve lifecycle.
 
 This module defines the explicit state machine that the auto-improve
-pipeline follows. It is a pure data-structure module — no behaviour
-in cai.py is changed by importing it.
+pipeline follows. Transitions are data; drivers in ``cai.py`` apply
+them through :func:`apply_transition` or
+:func:`apply_transition_with_confidence`.
 """
 from __future__ import annotations
 
+import re
 import sys
 from dataclasses import dataclass, field
 from enum import Enum
@@ -16,6 +18,59 @@ from cai_lib.config import (
     LABEL_IN_PROGRESS, LABEL_IN_PR, LABEL_MERGED, LABEL_SOLVED,
     LABEL_NEEDS_EXPLORATION, LABEL_HUMAN_NEEDED, LABEL_PR_HUMAN_NEEDED,
 )
+
+
+class Confidence(Enum):
+    """Qualitative confidence level emitted by agents.
+
+    Ordered so ``Confidence.LOW < Confidence.MEDIUM < Confidence.HIGH`` —
+    use comparison operators to gate transitions rather than comparing
+    raw ints.
+    """
+    LOW    = 1
+    MEDIUM = 2
+    HIGH   = 3
+
+    def __lt__(self, other: "Confidence") -> bool:
+        if not isinstance(other, Confidence):
+            return NotImplemented
+        return self.value < other.value
+
+    def __le__(self, other: "Confidence") -> bool:
+        if not isinstance(other, Confidence):
+            return NotImplemented
+        return self.value <= other.value
+
+    def __gt__(self, other: "Confidence") -> bool:
+        if not isinstance(other, Confidence):
+            return NotImplemented
+        return self.value > other.value
+
+    def __ge__(self, other: "Confidence") -> bool:
+        if not isinstance(other, Confidence):
+            return NotImplemented
+        return self.value >= other.value
+
+
+_CONFIDENCE_RE = re.compile(
+    r"^\s*Confidence\s*[:=]\s*(LOW|MEDIUM|HIGH)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def parse_confidence(text: str) -> Optional[Confidence]:
+    """Extract ``Confidence: LOW|MEDIUM|HIGH`` from agent structured output.
+
+    Returns the parsed level, or ``None`` when no well-formed line is
+    present. Callers must treat ``None`` as "missing" and divert to
+    HUMAN_NEEDED — never assume a default level.
+    """
+    if not text:
+        return None
+    m = _CONFIDENCE_RE.search(text)
+    if not m:
+        return None
+    return Confidence[m.group(1).upper()]
 
 
 class IssueState(str, Enum):
@@ -47,13 +102,25 @@ class Transition:
     to_state:   IssueState | PRState
     labels_add:    list[str] = field(default_factory=list)
     labels_remove: list[str] = field(default_factory=list)
-    min_confidence: float = 0.0
+    # Minimum confidence the emitting agent must report for the
+    # transition to fire. Default HIGH means only fully-confident moves
+    # auto-advance; anything lower diverts to ``human_label_if_below``.
+    min_confidence: Confidence = Confidence.HIGH
     human_label_if_below: str = LABEL_HUMAN_NEEDED
+
+    def accepts(self, confidence: Optional[Confidence]) -> bool:
+        """True if *confidence* meets or exceeds this transition's threshold.
+
+        ``None`` always fails — missing confidence must route to human review.
+        """
+        if confidence is None:
+            return False
+        return confidence >= self.min_confidence
 
 
 ISSUE_TRANSITIONS: list[Transition] = [
     Transition("raise_to_refine",         IssueState.RAISED,            IssueState.REFINED,
-               labels_remove=[LABEL_RAISED],            labels_add=[LABEL_REFINED],           min_confidence=0.6),
+               labels_remove=[LABEL_RAISED],            labels_add=[LABEL_REFINED]),
     Transition("raise_to_exploration",    IssueState.RAISED,            IssueState.NEEDS_EXPLORATION,
                labels_remove=[LABEL_RAISED],            labels_add=[LABEL_NEEDS_EXPLORATION]),
     Transition("raise_to_human",          IssueState.RAISED,            IssueState.HUMAN_NEEDED,
@@ -69,9 +136,9 @@ ISSUE_TRANSITIONS: list[Transition] = [
     Transition("in_progress_to_pr",       IssueState.IN_PROGRESS,       IssueState.PR,
                labels_remove=[LABEL_IN_PROGRESS],       labels_add=[LABEL_IN_PR]),
     Transition("pr_to_merged",            IssueState.PR,                IssueState.MERGED,
-               labels_remove=[LABEL_IN_PR],             labels_add=[LABEL_MERGED],            min_confidence=0.8),
+               labels_remove=[LABEL_IN_PR],             labels_add=[LABEL_MERGED]),
     Transition("merged_to_solved",        IssueState.MERGED,            IssueState.SOLVED,
-               labels_remove=[LABEL_MERGED],            labels_add=[LABEL_SOLVED],            min_confidence=0.7),
+               labels_remove=[LABEL_MERGED],            labels_add=[LABEL_SOLVED]),
     Transition("exploration_to_refine",   IssueState.NEEDS_EXPLORATION, IssueState.REFINED,
                labels_remove=[LABEL_NEEDS_EXPLORATION], labels_add=[LABEL_REFINED]),
     Transition("human_to_raised",         IssueState.HUMAN_NEEDED,      IssueState.RAISED,
@@ -89,7 +156,7 @@ PR_TRANSITIONS: list[Transition] = [
     Transition("reviewing_to_approved",         PRState.REVIEWING,        PRState.APPROVED,
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
     Transition("approved_to_merged",            PRState.APPROVED,         PRState.MERGED,
-               min_confidence=0.8, human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
     Transition("pr_to_human",                   PRState.REVIEWING,        PRState.PR_HUMAN_NEEDED,
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
     Transition("pr_human_to_reviewing",         PRState.PR_HUMAN_NEEDED,  PRState.REVIEWING,
@@ -135,6 +202,73 @@ def find_transition(name: str, transitions: Sequence[Transition] = _ALL_TRANSITI
         if t.name == name:
             return t
     raise KeyError(f"unknown transition: {name!r}")
+
+
+# ---------------------------------------------------------------------------
+# Pending-marker helpers
+#
+# When a transition diverts to HUMAN_NEEDED because confidence was too low (or
+# missing), we append a hidden marker to the issue body so the resume loop
+# knows what the agent was trying to do. The marker survives edits because we
+# key on the delimiter pair and replace in place.
+# ---------------------------------------------------------------------------
+
+_PENDING_MARKER_START = "<!-- cai-fsm-pending"
+_PENDING_MARKER_END   = "-->"
+_PENDING_MARKER_RE = re.compile(
+    r"<!--\s*cai-fsm-pending\s+(.*?)\s*-->",
+    re.DOTALL,
+)
+
+
+def render_pending_marker(
+    *,
+    transition_name: str,
+    from_state: IssueState | PRState,
+    intended_state: IssueState | PRState,
+    confidence: Optional[Confidence],
+) -> str:
+    """Serialize a pending-transition marker for an issue body."""
+    conf = confidence.name if confidence is not None else "MISSING"
+    from_name = from_state.name if hasattr(from_state, "name") else str(from_state)
+    intended_name = (
+        intended_state.name if hasattr(intended_state, "name") else str(intended_state)
+    )
+    return (
+        f"{_PENDING_MARKER_START} "
+        f"transition={transition_name} from={from_name} "
+        f"intended={intended_name} conf={conf} {_PENDING_MARKER_END}"
+    )
+
+
+def parse_pending_marker(body: str) -> Optional[dict]:
+    """Extract the pending-transition marker from an issue *body*.
+
+    Returns a dict with keys ``transition``, ``from``, ``intended``, ``conf``
+    (all strings), or ``None`` if no marker is present.
+    """
+    if not body:
+        return None
+    m = _PENDING_MARKER_RE.search(body)
+    if not m:
+        return None
+    fields: dict = {}
+    for token in m.group(1).split():
+        if "=" in token:
+            k, v = token.split("=", 1)
+            fields[k] = v
+    if "transition" not in fields:
+        return None
+    return fields
+
+
+def strip_pending_marker(body: str) -> str:
+    """Remove any pending-transition marker from *body* (and trailing blank lines)."""
+    if not body:
+        return body
+    new = _PENDING_MARKER_RE.sub("", body)
+    # Collapse the blank lines the marker may have left behind.
+    return re.sub(r"\n{3,}", "\n\n", new).rstrip() + ("\n" if body.endswith("\n") else "")
 
 
 def apply_transition(
@@ -183,14 +317,78 @@ def apply_transition(
     )
 
 
+def apply_transition_with_confidence(
+    issue_number: int,
+    transition_name: str,
+    confidence: Optional[Confidence],
+    *,
+    current_labels: Optional[list[str]] = None,
+    extra_remove: Sequence[str] = (),
+    log_prefix: str = "cai",
+    set_labels=None,
+) -> tuple[bool, bool]:
+    """Apply an issue FSM transition gated on *confidence*.
+
+    Returns ``(ok, diverted)``:
+
+    - When *confidence* is missing or below ``transition.min_confidence``,
+      the intended state change is refused and the issue is instead moved
+      to ``transition.human_label_if_below`` (defaults to
+      :data:`LABEL_HUMAN_NEEDED`). The caller is responsible for appending
+      a pending marker to the issue body so the resume loop can pick up
+      where the automation stopped — see :func:`render_pending_marker`.
+    - When confidence meets the threshold, delegates to
+      :func:`apply_transition` and returns ``(ok, False)``.
+    """
+    transition = find_transition(transition_name, ISSUE_TRANSITIONS)
+
+    if transition.accepts(confidence):
+        ok = apply_transition(
+            issue_number, transition_name,
+            current_labels=current_labels,
+            extra_remove=extra_remove,
+            log_prefix=log_prefix,
+            set_labels=set_labels,
+        )
+        return ok, False
+
+    # Divert: clear the from_state label and apply the human-needed label.
+    if current_labels is not None:
+        current = get_issue_state(current_labels)
+        if current != transition.from_state:
+            print(
+                f"[{log_prefix}] refusing divert for {transition_name!r} on "
+                f"#{issue_number}: current state {current} does not match "
+                f"expected {transition.from_state}",
+                file=sys.stderr,
+            )
+            return False, False
+
+    if set_labels is None:
+        from cai_lib.github import _set_labels as set_labels  # local import — avoids cycle at module load
+
+    conf_name = confidence.name if confidence is not None else "MISSING"
+    print(
+        f"[{log_prefix}] diverting {transition_name!r} on #{issue_number} to "
+        f"{transition.human_label_if_below} (confidence={conf_name}, "
+        f"required={transition.min_confidence.name})",
+        flush=True,
+    )
+    ok = set_labels(
+        issue_number,
+        add=[transition.human_label_if_below],
+        remove=list(transition.labels_remove) + list(extra_remove),
+        log_prefix=log_prefix,
+    )
+    return ok, True
+
+
 def render_fsm_mermaid(transitions: list[Transition], title: str = "FSM") -> str:
     """Render *transitions* as a Mermaid stateDiagram-v2 block."""
     lines = ["stateDiagram-v2"]
     for t in transitions:
         from_name = t.from_state.name if hasattr(t.from_state, "name") else str(t.from_state)
         to_name   = t.to_state.name   if hasattr(t.to_state,   "name") else str(t.to_state)
-        label = t.name
-        if t.min_confidence > 0.0:
-            label = f"{t.name} [≥{t.min_confidence}]"
+        label = f"{t.name} [≥{t.min_confidence.name}]"
         lines.append(f"    {from_name} --> {to_name} : {label}")
     return "\n".join(lines)

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -13,29 +13,29 @@ nav_order: 5
 
 ```mermaid
 stateDiagram-v2
-    RAISED --> REFINED : raise_to_refine [≥0.6]
-    RAISED --> NEEDS_EXPLORATION : raise_to_exploration
-    RAISED --> HUMAN_NEEDED : raise_to_human
-    REFINED --> PLANNED : refine_to_plan
-    PLANNED --> PLAN_APPROVED : plan_to_approved
-    PLAN_APPROVED --> IN_PROGRESS : approved_to_in_progress
-    REFINED --> IN_PROGRESS : refine_to_in_progress
-    IN_PROGRESS --> PR : in_progress_to_pr
-    PR --> MERGED : pr_to_merged [≥0.8]
-    MERGED --> SOLVED : merged_to_solved [≥0.7]
-    NEEDS_EXPLORATION --> REFINED : exploration_to_refine
-    HUMAN_NEEDED --> RAISED : human_to_raised
+    RAISED --> REFINED : raise_to_refine [≥HIGH]
+    RAISED --> NEEDS_EXPLORATION : raise_to_exploration [≥HIGH]
+    RAISED --> HUMAN_NEEDED : raise_to_human [≥HIGH]
+    REFINED --> PLANNED : refine_to_plan [≥HIGH]
+    PLANNED --> PLAN_APPROVED : plan_to_approved [≥HIGH]
+    PLAN_APPROVED --> IN_PROGRESS : approved_to_in_progress [≥HIGH]
+    REFINED --> IN_PROGRESS : refine_to_in_progress [≥HIGH]
+    IN_PROGRESS --> PR : in_progress_to_pr [≥HIGH]
+    PR --> MERGED : pr_to_merged [≥HIGH]
+    MERGED --> SOLVED : merged_to_solved [≥HIGH]
+    NEEDS_EXPLORATION --> REFINED : exploration_to_refine [≥HIGH]
+    HUMAN_NEEDED --> RAISED : human_to_raised [≥HIGH]
 ```
 
 ## PR state machine
 
 ```mermaid
 stateDiagram-v2
-    OPEN --> REVIEWING : pr_open_to_reviewing
-    REVIEWING --> REVISION_PENDING : reviewing_to_revision_pending
-    REVISION_PENDING --> REVIEWING : revision_pending_to_reviewing
-    REVIEWING --> APPROVED : reviewing_to_approved
-    APPROVED --> MERGED : approved_to_merged [≥0.8]
-    REVIEWING --> PR_HUMAN_NEEDED : pr_to_human
-    PR_HUMAN_NEEDED --> REVIEWING : pr_human_to_reviewing
+    OPEN --> REVIEWING : pr_open_to_reviewing [≥HIGH]
+    REVIEWING --> REVISION_PENDING : reviewing_to_revision_pending [≥HIGH]
+    REVISION_PENDING --> REVIEWING : revision_pending_to_reviewing [≥HIGH]
+    REVIEWING --> APPROVED : reviewing_to_approved [≥HIGH]
+    APPROVED --> MERGED : approved_to_merged [≥HIGH]
+    REVIEWING --> PR_HUMAN_NEEDED : pr_to_human [≥HIGH]
+    PR_HUMAN_NEEDED --> REVIEWING : pr_human_to_reviewing [≥HIGH]
 ```

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -7,13 +7,16 @@ from collections import deque
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from cai_lib.fsm import (
-    IssueState, PRState, Transition,
+    IssueState, PRState, Transition, Confidence,
     ISSUE_TRANSITIONS, PR_TRANSITIONS,
     get_issue_state, render_fsm_mermaid,
-    apply_transition, find_transition,
+    apply_transition, apply_transition_with_confidence, find_transition,
+    parse_confidence,
+    render_pending_marker, parse_pending_marker, strip_pending_marker,
 )
 from cai_lib.config import (
     LABEL_IN_PROGRESS, LABEL_RAISED, LABEL_REFINED, LABEL_HUMAN_SUBMITTED,
+    LABEL_HUMAN_NEEDED,
 )
 
 
@@ -63,10 +66,8 @@ class TestFsm(unittest.TestCase):
         for t in ISSUE_TRANSITIONS:
             self.assertIn(t.name, result,
                 f"Transition {t.name!r} missing from mermaid output")
-        for t in ISSUE_TRANSITIONS:
-            if t.min_confidence > 0.0:
-                self.assertIn(f"[≥{t.min_confidence}]", result,
-                    f"Confidence annotation missing for {t.name!r}")
+            self.assertIn(f"[≥{t.min_confidence.name}]", result,
+                f"Confidence annotation missing for {t.name!r}")
 
     def test_pr_transitions_are_transition_objects(self):
         self.assertTrue(len(PR_TRANSITIONS) > 0)
@@ -77,6 +78,31 @@ class TestFsm(unittest.TestCase):
                 f"from_state {t.from_state!r} is not a PRState member")
             self.assertIsInstance(t.to_state, PRState,
                 f"to_state {t.to_state!r} is not a PRState member")
+
+
+class TestConfidenceEnum(unittest.TestCase):
+
+    def test_ordering(self):
+        self.assertTrue(Confidence.LOW < Confidence.MEDIUM < Confidence.HIGH)
+        self.assertTrue(Confidence.HIGH >= Confidence.HIGH)
+        self.assertFalse(Confidence.LOW >= Confidence.HIGH)
+
+    def test_parse_valid(self):
+        self.assertEqual(parse_confidence("Confidence: HIGH"), Confidence.HIGH)
+        self.assertEqual(parse_confidence("some text\nConfidence: medium\nmore"), Confidence.MEDIUM)
+        self.assertEqual(parse_confidence("Confidence=LOW"), Confidence.LOW)
+
+    def test_parse_missing_returns_none(self):
+        self.assertIsNone(parse_confidence(""))
+        self.assertIsNone(parse_confidence("no confidence line here"))
+        self.assertIsNone(parse_confidence("Confidence: BOGUS"))
+
+    def test_transition_accepts(self):
+        t = find_transition("raise_to_refine")
+        # default threshold is HIGH
+        self.assertTrue(t.accepts(Confidence.HIGH))
+        self.assertFalse(t.accepts(Confidence.MEDIUM))
+        self.assertFalse(t.accepts(None))
 
 
 class TestApplyTransition(unittest.TestCase):
@@ -121,7 +147,7 @@ class TestApplyTransition(unittest.TestCase):
         calls, fake = self._recording_set_labels()
         ok = apply_transition(
             9, "raise_to_refine",
-            current_labels=[LABEL_REFINED],  # wrong from_state
+            current_labels=[LABEL_REFINED],
             set_labels=fake,
         )
         self.assertFalse(ok)
@@ -141,6 +167,110 @@ class TestApplyTransition(unittest.TestCase):
         t = find_transition("raise_to_refine")
         self.assertEqual(t.from_state, IssueState.RAISED)
         self.assertEqual(t.to_state, IssueState.REFINED)
+
+
+class TestApplyTransitionWithConfidence(unittest.TestCase):
+
+    def _recording_set_labels(self):
+        calls = []
+        def _fake(issue_number, *, add=(), remove=(), log_prefix="cai"):
+            calls.append({
+                "issue_number": issue_number,
+                "add": list(add),
+                "remove": list(remove),
+                "log_prefix": log_prefix,
+            })
+            return True
+        return calls, _fake
+
+    def test_high_confidence_applies_nominal_transition(self):
+        calls, fake = self._recording_set_labels()
+        ok, diverted = apply_transition_with_confidence(
+            11, "raise_to_refine", Confidence.HIGH,
+            current_labels=[LABEL_RAISED],
+            set_labels=fake,
+        )
+        self.assertTrue(ok)
+        self.assertFalse(diverted)
+        self.assertIn(LABEL_REFINED, calls[0]["add"])
+
+    def test_medium_confidence_diverts_to_human(self):
+        calls, fake = self._recording_set_labels()
+        ok, diverted = apply_transition_with_confidence(
+            12, "raise_to_refine", Confidence.MEDIUM,
+            current_labels=[LABEL_RAISED],
+            set_labels=fake,
+        )
+        self.assertTrue(ok)
+        self.assertTrue(diverted)
+        self.assertIn(LABEL_HUMAN_NEEDED, calls[0]["add"])
+        self.assertIn(LABEL_RAISED, calls[0]["remove"])
+        self.assertNotIn(LABEL_REFINED, calls[0]["add"])
+
+    def test_missing_confidence_diverts_to_human(self):
+        calls, fake = self._recording_set_labels()
+        ok, diverted = apply_transition_with_confidence(
+            13, "raise_to_refine", None,
+            current_labels=[LABEL_RAISED],
+            set_labels=fake,
+        )
+        self.assertTrue(ok)
+        self.assertTrue(diverted)
+        self.assertIn(LABEL_HUMAN_NEEDED, calls[0]["add"])
+
+    def test_divert_respects_from_state_mismatch(self):
+        calls, fake = self._recording_set_labels()
+        ok, diverted = apply_transition_with_confidence(
+            14, "raise_to_refine", None,
+            current_labels=[LABEL_REFINED],  # wrong state
+            set_labels=fake,
+        )
+        self.assertFalse(ok)
+        self.assertFalse(diverted)
+        self.assertEqual(calls, [])
+
+
+class TestPendingMarker(unittest.TestCase):
+
+    def test_roundtrip_with_confidence(self):
+        marker = render_pending_marker(
+            transition_name="raise_to_refine",
+            from_state=IssueState.RAISED,
+            intended_state=IssueState.REFINED,
+            confidence=Confidence.MEDIUM,
+        )
+        parsed = parse_pending_marker(f"body text\n{marker}\nmore text")
+        self.assertEqual(parsed["transition"], "raise_to_refine")
+        self.assertEqual(parsed["from"], "RAISED")
+        self.assertEqual(parsed["intended"], "REFINED")
+        self.assertEqual(parsed["conf"], "MEDIUM")
+
+    def test_roundtrip_with_missing_confidence(self):
+        marker = render_pending_marker(
+            transition_name="raise_to_refine",
+            from_state=IssueState.RAISED,
+            intended_state=IssueState.REFINED,
+            confidence=None,
+        )
+        parsed = parse_pending_marker(marker)
+        self.assertEqual(parsed["conf"], "MISSING")
+
+    def test_parse_returns_none_when_absent(self):
+        self.assertIsNone(parse_pending_marker("a plain issue body"))
+        self.assertIsNone(parse_pending_marker(""))
+
+    def test_strip_removes_marker(self):
+        marker = render_pending_marker(
+            transition_name="raise_to_refine",
+            from_state=IssueState.RAISED,
+            intended_state=IssueState.REFINED,
+            confidence=Confidence.LOW,
+        )
+        body = f"leading text\n\n{marker}\n\ntrailing text\n"
+        stripped = strip_pending_marker(body)
+        self.assertNotIn("cai-fsm-pending", stripped)
+        self.assertIn("leading text", stripped)
+        self.assertIn("trailing text", stripped)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `Confidence` enum (LOW/MEDIUM/HIGH) parsed from agent output; missing/malformed → `None` → divert to human (no default level)
- `Transition.min_confidence` is now `Confidence` (default `HIGH`); `accepts(confidence)` gates firing
- `apply_transition_with_confidence(...)` returns `(ok, diverted)`; diverts to `human_label_if_below` when confidence is insufficient
- Pending-marker helpers record "what the agent was trying to do" in the issue body for the upcoming resume loop
- `CAI_ADMIN_LOGINS` env var + `is_admin_login` — allowlist used by the future unblock command
- Regenerated `docs/fsm.md` with qualitative thresholds

Phase 1a — pure data-model PR, no call sites migrated yet.

## Test plan
- [x] `python -m unittest discover tests` — 62 passed, 1 skipped
- [x] `python -c "import cai"` smoke check
- [ ] CI green

Phase 1b will add `cmd_unblock` (admin-comment-driven resume via Haiku) and pilot cai-refine on the new helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)