### PR TITLE
chore: remove deprecated cmd_fix shim

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -44,7 +44,6 @@
 | `README.md` | Project documentation and usage guide |
 | `cai.py` | Main CLI dispatcher — 16+ subcommands for the self-improvement loop |
 | `cai_lib/__init__.py` | Package init for cai_lib library modules |
-| `cai_lib/cmd_fix.py` | Deprecated shim redirecting to cai_lib.cmd_implement |
 | `cai_lib/cmd_implement.py` | Helpers for the implement-subagent pipeline |
 | `cai_lib/cmd_lifecycle.py` | Pipeline state-transition helpers |
 | `cai_lib/cmd_unblock.py` | Admin-comment-driven FSM resume for :human-needed issues (calls cai-unblock) |

--- a/cai_lib/cmd_fix.py
+++ b/cai_lib/cmd_fix.py
@@ -1,3 +1,0 @@
-"""cai_lib.cmd_fix — deprecated shim; use cai_lib.cmd_implement instead."""
-
-from cai_lib.cmd_implement import _parse_decomposition  # noqa: F401

--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -57,7 +57,6 @@ declare -A DESCRIPTIONS=(
   [".github/workflows/docker-publish.yml"]="CI: build and publish Docker image to Docker Hub"
   [".github/workflows/regenerate-docs.yml"]="CI: regenerate CODEBASE_INDEX.md and docs/fsm.md, auto-commit drift"
   ["cai_lib/__init__.py"]="Package init for cai_lib library modules"
-  ["cai_lib/cmd_fix.py"]="Deprecated shim redirecting to cai_lib.cmd_implement"
   ["cai_lib/cmd_implement.py"]="Helpers for the implement-subagent pipeline"
   ["cai_lib/cmd_lifecycle.py"]="Pipeline state-transition helpers"
   ["cai_lib/cmd_unblock.py"]="Admin-comment-driven FSM resume for :human-needed issues (calls cai-unblock)"


### PR DESCRIPTION
## Summary
- Remove `cai_lib/cmd_fix.py`, a one-line re-export shim left over from the cai-fix → cai-implement rename with no importers.
- Drop its entries in `CODEBASE_INDEX.md` and `scripts/generate-index.sh`.

## Test plan
- [ ] CI green