### PR TITLE
refactor(fsm): model CI health and docs review as first-class PR states

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -198,8 +198,8 @@ from cai_lib.subprocess_utils import _run, _run_claude_p  # noqa: E402
 
 from cai_lib.github import (  # noqa: E402
     _gh_json, check_gh_auth, check_claude_auth, _transcript_dir_is_empty,
-    _set_labels, _issue_has_label, _build_issue_block, _build_implement_user_message,
-    _fetch_linked_issue_block,
+    _set_labels, _set_pr_labels, _issue_has_label, _build_issue_block,
+    _build_implement_user_message, _fetch_linked_issue_block,
 )
 from cai_lib.cmd_lifecycle import (  # noqa: E402
     _rollback_stale_in_progress, _reconcile_interrupted,
@@ -209,7 +209,10 @@ from cai_lib.cmd_unblock import cmd_unblock  # noqa: E402
 from cai_lib.fsm import (  # noqa: E402
     apply_transition,
     apply_transition_with_confidence,
+    apply_pr_transition,
     IssueState,
+    PRState,
+    get_pr_state,
     render_pending_marker,
     strip_pending_marker,
 )
@@ -3986,8 +3989,35 @@ def cmd_revise(args) -> int:
                 flush=True,
             )
 
-            # 11a. Advance pipeline state: branch now has new commits.
-            _pr_set_pipeline_state(pr_number, LABEL_PR_EDITED)
+            # 11a. Advance FSM state: branch now has new commits, so any
+            # post-review state must drop back to REVIEWING_CODE for the
+            # new SHA.
+            try:
+                pr_now = _gh_json([
+                    "pr", "view", str(pr_number),
+                    "--repo", REPO, "--json", "labels,merged,mergedAt,state",
+                ])
+            except subprocess.CalledProcessError:
+                pr_now = {}
+            current_state = get_pr_state(pr_now) if pr_now else None
+            if current_state == PRState.REVISION_PENDING:
+                apply_pr_transition(
+                    pr_number, "revision_pending_to_reviewing_code",
+                    log_prefix="cai revise",
+                )
+            elif current_state == PRState.CI_FAILING:
+                apply_pr_transition(
+                    pr_number, "ci_failing_to_reviewing_code",
+                    log_prefix="cai revise",
+                )
+            elif current_state == PRState.REVIEWING_DOCS:
+                apply_pr_transition(
+                    pr_number, "reviewing_docs_to_reviewing_code",
+                    log_prefix="cai revise",
+                )
+            # REVIEWING_CODE is already correct; OPEN / PR_HUMAN_NEEDED
+            # / MERGED are unexpected here and left for the sweep to
+            # reconcile.
 
             # 11. Post a summary comment describing what happened.
             if head_changed and has_uncommitted:
@@ -6603,11 +6633,26 @@ def cmd_review_pr(args) -> int:
                 capture_output=True,
             )
 
-            # Advance pipeline state based on review outcome.
+            # Advance FSM state based on review outcome. PRs entering
+            # review without a pipeline label (OPEN) are first bumped
+            # to REVIEWING_CODE so the outgoing transition's from_state
+            # check passes.
+            current_state = get_pr_state(pr)
+            if current_state == PRState.OPEN:
+                apply_pr_transition(
+                    pr_number, "open_to_reviewing_code",
+                    log_prefix="cai review-pr",
+                )
             if has_findings:
-                _pr_set_pipeline_state(pr_number, LABEL_PR_REVIEWED_REJECT)
+                apply_pr_transition(
+                    pr_number, "reviewing_code_to_revision_pending",
+                    log_prefix="cai review-pr",
+                )
             else:
-                _pr_set_pipeline_state(pr_number, LABEL_PR_REVIEWED_ACCEPT)
+                apply_pr_transition(
+                    pr_number, "reviewing_code_to_reviewing_docs",
+                    log_prefix="cai review-pr",
+                )
 
             _log_review_pr_findings(pr_number, head_sha, agent_output)
 
@@ -6720,19 +6765,6 @@ def cmd_review_docs(args) -> int:
                 already_reviewed = True
                 break
         if already_reviewed:
-            # Recovery: if we already posted a docs-review comment at this
-            # HEAD, docs are current — but an older `_pr_set_pipeline_state`
-            # call (before code and docs gates were decoupled) may have
-            # cleared `pr:documented`. Re-apply it so the merge gate
-            # doesn't wait forever. Safe to call when already present.
-            pr_labels = {l["name"] for l in pr.get("labels", [])}
-            if LABEL_PR_DOCUMENTED not in pr_labels:
-                print(
-                    f"[cai review-docs] PR #{pr_number}: re-applying "
-                    f"`pr:documented` for prior review at {head_sha[:8]}",
-                    flush=True,
-                )
-                _pr_set_pipeline_state(pr_number, LABEL_PR_DOCUMENTED)
             print(
                 f"[cai review-docs] PR #{pr_number}: already reviewed at {head_sha[:8]}; skipping",
                 flush=True,
@@ -6740,14 +6772,13 @@ def cmd_review_docs(args) -> int:
             skipped += 1
             continue
 
-        # Gate: only review docs after `pr:reviewed-accept` label is set,
-        # meaning cmd_review_pr has posted a clean verdict for this PR.
-        # Bootstrap note: PRs already in flight with no pr:* label will be
-        # skipped here until the next natural cmd_review_pr run sets the label.
-        pr_labels = {l["name"] for l in pr.get("labels", [])}
-        if LABEL_PR_REVIEWED_ACCEPT not in pr_labels:
+        # Gate: only run docs review when the FSM says REVIEWING_DOCS.
+        # That state is entered by cmd_review_pr after a clean code
+        # review. Bootstrap: PRs still in OPEN / REVIEWING_CODE wait
+        # for the next natural cmd_review_pr run.
+        if get_pr_state(pr) != PRState.REVIEWING_DOCS:
             print(
-                f"[cai review-docs] PR #{pr_number}: label `pr:reviewed-accept` not present; waiting",
+                f"[cai review-docs] PR #{pr_number}: not in REVIEWING_DOCS state; waiting",
                 flush=True,
             )
             skipped += 1
@@ -6885,13 +6916,14 @@ def cmd_review_docs(args) -> int:
                 capture_output=True,
             )
 
-            # Advance pipeline state based on docs review outcome.
+            # Advance FSM state based on docs review outcome.
             if has_doc_changes:
-                # Docs fix was pushed — branch updated, re-enter revise/review cycle.
-                _pr_set_pipeline_state(pr_number, LABEL_PR_EDITED)
-            else:
-                # No doc changes needed — docs confirmed current.
-                _pr_set_pipeline_state(pr_number, LABEL_PR_DOCUMENTED)
+                # Docs fix was pushed — branch updated, re-enter code review.
+                apply_pr_transition(
+                    pr_number, "reviewing_docs_to_reviewing_code",
+                    log_prefix="cai review-docs",
+                )
+            # else: stay in REVIEWING_DOCS so cmd_merge can advance.
 
             result_word = "fixes pushed" if has_doc_changes else "clean"
             print(
@@ -6955,72 +6987,10 @@ def _pr_set_needs_human(pr_number: int, needs: bool) -> None:
         )
 
 
-# PR pipeline-state labels (Step 1 of #557).  All live here so they remain
-# co-located with _pr_set_pipeline_state and avoid star-import visibility
-# issues that would arise if underscore-prefixed names were placed in config.
-LABEL_PR_EDITED          = "pr:edited"
-LABEL_PR_REVIEWED_REJECT = "pr:reviewed-reject"
-LABEL_PR_REVIEWED_ACCEPT = "pr:reviewed-accept"
-LABEL_PR_DOCUMENTED      = "pr:documented"
-
-# Code-review gate: exactly one of these labels at a time. `pr:edited`
-# means the branch changed and needs re-review; accept/reject are
-# terminal outcomes for a given HEAD.
-CODE_REVIEW_PIPELINE_LABELS = (
-    LABEL_PR_EDITED,
-    LABEL_PR_REVIEWED_REJECT,
-    LABEL_PR_REVIEWED_ACCEPT,
-)
-# Docs-review gate: independent from the code-review gate — a PR needs
-# both to merge, so setting a code-review label must not clear this one.
-DOCS_REVIEW_PIPELINE_LABELS = (
-    LABEL_PR_DOCUMENTED,
-)
-PR_PIPELINE_LABELS = CODE_REVIEW_PIPELINE_LABELS + DOCS_REVIEW_PIPELINE_LABELS
-
-
-def _pr_set_pipeline_state(pr_number: int, label: str) -> None:
-    """Set a PR pipeline-state label, clearing only labels in the same gate.
-
-    Code-review labels ({edited, reviewed-reject, reviewed-accept}) and
-    docs-review labels ({documented}) are independent gates — both must
-    be satisfied to merge. Setting one must not clear the other.
-
-    `pr:edited` is the one cross-gate case: it signals the branch just
-    changed, so any prior docs review is stale — we clear `pr:documented`
-    alongside the other code-review labels in that case.
-
-    Idempotent: gh silently no-ops if the label is already/not present.
-    Logged but not fatal on failure — labelling is a UX nicety.
-    """
-    if label in CODE_REVIEW_PIPELINE_LABELS:
-        to_remove = [lbl for lbl in CODE_REVIEW_PIPELINE_LABELS if lbl != label]
-        if label == LABEL_PR_EDITED:
-            # Branch changed: prior docs review is for a stale SHA.
-            to_remove.append(LABEL_PR_DOCUMENTED)
-    elif label in DOCS_REVIEW_PIPELINE_LABELS:
-        to_remove = [lbl for lbl in DOCS_REVIEW_PIPELINE_LABELS if lbl != label]
-    else:
-        to_remove = []
-
-    for lbl in to_remove:
-        # Swallow non-zero returns — the label simply wasn't on the PR.
-        _run(
-            ["gh", "pr", "edit", str(pr_number),
-             "--repo", REPO, "--remove-label", lbl],
-            capture_output=True,
-        )
-    res = _run(
-        ["gh", "pr", "edit", str(pr_number),
-         "--repo", REPO, "--add-label", label],
-        capture_output=True,
-    )
-    if res.returncode != 0:
-        print(
-            f"[cai] PR #{pr_number}: could not add pipeline label "
-            f"`{label}`:\n{res.stderr}",
-            file=sys.stderr,
-        )
+# PR pipeline-state labels are now first-class PRState members (see
+# cai_lib/fsm.PRState and LABEL_PR_* in cai_lib/config.py). Transitions
+# are applied via apply_pr_transition; there is no longer a separate
+# two-gate (code-review / docs-review) wrapper scheme.
 
 
 def _pr_label_sweep() -> tuple[int, int]:
@@ -7128,11 +7098,12 @@ def _pr_label_sweep() -> tuple[int, int]:
         if not needs and merge_state == "DIRTY":
             needs = True
 
-        # Step 3/3 (#567): If the PR carries a stale pipeline label
-        # (pr:reviewed-accept or pr:documented) and a non-bot commit was
-        # pushed AFTER the most recent bot pipeline comment, reset the
-        # label to pr:edited so the pipeline re-enters review.
-        stale_pipeline_labels = {LABEL_PR_REVIEWED_ACCEPT, LABEL_PR_DOCUMENTED}
+        # Step 3/3 (#567): If the PR is in a post-review state
+        # (pr:reviewing-docs) and a non-bot commit was pushed AFTER
+        # the most recent bot pipeline comment, drop the PR back to
+        # REVIEWING_CODE so the pipeline re-enters review on the new
+        # SHA.
+        stale_pipeline_labels = {LABEL_PR_REVIEWING_DOCS}
         if labels & stale_pipeline_labels and commits:
             # Proxy for "when was the pipeline label last applied":
             # find the most recent bot pipeline comment timestamp.
@@ -7165,7 +7136,10 @@ def _pr_label_sweep() -> tuple[int, int]:
                     or last_author_login.endswith("[bot]")  # any other bot account
                 )
                 if not is_bot_commit and commit_ts > latest_bot_comment_ts:
-                    _pr_set_pipeline_state(pr_number, LABEL_PR_EDITED)
+                    apply_pr_transition(
+                        pr_number, "reviewing_docs_to_reviewing_code",
+                        log_prefix="cai sweep",
+                    )
 
         if needs and not currently_labeled:
             _pr_set_needs_human(pr_number, True)
@@ -7302,24 +7276,31 @@ def cmd_merge(args) -> int:
         # `merge-blocked` label (and any `needs-human-review` label)
         # to restart the merge-evaluation cycle for those PRs.
 
-        # Safety filter 7: require a clean code review (`pr:reviewed-accept`)
-        # OR a completed docs review (`pr:documented`) before merging.
-        # pr_labels was computed once at the top of this loop.
-        # Bootstrap note: PRs already in flight with no pr:* label will be
-        # skipped here until the next natural cmd_review_pr run sets the label.
-        if LABEL_PR_REVIEWED_ACCEPT not in pr_labels and LABEL_PR_DOCUMENTED not in pr_labels:
+        # Safety filter 7: require FSM state == REVIEWING_DOCS AND a
+        # clean docs-review comment at the current HEAD. REVIEWING_DOCS
+        # means review-pr passed cleanly; the HEAD-scoped comment check
+        # confirms review-docs also ran cleanly on this exact SHA.
+        if get_pr_state(pr) != PRState.REVIEWING_DOCS:
             print(
-                f"[cai merge] PR #{pr_number}: neither `pr:reviewed-accept` nor "
-                f"`pr:documented` present; waiting",
+                f"[cai merge] PR #{pr_number}: not in REVIEWING_DOCS state; waiting",
                 flush=True,
             )
             continue
 
-        # Safety filter 7b: require docs review sign-off (`pr:documented`).
-        # pr_labels was computed once at the top of this loop.
-        if LABEL_PR_DOCUMENTED not in pr_labels:
+        head_sha_merge = pr.get("headRefOid", "")
+        docs_clean_at_head = False
+        for comment in pr.get("comments", []):
+            body_line = (comment.get("body") or "").split("\n", 1)[0]
+            if (
+                body_line.startswith(_DOCS_REVIEW_COMMENT_HEADING_CLEAN)
+                and head_sha_merge in body_line
+            ):
+                docs_clean_at_head = True
+                break
+        if not docs_clean_at_head:
             print(
-                f"[cai merge] PR #{pr_number}: label `pr:documented` not present; waiting",
+                f"[cai merge] PR #{pr_number}: no clean docs-review comment "
+                f"for HEAD {head_sha_merge[:8]}; waiting",
                 flush=True,
             )
             continue
@@ -8696,6 +8677,34 @@ def cmd_fix_ci(args) -> int:
             had_failure = True
             continue
 
+        # 1a. Advance PR FSM into CI_FAILING. The wrapper detected red
+        # checks via _select_ci_fix_targets; formalize that in the FSM
+        # so the diagram matches what's actually happening.
+        try:
+            pr_now = _gh_json([
+                "pr", "view", str(pr_number),
+                "--repo", REPO, "--json", "labels,merged,mergedAt,state",
+            ])
+        except subprocess.CalledProcessError:
+            pr_now = {}
+        current_state = get_pr_state(pr_now) if pr_now else None
+        if current_state == PRState.REVIEWING_CODE:
+            apply_pr_transition(
+                pr_number, "reviewing_code_to_ci_failing",
+                log_prefix="cai fix-ci",
+            )
+        elif current_state == PRState.REVISION_PENDING:
+            apply_pr_transition(
+                pr_number, "revision_pending_to_ci_failing",
+                log_prefix="cai fix-ci",
+            )
+        elif current_state == PRState.REVIEWING_DOCS:
+            apply_pr_transition(
+                pr_number, "reviewing_docs_to_ci_failing",
+                log_prefix="cai fix-ci",
+            )
+        # OPEN / CI_FAILING / PR_HUMAN_NEEDED: no transition needed.
+
         _run(["gh", "auth", "setup-git"], capture_output=True)
         _write_active_job("fix-ci", "issue", issue_number)
 
@@ -8856,6 +8865,14 @@ def cmd_fix_ci(args) -> int:
                     )
                 else:
                     print(f"[cai fix-ci] pushed fix for PR #{pr_number}", flush=True)
+                    # Exit CI_FAILING now that new commits are up; the
+                    # next tick re-evaluates check status, and if still
+                    # red _select_ci_fix_targets re-queues the PR
+                    # (which re-enters CI_FAILING via step 1a above).
+                    apply_pr_transition(
+                        pr_number, "ci_failing_to_reviewing_code",
+                        log_prefix="cai fix-ci",
+                    )
             else:
                 print(
                     f"[cai fix-ci] no changes produced by agent for PR #{pr_number}",

--- a/cai.py
+++ b/cai.py
@@ -204,6 +204,7 @@ from cai_lib.github import (  # noqa: E402
 from cai_lib.cmd_lifecycle import (  # noqa: E402
     _rollback_stale_in_progress, _reconcile_interrupted,
     _migrate_legacy_human_submitted,
+    _migrate_legacy_pr_pipeline_labels,
 )
 from cai_lib.cmd_unblock import cmd_unblock  # noqa: E402
 from cai_lib.fsm import (  # noqa: E402
@@ -7004,11 +7005,11 @@ def _pr_label_sweep() -> tuple[int, int]:
     `rebase resolution failed` once would never be labelled, since
     that failure path doesn't go through the merge agent. Refs #223.
 
-    Also detects when a non-bot commit was pushed after a stale
-    pipeline label (pr:reviewed-accept or pr:documented) and resets
-    the label to pr:edited to re-enter the review pipeline. This
-    ensures that human or external bot commits on auto-improve
-    branches trigger a re-review, even if no review comments are
+    Also detects when a non-bot commit was pushed after the PR
+    advanced to `pr:reviewing-docs` and transitions it back to
+    `pr:reviewing-code` so the review pipeline re-evaluates the new
+    SHA. Ensures human or external bot commits on auto-improve
+    branches trigger a re-review, even when no review comments are
     posted. Refs #567.
 
     Signals (each scoped to comments AFTER the latest commit so a
@@ -7020,7 +7021,7 @@ def _pr_label_sweep() -> tuple[int, int]:
     - any `## Revise subagent: no additional changes` comment
     - mergeStateStatus is DIRTY (unresolved conflict against main)
     - a non-bot commit pushed after the most recent bot pipeline
-      comment while PR carries pr:reviewed-accept or pr:documented
+      comment while PR is in `pr:reviewing-docs`
 
     Returns (added, removed) for the run summary (counts of
     `needs-human-review` labels added/removed; pipeline-state resets
@@ -9078,6 +9079,14 @@ def _cmd_cycle_inner(args) -> int:
     iteration = 0
     all_results: dict[str, int] = {}
     had_failure = False
+
+    # --- Phase 0: legacy PR-label migration (idempotent) ------------------
+    # Relabel any in-flight PRs still carrying retired
+    # pr:edited / pr:reviewed-* / pr:documented labels to the new
+    # PRState labels. Once the queue is empty this becomes a no-op.
+    migrated_prs = _migrate_legacy_pr_pipeline_labels()
+    if migrated_prs:
+        print(f"[cai cycle] migrated {migrated_prs} legacy PR label(s)", flush=True)
 
     # --- Phase 1: verify + confirm (initial state sync) -----------------
     for step_name, handler in [("verify", cmd_verify), ("confirm", cmd_confirm)]:

--- a/cai_lib/cmd_lifecycle.py
+++ b/cai_lib/cmd_lifecycle.py
@@ -19,10 +19,13 @@ from cai_lib.config import (
     LABEL_RAISED,
     LABEL_AUDIT_RAISED,
     LABEL_NEEDS_SPIKE,
+    LABEL_PR_REVIEWING_CODE,
+    LABEL_PR_REVISION_PENDING,
+    LABEL_PR_REVIEWING_DOCS,
     _STALE_IN_PROGRESS_HOURS,
     _STALE_REVISING_HOURS,
 )
-from cai_lib.github import _gh_json, _set_labels, _issue_has_label
+from cai_lib.github import _gh_json, _set_labels, _set_pr_labels, _issue_has_label
 from cai_lib.logging_utils import log_run
 
 
@@ -70,6 +73,65 @@ def _migrate_legacy_human_submitted() -> int:
                 f"[cai refine] migrated #{num}: human:submitted -> :raised",
                 flush=True,
             )
+    return migrated
+
+
+# Legacy PR pipeline labels retired when PRState absorbed CI health
+# and docs-review as first-class states. Mapping reflects the FSM
+# meaning of each old label:
+#   - pr:edited           → REVIEWING_CODE  (new SHA pending review)
+#   - pr:reviewed-reject  → REVISION_PENDING (review found issues)
+#   - pr:reviewed-accept  → REVIEWING_DOCS  (code clean, docs next)
+#   - pr:documented       → REVIEWING_DOCS  (docs reviewed; the HEAD-
+#                           scoped docs-clean comment is what actually
+#                           gates merge now)
+_LEGACY_PR_LABEL_MAP = {
+    "pr:edited":          LABEL_PR_REVIEWING_CODE,
+    "pr:reviewed-reject": LABEL_PR_REVISION_PENDING,
+    "pr:reviewed-accept": LABEL_PR_REVIEWING_DOCS,
+    "pr:documented":      LABEL_PR_REVIEWING_DOCS,
+}
+
+
+def _migrate_legacy_pr_pipeline_labels() -> int:
+    """Relabel open PRs carrying retired ``pr:*`` labels to new PRState labels.
+
+    Idempotent — safe to call at the top of every ``cmd_cycle`` tick.
+    Returns the number of PRs relabelled this invocation.
+    """
+    migrated = 0
+    for legacy, replacement in _LEGACY_PR_LABEL_MAP.items():
+        try:
+            prs = _gh_json([
+                "pr", "list",
+                "--repo", REPO,
+                "--state", "open",
+                "--label", legacy,
+                "--json", "number,labels",
+                "--limit", "100",
+            ]) or []
+        except subprocess.CalledProcessError as e:
+            print(
+                f"[cai cycle] legacy-PR migration gh pr list failed for "
+                f"{legacy!r}:\n{e.stderr}",
+                file=sys.stderr,
+            )
+            continue
+        for pr in prs:
+            num = pr["number"]
+            labels = {lbl["name"] for lbl in pr.get("labels", [])}
+            add = [] if replacement in labels else [replacement]
+            if _set_pr_labels(
+                num,
+                add=add,
+                remove=[legacy],
+                log_prefix="cai cycle",
+            ):
+                migrated += 1
+                print(
+                    f"[cai cycle] migrated PR #{num}: {legacy} -> {replacement}",
+                    flush=True,
+                )
     return migrated
 
 

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -76,6 +76,15 @@ LABEL_TRIAGING         = "auto-improve:triaging"
 LABEL_KIND_CODE        = "kind:code"
 LABEL_KIND_MAINTENANCE = "kind:maintenance"
 
+# PR pipeline-state labels — one per PRState. Set by FSM transitions
+# (apply_pr_transition) and read by dispatch. Replaces the legacy
+# pr:edited / pr:reviewed-accept / pr:reviewed-reject / pr:documented
+# two-layer scheme (see _migrate_legacy_pr_pipeline_labels).
+LABEL_PR_REVIEWING_CODE   = "pr:reviewing-code"    # PRState.REVIEWING_CODE
+LABEL_PR_REVISION_PENDING = "pr:revision-pending"  # PRState.REVISION_PENDING
+LABEL_PR_REVIEWING_DOCS   = "pr:reviewing-docs"    # PRState.REVIEWING_DOCS
+LABEL_PR_CI_FAILING       = "pr:ci-failing"        # PRState.CI_FAILING
+
 # PR-level label applied by `cai merge` when the verdict is below the
 # auto-merge threshold. Lets a human filter open PRs that are waiting
 # on their decision (`label:needs-human-review`). Issue #216.

--- a/cai_lib/fsm.py
+++ b/cai_lib/fsm.py
@@ -19,6 +19,8 @@ from cai_lib.config import (
     LABEL_IN_PROGRESS, LABEL_PR_OPEN, LABEL_MERGED, LABEL_SOLVED,
     LABEL_NEEDS_EXPLORATION, LABEL_HUMAN_NEEDED, LABEL_PR_HUMAN_NEEDED,
     LABEL_TRIAGING,
+    LABEL_PR_REVIEWING_CODE, LABEL_PR_REVISION_PENDING,
+    LABEL_PR_REVIEWING_DOCS, LABEL_PR_CI_FAILING,
 )
 
 
@@ -114,12 +116,20 @@ class IssueState(str, Enum):
 
 
 class PRState(str, Enum):
-    OPEN              = "pr:open"
-    REVIEWING         = "pr:reviewing"
-    REVISION_PENDING  = "pr:revision_pending"
-    APPROVED          = "pr:approved"
-    MERGED            = "pr:merged"
-    PR_HUMAN_NEEDED   = "pr:human_needed"
+    """Persistent PR pipeline state, tracked via GitHub labels.
+
+    Unlike the prior model (which derived state from GitHub's native
+    ``reviewDecision`` and ran CI / docs review as out-of-band loops),
+    every state here is first-class: one label per state, one action
+    per state. See ``PR_TRANSITIONS`` for allowed moves.
+    """
+    OPEN              = "pr:open"                     # no label yet
+    REVIEWING_CODE    = LABEL_PR_REVIEWING_CODE       # cai-review-pr runs
+    REVISION_PENDING  = LABEL_PR_REVISION_PENDING     # findings; awaiting revise push
+    REVIEWING_DOCS    = LABEL_PR_REVIEWING_DOCS       # cai-review-docs runs / merge gate
+    CI_FAILING        = LABEL_PR_CI_FAILING           # cai-fix-ci runs
+    MERGED            = "pr:merged"                   # derived from gh merged flag
+    PR_HUMAN_NEEDED   = LABEL_PR_HUMAN_NEEDED         # parked for admin comment
 
 
 @dataclass
@@ -231,28 +241,92 @@ ISSUE_TRANSITIONS: list[Transition] = [
 
 
 PR_TRANSITIONS: list[Transition] = [
-    Transition("pr_open_to_reviewing",          PRState.OPEN,             PRState.REVIEWING,
+    # Entry: brand-new PR → code review.
+    Transition("open_to_reviewing_code",
+               PRState.OPEN, PRState.REVIEWING_CODE,
+               labels_add=[LABEL_PR_REVIEWING_CODE],
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
-    Transition("reviewing_to_revision_pending", PRState.REVIEWING,        PRState.REVISION_PENDING,
+
+    # Code-review outcomes.
+    Transition("reviewing_code_to_revision_pending",
+               PRState.REVIEWING_CODE, PRState.REVISION_PENDING,
+               labels_remove=[LABEL_PR_REVIEWING_CODE],
+               labels_add=[LABEL_PR_REVISION_PENDING],
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
-    Transition("revision_pending_to_reviewing", PRState.REVISION_PENDING, PRState.REVIEWING,
+    # Gated: advance to docs review only at HIGH confidence.
+    Transition("reviewing_code_to_reviewing_docs",
+               PRState.REVIEWING_CODE, PRState.REVIEWING_DOCS,
+               labels_remove=[LABEL_PR_REVIEWING_CODE],
+               labels_add=[LABEL_PR_REVIEWING_DOCS],
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
-    Transition("reviewing_to_approved",         PRState.REVIEWING,        PRState.APPROVED,
+
+    # After a revise push, the new SHA needs code review again.
+    Transition("revision_pending_to_reviewing_code",
+               PRState.REVISION_PENDING, PRState.REVIEWING_CODE,
+               labels_remove=[LABEL_PR_REVISION_PENDING],
+               labels_add=[LABEL_PR_REVIEWING_CODE],
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
-    Transition("approved_to_merged",            PRState.APPROVED,         PRState.MERGED,
+
+    # Docs review may self-heal by pushing; a new SHA → back to code review.
+    Transition("reviewing_docs_to_reviewing_code",
+               PRState.REVIEWING_DOCS, PRState.REVIEWING_CODE,
+               labels_remove=[LABEL_PR_REVIEWING_DOCS],
+               labels_add=[LABEL_PR_REVIEWING_CODE],
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
-    Transition("pr_to_human",                   PRState.REVIEWING,        PRState.PR_HUMAN_NEEDED,
+    # Terminal gate: docs clean → merge (CI-green check is at merge time).
+    Transition("reviewing_docs_to_merged",
+               PRState.REVIEWING_DOCS, PRState.MERGED,
+               labels_remove=[LABEL_PR_REVIEWING_DOCS],
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
-    Transition("pr_human_to_reviewing",         PRState.PR_HUMAN_NEEDED,  PRState.REVIEWING,
+
+    # CI orthogonal gate: any pre-merge state can dive into CI_FAILING
+    # on red checks; once green, return to code review since the branch
+    # has new commits that need re-review.
+    Transition("reviewing_code_to_ci_failing",
+               PRState.REVIEWING_CODE, PRState.CI_FAILING,
+               labels_remove=[LABEL_PR_REVIEWING_CODE],
+               labels_add=[LABEL_PR_CI_FAILING],
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
-    # Admin-comment-driven re-entries out of PR_HUMAN_NEEDED.
-    Transition("pr_human_to_revision_pending",  PRState.PR_HUMAN_NEEDED,  PRState.REVISION_PENDING,
+    Transition("revision_pending_to_ci_failing",
+               PRState.REVISION_PENDING, PRState.CI_FAILING,
+               labels_remove=[LABEL_PR_REVISION_PENDING],
+               labels_add=[LABEL_PR_CI_FAILING],
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
-    Transition("pr_human_to_approved",          PRState.PR_HUMAN_NEEDED,  PRState.APPROVED,
+    Transition("reviewing_docs_to_ci_failing",
+               PRState.REVIEWING_DOCS, PRState.CI_FAILING,
+               labels_remove=[LABEL_PR_REVIEWING_DOCS],
+               labels_add=[LABEL_PR_CI_FAILING],
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    Transition("ci_failing_to_reviewing_code",
+               PRState.CI_FAILING, PRState.REVIEWING_CODE,
+               labels_remove=[LABEL_PR_CI_FAILING],
+               labels_add=[LABEL_PR_REVIEWING_CODE],
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+
+    # Human-needed divert + resume paths.
+    Transition("reviewing_code_to_human",
+               PRState.REVIEWING_CODE, PRState.PR_HUMAN_NEEDED,
+               labels_remove=[LABEL_PR_REVIEWING_CODE],
+               labels_add=[LABEL_PR_HUMAN_NEEDED],
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    Transition("pr_human_to_reviewing_code",
+               PRState.PR_HUMAN_NEEDED, PRState.REVIEWING_CODE,
+               labels_remove=[LABEL_PR_HUMAN_NEEDED],
+               labels_add=[LABEL_PR_REVIEWING_CODE],
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    Transition("pr_human_to_revision_pending",
+               PRState.PR_HUMAN_NEEDED, PRState.REVISION_PENDING,
+               labels_remove=[LABEL_PR_HUMAN_NEEDED],
+               labels_add=[LABEL_PR_REVISION_PENDING],
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    Transition("pr_human_to_reviewing_docs",
+               PRState.PR_HUMAN_NEEDED, PRState.REVIEWING_DOCS,
+               labels_remove=[LABEL_PR_HUMAN_NEEDED],
+               labels_add=[LABEL_PR_REVIEWING_DOCS],
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
     # NOTE: no pr_human_to_merged — PR_HUMAN_NEEDED must funnel back
-    # through REVISION_PENDING / APPROVED so a PR never bypasses the
-    # review → approve flow on its way to MERGED.
+    # through the review states so a PR never bypasses review on its
+    # way to MERGED.
 ]
 
 
@@ -265,23 +339,40 @@ def get_issue_state(labels: list[str]) -> Optional[IssueState]:
     return None
 
 
+_PR_LABEL_STATES = [
+    (LABEL_PR_HUMAN_NEEDED,     PRState.PR_HUMAN_NEEDED),
+    (LABEL_PR_CI_FAILING,       PRState.CI_FAILING),
+    (LABEL_PR_REVISION_PENDING, PRState.REVISION_PENDING),
+    (LABEL_PR_REVIEWING_DOCS,   PRState.REVIEWING_DOCS),
+    (LABEL_PR_REVIEWING_CODE,   PRState.REVIEWING_CODE),
+]
+
+
 def get_pr_state(pr: dict) -> PRState:
-    """Derive the current PRState from a GitHub PR JSON dict."""
+    """Derive the current PRState from a GitHub PR JSON dict.
+
+    Precedence:
+    1. Merged flag → ``MERGED`` (terminal).
+    2. Pipeline labels (checked in ``_PR_LABEL_STATES`` order so
+       human-needed and CI-failing outrank any stuck review label).
+    3. No pipeline label → ``OPEN`` (brand-new PR; dispatcher applies
+       ``open_to_reviewing_code``).
+
+    CI-red-overrides-label is NOT baked in here — the dispatcher
+    compares check status against the current state and explicitly
+    applies a ``*_to_ci_failing`` transition. Keeping derivation pure
+    lets tests stub PR dicts without checkrollup data.
+    """
     if pr.get("merged") or pr.get("mergedAt") or pr.get("state") == "MERGED":
         return PRState.MERGED
-    review_decision = pr.get("reviewDecision") or ""
-    if review_decision == "APPROVED":
-        return PRState.APPROVED
-    if review_decision == "CHANGES_REQUESTED":
-        return PRState.REVISION_PENDING
-    reviews = pr.get("reviews", {})
-    total_count = 0
-    if isinstance(reviews, dict):
-        total_count = reviews.get("totalCount", 0)
-    elif isinstance(reviews, list):
-        total_count = len(reviews)
-    if total_count > 0:
-        return PRState.REVIEWING
+    labels_raw = pr.get("labels", [])
+    label_set = {
+        (lbl.get("name") if isinstance(lbl, dict) else lbl)
+        for lbl in labels_raw
+    }
+    for label_value, state in _PR_LABEL_STATES:
+        if label_value in label_set:
+            return state
     return PRState.OPEN
 
 
@@ -492,6 +583,98 @@ def resume_transition_for(target_state_name: str) -> Optional[Transition]:
         if t.from_state == IssueState.HUMAN_NEEDED and t.to_state == target:
             return t
     return None
+
+
+def apply_pr_transition(
+    pr_number: int,
+    transition_name: str,
+    *,
+    current_pr: Optional[dict] = None,
+    log_prefix: str = "cai",
+    set_pr_labels=None,
+) -> bool:
+    """Apply a named PR FSM transition via ``_set_pr_labels``.
+
+    When *current_pr* is provided, the current PRState is derived and
+    compared to ``transition.from_state``. A mismatch is refused (logs
+    and returns False) so drift cannot silently compound.
+
+    *set_pr_labels* is injectable for tests; defaults to
+    ``cai_lib.github._set_pr_labels``.
+    """
+    transition = find_transition(transition_name, PR_TRANSITIONS)
+
+    if current_pr is not None:
+        current = get_pr_state(current_pr)
+        if current != transition.from_state:
+            print(
+                f"[{log_prefix}] refusing PR transition {transition_name!r} on "
+                f"#{pr_number}: current state {current} does not match "
+                f"expected {transition.from_state}",
+                file=sys.stderr,
+            )
+            return False
+
+    if set_pr_labels is None:
+        from cai_lib.github import _set_pr_labels as set_pr_labels  # local import — avoids cycle at module load
+
+    return set_pr_labels(
+        pr_number,
+        add=list(transition.labels_add),
+        remove=list(transition.labels_remove),
+        log_prefix=log_prefix,
+    )
+
+
+def apply_pr_transition_with_confidence(
+    pr_number: int,
+    transition_name: str,
+    confidence: Optional[Confidence],
+    *,
+    current_pr: Optional[dict] = None,
+    log_prefix: str = "cai",
+    set_pr_labels=None,
+) -> tuple[bool, bool]:
+    """Confidence-gated PR transition. Mirrors ``apply_transition_with_confidence``."""
+    transition = find_transition(transition_name, PR_TRANSITIONS)
+
+    if transition.accepts(confidence):
+        ok = apply_pr_transition(
+            pr_number, transition_name,
+            current_pr=current_pr,
+            log_prefix=log_prefix,
+            set_pr_labels=set_pr_labels,
+        )
+        return ok, False
+
+    if current_pr is not None:
+        current = get_pr_state(current_pr)
+        if current != transition.from_state:
+            print(
+                f"[{log_prefix}] refusing PR divert for {transition_name!r} on "
+                f"#{pr_number}: current state {current} does not match "
+                f"expected {transition.from_state}",
+                file=sys.stderr,
+            )
+            return False, False
+
+    if set_pr_labels is None:
+        from cai_lib.github import _set_pr_labels as set_pr_labels  # local import — avoids cycle at module load
+
+    conf_name = confidence.name if confidence is not None else "MISSING"
+    print(
+        f"[{log_prefix}] diverting PR {transition_name!r} on #{pr_number} to "
+        f"{transition.human_label_if_below} (confidence={conf_name}, "
+        f"required={transition.min_confidence.name})",
+        flush=True,
+    )
+    ok = set_pr_labels(
+        pr_number,
+        add=[transition.human_label_if_below],
+        remove=list(transition.labels_remove),
+        log_prefix=log_prefix,
+    )
+    return ok, True
 
 
 def resume_pr_transition_for(target_state_name: str) -> Optional[Transition]:

--- a/cai_lib/github.py
+++ b/cai_lib/github.py
@@ -108,6 +108,23 @@ def _set_labels(issue_number: int, *, add: list[str] = (), remove: list[str] = (
     return True
 
 
+def _set_pr_labels(pr_number: int, *, add: list[str] = (), remove: list[str] = (), log_prefix: str = "cai") -> bool:
+    """Add and/or remove labels on a PR. Returns True on success."""
+    args = ["pr", "edit", str(pr_number), "--repo", REPO]
+    for label in add:
+        args.extend(["--add-label", label])
+    for label in remove:
+        args.extend(["--remove-label", label])
+    result = _run(["gh"] + args, capture_output=True)
+    if result.returncode != 0:
+        print(
+            f"[{log_prefix}] failed to update labels on PR #{pr_number}:\n{result.stderr}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
 def _issue_has_label(issue_number: int, label: str) -> bool:
     """Re-fetch an issue's labels and check for *label*. Avoids stale-snapshot races."""
     try:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@
 5. **Plan** — `cai plan` runs plan-select agents to generate and select an implementation plan. The plan is stored in the issue body. The select agent emits a trailing `Confidence:` line: at `HIGH` the label auto-transitions to `auto-improve:plan-approved`; at `MEDIUM` / `LOW` / missing it diverts to `auto-improve:human-needed` with a pending marker so an admin can review the plan.
 6. **Admin Resume (low-confidence only)** — `cai unblock` classifies an admin's comment on a `:human-needed` issue; a HIGH-confidence `PLAN_APPROVED` verdict fires `human_to_plan_approved` and the issue continues. Ambiguous or dissenting admin comments send the issue back through the planner.
 7. **Fix** — `cai implement` calls `cai-implement` on `auto-improve:plan-approved` issues in a fresh git worktree. The wrapper commits, pushes, and opens a PR. Label transitions to `auto-improve:in-progress` → `auto-improve:pr-open`.
-8. **Review** — `cai review-pr` checks for ripple-effect inconsistencies, posts findings as PR comments, and sets the `pr:reviewed-accept` or `pr:reviewed-reject` label. `cai review-docs` then (and only after review-pr has set `pr:reviewed-accept`) checks for stale documentation, directly fixes issues it can resolve, and commits/pushes those changes to the PR branch. Remaining unfixable issues are posted as `### Finding: stale_docs` comments. This ordering is enforced: review-docs skips PRs until the `pr:reviewed-accept` label is present.
+8. **Review** — `cai review-pr` checks for ripple-effect inconsistencies, posts findings as PR comments, and transitions the PR into `pr:reviewing-docs` (clean) or `pr:revision-pending` (findings). `cai review-docs` only runs on PRs in `pr:reviewing-docs`: it checks for stale documentation, directly fixes issues it can resolve, and commits/pushes those changes to the PR branch. Remaining unfixable issues are posted as `### Finding: stale_docs` comments. Docs review is terminal — on clean the PR stays in `pr:reviewing-docs` so `cai merge` can advance; on a docs push the PR drops back to `pr:reviewing-code` for re-review.
 9. **Revise** — `cai revise` calls `cai-revise` or `cai-rebase` to address review comments or rebase conflicts. Label transitions to `auto-improve:revising`.
 9.5. **CI Fix** — `cai fix-ci` calls `cai-fix-ci` to diagnose and fix failing GitHub Actions checks on open PRs. The subagent reads the failure log (last 200 lines, up to 2 failing checks), locates the root cause in the clone, and makes the minimal fix. A per-SHA marker comment (`## CI-fix subagent: fix attempt`) is always posted after each run — whether or not a fix was produced — so the loop guard fires on the next tick if CI is still red. PRs with unaddressed review comments are skipped (left for `cai revise`); PRs with `:needs-human-review` or `:merge-blocked` are always skipped.
 10. **Merge** — `cai merge` calls `cai-merge` to assess confidence and auto-merges PRs that meet the threshold. Label transitions to `auto-improve:merged`.
@@ -39,10 +39,10 @@
 | `audit:needs-human` | Audit finding escalated to human |
 | `merge-blocked` | PR has a blocking review finding; will not auto-merge |
 | `needs-human-review` | Issue or PR requires human attention |
-| `pr:edited` | PR branch has been updated by `cai revise`, `cai review-docs`, or polling sweep (when non-bot commits are detected after a stale pipeline label) |
-| `pr:reviewed-accept` | `cai review-pr` completed and posted a clean verdict (no findings) |
-| `pr:reviewed-reject` | `cai review-pr` completed and posted findings (changes needed) |
-| `pr:documented` | `cai review-docs` completed (documentation is current) |
+| `pr:reviewing-code` | PR is in code review (`cai review-pr`); a new SHA lands here on any push |
+| `pr:revision-pending` | `cai review-pr` posted findings; `cai revise` will address them |
+| `pr:reviewing-docs` | Code review clean; docs review is next, and merge fires from this state once a clean docs comment lands at HEAD |
+| `pr:ci-failing` | Checks are red; `cai fix-ci` is the action — returns to `pr:reviewing-code` after a push |
 
 ## The Cycle Command
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -140,7 +140,7 @@ Run the plan-select pipeline on the oldest `auto-improve:refined` issue. Clones 
 
 Review open PRs for stale documentation using `cai-review-docs`. Directly fixes stale documentation it finds and pushes commits to the PR branch. Posts `### Fixed: stale_docs` blocks for successfully fixed docs, and `### Finding: stale_docs` blocks for issues that cannot be fixed automatically.
 
-**Note:** `review-docs` skips PRs until the `pr:reviewed-accept` label is set (set by `cai review-pr`). This enforces the `review-pr` → `review-docs` → `merge` ordering.
+**Note:** `review-docs` only runs on PRs in the `pr:reviewing-docs` state (set by `cai review-pr` after a clean code review). This enforces the `review-pr` → `review-docs` → `merge` ordering.
 
 | Argument | Type | Description |
 |---|---|---|

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -42,13 +42,18 @@ stateDiagram-v2
 
 ```mermaid
 stateDiagram-v2
-    OPEN --> REVIEWING : pr_open_to_reviewing [≥HIGH]
-    REVIEWING --> REVISION_PENDING : reviewing_to_revision_pending [≥HIGH]
-    REVISION_PENDING --> REVIEWING : revision_pending_to_reviewing [≥HIGH]
-    REVIEWING --> APPROVED : reviewing_to_approved [≥HIGH]
-    APPROVED --> MERGED : approved_to_merged [≥HIGH]
-    REVIEWING --> PR_HUMAN_NEEDED : pr_to_human [≥HIGH]
-    PR_HUMAN_NEEDED --> REVIEWING : pr_human_to_reviewing [≥HIGH]
+    OPEN --> REVIEWING_CODE : open_to_reviewing_code [≥HIGH]
+    REVIEWING_CODE --> REVISION_PENDING : reviewing_code_to_revision_pending [≥HIGH]
+    REVIEWING_CODE --> REVIEWING_DOCS : reviewing_code_to_reviewing_docs [≥HIGH]
+    REVISION_PENDING --> REVIEWING_CODE : revision_pending_to_reviewing_code [≥HIGH]
+    REVIEWING_DOCS --> REVIEWING_CODE : reviewing_docs_to_reviewing_code [≥HIGH]
+    REVIEWING_DOCS --> MERGED : reviewing_docs_to_merged [≥HIGH]
+    REVIEWING_CODE --> CI_FAILING : reviewing_code_to_ci_failing [≥HIGH]
+    REVISION_PENDING --> CI_FAILING : revision_pending_to_ci_failing [≥HIGH]
+    REVIEWING_DOCS --> CI_FAILING : reviewing_docs_to_ci_failing [≥HIGH]
+    CI_FAILING --> REVIEWING_CODE : ci_failing_to_reviewing_code [≥HIGH]
+    REVIEWING_CODE --> PR_HUMAN_NEEDED : reviewing_code_to_human [≥HIGH]
+    PR_HUMAN_NEEDED --> REVIEWING_CODE : pr_human_to_reviewing_code [≥HIGH]
     PR_HUMAN_NEEDED --> REVISION_PENDING : pr_human_to_revision_pending [≥HIGH]
-    PR_HUMAN_NEEDED --> APPROVED : pr_human_to_approved [≥HIGH]
+    PR_HUMAN_NEEDED --> REVIEWING_DOCS : pr_human_to_reviewing_docs [≥HIGH]
 ```

--- a/publish.py
+++ b/publish.py
@@ -105,10 +105,10 @@ LABELS = [
     ("auto-improve:pr-human-needed", "e11d48", "PR parked awaiting admin comment (cai-unblock resume)"),
     ("merge-blocked", "e11d48", "Merge subcommand reviewed and decided not to auto-merge; awaiting human"),
     ("needs-human-review", "e11d48", "PR needs a human decision before merge"),
-    ("pr:edited",          "e4e669", "Branch was pushed; needs review-pr"),
-    ("pr:reviewed-reject", "d93f0b", "review-pr posted findings; revise needed"),
-    ("pr:reviewed-accept", "0075ca", "review-pr clean; ready for review-docs"),
-    ("pr:documented",      "0e8a16", "review-docs clean; ready for merge"),
+    ("pr:reviewing-code",   "e4e669", "PR is in code review (cai-review-pr)"),
+    ("pr:revision-pending", "d93f0b", "Code review posted findings; revise needed"),
+    ("pr:reviewing-docs",   "0075ca", "Code clean; in docs review (cai-review-docs)"),
+    ("pr:ci-failing",       "e11d48", "CI is red; cai-fix-ci will attempt a repair"),
     ("category:reliability", "d73a4a", "Errors, failures, flaky behavior"),
     ("category:cost_reduction", "fbca04", "Token waste, unnecessary tool calls"),
     ("category:prompt_quality", "0075ca", "Unclear or missing prompt guidance"),
@@ -124,6 +124,13 @@ LABELS_TO_DELETE = [
     "auto-improve:merge-blocked",     # stale — superseded by merge-blocked
     "auto-improve:needs-refinement",  # stale — superseded by the refine agent deciding on exploration
     "auto-improve:in-pr",             # dead — FSM drift with auto-improve:pr-open; aligned on :pr-open
+    # Legacy PR pipeline labels — replaced by first-class PRState labels
+    # (pr:reviewing-code / pr:revision-pending / pr:reviewing-docs /
+    # pr:ci-failing). Migration runs on cmd_cycle entry.
+    "pr:edited",
+    "pr:reviewed-reject",
+    "pr:reviewed-accept",
+    "pr:documented",
 ]
 
 AUDIT_LABELS = [

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -323,7 +323,7 @@ class TestResumeFromHuman(unittest.TestCase):
 class TestResumePRTransition(unittest.TestCase):
 
     def test_known_pr_targets(self):
-        for name in ("REVIEWING", "REVISION_PENDING", "APPROVED"):
+        for name in ("REVIEWING_CODE", "REVISION_PENDING", "REVIEWING_DOCS"):
             t = resume_pr_transition_for(name)
             self.assertIsNotNone(t, f"no PR resume transition for {name}")
             self.assertEqual(t.from_state, PRState.PR_HUMAN_NEEDED)
@@ -335,13 +335,13 @@ class TestResumePRTransition(unittest.TestCase):
         # PRState has no OPEN→from-PR_HUMAN_NEEDED path.
         self.assertIsNone(resume_pr_transition_for("OPEN"))
         # MERGED is deliberately excluded — PRs must funnel through
-        # REVIEWING / REVISION_PENDING / APPROVED; admins never merge
-        # a PR from PR_HUMAN_NEEDED directly.
+        # the review states; admins never merge from PR_HUMAN_NEEDED
+        # directly.
         self.assertIsNone(resume_pr_transition_for("MERGED"))
 
     def test_issue_and_pr_resolvers_are_disjoint(self):
         # Passing a PRState name to the issue resolver must return None.
-        self.assertIsNone(resume_transition_for("REVIEWING"))
+        self.assertIsNone(resume_transition_for("REVIEWING_CODE"))
         # Passing an IssueState-only name to the PR resolver must return None.
         self.assertIsNone(resume_pr_transition_for("REFINING"))
 
@@ -457,7 +457,73 @@ class TestTransientStatesShape(unittest.TestCase):
         ]
         self.assertEqual(forbidden, [],
             "PR_HUMAN_NEEDED → MERGED must not exist; admins funnel back "
-            "through REVISION_PENDING / APPROVED")
+            "through REVIEWING_CODE / REVISION_PENDING / REVIEWING_DOCS")
+
+
+class TestPRStateShape(unittest.TestCase):
+    """Pin the redesigned PRState shape (CI_FAILING + REVIEWING_DOCS first-class)."""
+
+    def test_expected_pr_states(self):
+        expected = {
+            "OPEN", "REVIEWING_CODE", "REVISION_PENDING",
+            "REVIEWING_DOCS", "CI_FAILING", "MERGED", "PR_HUMAN_NEEDED",
+        }
+        self.assertEqual({s.name for s in PRState}, expected)
+
+    def test_ci_failing_reachable_from_all_pre_merge(self):
+        """Every pre-merge non-CI_FAILING state must have a path into CI_FAILING."""
+        pre_merge = {
+            PRState.REVIEWING_CODE, PRState.REVISION_PENDING, PRState.REVIEWING_DOCS,
+        }
+        have_path = {
+            t.from_state for t in PR_TRANSITIONS
+            if t.to_state == PRState.CI_FAILING
+        }
+        self.assertFalse(pre_merge - have_path,
+                         f"no *_to_ci_failing from: {pre_merge - have_path}")
+
+    def test_ci_failing_returns_to_reviewing_code(self):
+        t = find_transition("ci_failing_to_reviewing_code")
+        self.assertEqual(t.from_state, PRState.CI_FAILING)
+        self.assertEqual(t.to_state, PRState.REVIEWING_CODE)
+
+    def test_reviewing_docs_terminal_gate(self):
+        """REVIEWING_DOCS outgoing: back to code, MERGED, or CI_FAILING."""
+        dests = {
+            t.to_state
+            for t in PR_TRANSITIONS
+            if t.from_state == PRState.REVIEWING_DOCS
+        }
+        self.assertEqual(
+            dests, {PRState.REVIEWING_CODE, PRState.MERGED, PRState.CI_FAILING},
+        )
+
+    def test_get_pr_state_from_labels(self):
+        """get_pr_state derives from pipeline labels (post-redesign)."""
+        from cai_lib.fsm import get_pr_state
+        from cai_lib.config import (
+            LABEL_PR_REVIEWING_CODE, LABEL_PR_REVIEWING_DOCS,
+            LABEL_PR_CI_FAILING, LABEL_PR_REVISION_PENDING,
+            LABEL_PR_HUMAN_NEEDED,
+        )
+        cases = [
+            ([LABEL_PR_REVIEWING_CODE],    PRState.REVIEWING_CODE),
+            ([LABEL_PR_REVISION_PENDING],  PRState.REVISION_PENDING),
+            ([LABEL_PR_REVIEWING_DOCS],    PRState.REVIEWING_DOCS),
+            ([LABEL_PR_CI_FAILING],        PRState.CI_FAILING),
+            ([LABEL_PR_HUMAN_NEEDED],      PRState.PR_HUMAN_NEEDED),
+            ([],                           PRState.OPEN),
+        ]
+        for labels, expected in cases:
+            pr = {"labels": [{"name": l} for l in labels]}
+            self.assertEqual(get_pr_state(pr), expected, f"labels={labels}")
+
+        self.assertEqual(
+            get_pr_state({"merged": True, "labels": [{"name": LABEL_PR_REVIEWING_CODE}]}),
+            PRState.MERGED,
+        )
+        both = [{"name": LABEL_PR_REVIEWING_CODE}, {"name": LABEL_PR_CI_FAILING}]
+        self.assertEqual(get_pr_state({"labels": both}), PRState.CI_FAILING)
 
 
 class TestTriagingState(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Collapse the old two-layer PR state scheme (`PRState` derived from GitHub's `reviewDecision` + separate wrapper-side `pr:edited` / `pr:reviewed-accept` / `pr:reviewed-reject` / `pr:documented` labels managed by `_pr_set_pipeline_state`) onto one label per PRState.
- New states: `REVIEWING_CODE`, `REVISION_PENDING`, `REVIEWING_DOCS`, `CI_FAILING` (plus existing `OPEN`, `MERGED`, `PR_HUMAN_NEEDED`). Dropped `REVIEWING` and `APPROVED` from the enum.
- Wire every call site through the new `apply_pr_transition` helper: `cmd_review_pr`, `cmd_review_docs`, `cmd_revise`, `cmd_fix_ci`, `cmd_merge`, and the PR label sweep.
- Merge gate tightened: require `PRState.REVIEWING_DOCS` AND a clean docs-review comment at current HEAD (was: `pr:reviewed-accept OR pr:documented`, then `pr:documented`).
- One-time idempotent migration helper (`_migrate_legacy_pr_pipeline_labels`) runs at the top of every `cmd_cycle` tick; becomes a no-op once the queue is clear.

## Why

CI health and docs review were running as out-of-band phase loops around the FSM — the exact "parallel wrapper-side safety net" antipattern flagged in the project's own memory. This refactor folds both into the FSM so every observable PR condition corresponds to one state with one action. Prerequisite for the upcoming issue-serial cycle dispatcher (dispatch becomes "read state → run the one action for that state").

## Test plan

- [x] `python -m unittest discover tests` — 101/101 pass (added `TestPRStateShape` covering CI_FAILING reachability, REVIEWING_DOCS as terminal gate, label-based `get_pr_state` derivation).
- [x] `scripts/generate-fsm-docs.py` regenerates `docs/fsm.md` cleanly from the new transition table.
- [x] No dangling references to the legacy labels or `_pr_set_pipeline_state` in code (only in the migration map and `LABELS_TO_DELETE`).
- [ ] In-container smoke: `cmd_cycle` Phase 0 migrates any PR that was carrying old labels (idempotent — second run is a no-op).

Three follow-on commits on this branch, each self-contained:
1. `refactor(fsm): add PRState first-class CI_FAILING + REVIEWING_DOCS` — enum/labels/tests
2. `refactor(cycle): swap PR caller sites onto apply_pr_transition` — wrapper call sites
3. `refactor(fsm): migrate in-flight PRs + regenerate docs` — migration + docs regen

PR #634 is an unrelated parallel fix (review-pr budget salvage); do not conflate.