### PR TITLE
chore: remove references to deprecated human:submitted label

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,8 +363,7 @@ The threshold defaults to `high` — only the most clear-cut PRs merge
 or close automatically. Relax to `medium` by editing the env var once
 trust builds.
 
-`auto-improve:raised` is the sole human entry point into the pipeline
-(the former `human:submitted` label has been folded back into `:raised`).
+`auto-improve:raised` is the sole human entry point into the pipeline.
 It is restricted to repo admins by `.github/workflows/admin-only-label.yml` — a non-admin who
 applies it gets the label removed and a comment explaining why. Issues labelled `auto-improve:raised`
 transition through the full planning pipeline: `refine` → `plan` → `auto-improve:plan-approved`

--- a/cai.py
+++ b/cai.py
@@ -203,7 +203,6 @@ from cai_lib.github import (  # noqa: E402
 )
 from cai_lib.cmd_lifecycle import (  # noqa: E402
     _rollback_stale_in_progress, _reconcile_interrupted,
-    _migrate_legacy_human_submitted,
     _migrate_legacy_pr_pipeline_labels,
 )
 from cai_lib.cmd_unblock import cmd_unblock  # noqa: E402
@@ -7826,10 +7825,6 @@ def cmd_refine(args) -> int:
     """Invoke the cai-refine agent on the oldest :raised issue."""
     print("[cai refine] looking for issues to refine", flush=True)
     t0 = time.monotonic()
-
-    # Drain any open issues still carrying the retired human:submitted
-    # label — idempotent and free once the queue is empty.
-    _migrate_legacy_human_submitted()
 
     # 1. Find candidates.
     if getattr(args, "issue", None) is not None:

--- a/cai_lib/cmd_lifecycle.py
+++ b/cai_lib/cmd_lifecycle.py
@@ -29,53 +29,6 @@ from cai_lib.github import _gh_json, _set_labels, _set_pr_labels, _issue_has_lab
 from cai_lib.logging_utils import log_run
 
 
-# Label retired in favour of folding human submissions directly into
-# :raised. Helper below migrates any open issue still carrying it.
-_LEGACY_HUMAN_SUBMITTED_LABEL = "human:submitted"
-
-
-def _migrate_legacy_human_submitted() -> int:
-    """Relabel open issues carrying the retired ``human:submitted`` to ``:raised``.
-
-    Idempotent — safe to invoke at the top of every cmd_refine run; once
-    the queue is empty the function becomes a single gh call that does
-    nothing. Returns the number of issues relabelled this invocation.
-    """
-    try:
-        issues = _gh_json([
-            "issue", "list",
-            "--repo", REPO,
-            "--label", _LEGACY_HUMAN_SUBMITTED_LABEL,
-            "--state", "open",
-            "--json", "number,labels",
-            "--limit", "100",
-        ]) or []
-    except subprocess.CalledProcessError as e:
-        print(
-            f"[cai refine] migration gh issue list failed:\n{e.stderr}",
-            file=sys.stderr,
-        )
-        return 0
-
-    migrated = 0
-    for issue in issues:
-        num = issue["number"]
-        labels = {lbl["name"] for lbl in issue.get("labels", [])}
-        add = [] if LABEL_RAISED in labels else [LABEL_RAISED]
-        if _set_labels(
-            num,
-            add=add,
-            remove=[_LEGACY_HUMAN_SUBMITTED_LABEL],
-            log_prefix="cai refine",
-        ):
-            migrated += 1
-            print(
-                f"[cai refine] migrated #{num}: human:submitted -> :raised",
-                flush=True,
-            )
-    return migrated
-
-
 # Legacy PR pipeline labels retired when PRState absorbed CI health
 # and docs-review as first-class states. Mapping reflects the FSM
 # meaning of each old label:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 `robotsix-cai` is a self-improving agent system. The continuous loop runs inside a long-lived Docker container and drives GitHub issues through a well-defined lifecycle:
 
-1. **Raise** — `cai analyze`, `cai propose`, `cai code-audit`, `cai audit`, or a human files an issue labeled `auto-improve:raised` (the sole entry point — the former `human:submitted` label has been folded into `:raised`).
+1. **Raise** — `cai analyze`, `cai propose`, `cai code-audit`, `cai audit`, or a human files an issue labeled `auto-improve:raised` (the sole entry point).
 2. **Triage** — `cai triage` calls `cai-triage` to classify the issue as REFINE, DISMISS_DUPLICATE, DISMISS_RESOLVED, or HUMAN. DISMISS verdicts at HIGH confidence close the issue; others route to REFINE, setting a `kind:{code,maintenance}` label. Label transitions to `auto-improve:triaging` → `auto-improve:refining` (or `auto-improve:human-needed`).
 3. **Refine** — `cai refine` calls `cai-refine` to rewrite the issue into a structured plan with steps, verification, and scope guardrails. Label transitions to `auto-improve:refined`.
 5. **Plan** — `cai plan` runs plan-select agents to generate and select an implementation plan. The plan is stored in the issue body. The select agent emits a trailing `Confidence:` line: at `HIGH` the label auto-transitions to `auto-improve:plan-approved`; at `MEDIUM` / `LOW` / missing it diverts to `auto-improve:human-needed` with a pending marker so an admin can review the plan.

--- a/publish.py
+++ b/publish.py
@@ -120,7 +120,6 @@ LABELS = [
 # when the label is absent, so check=False is required).
 LABELS_TO_DELETE = [
     "human:requested",                # removed — auto-improve:raised is the sole human entry point
-    "human:submitted",                # removed — folded back into auto-improve:raised
     "auto-improve:merge-blocked",     # stale — superseded by merge-blocked
     "auto-improve:needs-refinement",  # stale — superseded by the refine agent deciding on exploration
     "auto-improve:in-pr",             # dead — FSM drift with auto-improve:pr-open; aligned on :pr-open


### PR DESCRIPTION
## Summary
- Drop the `_LEGACY_HUMAN_SUBMITTED_LABEL` constant and `_migrate_legacy_human_submitted()` helper from `cai_lib/cmd_lifecycle.py`
- Remove the import and call site in `cai.py` (`cmd_refine`)
- Remove `human:submitted` from `publish.py` `LABELS_TO_DELETE`
- Trim the "folded into :raised" parentheticals from `README.md` and `docs/architecture.md`

## Test plan
- [ ] CI green

Generated with Claude Code