### PR TITLE
feat(fsm): unblock parity for PR submachine

### DIFF
--- a/.claude/agents/cai-unblock.md
+++ b/.claude/agents/cai-unblock.md
@@ -1,6 +1,6 @@
 ---
 name: cai-unblock
-description: Classify an admin's GitHub comment on a :human-needed issue into a FSM resume target so the auto-improve pipeline can continue.
+description: Classify an admin's GitHub comment on an issue or PR parked in the human-needed state into a FSM resume target so the auto-improve pipeline can continue.
 tools: Read
 model: claude-haiku-4-5-20251001
 memory: project
@@ -8,46 +8,74 @@ memory: project
 
 # Unblock Agent
 
-You are the unblock agent for `robotsix-cai`. An auto-improve issue
-is parked in `auto-improve:human-needed` because an earlier agent
-could not move forward with high confidence. An admin has now
-commented on the issue. Your job is to read the comment and decide
-which state the FSM should resume from.
+You are the unblock agent for `robotsix-cai`. Either an auto-improve
+issue is parked in `auto-improve:human-needed`, or an auto-improve
+pull request is parked in `auto-improve:pr-human-needed`, because an
+earlier agent could not move forward with high confidence. An admin
+has now commented. Your job is to read the comment and decide which
+state the FSM should resume from.
 
 ## What you receive
 
-The user message contains three sections:
+The user message begins with a `Kind:` header that tells you which
+world you are in:
+
+- `Kind: issue` — the target is an auto-improve issue; use the
+  **Issue resume targets** table below.
+- `Kind: pr` — the target is an auto-improve pull request; use the
+  **PR resume targets** table below.
+
+After the header, three sections follow:
 
 1. **Pending transition marker** — what the automation was trying
    to do when it paused (e.g. `transition=raise_to_refine
    from=RAISED intended=REFINED conf=MEDIUM`).
-2. **Issue body** — the issue text the admin is commenting on.
+2. **Body** — the issue or PR text the admin is commenting on.
 3. **Admin comments** — only comments from admin logins are shown,
    newest last.
 
-## Valid resume targets
+## Issue resume targets (Kind: issue)
 
 Return exactly one of these state names in a `ResumeTo:` line. Each
-maps to a `human_to_<state>` transition already defined in
+maps to a `human_to_<state>` transition defined in
 `cai_lib/fsm.py`.
 
-| State           | Admin intent (examples)                                     |
-|-----------------|-------------------------------------------------------------|
-| `RAISED`        | "start over" / "re-triage this" / comment is ambiguous      |
-| `REFINED`       | "skip refinement, it's clear enough, go to plan"            |
-| `PLANNED`       | "accept the stored plan as-is" (rare)                       |
-| `PLAN_APPROVED` | "approve the plan — let the implement agent run"            |
-| `NEEDS_EXPLORATION` | "investigate further before doing anything"             |
-| `SOLVED`        | "close this — not worth doing" / "already fixed elsewhere"  |
+| State               | Admin intent (examples)                                     |
+|---------------------|-------------------------------------------------------------|
+| `RAISED`            | "start over" / "re-triage this" / comment is ambiguous      |
+| `REFINED`           | "skip refinement, it's clear enough, go to plan"            |
+| `PLANNED`           | "accept the stored plan as-is" (rare)                       |
+| `PLAN_APPROVED`     | "approve the plan — let the implement agent run"            |
+| `NEEDS_EXPLORATION` | "investigate further before doing anything"                 |
+| `SOLVED`            | "close this — not worth doing" / "already fixed elsewhere"  |
+
+## PR resume targets (Kind: pr)
+
+Return exactly one of these state names in a `ResumeTo:` line. Each
+maps to a `pr_human_to_<state>` transition defined in
+`cai_lib/fsm.py`.
+
+| State              | Admin intent (examples)                                   |
+|--------------------|-----------------------------------------------------------|
+| `REVIEWING`        | "re-run the automated review" / ambiguous comment         |
+| `REVISION_PENDING` | "revise this PR per my comments"                          |
+| `APPROVED`         | "looks good — queue for merge"                            |
+| `MERGED`           | "merge this now" (the driver will perform the actual merge) |
+
+## Fallback
 
 If the admin's comment is unrelated to the pending decision or you
-cannot decide with confidence, emit `ResumeTo: RAISED` at `LOW`
-confidence — that restarts triage without pretending certainty.
+cannot decide with confidence:
+
+- For `Kind: issue`, emit `ResumeTo: RAISED` with `Confidence: LOW`.
+- For `Kind: pr`, emit `ResumeTo: REVIEWING` with `Confidence: LOW`.
+
+Either restarts the relevant submachine without pretending certainty.
 
 ## Output format
 
-Your last non-empty reply must end with these two lines, each on
-its own line, in this exact casing:
+Your last non-empty reply must end with these two lines, each on its
+own line, in this exact casing:
 
 ```
 ResumeTo: <STATE_NAME>
@@ -60,9 +88,9 @@ sections.
 
 ## Hard rules
 
-- Never invent states that are not in the table above.
-- Never emit `ResumeTo: HUMAN_NEEDED` (that's where the issue
-  already is).
-- If you set `Confidence: LOW`, the wrapper will leave the issue
+- Never invent states that are not in the table for the given kind.
+- Never emit `ResumeTo: HUMAN_NEEDED` or `ResumeTo: PR_HUMAN_NEEDED`
+  — the target is already parked there.
+- If you set `Confidence: LOW`, the wrapper will leave the target
   parked rather than firing the resume transition — that is the
   correct outcome when the admin comment is ambiguous.

--- a/.claude/agents/cai-unblock.md
+++ b/.claude/agents/cai-unblock.md
@@ -44,10 +44,15 @@ maps to a `human_to_<state>` transition defined in
 |---------------------|-------------------------------------------------------------|
 | `RAISED`            | "start over" / "re-triage this" / comment is ambiguous      |
 | `REFINED`           | "skip refinement, it's clear enough, go to plan"            |
-| `PLANNED`           | "accept the stored plan as-is" (rare)                       |
-| `PLAN_APPROVED`     | "approve the plan — let the implement agent run"            |
+| `PLAN_APPROVED`     | "approve the existing plan — let the implement agent run"   |
 | `NEEDS_EXPLORATION` | "investigate further before doing anything"                 |
 | `SOLVED`            | "close this — not worth doing" / "already fixed elsewhere"  |
+
+(`PLANNED` is not a valid resume target — the plan block only exists
+after the plan agent has run, so there is no admin pathway that
+justifies jumping directly there. Resume to `REFINED` to have the
+plan agent produce a plan, or to `PLAN_APPROVED` to accept one that
+already exists.)
 
 ## PR resume targets (Kind: pr)
 

--- a/cai_lib/fsm.py
+++ b/cai_lib/fsm.py
@@ -169,8 +169,11 @@ ISSUE_TRANSITIONS: list[Transition] = [
     # cmd_unblock after a Haiku agent classifies the admin's reply.
     Transition("human_to_refined",        IssueState.HUMAN_NEEDED,      IssueState.REFINED,
                labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_REFINED]),
-    Transition("human_to_planned",        IssueState.HUMAN_NEEDED,      IssueState.PLANNED,
-               labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_PLANNED]),
+    # NOTE: no human_to_planned — PLANNED means the plan block already
+    # exists in the issue body, which only happens after the plan agent
+    # runs. An admin who wants to plan should resume to REFINED; an
+    # admin who wants to approve an existing plan should resume to
+    # PLAN_APPROVED.
     Transition("human_to_plan_approved",  IssueState.HUMAN_NEEDED,      IssueState.PLAN_APPROVED,
                labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_PLAN_APPROVED]),
     Transition("human_to_exploration",    IssueState.HUMAN_NEEDED,      IssueState.NEEDS_EXPLORATION,

--- a/cai_lib/fsm.py
+++ b/cai_lib/fsm.py
@@ -443,6 +443,32 @@ def resume_transition_for(target_state_name: str) -> Optional[Transition]:
     return None
 
 
+def resume_pr_transition_for(target_state_name: str) -> Optional[Transition]:
+    """PR-submachine counterpart of :func:`resume_transition_for`.
+
+    Maps a ``ResumeTo: <STATE>`` token to the matching
+    ``pr_human_to_<state>`` transition whose ``from_state`` is
+    :attr:`PRState.PR_HUMAN_NEEDED`. Returns ``None`` when the name is
+    not a known :class:`PRState` member or no resume transition lands
+    on that state.
+
+    The two resolvers are split (rather than unified) because
+    :attr:`IssueState.MERGED` and :attr:`PRState.MERGED` share a name —
+    the caller already knows whether it's acting on an issue or a PR,
+    so each side stays unambiguous by construction.
+    """
+    if not target_state_name:
+        return None
+    try:
+        target = PRState[target_state_name.upper()]
+    except KeyError:
+        return None
+    for t in PR_TRANSITIONS:
+        if t.from_state == PRState.PR_HUMAN_NEEDED and t.to_state == target:
+            return t
+    return None
+
+
 def render_fsm_mermaid(transitions: list[Transition], title: str = "FSM") -> str:
     """Render *transitions* as a Mermaid stateDiagram-v2 block."""
     lines = ["stateDiagram-v2"]

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -26,7 +26,6 @@ stateDiagram-v2
     NEEDS_EXPLORATION --> REFINED : exploration_to_refine [≥HIGH]
     HUMAN_NEEDED --> RAISED : human_to_raised [≥HIGH]
     HUMAN_NEEDED --> REFINED : human_to_refined [≥HIGH]
-    HUMAN_NEEDED --> PLANNED : human_to_planned [≥HIGH]
     HUMAN_NEEDED --> PLAN_APPROVED : human_to_plan_approved [≥HIGH]
     HUMAN_NEEDED --> NEEDS_EXPLORATION : human_to_exploration [≥HIGH]
     HUMAN_NEEDED --> SOLVED : human_to_solved [≥HIGH]

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -286,7 +286,7 @@ class TestResumeFromHuman(unittest.TestCase):
         self.assertIsNone(parse_resume_target("no resume line here"))
 
     def test_resume_transition_for_known_targets(self):
-        for name in ("RAISED", "REFINED", "PLANNED", "PLAN_APPROVED",
+        for name in ("RAISED", "REFINED", "PLAN_APPROVED",
                      "NEEDS_EXPLORATION", "SOLVED"):
             t = resume_transition_for(name)
             self.assertIsNotNone(t, f"no resume transition for {name}")
@@ -299,6 +299,9 @@ class TestResumeFromHuman(unittest.TestCase):
         # States that exist but have no human_to_* path must return None.
         self.assertIsNone(resume_transition_for("IN_PROGRESS"))
         self.assertIsNone(resume_transition_for("MERGED"))
+        # PLANNED is deliberately excluded: admins cannot jump straight
+        # to PLANNED because the plan block only exists post-plan-agent.
+        self.assertIsNone(resume_transition_for("PLANNED"))
 
     def test_every_widened_transition_is_reachable(self):
         """Every human_to_<state> transition must be discoverable via resume_transition_for."""
@@ -306,7 +309,7 @@ class TestResumeFromHuman(unittest.TestCase):
             t for t in ISSUE_TRANSITIONS
             if t.from_state == IssueState.HUMAN_NEEDED
         ]
-        self.assertGreaterEqual(len(widened), 6)
+        self.assertGreaterEqual(len(widened), 5)
         for t in widened:
             resolved = resume_transition_for(t.to_state.name)
             self.assertIs(resolved, t,

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -11,7 +11,8 @@ from cai_lib.fsm import (
     ISSUE_TRANSITIONS, PR_TRANSITIONS,
     get_issue_state, render_fsm_mermaid,
     apply_transition, apply_transition_with_confidence, find_transition,
-    parse_confidence, parse_resume_target, resume_transition_for,
+    parse_confidence, parse_resume_target,
+    resume_transition_for, resume_pr_transition_for,
     render_pending_marker, parse_pending_marker, strip_pending_marker,
 )
 from cai_lib.config import (
@@ -310,6 +311,36 @@ class TestResumeFromHuman(unittest.TestCase):
             resolved = resume_transition_for(t.to_state.name)
             self.assertIs(resolved, t,
                 f"resume_transition_for({t.to_state.name}) did not return {t.name}")
+
+
+class TestResumePRTransition(unittest.TestCase):
+
+    def test_known_pr_targets(self):
+        for name in ("REVIEWING", "REVISION_PENDING", "APPROVED", "MERGED"):
+            t = resume_pr_transition_for(name)
+            self.assertIsNotNone(t, f"no PR resume transition for {name}")
+            self.assertEqual(t.from_state, PRState.PR_HUMAN_NEEDED)
+            self.assertEqual(t.to_state, PRState[name])
+
+    def test_unknown_returns_none(self):
+        self.assertIsNone(resume_pr_transition_for("NOT_A_STATE"))
+        self.assertIsNone(resume_pr_transition_for(""))
+        # PRState has no OPEN→from-PR_HUMAN_NEEDED path.
+        self.assertIsNone(resume_pr_transition_for("OPEN"))
+
+    def test_issue_and_pr_resolvers_disambiguate_merged(self):
+        """MERGED exists in both enums — the two resolvers keep them separate."""
+        issue_t = resume_transition_for("SOLVED")  # Issue path uses SOLVED, not MERGED
+        pr_t = resume_pr_transition_for("MERGED")
+        self.assertIsNotNone(issue_t)
+        self.assertIsNotNone(pr_t)
+        self.assertEqual(issue_t.to_state, IssueState.SOLVED)
+        self.assertEqual(pr_t.to_state, PRState.MERGED)
+
+        # Passing a PRState name to the issue resolver must return None.
+        self.assertIsNone(resume_transition_for("REVIEWING"))
+        # Passing an IssueState-only name to the PR resolver must return None.
+        self.assertIsNone(resume_pr_transition_for("REFINED"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `resume_pr_transition_for(name)` — PR-side sibling of the existing issue resolver
- Generalize the `cai-unblock` Haiku agent to handle both issues and PRs via a `Kind: issue | pr` header in its input, with separate valid-targets tables
- Two resolvers (not one) keep the `MERGED` name collision between `IssueState` and `PRState` unambiguous — the caller knows which world it's in

Admin-comment-driven resume now works symmetrically for issues and PRs. Still no driver wiring — that arrives with the unified-cron redesign.

## Test plan
- [x] `python -m unittest discover tests` — 70 passed, 1 skipped
- [x] `python -c "import cai"` smoke check
- [ ] CI green

Follow-up to #609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)