### PR TITLE
feat(fsm): widen human-needed re-entries + cai-unblock agent

### DIFF
--- a/.claude/agents/cai-unblock.md
+++ b/.claude/agents/cai-unblock.md
@@ -1,0 +1,68 @@
+---
+name: cai-unblock
+description: Classify an admin's GitHub comment on a :human-needed issue into a FSM resume target so the auto-improve pipeline can continue.
+tools: Read
+model: claude-haiku-4-5-20251001
+memory: project
+---
+
+# Unblock Agent
+
+You are the unblock agent for `robotsix-cai`. An auto-improve issue
+is parked in `auto-improve:human-needed` because an earlier agent
+could not move forward with high confidence. An admin has now
+commented on the issue. Your job is to read the comment and decide
+which state the FSM should resume from.
+
+## What you receive
+
+The user message contains three sections:
+
+1. **Pending transition marker** — what the automation was trying
+   to do when it paused (e.g. `transition=raise_to_refine
+   from=RAISED intended=REFINED conf=MEDIUM`).
+2. **Issue body** — the issue text the admin is commenting on.
+3. **Admin comments** — only comments from admin logins are shown,
+   newest last.
+
+## Valid resume targets
+
+Return exactly one of these state names in a `ResumeTo:` line. Each
+maps to a `human_to_<state>` transition already defined in
+`cai_lib/fsm.py`.
+
+| State           | Admin intent (examples)                                     |
+|-----------------|-------------------------------------------------------------|
+| `RAISED`        | "start over" / "re-triage this" / comment is ambiguous      |
+| `REFINED`       | "skip refinement, it's clear enough, go to plan"            |
+| `PLANNED`       | "accept the stored plan as-is" (rare)                       |
+| `PLAN_APPROVED` | "approve the plan — let the implement agent run"            |
+| `NEEDS_EXPLORATION` | "investigate further before doing anything"             |
+| `SOLVED`        | "close this — not worth doing" / "already fixed elsewhere"  |
+
+If the admin's comment is unrelated to the pending decision or you
+cannot decide with confidence, emit `ResumeTo: RAISED` at `LOW`
+confidence — that restarts triage without pretending certainty.
+
+## Output format
+
+Your last non-empty reply must end with these two lines, each on
+its own line, in this exact casing:
+
+```
+ResumeTo: <STATE_NAME>
+Confidence: HIGH | MEDIUM | LOW
+```
+
+Before those two lines, include one short paragraph (≤3 sentences)
+explaining how you interpreted the admin's comment. No other
+sections.
+
+## Hard rules
+
+- Never invent states that are not in the table above.
+- Never emit `ResumeTo: HUMAN_NEEDED` (that's where the issue
+  already is).
+- If you set `Confidence: LOW`, the wrapper will leave the issue
+  parked rather than firing the resume transition — that is the
+  correct outcome when the admin comment is ambiguous.

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,9 +5,19 @@
 
 | File | Purpose |
 |------|---------|
+| `cai_lib/cmd_fix.py` | Deprecated shim redirecting to cai_lib.cmd_implement |
+| `cai_lib/cmd_implement.py` | Helpers for the implement-subagent pipeline |
+| `cai_lib/cmd_lifecycle.py` | Pipeline state-transition helpers |
+| `cai_lib/config.py` | Shared constants and path definitions |
+| `cai_lib/fsm.py` | TODO: add description |
+| `cai_lib/github.py` | GitHub/gh CLI helpers and shared label utilities |
+| `cai_lib/__init__.py` | Package init for cai_lib library modules |
+| `cai_lib/logging_utils.py` | Logging utilities extracted from cai.py |
+| `cai_lib/subprocess_utils.py` | Subprocess helpers extracted from cai.py |
+| `cai.py` | Main CLI dispatcher — 16+ subcommands for the self-improvement loop |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
-| `.claude/agents/cai-audit-triage.md` | Agent: triage `audit:raised` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |
+| `.claude/agents/cai-audit-triage.md` | Agent: triage `audit:raised` findings with structured verdicts |
 | `.claude/agents/cai-check-workflows.md` | Agent: analyze recent GitHub Actions workflow failures and emit structured findings |
 | `.claude/agents/cai-code-audit.md` | Agent: read-only source tree audit for inconsistencies and dead code |
 | `.claude/agents/cai-confirm.md` | Agent: verify merged PRs actually resolved their issues |
@@ -19,8 +29,8 @@
 | `.claude/agents/cai-implement.md` | Agent: autonomous code-editing subagent — canonical successor to cai-fix |
 | `.claude/agents/cai-merge.md` | Agent: assess PR correctness and emit merge verdict |
 | `.claude/agents/cai-plan.md` | Agent: generate detailed fix plan for an issue |
-| `.claude/agents/cai-propose-review.md` | Agent: review creative proposals for feasibility |
 | `.claude/agents/cai-propose.md` | Agent: weekly creative improvement proposals |
+| `.claude/agents/cai-propose-review.md` | Agent: review creative proposals for feasibility |
 | `.claude/agents/cai-rebase.md` | Agent: rebase-only conflict resolution |
 | `.claude/agents/cai-refine.md` | Agent: rewrite human-filed issues into structured plans |
 | `.claude/agents/cai-review-docs.md` | Agent: pre-merge documentation review |
@@ -28,42 +38,33 @@
 | `.claude/agents/cai-revise.md` | Agent: handle review comments on auto-improve PRs |
 | `.claude/agents/cai-select.md` | Agent: evaluate and select best fix plan |
 | `.claude/agents/cai-spike.md` | Agent: research spike for needs-spike issues |
+| `.claude/agents/cai-unblock.md` | Agent: classify admin comments on :human-needed issues into FSM resume targets |
 | `.claude/agents/cai-update-check.md` | Agent: check for new Claude Code releases |
+| `CLAUDE.md` | Shared efficiency guidance loaded by all subagents |
 | `.claude/settings.json` | Claude Code harness configuration |
+| `CODEBASE_INDEX.md` | This file — static file-level index for fast agent orientation |
+| `docker-compose.yml` | Multi-service orchestration with named volumes |
+| `Dockerfile` | Container image definition (Python 3.12 + Node + claude-code CLI) |
+| `docs/agents.md` | Documentation: agent definitions and pipeline phase mapping |
+| `docs/architecture.md` | Documentation: pipeline overview and system architecture |
+| `docs/cli.md` | Documentation: CLI reference for all cai.py subcommands |
+| `docs/configuration.md` | Documentation: environment variables and configuration |
+| `docs/_config.yml` | Jekyll configuration for GitHub Pages docs |
+| `docs/fsm.md` | Auto-generated lifecycle FSM diagrams (issue + PR state machines) |
+| `docs/index.md` | Documentation site landing page |
+| `entrypoint.sh` | Docker entrypoint — templates crontab, runs initial cycle, execs supercronic |
 | `.env.example` | Template for required environment variables |
 | `.github/workflows/admin-only-label.yml` | CI: restrict auto-improve:requested label to admins |
 | `.github/workflows/cleanup-pr-context.yml` | CI: clean up PR context on close |
 | `.github/workflows/docker-publish.yml` | CI: build and publish Docker image to Docker Hub |
 | `.github/workflows/regenerate-docs.yml` | CI: regenerate CODEBASE_INDEX.md and docs/fsm.md, auto-commit drift |
 | `.gitignore` | Git ignore rules |
-| `CLAUDE.md` | Shared efficiency guidance loaded by all subagents |
-| `CODEBASE_INDEX.md` | This file — static file-level index for fast agent orientation |
-| `Dockerfile` | Container image definition (Python 3.12 + Node + claude-code CLI) |
-| `LICENSE` | MIT license |
-| `README.md` | Project documentation and usage guide |
-| `cai.py` | Main CLI dispatcher — 16+ subcommands for the self-improvement loop |
-| `cai_lib/__init__.py` | Package init for cai_lib library modules |
-| `cai_lib/cmd_fix.py` | Deprecated shim redirecting to cai_lib.cmd_implement |
-| `cai_lib/cmd_implement.py` | Helpers for the implement-subagent pipeline |
-| `cai_lib/cmd_lifecycle.py` | Pipeline state-transition helpers |
-| `cai_lib/config.py` | Shared constants and path definitions |
-| `cai_lib/fsm.py` | TODO: add description |
-| `cai_lib/github.py` | GitHub/gh CLI helpers and shared label utilities |
-| `cai_lib/logging_utils.py` | Logging utilities extracted from cai.py |
-| `cai_lib/subprocess_utils.py` | Subprocess helpers extracted from cai.py |
-| `docker-compose.yml` | Multi-service orchestration with named volumes |
-| `docs/_config.yml` | Jekyll configuration for GitHub Pages docs |
-| `docs/agents.md` | Documentation: agent definitions and pipeline phase mapping |
-| `docs/architecture.md` | Documentation: pipeline overview and system architecture |
-| `docs/cli.md` | Documentation: CLI reference for all cai.py subcommands |
-| `docs/configuration.md` | Documentation: environment variables and configuration |
-| `docs/fsm.md` | Auto-generated lifecycle FSM diagrams (issue + PR state machines) |
-| `docs/index.md` | Documentation site landing page |
-| `entrypoint.sh` | Docker entrypoint — templates crontab, runs initial cycle, execs supercronic |
 | `install.sh` | Interactive installer for end-users |
+| `LICENSE` | MIT license |
 | `parse.py` | Deterministic signal extractor from Claude Code JSONL transcripts |
 | `publish.py` | GitHub issue publisher with fingerprint dedup |
 | `pyproject.toml` | Python project configuration (ruff lint settings) |
+| `README.md` | Project documentation and usage guide |
 | `scripts/generate-fsm-docs.py` | Generator script for docs/fsm.md (renders cai_lib.fsm transitions as Mermaid) |
 | `scripts/generate-index.sh` | Generator script for CODEBASE_INDEX.md |
 | `tests/__init__.py` | Test package init |

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,19 +5,9 @@
 
 | File | Purpose |
 |------|---------|
-| `cai_lib/cmd_fix.py` | Deprecated shim redirecting to cai_lib.cmd_implement |
-| `cai_lib/cmd_implement.py` | Helpers for the implement-subagent pipeline |
-| `cai_lib/cmd_lifecycle.py` | Pipeline state-transition helpers |
-| `cai_lib/config.py` | Shared constants and path definitions |
-| `cai_lib/fsm.py` | TODO: add description |
-| `cai_lib/github.py` | GitHub/gh CLI helpers and shared label utilities |
-| `cai_lib/__init__.py` | Package init for cai_lib library modules |
-| `cai_lib/logging_utils.py` | Logging utilities extracted from cai.py |
-| `cai_lib/subprocess_utils.py` | Subprocess helpers extracted from cai.py |
-| `cai.py` | Main CLI dispatcher — 16+ subcommands for the self-improvement loop |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
-| `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `audit:raised` findings with structured verdicts |
+| `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |
 | `.claude/agents/cai-check-workflows.md` | Agent: analyze recent GitHub Actions workflow failures and emit structured findings |
 | `.claude/agents/cai-code-audit.md` | Agent: read-only source tree audit for inconsistencies and dead code |
 | `.claude/agents/cai-confirm.md` | Agent: verify merged PRs actually resolved their issues |
@@ -29,8 +19,8 @@
 | `.claude/agents/cai-implement.md` | Agent: autonomous code-editing subagent — canonical successor to cai-fix |
 | `.claude/agents/cai-merge.md` | Agent: assess PR correctness and emit merge verdict |
 | `.claude/agents/cai-plan.md` | Agent: generate detailed fix plan for an issue |
-| `.claude/agents/cai-propose.md` | Agent: weekly creative improvement proposals |
 | `.claude/agents/cai-propose-review.md` | Agent: review creative proposals for feasibility |
+| `.claude/agents/cai-propose.md` | Agent: weekly creative improvement proposals |
 | `.claude/agents/cai-rebase.md` | Agent: rebase-only conflict resolution |
 | `.claude/agents/cai-refine.md` | Agent: rewrite human-filed issues into structured plans |
 | `.claude/agents/cai-review-docs.md` | Agent: pre-merge documentation review |
@@ -40,31 +30,41 @@
 | `.claude/agents/cai-spike.md` | Agent: research spike for needs-spike issues |
 | `.claude/agents/cai-unblock.md` | Agent: classify admin comments on :human-needed issues into FSM resume targets |
 | `.claude/agents/cai-update-check.md` | Agent: check for new Claude Code releases |
-| `CLAUDE.md` | Shared efficiency guidance loaded by all subagents |
 | `.claude/settings.json` | Claude Code harness configuration |
-| `CODEBASE_INDEX.md` | This file — static file-level index for fast agent orientation |
-| `docker-compose.yml` | Multi-service orchestration with named volumes |
-| `Dockerfile` | Container image definition (Python 3.12 + Node + claude-code CLI) |
-| `docs/agents.md` | Documentation: agent definitions and pipeline phase mapping |
-| `docs/architecture.md` | Documentation: pipeline overview and system architecture |
-| `docs/cli.md` | Documentation: CLI reference for all cai.py subcommands |
-| `docs/configuration.md` | Documentation: environment variables and configuration |
-| `docs/_config.yml` | Jekyll configuration for GitHub Pages docs |
-| `docs/fsm.md` | Auto-generated lifecycle FSM diagrams (issue + PR state machines) |
-| `docs/index.md` | Documentation site landing page |
-| `entrypoint.sh` | Docker entrypoint — templates crontab, runs initial cycle, execs supercronic |
 | `.env.example` | Template for required environment variables |
 | `.github/workflows/admin-only-label.yml` | CI: restrict auto-improve:requested label to admins |
 | `.github/workflows/cleanup-pr-context.yml` | CI: clean up PR context on close |
 | `.github/workflows/docker-publish.yml` | CI: build and publish Docker image to Docker Hub |
 | `.github/workflows/regenerate-docs.yml` | CI: regenerate CODEBASE_INDEX.md and docs/fsm.md, auto-commit drift |
 | `.gitignore` | Git ignore rules |
-| `install.sh` | Interactive installer for end-users |
+| `CLAUDE.md` | Shared efficiency guidance loaded by all subagents |
+| `CODEBASE_INDEX.md` | This file — static file-level index for fast agent orientation |
+| `Dockerfile` | Container image definition (Python 3.12 + Node + claude-code CLI) |
 | `LICENSE` | MIT license |
+| `README.md` | Project documentation and usage guide |
+| `cai.py` | Main CLI dispatcher — 16+ subcommands for the self-improvement loop |
+| `cai_lib/__init__.py` | Package init for cai_lib library modules |
+| `cai_lib/cmd_fix.py` | Deprecated shim redirecting to cai_lib.cmd_implement |
+| `cai_lib/cmd_implement.py` | Helpers for the implement-subagent pipeline |
+| `cai_lib/cmd_lifecycle.py` | Pipeline state-transition helpers |
+| `cai_lib/config.py` | Shared constants and path definitions |
+| `cai_lib/fsm.py` | TODO: add description |
+| `cai_lib/github.py` | GitHub/gh CLI helpers and shared label utilities |
+| `cai_lib/logging_utils.py` | Logging utilities extracted from cai.py |
+| `cai_lib/subprocess_utils.py` | Subprocess helpers extracted from cai.py |
+| `docker-compose.yml` | Multi-service orchestration with named volumes |
+| `docs/_config.yml` | Jekyll configuration for GitHub Pages docs |
+| `docs/agents.md` | Documentation: agent definitions and pipeline phase mapping |
+| `docs/architecture.md` | Documentation: pipeline overview and system architecture |
+| `docs/cli.md` | Documentation: CLI reference for all cai.py subcommands |
+| `docs/configuration.md` | Documentation: environment variables and configuration |
+| `docs/fsm.md` | Auto-generated lifecycle FSM diagrams (issue + PR state machines) |
+| `docs/index.md` | Documentation site landing page |
+| `entrypoint.sh` | Docker entrypoint — templates crontab, runs initial cycle, execs supercronic |
+| `install.sh` | Interactive installer for end-users |
 | `parse.py` | Deterministic signal extractor from Claude Code JSONL transcripts |
 | `publish.py` | GitHub issue publisher with fingerprint dedup |
 | `pyproject.toml` | Python project configuration (ruff lint settings) |
-| `README.md` | Project documentation and usage guide |
 | `scripts/generate-fsm-docs.py` | Generator script for docs/fsm.md (renders cai_lib.fsm transitions as Mermaid) |
 | `scripts/generate-index.sh` | Generator script for CODEBASE_INDEX.md |
 | `tests/__init__.py` | Test package init |

--- a/cai_lib/fsm.py
+++ b/cai_lib/fsm.py
@@ -73,6 +73,28 @@ def parse_confidence(text: str) -> Optional[Confidence]:
     return Confidence[m.group(1).upper()]
 
 
+_RESUME_RE = re.compile(
+    r"^\s*ResumeTo\s*[:=]\s*([A-Z_]+)\s*$",
+    re.MULTILINE,
+)
+
+
+def parse_resume_target(text: str) -> Optional[str]:
+    """Extract ``ResumeTo: <STATE_NAME>`` from a cai-unblock agent reply.
+
+    Returns the raw state name as written by the agent (uppercased per
+    our structured-output convention) or ``None`` if the marker is
+    missing. The caller decides whether the returned name maps to a
+    real IssueState/PRState member.
+    """
+    if not text:
+        return None
+    m = _RESUME_RE.search(text)
+    if not m:
+        return None
+    return m.group(1).upper()
+
+
 class IssueState(str, Enum):
     RAISED            = LABEL_RAISED
     REFINED           = LABEL_REFINED
@@ -143,6 +165,18 @@ ISSUE_TRANSITIONS: list[Transition] = [
                labels_remove=[LABEL_NEEDS_EXPLORATION], labels_add=[LABEL_REFINED]),
     Transition("human_to_raised",         IssueState.HUMAN_NEEDED,      IssueState.RAISED,
                labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_RAISED]),
+    # Admin-comment-driven re-entries out of HUMAN_NEEDED. Fired by
+    # cmd_unblock after a Haiku agent classifies the admin's reply.
+    Transition("human_to_refined",        IssueState.HUMAN_NEEDED,      IssueState.REFINED,
+               labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_REFINED]),
+    Transition("human_to_planned",        IssueState.HUMAN_NEEDED,      IssueState.PLANNED,
+               labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_PLANNED]),
+    Transition("human_to_plan_approved",  IssueState.HUMAN_NEEDED,      IssueState.PLAN_APPROVED,
+               labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_PLAN_APPROVED]),
+    Transition("human_to_exploration",    IssueState.HUMAN_NEEDED,      IssueState.NEEDS_EXPLORATION,
+               labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_NEEDS_EXPLORATION]),
+    Transition("human_to_solved",         IssueState.HUMAN_NEEDED,      IssueState.SOLVED,
+               labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_SOLVED]),
 ]
 
 
@@ -160,6 +194,13 @@ PR_TRANSITIONS: list[Transition] = [
     Transition("pr_to_human",                   PRState.REVIEWING,        PRState.PR_HUMAN_NEEDED,
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
     Transition("pr_human_to_reviewing",         PRState.PR_HUMAN_NEEDED,  PRState.REVIEWING,
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    # Admin-comment-driven re-entries out of PR_HUMAN_NEEDED.
+    Transition("pr_human_to_revision_pending",  PRState.PR_HUMAN_NEEDED,  PRState.REVISION_PENDING,
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    Transition("pr_human_to_approved",          PRState.PR_HUMAN_NEEDED,  PRState.APPROVED,
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    Transition("pr_human_to_merged",            PRState.PR_HUMAN_NEEDED,  PRState.MERGED,
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
 ]
 
@@ -381,6 +422,25 @@ def apply_transition_with_confidence(
         log_prefix=log_prefix,
     )
     return ok, True
+
+
+def resume_transition_for(target_state_name: str) -> Optional[Transition]:
+    """Map a ``ResumeTo: <STATE>`` token to the matching ``human_to_<state>`` transition.
+
+    Only transitions whose ``from_state`` is :attr:`IssueState.HUMAN_NEEDED`
+    are considered. Returns ``None`` when the name does not correspond to
+    a known IssueState or no resume transition lands on that state.
+    """
+    if not target_state_name:
+        return None
+    try:
+        target = IssueState[target_state_name.upper()]
+    except KeyError:
+        return None
+    for t in ISSUE_TRANSITIONS:
+        if t.from_state == IssueState.HUMAN_NEEDED and t.to_state == target:
+            return t
+    return None
 
 
 def render_fsm_mermaid(transitions: list[Transition], title: str = "FSM") -> str:

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -25,6 +25,11 @@ stateDiagram-v2
     MERGED --> SOLVED : merged_to_solved [≥HIGH]
     NEEDS_EXPLORATION --> REFINED : exploration_to_refine [≥HIGH]
     HUMAN_NEEDED --> RAISED : human_to_raised [≥HIGH]
+    HUMAN_NEEDED --> REFINED : human_to_refined [≥HIGH]
+    HUMAN_NEEDED --> PLANNED : human_to_planned [≥HIGH]
+    HUMAN_NEEDED --> PLAN_APPROVED : human_to_plan_approved [≥HIGH]
+    HUMAN_NEEDED --> NEEDS_EXPLORATION : human_to_exploration [≥HIGH]
+    HUMAN_NEEDED --> SOLVED : human_to_solved [≥HIGH]
 ```
 
 ## PR state machine
@@ -38,4 +43,7 @@ stateDiagram-v2
     APPROVED --> MERGED : approved_to_merged [≥HIGH]
     REVIEWING --> PR_HUMAN_NEEDED : pr_to_human [≥HIGH]
     PR_HUMAN_NEEDED --> REVIEWING : pr_human_to_reviewing [≥HIGH]
+    PR_HUMAN_NEEDED --> REVISION_PENDING : pr_human_to_revision_pending [≥HIGH]
+    PR_HUMAN_NEEDED --> APPROVED : pr_human_to_approved [≥HIGH]
+    PR_HUMAN_NEEDED --> MERGED : pr_human_to_merged [≥HIGH]
 ```

--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -51,6 +51,7 @@ declare -A DESCRIPTIONS=(
   [".claude/agents/cai-revise.md"]="Agent: handle review comments on auto-improve PRs"
   [".claude/agents/cai-select.md"]="Agent: evaluate and select best fix plan"
   [".claude/agents/cai-spike.md"]="Agent: research spike for needs-spike issues"
+  [".claude/agents/cai-unblock.md"]="Agent: classify admin comments on :human-needed issues into FSM resume targets"
   [".claude/agents/cai-update-check.md"]="Agent: check for new Claude Code releases"
   [".github/workflows/admin-only-label.yml"]="CI: restrict auto-improve:requested label to admins"
   [".github/workflows/cleanup-pr-context.yml"]="CI: clean up PR context on close"

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -11,7 +11,7 @@ from cai_lib.fsm import (
     ISSUE_TRANSITIONS, PR_TRANSITIONS,
     get_issue_state, render_fsm_mermaid,
     apply_transition, apply_transition_with_confidence, find_transition,
-    parse_confidence,
+    parse_confidence, parse_resume_target, resume_transition_for,
     render_pending_marker, parse_pending_marker, strip_pending_marker,
 )
 from cai_lib.config import (
@@ -271,6 +271,45 @@ class TestPendingMarker(unittest.TestCase):
         self.assertNotIn("cai-fsm-pending", stripped)
         self.assertIn("leading text", stripped)
         self.assertIn("trailing text", stripped)
+
+
+class TestResumeFromHuman(unittest.TestCase):
+
+    def test_parse_resume_target_valid(self):
+        self.assertEqual(parse_resume_target("ResumeTo: REFINED"), "REFINED")
+        self.assertEqual(parse_resume_target("lead\nResumeTo: PLAN_APPROVED\ntail"), "PLAN_APPROVED")
+        self.assertEqual(parse_resume_target("ResumeTo=SOLVED"), "SOLVED")
+
+    def test_parse_resume_target_missing(self):
+        self.assertIsNone(parse_resume_target(""))
+        self.assertIsNone(parse_resume_target("no resume line here"))
+
+    def test_resume_transition_for_known_targets(self):
+        for name in ("RAISED", "REFINED", "PLANNED", "PLAN_APPROVED",
+                     "NEEDS_EXPLORATION", "SOLVED"):
+            t = resume_transition_for(name)
+            self.assertIsNotNone(t, f"no resume transition for {name}")
+            self.assertEqual(t.from_state, IssueState.HUMAN_NEEDED)
+            self.assertEqual(t.to_state, IssueState[name])
+
+    def test_resume_transition_for_unknown_returns_none(self):
+        self.assertIsNone(resume_transition_for("NOT_A_STATE"))
+        self.assertIsNone(resume_transition_for(""))
+        # States that exist but have no human_to_* path must return None.
+        self.assertIsNone(resume_transition_for("IN_PROGRESS"))
+        self.assertIsNone(resume_transition_for("MERGED"))
+
+    def test_every_widened_transition_is_reachable(self):
+        """Every human_to_<state> transition must be discoverable via resume_transition_for."""
+        widened = [
+            t for t in ISSUE_TRANSITIONS
+            if t.from_state == IssueState.HUMAN_NEEDED
+        ]
+        self.assertGreaterEqual(len(widened), 6)
+        for t in widened:
+            resolved = resume_transition_for(t.to_state.name)
+            self.assertIs(resolved, t,
+                f"resume_transition_for({t.to_state.name}) did not return {t.name}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Widen `ISSUE_TRANSITIONS` with five new `human_to_<state>` transitions; `PR_TRANSITIONS` gains three new `pr_human_to_<state>` re-entries
- `parse_resume_target` / `resume_transition_for` helpers map a `ResumeTo: <STATE>` token (emitted by cai-unblock) to the right Transition
- New Haiku agent `cai-unblock` classifies admin comments on `:human-needed` issues into one of the six valid resume targets
- Regenerated `docs/fsm.md` to show the new transitions

Phase 1b (library slice). No driver wiring yet — the consumer of this lives in the unified-cron redesign that replaces the per-phase cron zoo with a single end-to-end issue driver.

## Test plan
- [x] `python -m unittest discover tests` — 67 passed, 1 skipped
- [x] `python scripts/generate-fsm-docs.py` produces the widened diagram
- [x] `python -c "import cai"` smoke check
- [ ] CI green

Follow-up to #608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)