### PR TITLE
feat(fsm): confidence-gated plan approval, drop human:plan-approved label

### DIFF
--- a/.claude/agents/cai-audit.md
+++ b/.claude/agents/cai-audit.md
@@ -62,7 +62,7 @@ a soft `forgotten_backlog` finding with **low** confidence as a gentle
 reminder. This is distinct from `stale_lifecycle`, which applies only
 to issues that have entered an active state.
 
-Active states (`:raised`, `:refined`, `:planned`, `human:plan-approved`, `:in-progress`, `:pr-open`,
+Active states (`:raised`, `:refined`, `:planned`, `auto-improve:plan-approved`, `:in-progress`, `:pr-open`,
 `:merged`, `:no-action`, `:needs-spike`, `:revising`) should continue to be checked
 normally against all the rules below. (Note: stale `:no-action`
 issues are rolled back to `:raised` before the LLM audit runs, and
@@ -97,7 +97,7 @@ did not actually succeed. Flag these as `silent_failure`.
 | `[publish] created=0 skipped=0 failed=0` after `parsed N finding(s)` where N > 0 | All findings silently lost |
 | `[implement] result=push_failed exit=1` (≥2 occurrences in window) | Recurring git push problem |
 | `[implement] result=clone_failed exit=1` (≥2 occurrences in window) | Recurring gh/git auth problem |
-| `[implement] result=no_eligible_issues` repeating ≥7 times in a row while open `:refined`/`human:plan-approved` issues exist | Bot is skipping issues it should be picking |
+| `[implement] result=no_eligible_issues` repeating ≥7 times in a row while open `:refined`/`auto-improve:plan-approved` issues exist | Bot is skipping issues it should be picking |
 | `[cai analyze] claude -p failed (exit N)` | API errors (rate limit, auth, network) |
 | `[cai analyze] parse.py failed (exit N)` | Parser crash |
 | `level=error msg="..."` lines from supercronic itself | Scheduler errors |

--- a/.claude/agents/cai-select.md
+++ b/.claude/agents/cai-select.md
@@ -58,11 +58,28 @@ Assess each plan on these criteria, in order of importance:
 
 Output **only** the chosen plan — paste it exactly as provided with
 no modifications. Do not emit any selection metadata, plan numbers,
-reasoning, or wrapper headings. Your entire response should be the
-plan text and nothing else.
+reasoning, or wrapper headings. The plan text must be followed by
+exactly one trailing line:
+
+```
+Confidence: HIGH | MEDIUM | LOW
+```
+
+That confidence line drives the FSM. At **HIGH**, the wrapper
+auto-approves the plan and sends the issue straight into the
+implement pipeline — pick HIGH only when the chosen plan is
+correct, minimal, specific, and you see no material risks. At
+**MEDIUM** or **LOW**, the wrapper parks the issue in
+`auto-improve:human-needed` for an admin to review the plan
+before it is implemented — use these levels whenever either
+plan has ambiguity, unclear scope, non-trivial risk of
+regressions, or you are choosing a least-bad option.
 
 If all plans are equally bad or none correctly addresses the issue,
-pick the least-bad option. You may insert a single `> **Note:** …`
-blockquote at the very top of the output (before the plan content)
-to flag critical weaknesses for the fix agent, but keep it to one
-sentence.
+pick the least-bad option and emit `Confidence: LOW`. You may
+insert a single `> **Note:** …` blockquote at the very top of the
+output (before the plan content) to flag critical weaknesses for
+the fix agent, but keep it to one sentence.
+
+Do not emit any other text, headings, or metadata besides the plan
+body and the trailing `Confidence:` line.

--- a/.github/workflows/admin-only-label.yml
+++ b/.github/workflows/admin-only-label.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   enforce:
     if: >-
-      contains(fromJSON('["human:plan-approved","auto-improve:raised","auto-improve:refined","audit:raised"]'), github.event.label.name)
+      contains(fromJSON('["auto-improve:plan-approved","auto-improve:raised","auto-improve:refined","audit:raised"]'), github.event.label.name)
     runs-on: ubuntu-latest
     steps:
       - name: Check sender's permission

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,20 +5,9 @@
 
 | File | Purpose |
 |------|---------|
-| `cai_lib/cmd_fix.py` | Deprecated shim redirecting to cai_lib.cmd_implement |
-| `cai_lib/cmd_implement.py` | Helpers for the implement-subagent pipeline |
-| `cai_lib/cmd_lifecycle.py` | Pipeline state-transition helpers |
-| `cai_lib/cmd_unblock.py` | Admin-comment-driven FSM resume for :human-needed issues (calls cai-unblock) |
-| `cai_lib/config.py` | Shared constants and path definitions |
-| `cai_lib/fsm.py` | FSM data structures + transition application helpers (Confidence enum, apply_transition, divert-to-human, pending markers) |
-| `cai_lib/github.py` | GitHub/gh CLI helpers and shared label utilities |
-| `cai_lib/__init__.py` | Package init for cai_lib library modules |
-| `cai_lib/logging_utils.py` | Logging utilities extracted from cai.py |
-| `cai_lib/subprocess_utils.py` | Subprocess helpers extracted from cai.py |
-| `cai.py` | Main CLI dispatcher — 16+ subcommands for the self-improvement loop |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
-| `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `audit:raised` findings with structured verdicts |
+| `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |
 | `.claude/agents/cai-check-workflows.md` | Agent: analyze recent GitHub Actions workflow failures and emit structured findings |
 | `.claude/agents/cai-code-audit.md` | Agent: read-only source tree audit for inconsistencies and dead code |
 | `.claude/agents/cai-confirm.md` | Agent: verify merged PRs actually resolved their issues |
@@ -30,8 +19,8 @@
 | `.claude/agents/cai-implement.md` | Agent: autonomous code-editing subagent — canonical successor to cai-fix |
 | `.claude/agents/cai-merge.md` | Agent: assess PR correctness and emit merge verdict |
 | `.claude/agents/cai-plan.md` | Agent: generate detailed fix plan for an issue |
-| `.claude/agents/cai-propose.md` | Agent: weekly creative improvement proposals |
 | `.claude/agents/cai-propose-review.md` | Agent: review creative proposals for feasibility |
+| `.claude/agents/cai-propose.md` | Agent: weekly creative improvement proposals |
 | `.claude/agents/cai-rebase.md` | Agent: rebase-only conflict resolution |
 | `.claude/agents/cai-refine.md` | Agent: rewrite human-filed issues into structured plans |
 | `.claude/agents/cai-review-docs.md` | Agent: pre-merge documentation review |
@@ -41,31 +30,42 @@
 | `.claude/agents/cai-spike.md` | Agent: research spike for needs-spike issues |
 | `.claude/agents/cai-unblock.md` | Agent: classify admin comments on :human-needed issues into FSM resume targets |
 | `.claude/agents/cai-update-check.md` | Agent: check for new Claude Code releases |
-| `CLAUDE.md` | Shared efficiency guidance loaded by all subagents |
 | `.claude/settings.json` | Claude Code harness configuration |
-| `CODEBASE_INDEX.md` | This file — static file-level index for fast agent orientation |
-| `docker-compose.yml` | Multi-service orchestration with named volumes |
-| `Dockerfile` | Container image definition (Python 3.12 + Node + claude-code CLI) |
-| `docs/agents.md` | Documentation: agent definitions and pipeline phase mapping |
-| `docs/architecture.md` | Documentation: pipeline overview and system architecture |
-| `docs/cli.md` | Documentation: CLI reference for all cai.py subcommands |
-| `docs/configuration.md` | Documentation: environment variables and configuration |
-| `docs/_config.yml` | Jekyll configuration for GitHub Pages docs |
-| `docs/fsm.md` | Auto-generated lifecycle FSM diagrams (issue + PR state machines) |
-| `docs/index.md` | Documentation site landing page |
-| `entrypoint.sh` | Docker entrypoint — templates crontab, runs initial cycle, execs supercronic |
 | `.env.example` | Template for required environment variables |
 | `.github/workflows/admin-only-label.yml` | CI: restrict auto-improve:requested label to admins |
 | `.github/workflows/cleanup-pr-context.yml` | CI: clean up PR context on close |
 | `.github/workflows/docker-publish.yml` | CI: build and publish Docker image to Docker Hub |
 | `.github/workflows/regenerate-docs.yml` | CI: regenerate CODEBASE_INDEX.md and docs/fsm.md, auto-commit drift |
 | `.gitignore` | Git ignore rules |
-| `install.sh` | Interactive installer for end-users |
+| `CLAUDE.md` | Shared efficiency guidance loaded by all subagents |
+| `CODEBASE_INDEX.md` | This file — static file-level index for fast agent orientation |
+| `Dockerfile` | Container image definition (Python 3.12 + Node + claude-code CLI) |
 | `LICENSE` | MIT license |
+| `README.md` | Project documentation and usage guide |
+| `cai.py` | Main CLI dispatcher — 16+ subcommands for the self-improvement loop |
+| `cai_lib/__init__.py` | Package init for cai_lib library modules |
+| `cai_lib/cmd_fix.py` | Deprecated shim redirecting to cai_lib.cmd_implement |
+| `cai_lib/cmd_implement.py` | Helpers for the implement-subagent pipeline |
+| `cai_lib/cmd_lifecycle.py` | Pipeline state-transition helpers |
+| `cai_lib/cmd_unblock.py` | Admin-comment-driven FSM resume for :human-needed issues (calls cai-unblock) |
+| `cai_lib/config.py` | Shared constants and path definitions |
+| `cai_lib/fsm.py` | FSM data structures + transition application helpers (Confidence enum, apply_transition, divert-to-human, pending markers) |
+| `cai_lib/github.py` | GitHub/gh CLI helpers and shared label utilities |
+| `cai_lib/logging_utils.py` | Logging utilities extracted from cai.py |
+| `cai_lib/subprocess_utils.py` | Subprocess helpers extracted from cai.py |
+| `docker-compose.yml` | Multi-service orchestration with named volumes |
+| `docs/_config.yml` | Jekyll configuration for GitHub Pages docs |
+| `docs/agents.md` | Documentation: agent definitions and pipeline phase mapping |
+| `docs/architecture.md` | Documentation: pipeline overview and system architecture |
+| `docs/cli.md` | Documentation: CLI reference for all cai.py subcommands |
+| `docs/configuration.md` | Documentation: environment variables and configuration |
+| `docs/fsm.md` | Auto-generated lifecycle FSM diagrams (issue + PR state machines) |
+| `docs/index.md` | Documentation site landing page |
+| `entrypoint.sh` | Docker entrypoint — templates crontab, runs initial cycle, execs supercronic |
+| `install.sh` | Interactive installer for end-users |
 | `parse.py` | Deterministic signal extractor from Claude Code JSONL transcripts |
 | `publish.py` | GitHub issue publisher with fingerprint dedup |
 | `pyproject.toml` | Python project configuration (ruff lint settings) |
-| `README.md` | Project documentation and usage guide |
 | `scripts/generate-fsm-docs.py` | Generator script for docs/fsm.md (renders cai_lib.fsm transitions as Mermaid) |
 | `scripts/generate-index.sh` | Generator script for CODEBASE_INDEX.md |
 | `tests/__init__.py` | Test package init |

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,9 +5,20 @@
 
 | File | Purpose |
 |------|---------|
+| `cai_lib/cmd_fix.py` | Deprecated shim redirecting to cai_lib.cmd_implement |
+| `cai_lib/cmd_implement.py` | Helpers for the implement-subagent pipeline |
+| `cai_lib/cmd_lifecycle.py` | Pipeline state-transition helpers |
+| `cai_lib/cmd_unblock.py` | Admin-comment-driven FSM resume for :human-needed issues (calls cai-unblock) |
+| `cai_lib/config.py` | Shared constants and path definitions |
+| `cai_lib/fsm.py` | FSM data structures + transition application helpers (Confidence enum, apply_transition, divert-to-human, pending markers) |
+| `cai_lib/github.py` | GitHub/gh CLI helpers and shared label utilities |
+| `cai_lib/__init__.py` | Package init for cai_lib library modules |
+| `cai_lib/logging_utils.py` | Logging utilities extracted from cai.py |
+| `cai_lib/subprocess_utils.py` | Subprocess helpers extracted from cai.py |
+| `cai.py` | Main CLI dispatcher — 16+ subcommands for the self-improvement loop |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
-| `.claude/agents/cai-audit-triage.md` | Agent: triage `audit:raised` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |
+| `.claude/agents/cai-audit-triage.md` | Agent: triage `audit:raised` findings with structured verdicts |
 | `.claude/agents/cai-check-workflows.md` | Agent: analyze recent GitHub Actions workflow failures and emit structured findings |
 | `.claude/agents/cai-code-audit.md` | Agent: read-only source tree audit for inconsistencies and dead code |
 | `.claude/agents/cai-confirm.md` | Agent: verify merged PRs actually resolved their issues |
@@ -19,8 +30,8 @@
 | `.claude/agents/cai-implement.md` | Agent: autonomous code-editing subagent — canonical successor to cai-fix |
 | `.claude/agents/cai-merge.md` | Agent: assess PR correctness and emit merge verdict |
 | `.claude/agents/cai-plan.md` | Agent: generate detailed fix plan for an issue |
-| `.claude/agents/cai-propose-review.md` | Agent: review creative proposals for feasibility |
 | `.claude/agents/cai-propose.md` | Agent: weekly creative improvement proposals |
+| `.claude/agents/cai-propose-review.md` | Agent: review creative proposals for feasibility |
 | `.claude/agents/cai-rebase.md` | Agent: rebase-only conflict resolution |
 | `.claude/agents/cai-refine.md` | Agent: rewrite human-filed issues into structured plans |
 | `.claude/agents/cai-review-docs.md` | Agent: pre-merge documentation review |
@@ -30,42 +41,31 @@
 | `.claude/agents/cai-spike.md` | Agent: research spike for needs-spike issues |
 | `.claude/agents/cai-unblock.md` | Agent: classify admin comments on :human-needed issues into FSM resume targets |
 | `.claude/agents/cai-update-check.md` | Agent: check for new Claude Code releases |
+| `CLAUDE.md` | Shared efficiency guidance loaded by all subagents |
 | `.claude/settings.json` | Claude Code harness configuration |
+| `CODEBASE_INDEX.md` | This file — static file-level index for fast agent orientation |
+| `docker-compose.yml` | Multi-service orchestration with named volumes |
+| `Dockerfile` | Container image definition (Python 3.12 + Node + claude-code CLI) |
+| `docs/agents.md` | Documentation: agent definitions and pipeline phase mapping |
+| `docs/architecture.md` | Documentation: pipeline overview and system architecture |
+| `docs/cli.md` | Documentation: CLI reference for all cai.py subcommands |
+| `docs/configuration.md` | Documentation: environment variables and configuration |
+| `docs/_config.yml` | Jekyll configuration for GitHub Pages docs |
+| `docs/fsm.md` | Auto-generated lifecycle FSM diagrams (issue + PR state machines) |
+| `docs/index.md` | Documentation site landing page |
+| `entrypoint.sh` | Docker entrypoint — templates crontab, runs initial cycle, execs supercronic |
 | `.env.example` | Template for required environment variables |
 | `.github/workflows/admin-only-label.yml` | CI: restrict auto-improve:requested label to admins |
 | `.github/workflows/cleanup-pr-context.yml` | CI: clean up PR context on close |
 | `.github/workflows/docker-publish.yml` | CI: build and publish Docker image to Docker Hub |
 | `.github/workflows/regenerate-docs.yml` | CI: regenerate CODEBASE_INDEX.md and docs/fsm.md, auto-commit drift |
 | `.gitignore` | Git ignore rules |
-| `CLAUDE.md` | Shared efficiency guidance loaded by all subagents |
-| `CODEBASE_INDEX.md` | This file — static file-level index for fast agent orientation |
-| `Dockerfile` | Container image definition (Python 3.12 + Node + claude-code CLI) |
-| `LICENSE` | MIT license |
-| `README.md` | Project documentation and usage guide |
-| `cai.py` | Main CLI dispatcher — 16+ subcommands for the self-improvement loop |
-| `cai_lib/__init__.py` | Package init for cai_lib library modules |
-| `cai_lib/cmd_fix.py` | Deprecated shim redirecting to cai_lib.cmd_implement |
-| `cai_lib/cmd_implement.py` | Helpers for the implement-subagent pipeline |
-| `cai_lib/cmd_lifecycle.py` | Pipeline state-transition helpers |
-| `cai_lib/cmd_unblock.py` | Admin-comment-driven FSM resume for :human-needed issues (calls cai-unblock) |
-| `cai_lib/config.py` | Shared constants and path definitions |
-| `cai_lib/fsm.py` | FSM data structures + transition application helpers (Confidence enum, apply_transition, divert-to-human, pending markers) |
-| `cai_lib/github.py` | GitHub/gh CLI helpers and shared label utilities |
-| `cai_lib/logging_utils.py` | Logging utilities extracted from cai.py |
-| `cai_lib/subprocess_utils.py` | Subprocess helpers extracted from cai.py |
-| `docker-compose.yml` | Multi-service orchestration with named volumes |
-| `docs/_config.yml` | Jekyll configuration for GitHub Pages docs |
-| `docs/agents.md` | Documentation: agent definitions and pipeline phase mapping |
-| `docs/architecture.md` | Documentation: pipeline overview and system architecture |
-| `docs/cli.md` | Documentation: CLI reference for all cai.py subcommands |
-| `docs/configuration.md` | Documentation: environment variables and configuration |
-| `docs/fsm.md` | Auto-generated lifecycle FSM diagrams (issue + PR state machines) |
-| `docs/index.md` | Documentation site landing page |
-| `entrypoint.sh` | Docker entrypoint — templates crontab, runs initial cycle, execs supercronic |
 | `install.sh` | Interactive installer for end-users |
+| `LICENSE` | MIT license |
 | `parse.py` | Deterministic signal extractor from Claude Code JSONL transcripts |
 | `publish.py` | GitHub issue publisher with fingerprint dedup |
 | `pyproject.toml` | Python project configuration (ruff lint settings) |
+| `README.md` | Project documentation and usage guide |
 | `scripts/generate-fsm-docs.py` | Generator script for docs/fsm.md (renders cai_lib.fsm transitions as Mermaid) |
 | `scripts/generate-index.sh` | Generator script for CODEBASE_INDEX.md |
 | `tests/__init__.py` | Test package init |

--- a/README.md
+++ b/README.md
@@ -49,14 +49,16 @@ dispatcher so each task is its own subprocess with no shared state.
 
 The issue-solving pipeline is split across two cron lines:
 
-- `cai.py cycle` drains pending PRs and fixes `human:plan-approved`
+- `cai.py cycle` drains pending PRs and fixes `auto-improve:plan-approved`
   issues only. `:raised`, `:refined`, and `:planned` issues are
-  invisible to the implement loop — a human approves a plan into
-  `human:plan-approved` before the cycle will act on it.
+  invisible to the implement loop.
 - `cai.py plan-all` drives every `:raised` / `:refined` issue
-  through refine → plan → `:planned`, producing the backlog humans
-  review. It also runs at the end of each `cycle` so the next
-  approval pass has a fresh queue.
+  through refine → plan. HIGH-confidence plans auto-promote to
+  `:plan-approved` and feed the implement loop on the next tick;
+  lower-confidence plans divert to `:human-needed` for admin review,
+  where an admin comment resumes them via `cai unblock`. `plan-all`
+  also runs at the end of each `cycle` so the next approval pass has
+  a fresh queue.
 
 A flock in `cmd_cycle` serializes overlapping runs, so issues are
 processed one at a time: each cycle fixes, drains pending PRs, and
@@ -68,7 +70,7 @@ The individual pipeline subcommands (`implement`, `refine`, `plan`,
 
 | Subcommand | Default schedule | What it does |
 |---|---|---|
-| `cai.py cycle` | `0 * * * *` (hourly, startup, manual) | Implement pipeline on `human:plan-approved` issues: verify → confirm → drain pending PRs (revise → fix-ci → review-pr → review-docs → merge) → loop(implement/spike/explore → drain) → plan-all → confirm. A flock serializes overlapping runs; the entrypoint also runs this once synchronously at `docker compose up -d` so startup logs are immediate |
+| `cai.py cycle` | `0 * * * *` (hourly, startup, manual) | Implement pipeline on `auto-improve:plan-approved` issues: verify → confirm → drain pending PRs (revise → fix-ci → review-pr → review-docs → merge) → loop(implement/spike/explore → drain) → plan-all → confirm. A flock serializes overlapping runs; the entrypoint also runs this once synchronously at `docker compose up -d` so startup logs are immediate |
 | `cai.py plan-all` | `30 * * * *` (hourly, offset 30) | Drains every open `:raised` / `:refined` issue through refine → plan → `:planned` so humans have a queue to review. Also runs at the end of each `cycle`; the cron line provides a mid-cycle catch-up pass |
 | `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` (6-hour TTL) and `:revising` (1-hour TTL) locks and stale `:no-action` issues, flags stale `:merged` issues for human review, recovers `:pr-open` issues whose linked PR was closed (rolls back to `:refined`), deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |
@@ -111,15 +113,19 @@ action so two concurrent `implement` runs can't pick the same issue.
                                 │ plan
                                 ▼
                              planned  ◄──┐
-                                │       │ (PR closed
-                    (human approval)   │  unmerged, or
-                                │       │  pre-screen ambiguous
-                                ▼       │  → rolled back to
-                        plan-approved  │  origin label)
                                 │       │
-                                │ fix   │
-                                ▼       │
-                          in-progress   │
+                     (confidence gate)   │ (PR closed unmerged,
+                     HIGH /    \ low     │  or pre-screen
+                          ▼     ▼        │  ambiguous → rolled
+                 plan-approved  │        │  back to origin label)
+                     ▲          ▼        │
+                     │    human-needed   │
+                     │       │ unblock   │
+                     └───────┘           │
+                                │        │
+                                │ fix    │
+                                ▼        │
+                          in-progress    │
                                 │       │
                           pre-screen    │
                             (Haiku)     │
@@ -357,8 +363,9 @@ trust builds.
 (the former `human:submitted` label has been folded back into `:raised`).
 It is restricted to repo admins by `.github/workflows/admin-only-label.yml` — a non-admin who
 applies it gets the label removed and a comment explaining why. Issues labelled `auto-improve:raised`
-transition through the full planning pipeline: `refine` → `plan` → `human:plan-approved`
-(admin grants approval) → `implement`. On `refine`, the agent additionally decides whether to route the
+transition through the full planning pipeline: `refine` → `plan` → `auto-improve:plan-approved`
+(auto on HIGH confidence, else `:human-needed` until an admin comment resumes via `cai unblock`) → `implement`.
+On `refine`, the agent additionally decides whether to route the
 issue through `auto-improve:needs-exploration` first by emitting `NextStep: EXPLORE`.
 
 ### Triggering tasks ad-hoc

--- a/cai.py
+++ b/cai.py
@@ -14,10 +14,11 @@ Subcommands:
 
     python cai.py fix       Score eligible issues by age, category
                             success rate, and prior fix attempts; pick
-                            the highest scorer labelled `human:
-                            plan-approved` or `human:
-                            requested` (audit issues reach fix via
-                            triage relabelling), run a cheap Haiku
+                            the highest scorer labelled
+                            `auto-improve:plan-approved` (reached
+                            either automatically on a HIGH-confidence
+                            plan or via admin resume from
+                            `:human-needed`), run a cheap Haiku
                             pre-screen to classify the issue; spike/
                             ambiguous issues are returned to their origin
                             label without cloning; if actionable, lock it
@@ -205,7 +206,13 @@ from cai_lib.cmd_lifecycle import (  # noqa: E402
     _migrate_legacy_human_submitted,
 )
 from cai_lib.cmd_unblock import cmd_unblock  # noqa: E402
-from cai_lib.fsm import apply_transition  # noqa: E402
+from cai_lib.fsm import (  # noqa: E402
+    apply_transition,
+    apply_transition_with_confidence,
+    IssueState,
+    render_pending_marker,
+    strip_pending_marker,
+)
 from cai_lib.cmd_implement import _parse_decomposition  # noqa: E402
 
 
@@ -651,19 +658,19 @@ def _select_fix_target(exclude: set[int] | None = None):
     Categories with fewer than 3 observations get a neutral prior of 0.60.
     This replaces the previous FIFO (oldest-first) selection.
 
-    Eligible = labelled `human:plan-approved`, NOT labelled `:in-progress`
-    or `:pr-open`, AND carrying a stored plan block in the issue body
-    (written by `cai plan`).  `human:plan-approved` is the gate: the
-    `plan-all` step drives every :raised / :refined issue to :planned,
-    and a human then promotes :planned → human:plan-approved when the
-    plan looks good.  Issues with that label but no stored plan are
-    demoted back to `:refined` so `plan-all` re-plans them.  `:refined`
-    and `:planned` issues sit outside the fix pipeline until a human
-    approves.
+    Eligible = labelled `auto-improve:plan-approved`, NOT labelled
+    `:in-progress` or `:pr-open`, AND carrying a stored plan block in
+    the issue body (written by `cai plan`).  `:plan-approved` is the
+    gate: `cai plan` auto-promotes a :planned issue to :plan-approved
+    when the select agent's confidence is HIGH; lower confidence diverts
+    to `:human-needed` for admin review, and the admin resumes into
+    `:plan-approved` via `cai unblock`.  Issues with the label but no
+    stored plan are demoted back to `:refined` so `plan-all` re-plans
+    them.
 
     `audit:raised` issues are handled exclusively by the audit-triage
     agent — only issues that triage re-labels to `auto-improve:raised`
-    (and subsequently refine → plan → human:plan-approved) enter the fix
+    (and subsequently refine → plan → :plan-approved) enter the fix
     pipeline.
 
     If no candidates are found, attempts to recover stale `:pr-open`
@@ -691,9 +698,9 @@ def _select_fix_target(exclude: set[int] | None = None):
             if LABEL_IN_PROGRESS in label_names or LABEL_PR_OPEN in label_names:
                 continue
             # Skip issues that already reached a terminal lifecycle state.
-            # An issue can carry both `human:plan-approved` and a terminal
+            # An issue can carry both `:plan-approved` and a terminal
             # label (e.g. `:no-action`, `:merged`, `:needs-spike`) when an
-            # earlier transition forgot to strip the human approval. Without
+            # earlier transition forgot to strip the approval. Without
             # this guard, the implement loop keeps re-selecting the same issue and
             # the cai-implement subagent correctly reports "no action needed" every
             # run — wasting cycles forever.
@@ -707,7 +714,7 @@ def _select_fix_target(exclude: set[int] | None = None):
                 continue
             # Hard plan gate: never let the fix subagent run on an
             # issue that hasn't been through the plan step.
-            # `human:plan-approved` requires a stored plan block in the
+            # `:plan-approved` requires a stored plan block in the
             # issue body (written by `cai plan`). Issues missing a plan
             # are skipped here and
             # re-routed to `:refined` so `plan-all` picks them up.
@@ -1006,15 +1013,25 @@ def _run_select_agent(issue: dict, plans: list[str], work_dir: Path) -> str:
     return result.stdout or ""
 
 
-def _run_plan_select_pipeline(issue: dict, work_dir: Path, attempt_history_block: str = "") -> str | None:
-    """Run the serial 2-plan → select pipeline and return the selected plan.
+def _run_plan_select_pipeline(
+    issue: dict, work_dir: Path, attempt_history_block: str = "",
+) -> tuple[str, "Confidence | None"] | None:
+    """Run the serial 2-plan → select pipeline.
 
     Plan 1 runs first; Plan 2 receives Plan 1's output and is asked
-    to find an alternative approach. The select agent then picks the best.
+    to find an alternative approach. The select agent then picks the
+    best and emits a trailing ``Confidence: HIGH|MEDIUM|LOW`` line
+    indicating how sure it is that the chosen plan will succeed.
 
-    Returns the selected plan text to prepend to the fix agent's
-    user message, or None if the pipeline fails.
+    Returns ``(plan_text, confidence)`` — the confidence line is
+    stripped from ``plan_text`` before it is stored on the issue so
+    the implement agent receives only the plan. ``confidence`` is
+    ``None`` when the select agent omits the marker (treated as
+    below-threshold by the caller).
+    Returns ``None`` if the pipeline fails to produce any output.
     """
+    from cai_lib.fsm import parse_confidence
+
     issue_number = issue["number"]
 
     # Step 1: Run Plan 1.
@@ -1036,8 +1053,22 @@ def _run_plan_select_pipeline(issue: dict, work_dir: Path, attempt_history_block
         print("[cai plan] select agent produced no output; skipping pipeline", flush=True)
         return None
 
-    print(f"[cai plan] select agent produced {len(selection)} chars", flush=True)
-    return selection
+    confidence = parse_confidence(selection)
+    # Strip the trailing ``Confidence: X`` line so the stored plan is
+    # clean — the confidence drives the FSM transition, not the plan body.
+    plan_text = re.sub(
+        r"(?im)^\s*Confidence\s*[:=]\s*(LOW|MEDIUM|HIGH)\s*$",
+        "",
+        selection,
+    ).rstrip() + "\n"
+
+    conf_name = confidence.name if confidence else "MISSING"
+    print(
+        f"[cai plan] select agent produced {len(plan_text)} chars "
+        f"(confidence={conf_name})",
+        flush=True,
+    )
+    return plan_text, confidence
 
 
 def _extract_stored_plan(issue_body: str) -> str | None:
@@ -1138,19 +1169,23 @@ def cmd_plan(args) -> int:
             )
 
         # 4. Run plan-select pipeline.
-        selected_plan = _run_plan_select_pipeline(
+        pipeline_result = _run_plan_select_pipeline(
             issue, work_dir, attempt_history_block,
         )
-        if selected_plan is None:
+        if pipeline_result is None:
             print(f"[cai plan] plan pipeline failed for #{issue_number}",
                   file=sys.stderr)
             dur = f"{int(time.monotonic() - t0)}s"
             log_run("plan", repo=REPO, issue=issue_number,
                     duration=dur, result="pipeline_failed", exit=1)
             return 1
+        selected_plan, plan_confidence = pipeline_result
 
         # 5. Store plan in issue body (strip any old plan block first).
         current_body = _strip_stored_plan_block(issue.get("body", "") or "")
+        # Also strip any stale pending marker left from a prior run — the
+        # upcoming confidence gate will re-add one if it diverts.
+        current_body = strip_pending_marker(current_body)
         plan_block = (
             "<!-- cai-plan-start -->\n"
             "## Selected Implementation Plan\n\n"
@@ -1171,21 +1206,52 @@ def cmd_plan(args) -> int:
                     duration=dur, result="edit_failed", exit=1)
             return 1
 
-        # 6. Transition labels: :planning → :planned.
+        # 6. Transition labels: :planning → :planned (waypoint).
         apply_transition(
             issue_number, "planning_to_planned",
             current_labels=[LABEL_PLANNING],
             log_prefix="cai plan",
         )
 
+        # 7. Confidence-gated auto-approval. HIGH → :plan-approved
+        #    (enters the implement pipeline). Below HIGH (or MISSING)
+        #    diverts to :human-needed with a pending marker so an admin
+        #    can review the plan and resume via cai-unblock.
+        ok, diverted = apply_transition_with_confidence(
+            issue_number, "planned_to_plan_approved", plan_confidence,
+            current_labels=[LABEL_PLANNED],
+            log_prefix="cai plan",
+        )
+        if diverted:
+            # Append a pending marker so cai-unblock knows what we were
+            # trying to do when the admin comments. Re-read the body
+            # because the label write above may have been accompanied by
+            # issue_edit elsewhere; we want the freshest body.
+            marker = render_pending_marker(
+                transition_name="planned_to_plan_approved",
+                from_state=IssueState.PLANNED,
+                intended_state=IssueState.PLAN_APPROVED,
+                confidence=plan_confidence,
+            )
+            marker_body = f"{new_body}\n\n{marker}\n"
+            _run(
+                ["gh", "issue", "edit", str(issue_number),
+                 "--repo", REPO, "--body", marker_body],
+                capture_output=True,
+            )
+
         dur = f"{int(time.monotonic() - t0)}s"
+        conf_name = plan_confidence.name if plan_confidence else "MISSING"
+        final_state = "human-needed" if diverted else "plan-approved"
         print(
             f"[cai plan] #{issue_number} planned and transitioned to "
-            f":planned in {dur}",
+            f":{final_state} in {dur} (confidence={conf_name})",
             flush=True,
         )
         log_run("plan", repo=REPO, issue=issue_number,
-                duration=dur, result="ok", exit=0)
+                duration=dur, result="ok",
+                confidence=conf_name, diverted=int(diverted),
+                exit=0)
         return 0
 
     finally:
@@ -1218,10 +1284,11 @@ def cmd_plan_all(args) -> int:
     consecutive iterations make no progress (to avoid spinning on a
     perpetually-failing issue).
 
-    This step produces the :planned backlog that humans review and
-    promote to :plan-approved. The implement loop in `cycle` only consumes
-    :plan-approved work, so without this step nothing new would ever
-    reach a state a human can approve.
+    This step produces the :plan-approved backlog the implement loop
+    consumes. HIGH-confidence plans auto-promote to :plan-approved;
+    lower-confidence plans divert to :human-needed for admin review
+    via `cai unblock`. Without this step nothing new would ever reach
+    the implement pipeline.
     """
     t0 = time.monotonic()
     print("[cai plan-all] draining :raised and :refined queues", flush=True)
@@ -2129,7 +2196,7 @@ def cmd_implement(args) -> int:
 
     if ps_verdict == "ambiguous":
         # Bounce to :refined (not :plan-approved) so the issue re-flows
-        # through refine → plan → human approval. Returning to
+        # through refine → plan → confidence-gated approval. Returning to
         # :plan-approved would make _select_fix_target pick it up again
         # immediately and loop on the same pre-screen verdict.
         _set_labels(
@@ -2203,8 +2270,9 @@ def cmd_implement(args) -> int:
             )
 
         # 4c. Retrieve the pre-computed plan from the issue body.
-        #     `cai plan` stored the plan; a human approved it via
-        #     `human:plan-approved`.
+        #     `cai plan` stored the plan; it was auto-approved on HIGH
+        #     confidence, or an admin resumed it via cai-unblock. Either
+        #     way it now carries `:plan-approved`.
         selected_plan = _get_plan_for_fix(issue)
 
         # 4d. Pre-create the `.cai-staging/agents/` directory so the
@@ -2367,8 +2435,8 @@ def cmd_implement(args) -> int:
                 capture_output=True,
             )
             # Transition: in-progress -> target_label (NOT back to :raised).
-            # Strip the human approval label as well — if we leave
-            # `human:plan-approved` in place, the fix selector will keep
+            # Strip the approval label as well — if we leave
+            # `:plan-approved` in place, the fix selector will keep
             # re-picking this issue forever because it gates on that label.
             terminal_remove = [
                 LABEL_IN_PROGRESS,
@@ -8698,12 +8766,14 @@ def cmd_cycle(args) -> int:
       1.5. recover stale locks (:in-progress / :revising)
       2. drain pending PRs (revise → fix-ci → review-pr → review-docs → merge)
       3. loop: verify → fix/spike/explore → drain → repeat
-         (fix picks only human:plan-approved — nothing raised
-         or refined is auto-consumed here; an issue whose fix fails
+         (fix picks only :plan-approved — nothing :raised / :refined
+         / :planned is auto-consumed here; an issue whose fix fails
          is skipped for the rest of the cycle so the remaining fix
          targets still get a chance before plan-all runs)
       3.5. plan-all — drive every remaining :raised / :refined issue
-         to :planned so humans have a queue to approve against
+         through refine → plan. HIGH-confidence plans auto-promote to
+         :plan-approved; lower-confidence plans divert to
+         :human-needed for admin review.
       4. final confirm
 
     A non-blocking flock on `_CYCLE_LOCK_PATH` ensures at most one
@@ -8767,9 +8837,10 @@ def _cmd_cycle_inner(args) -> int:
         had_failure = True
 
     # --- Phase 3+3.5: implement loop → plan-all, repeat while new implement targets appear
-    # plan-all may expose a fresh human:plan-approved (human promotes
-    # :planned mid-plan-all) — in that case we re-enter the implement loop
-    # instead of waiting for the next cycle tick.
+    # plan-all may expose a fresh :plan-approved (HIGH-confidence plan
+    # auto-promoted, or an admin resumed one mid-plan-all) — in that
+    # case we re-enter the implement loop instead of waiting for the
+    # next cycle tick.
     _MAX_DRAIN_ONLY_PASSES = 3  # cap drain-only iterations to avoid infinite loops
     _MAX_OUTER_PASSES = 5  # cap plan-all ↔ implement-loop re-entries
     # Issues whose implementation failed in this cycle — skip them for the rest of
@@ -8922,10 +8993,10 @@ def _cmd_cycle_inner(args) -> int:
                     had_failure = True
 
         # --- Phase 3.5: plan-all — drive :raised/:refined to :planned ---
-        # The implement loop only acts on human:plan-approved
+        # The implement loop only acts on :plan-approved
         # issues, so any :raised or :refined work would sit idle without this
         # step. plan-all loops refine → plan until the queue is exhausted or
-        # a new human:plan-approved issue appears (so we can re-enter the
+        # a new :plan-approved issue appears (so we can re-enter the
         # implement loop without waiting for the next cycle tick).
         rc = _run_step("plan-all", cmd_plan_all, args)
         all_results[f"plan-all.{outer_pass}"] = rc
@@ -9063,7 +9134,7 @@ def cmd_health_report(args) -> int:
         ("raised", LABEL_RAISED),
         ("refined", LABEL_REFINED),
         ("planned", LABEL_PLANNED),
-        ("h:plan-approved", LABEL_PLAN_APPROVED),
+        ("plan-approved", LABEL_PLAN_APPROVED),
         ("in-progress", LABEL_IN_PROGRESS),
         ("pr-open", LABEL_PR_OPEN),
         ("merged", LABEL_MERGED),

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -64,7 +64,7 @@ LABEL_MERGE_BLOCKED = "merge-blocked"
 LABEL_AUDIT_RAISED = "audit:raised"
 LABEL_AUDIT_NEEDS_HUMAN = "audit:needs-human"
 LABEL_PLANNED = "auto-improve:planned"
-LABEL_PLAN_APPROVED = "human:plan-approved"
+LABEL_PLAN_APPROVED = "auto-improve:plan-approved"
 # Transient "actively working" states — the driver sets these while the
 # corresponding agent runs. Confidence gates on their exit transitions
 # divert to :human-needed instead of the nominal target.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,14 +28,14 @@ services:
       # 5-field cron line works — see https://crontab.guru/ —
       # supercronic also supports @hourly, @daily, etc.
       #
-      # CAI_CYCLE_SCHEDULE drives the fix pipeline on human:plan-approved
+      # CAI_CYCLE_SCHEDULE drives the fix pipeline on auto-improve:plan-approved
       # issues (fix → revise → review-pr → merge → confirm). A flock
       # in cmd_cycle serializes overlapping runs so issues are
       # processed one at a time. CAI_PLAN_ALL_SCHEDULE drives the
       # upstream refine → plan flow that turns :raised/:refined
       # issues into :planned for humans to approve. The remaining
       # schedules are for orthogonal tasks that run independently.
-      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on human:plan-approved
+      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on auto-improve:plan-approved
       CAI_PLAN_ALL_SCHEDULE: "30 * * * *"   # hourly @30 — drain :raised/:refined into :planned
       CAI_ANALYZER_SCHEDULE: "0 0 * * *"   # daily at 00:00 UTC (LLM call)
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet: LLM audit + deterministic cleanup; see README)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,9 +6,9 @@
 
 1. **Raise** — `cai analyze`, `cai propose`, `cai code-audit`, `cai audit`, or a human files an issue labeled `auto-improve:raised` (the sole entry point — the former `human:submitted` label has been folded into `:raised`).
 2. **Refine** — `cai refine` calls `cai-refine` to rewrite the issue into a structured plan with steps, verification, and scope guardrails. Label transitions to `auto-improve:refined`.
-3. **Plan** — `cai plan` runs plan-select agents to generate and select an implementation plan. The plan is stored in the issue body. Label transitions to `auto-improve:planned`, awaiting human approval.
-4. **Human Approval** — A human reviews the generated plan and applies `human:plan-approved` label to approve the issue for fixing.
-5. **Fix** — `cai implement` calls `cai-implement` on `human:plan-approved` issues in a fresh git worktree. The wrapper commits, pushes, and opens a PR. Label transitions to `auto-improve:in-progress` → `auto-improve:pr-open`.
+3. **Plan** — `cai plan` runs plan-select agents to generate and select an implementation plan. The plan is stored in the issue body. The select agent emits a trailing `Confidence:` line: at `HIGH` the label auto-transitions to `auto-improve:plan-approved`; at `MEDIUM` / `LOW` / missing it diverts to `auto-improve:human-needed` with a pending marker so an admin can review the plan.
+4. **Admin Resume (low-confidence only)** — `cai unblock` classifies an admin's comment on a `:human-needed` issue; a HIGH-confidence `PLAN_APPROVED` verdict fires `human_to_plan_approved` and the issue continues. Ambiguous or dissenting admin comments send the issue back through the planner.
+5. **Fix** — `cai implement` calls `cai-implement` on `auto-improve:plan-approved` issues in a fresh git worktree. The wrapper commits, pushes, and opens a PR. Label transitions to `auto-improve:in-progress` → `auto-improve:pr-open`.
 6. **Review** — `cai review-pr` checks for ripple-effect inconsistencies, posts findings as PR comments, and sets the `pr:reviewed-accept` or `pr:reviewed-reject` label. `cai review-docs` then (and only after review-pr has set `pr:reviewed-accept`) checks for stale documentation, directly fixes issues it can resolve, and commits/pushes those changes to the PR branch. Remaining unfixable issues are posted as `### Finding: stale_docs` comments. This ordering is enforced: review-docs skips PRs until the `pr:reviewed-accept` label is present.
 7. **Revise** — `cai revise` calls `cai-revise` or `cai-rebase` to address review comments or rebase conflicts. Label transitions to `auto-improve:revising`.
 7.5. **CI Fix** — `cai fix-ci` calls `cai-fix-ci` to diagnose and fix failing GitHub Actions checks on open PRs. The subagent reads the failure log (last 200 lines, up to 2 failing checks), locates the root cause in the clone, and makes the minimal fix. A per-SHA marker comment (`## CI-fix subagent: fix attempt`) is always posted after each run — whether or not a fix was produced — so the loop guard fires on the next tick if CI is still red. PRs with unaddressed review comments are skipped (left for `cai revise`); PRs with `:needs-human-review` or `:merge-blocked` are always skipped.
@@ -29,8 +29,8 @@
 | `auto-improve:no-action` | No fix needed (7 d stale timeout → re-queued to `:raised`) |
 | `auto-improve:needs-spike` | Needs research investigation (`cai spike`) |
 | `auto-improve:needs-exploration` | Needs autonomous exploration (`cai explore`) |
-| `auto-improve:planned` | Plan generated and stored in issue body; awaiting human approval |
-| `human:plan-approved` | Plan approved by human; ready for implement subagent |
+| `auto-improve:planned` | Plan generated and stored in issue body; confidence gate pending |
+| `auto-improve:plan-approved` | Plan approved (HIGH confidence auto-approval or admin resume); ready for implement subagent |
 | `auto-improve:parent` | Parent issue; child sub-issues carry the work |
 | `audit:raised` | Audit finding awaiting triage by `cai audit-triage` |
 | `audit:needs-human` | Audit finding escalated to human |
@@ -49,8 +49,8 @@
 2. **Recover stale locks** — roll back `:in-progress` and `:revising` issues past their timeout.
 3. **Ingest unlabeled** — attach `auto-improve` to any unlabeled issues that belong to the pipeline.
 4. **Drain PRs** — for each open auto-improve PR: revise → fix-ci → review-pr → review-docs → merge.
-5. **Implement loop** — repeatedly call `implement`, `spike`, or `explore` on `human:plan-approved` issues until no eligible work remains, draining PRs after each implementation. `:raised`, `:refined`, and `:planned` issues are not consumed here — they wait on the human:plan-approved gate.
-6. **Plan-all** — run `plan-all` to drain every open `:raised` / `:refined` issue through refine → plan → `:planned` so humans have a backlog to review before the next cycle.
+5. **Implement loop** — repeatedly call `implement`, `spike`, or `explore` on `auto-improve:plan-approved` issues until no eligible work remains, draining PRs after each implementation. `:raised`, `:refined`, and `:planned` issues are not consumed here — they wait on the auto-improve:plan-approved gate.
+6. **Plan-all** — run `plan-all` to drain every open `:raised` / `:refined` issue through refine → plan. HIGH-confidence plans auto-promote to `:plan-approved` and feed the implement loop; lower-confidence plans land in `:human-needed` for admin review.
 7. **Final confirm** — one last confirm pass.
 
 `plan-all` also runs on its own cron line (default `30 * * * *`) so the `:planned` queue stays current between cycles.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,7 +78,7 @@ Diagnose and fix failing GitHub Actions checks on open auto-improve PRs. Invokes
 
 ## implement
 
-Run the `cai-implement` agent against one eligible `human:plan-approved` issue in a fresh git worktree. The wrapper handles commit, push, and PR creation. The issue must have a plan pre-computed by `cai plan` and approved by a human reviewer.
+Run the `cai-implement` agent against one eligible `auto-improve:plan-approved` issue in a fresh git worktree. The wrapper handles commit, push, and PR creation. The issue must have a plan pre-computed by `cai plan`; approval is either the automatic HIGH-confidence auto-promotion or an admin resume via `cai unblock`.
 
 | Argument | Type | Description |
 |---|---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,11 +16,11 @@
 
 Cron schedules are configurable via environment variables. Default values are set in `entrypoint.sh`; most are also explicitly configured in `docker-compose.yml`.
 
-The issue-solving pipeline is split in two. `CAI_CYCLE_SCHEDULE` drives implement → revise → fix-ci → review-pr → review-docs → merge → confirm on `human:plan-approved` issues (flock-serialized, one issue at a time). `CAI_PLAN_ALL_SCHEDULE` drives every `:raised` / `:refined` issue through refine → plan → `:planned` so humans have a backlog to approve; `plan-all` also runs at the end of each `cycle`. `:raised`, `:refined`, and `:planned` issues are never auto-fixed — a human must promote `:planned` → `human:plan-approved` before the implement loop touches them. Individual pipeline subcommands (`implement`, `refine`, `plan`, `plan-all`, `spike`, `revise`, `fix-ci`, `review-pr`, `review-docs`, `merge`, `verify`, `confirm`) remain callable manually or from GitHub Actions.
+The issue-solving pipeline is split in two. `CAI_CYCLE_SCHEDULE` drives implement → revise → fix-ci → review-pr → review-docs → merge → confirm on `auto-improve:plan-approved` issues (flock-serialized, one issue at a time). `CAI_PLAN_ALL_SCHEDULE` drives every `:raised` / `:refined` issue through refine → plan; `plan-all` also runs at the end of each `cycle`. The plan step is confidence-gated: at HIGH confidence the issue auto-promotes to `:plan-approved` and enters the implement loop on the next tick; at MEDIUM / LOW / missing confidence it diverts to `:human-needed` with a pending marker, where an admin comment resumes it via `cai unblock`. `:raised`, `:refined`, and `:planned` are never picked up by the implement loop. Individual pipeline subcommands (`implement`, `refine`, `plan`, `plan-all`, `spike`, `revise`, `fix-ci`, `review-pr`, `review-docs`, `merge`, `verify`, `confirm`, `unblock`) remain callable manually or from GitHub Actions.
 
 | Variable | Default | Description |
 |---|---|---|
-| `CAI_CYCLE_SCHEDULE` | `0 * * * *` | Hourly implement pipeline on `human:plan-approved` issues (flock-serialized) |
+| `CAI_CYCLE_SCHEDULE` | `0 * * * *` | Hourly implement pipeline on `auto-improve:plan-approved` issues (flock-serialized) |
 | `CAI_PLAN_ALL_SCHEDULE` | `30 * * * *` | Hourly (offset 30) — drain `:raised`/`:refined` into `:planned` |
 | `CAI_ANALYZER_SCHEDULE` | `0 0 * * *` | Daily transcript analysis and issue raising |
 | `CAI_AUDIT_SCHEDULE` | `0 */6 * * *` | Every 6 hours — queue/PR lifecycle audit |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@
 #
 #    Pipeline (issue-solving) — a `cai.py cycle` line drives the
 #    fix → revise → review-pr → merge → confirm flow on
-#    human:plan-approved issues, while a separate `cai.py plan-all` line
+#    auto-improve:plan-approved issues, while a separate `cai.py plan-all` line
 #    drives :raised and :refined issues through refine → plan → :planned
 #    so humans can review and approve plans out-of-band. A flock in
 #    cmd_cycle guarantees at most one cycle runs at a time, so issues

--- a/install.sh
+++ b/install.sh
@@ -133,14 +133,14 @@ services:
       # Crontab expressions for the scheduled tasks (any valid
       # 5-field cron line — see https://crontab.guru/).
       #
-      # CAI_CYCLE_SCHEDULE drives the fix pipeline on human:plan-approved
+      # CAI_CYCLE_SCHEDULE drives the fix pipeline on auto-improve:plan-approved
       # issues (fix → revise → review-pr → merge → confirm). A flock
       # in cmd_cycle serializes overlapping runs so issues are
       # processed one at a time. CAI_PLAN_ALL_SCHEDULE drives the
       # upstream refine → plan flow that turns :raised/:refined
       # issues into :planned for humans to approve. The remaining
       # schedules are for orthogonal tasks that run independently.
-      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on human:plan-approved
+      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on auto-improve:plan-approved
       CAI_PLAN_ALL_SCHEDULE: "30 * * * *"   # hourly @30 — drain :raised/:refined into :planned
       CAI_ANALYZER_SCHEDULE: "0 0 * * *"   # daily 00:00 UTC (LLM call)
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet: LLM audit + deterministic cleanup; see README)
@@ -205,14 +205,14 @@ services:
       # Crontab expressions for the scheduled tasks (any valid
       # 5-field cron line — see https://crontab.guru/).
       #
-      # CAI_CYCLE_SCHEDULE drives the fix pipeline on human:plan-approved
+      # CAI_CYCLE_SCHEDULE drives the fix pipeline on auto-improve:plan-approved
       # issues (fix → revise → review-pr → merge → confirm). A flock
       # in cmd_cycle serializes overlapping runs so issues are
       # processed one at a time. CAI_PLAN_ALL_SCHEDULE drives the
       # upstream refine → plan flow that turns :raised/:refined
       # issues into :planned for humans to approve. The remaining
       # schedules are for orthogonal tasks that run independently.
-      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on human:plan-approved
+      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on auto-improve:plan-approved
       CAI_PLAN_ALL_SCHEDULE: "30 * * * *"   # hourly @30 — drain :raised/:refined into :planned
       CAI_ANALYZER_SCHEDULE: "0 0 * * *"   # daily 00:00 UTC (LLM call)
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet: LLM audit + deterministic cleanup; see README)

--- a/publish.py
+++ b/publish.py
@@ -96,7 +96,7 @@ LABELS = [
     ("auto-improve:revising", "d4c5f9", "Revise subagent is actively iterating on a PR"),
     ("auto-improve:solved", "0e8a16", "Pattern verified absent from recent transcripts"),
     ("auto-improve:planned", "e4e669", "Plan generated and stored in issue body; awaiting human approval"),
-    ("human:plan-approved", "0e8a16", "Plan approved by human; ready for implement subagent"),
+    ("auto-improve:plan-approved", "0e8a16", "Plan approved (auto via high confidence, or human resume); ready for implement subagent"),
     ("auto-improve:parent", "c5def5", "Parent issue with sub-issues"),
     ("auto-improve:human-needed", "e11d48", "Issue parked awaiting admin comment (cai-unblock resume)"),
     ("auto-improve:pr-human-needed", "e11d48", "PR parked awaiting admin comment (cai-unblock resume)"),


### PR DESCRIPTION
## Summary
- `cai plan` auto-promotes :planned -> :plan-approved when cai-select reports `Confidence: HIGH`. MEDIUM / LOW / missing diverts to :human-needed with a pending marker; an admin resumes via `cai unblock` (supports `ResumeTo: PLAN_APPROVED` already).
- Label renamed `human:plan-approved` -> `auto-improve:plan-approved` (LABEL_PLAN_APPROVED constant unchanged, value updated).
- cai-select output format now requires a trailing `Confidence:` line; docs, workflow guard, and ASCII lifecycle diagram updated.

## Migration note
The old `human:plan-approved` label still exists on the repo. After merging, rename it to `auto-improve:plan-approved` in the GitHub UI (atomic, preserves issues) — or delete it once no issues still carry it.

## Test plan
- [x] `python -m unittest discover tests -q` — 91 pass (1 skipped)
- [ ] One end-to-end `cai plan` run on a real :refined issue to confirm the confidence branch fires correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)