### PR TITLE
fix: salvage review-pr verdict when run hits --max-budget-usd

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,7 +5,6 @@
 
 | File | Purpose |
 |------|---------|
-| `.cai/pr-context.md` | Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `audit:raised` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |

--- a/cai.py
+++ b/cai.py
@@ -6475,15 +6475,33 @@ def cmd_review_pr(args) -> int:
             )
             if agent.stdout:
                 print(agent.stdout, flush=True)
-            if agent.returncode != 0:
+
+            agent_output = (agent.stdout or "").strip()
+
+            # A nonzero exit combined with a usable verdict in stdout
+            # happens when the run hits --max-budget-usd after the
+            # agent already produced its final answer (the result
+            # envelope arrives with subtype=error_max_budget_usd and
+            # no `result` field, so _run_claude_p salvages the last
+            # assistant text). Post the salvaged verdict instead of
+            # discarding the work.
+            has_verdict = (
+                "### Finding:" in agent_output
+                or "No ripple effects found" in agent_output
+            )
+            if agent.returncode != 0 and not has_verdict:
                 print(
                     f"[cai review-pr] agent failed for PR #{pr_number} "
                     f"(exit {agent.returncode}):\n{agent.stderr}",
                     file=sys.stderr,
                 )
                 continue
-
-            agent_output = (agent.stdout or "").strip()
+            if agent.returncode != 0 and has_verdict:
+                print(
+                    f"[cai review-pr] agent exited {agent.returncode} "
+                    f"for PR #{pr_number} but produced a verdict; salvaging",
+                    flush=True,
+                )
 
             # Parse and create any out-of-scope issues emitted by the agent,
             # then strip them from agent_output so they don't appear in the

--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -158,9 +158,34 @@ def _run_claude_p(
         log_cost(row)
 
         # Rewrite stdout to the result text so existing callers stay
-        # backwards compatible. If `result` is missing, fall back to
-        # the raw envelope so callers still see *something*.
+        # backwards compatible. If `result` is missing (e.g. the run
+        # ended with subtype=error_max_budget_usd, which omits the
+        # result field), fall back to the text of the last assistant
+        # stream event so callers still see the agent's final output
+        # instead of the raw JSON envelope.
         if "result" in envelope and isinstance(envelope["result"], str):
             proc.stdout = envelope["result"]
+        elif isinstance(parsed, list):
+            salvaged = _last_assistant_text(parsed)
+            if salvaged:
+                proc.stdout = salvaged
 
     return proc
+
+
+def _last_assistant_text(events: list) -> str:
+    """Return the concatenated text of the final assistant event, or ''."""
+    for event in reversed(events):
+        if not isinstance(event, dict) or event.get("type") != "assistant":
+            continue
+        message = event.get("message") or {}
+        content = message.get("content") or []
+        parts = [
+            item.get("text", "")
+            for item in content
+            if isinstance(item, dict) and item.get("type") == "text"
+        ]
+        text = "".join(parts).strip()
+        if text:
+            return text
+    return ""


### PR DESCRIPTION
## Summary

Rescues output from `claude -p` runs that exit nonzero because of `--max-budget-usd` after the agent already produced its final answer. Previously the review-pr wrapper threw away a clean "No ripple effects found." verdict because `claude-code` exited 1 with subtype `error_max_budget_usd` and no `result` field, leaving stdout as raw JSON.

- `_run_claude_p` now falls back to the last assistant stream event's text when the result envelope has no `result` field
- `cmd_review_pr` no longer treats a nonzero exit as failure if stdout contains `### Finding:` or `No ripple effects found.` — it logs a "salvaging" note and proceeds to post the comment and advance pipeline state

## Why

PR #633 review hit the $0.50 budget cap after producing "No ripple effects found." as the final verdict. The wrapper discarded the run as a failure due to the exit code, forcing an unnecessary re-review. This fix preserves clean verdicts even when the budget limit is reached mid-teardown.

## Testing

- Verify that `review-pr` now succeeds when reviewing a PR that causes a budget-capped `claude -p` run
- Confirm the comment is posted and pipeline state advances