### PR TITLE
fix: import underscore-prefixed stale thresholds explicitly

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -176,6 +176,9 @@ from publish import ensure_all_labels
 
 
 from cai_lib.config import *  # noqa: E402,F403
+from cai_lib.config import (  # noqa: E402
+    _STALE_NO_ACTION_DAYS, _STALE_MERGED_DAYS,
+)
 
 
 from cai_lib.logging_utils import (  # noqa: E402


### PR DESCRIPTION
## Summary

Fixed a `NameError` crash in `cai audit` caused by underscore-prefixed constants not being imported properly.

The star-import from `cai_lib.config` (`from cai_lib.config import *`) skips names starting with underscore by Python convention, leaving `_STALE_NO_ACTION_DAYS` and `_STALE_MERGED_DAYS` unbound at their use sites in cai.py. This patch adds an explicit import for these constants alongside the star-import.

## Test plan

- Run `cai audit` to verify it no longer crashes with `NameError: name '_STALE_NO_ACTION_DAYS' is not defined`
- Verify other imports from cai_lib.config still work as expected

Generated with Claude Code