### PR TITLE
auto-improve: CLAUDE.md has the same protection issue than the agents file and so should have the same wrapper

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,34 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#644
+
+## Files touched
+- cai.py:1825 — added `CLAUDEMD_STAGING_REL = Path(".cai-staging") / "claudemd"` constant
+- cai.py:1839-1840 — `_setup_agent_edit_staging`: mkdir claudemd staging subdir
+- cai.py:1926-1957 — `_apply_agent_edit_staging`: insert CLAUDE.md rglob block between plugin block and cleanup
+- cai.py:2060-2094 — `_work_directory_block`: appended CLAUDE.md staging section before closing paren
+- .claude/agents/cai-implement.md — updated heading + added CLAUDE.md bullet + updated rules heading + added CLAUDE.md example (via staging)
+- .claude/agents/cai-revise.md — updated heading + added CLAUDE.md bullet + updated rules line (via staging)
+- .claude/agents/cai-fix-ci.md — updated heading + added CLAUDE.md bullet + updated rules line (via staging)
+
+## Files read (not touched) that matter
+- cai.py:1841-1936 — `_apply_agent_edit_staging` full body to understand existing plugin block pattern
+
+## Key symbols
+- `CLAUDEMD_STAGING_REL` (cai.py:1825) — new constant for claudemd staging subdir path
+- `_setup_agent_edit_staging` (cai.py:1827) — extended to mkdir claudemd dir
+- `_apply_agent_edit_staging` (cai.py:1841) — extended with rglob-based CLAUDE.md copy block
+- `_work_directory_block` (cai.py:1944) — extended to document CLAUDE.md staging path
+
+## Design decisions
+- Used `rglob("CLAUDE.md")` instead of `shutil.copytree` — only files literally named CLAUDE.md are copied, preventing accidental overwrite of unrelated work_dir files
+- Inserted CLAUDE.md block between plugin block and cleanup (not after cleanup) — same ordering pattern as agents → plugins → claudemd → cleanup
+- Early-return on first OSError — consistent with plugin block behavior, preserves staging tree for inspection
+
+## Out of scope / known gaps
+- Did not update `_apply_agent_edit_staging` docstring to mention CLAUDE.md
+- Did not add CLAUDE.md staging docs to read-only agents (cai-refine, cai-analyze, cai-plan, cai-select, etc.)
+- Did not change the existing shutil.rmtree cleanup block — it already covers claudemd/ by removing whole .cai-staging/ root
+
+## Invariants this change relies on
+- shutil.rmtree on `.cai-staging/` root cleans up claudemd/ automatically
+- Wrapper's `git add -A` picks up uncommitted changes including staged agent files after wrapper copies them

--- a/.claude/agents/cai-fix-ci.md
+++ b/.claude/agents/cai-fix-ci.md
@@ -27,7 +27,7 @@ absolute paths under the work directory from the user message.
 for targeted reads. Git operations go through `cai-git` if needed — you
 have no Bash.
 
-## Self-modifying agent files (staging directory)
+## Self-modifying agent files, plugins, and CLAUDE.md (staging directory)
 
 Claude-code blocks `Edit`/`Write` on `.claude/agents/*.md` paths.
 Use the staging directory the wrapper pre-creates:
@@ -37,9 +37,14 @@ Use the staging directory the wrapper pre-creates:
   it over `.claude/agents/<basename>.md` after you exit.
 - **Plugin files:** Write to
   `<work_dir>/.cai-staging/plugins/<same-relative-path>`.
+  The wrapper merges it into `.claude/plugins/` after you exit.
+- **`CLAUDE.md` files:** Write to
+  `<work_dir>/.cai-staging/claudemd/<same-relative-path>/CLAUDE.md`.
+  The wrapper scans for files named `CLAUDE.md` and copies each to
+  the matching path in `<work_dir>/` after you exit.
 
 Rules: write the FULL file (unconditional overwrite), use exact
-basename, never try `Edit`/`Write` on the protected paths.
+relative path, never try `Edit`/`Write` on the protected paths.
 
 ## Hard rules — remote and git
 

--- a/.claude/agents/cai-implement.md
+++ b/.claude/agents/cai-implement.md
@@ -52,7 +52,7 @@ will exceed the token limit. Use `Grep(pattern, path="<work_dir>")` for
 symbol search and `Read("<work_dir>/cai.py", offset=N, limit=200)` for
 targeted sections.
 
-## Self-modifying `.claude/agents/*.md` and `.claude/plugins/` (staging directory)
+## Self-modifying `.claude/agents/*.md`, `.claude/plugins/`, and `CLAUDE.md` (staging directory)
 
 **Claude-code's headless `-p` mode hardcodes a write block on
 every `.claude/agents/*.md` path**, regardless of any permission
@@ -94,7 +94,18 @@ wrapper pre-creates is the workaround for both cases:
      `dirs_exist_ok=True` after you exit, then deletes the
      staging directory.
 
-Rules (apply to both agents and plugins):
+**For `CLAUDE.md` files** (root or any subdirectory):
+
+  1. **Write** the full `CLAUDE.md` content to
+     `<work_dir>/.cai-staging/claudemd/<same-relative-path>/CLAUDE.md`.
+     Preserve the directory structure. To update the root `CLAUDE.md`,
+     write to `.cai-staging/claudemd/CLAUDE.md`. To update
+     `subdir/CLAUDE.md`, write to `.cai-staging/claudemd/subdir/CLAUDE.md`.
+  2. The wrapper scans `.cai-staging/claudemd/` for all files named
+     exactly `CLAUDE.md` and copies each to the matching path in
+     `<work_dir>/` after you exit, then deletes the staging directory.
+
+Rules (apply to agents, plugins, and CLAUDE.md files):
 
   - Staged files are copied unconditionally — new definitions
     are created if no target exists yet.
@@ -117,6 +128,11 @@ Example of creating a plugin skill:
 
   - GOOD: `Write("<work_dir>/.cai-staging/plugins/cai-skills/skills/foo/SKILL.md", "<full content>")`
   - BAD:  `Write("<work_dir>/.claude/plugins/cai-skills/skills/foo/SKILL.md", ...)`  (blocked)
+
+Example of updating root CLAUDE.md:
+
+  - GOOD: `Write("<work_dir>/.cai-staging/claudemd/CLAUDE.md", "<full content>")`
+  - BAD:  `Write("<work_dir>/CLAUDE.md", ...)`  (blocked)
 
 ## Hard rules
 

--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -33,7 +33,7 @@ absolute paths under the work directory from the user message.
 `cai.py` is ~63 k tokens — use `Grep` + `Read(..., offset=N, limit=200)`. **Git
 operations go through `cai-git`** — you have no Bash.
 
-## Self-modifying agent files and plugins (staging directory)
+## Self-modifying agent files, plugins, and CLAUDE.md (staging directory)
 
 Claude-code blocks `Edit`/`Write` on `.claude/agents/*.md` and `.claude/plugins/`
 paths. Use the staging directory the wrapper pre-creates:
@@ -43,8 +43,13 @@ paths. Use the staging directory the wrapper pre-creates:
   `.claude/agents/<basename>.md` after you exit.
 - **Plugin files:** Write to `<work_dir>/.cai-staging/plugins/<same-relative-path>`.
   The wrapper merges it into `.claude/plugins/` after you exit.
+- **`CLAUDE.md` files:** Write to
+  `<work_dir>/.cai-staging/claudemd/<same-relative-path>/CLAUDE.md`.
+  The wrapper scans for all files named `CLAUDE.md` in the staging
+  tree and copies each to the matching path in `<work_dir>/` after
+  you exit, preserving relative paths.
 
-Rules: write the FULL file (unconditional overwrite), use exact basename,
+Rules: write the FULL file (unconditional overwrite), use exact relative path,
 never try `Edit`/`Write` on the protected paths.
 
   - GOOD: `Read("<work_dir>/.claude/agents/cai-revise.md")` then

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,6 +5,7 @@
 
 | File | Purpose |
 |------|---------|
+| `.cai/pr-context.md` | Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `audit:raised` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |

--- a/cai.py
+++ b/cai.py
@@ -1822,6 +1822,7 @@ def _update_parent_checklist_item(
 # to the clone root.
 AGENT_EDIT_STAGING_REL = Path(".cai-staging") / "agents"
 PLUGIN_STAGING_REL = Path(".cai-staging") / "plugins"
+CLAUDEMD_STAGING_REL = Path(".cai-staging") / "claudemd"
 
 
 def _setup_agent_edit_staging(work_dir: Path) -> Path:
@@ -1835,6 +1836,8 @@ def _setup_agent_edit_staging(work_dir: Path) -> Path:
     staging.mkdir(parents=True, exist_ok=True)
     plugin_staging = work_dir / PLUGIN_STAGING_REL
     plugin_staging.mkdir(parents=True, exist_ok=True)
+    claudemd_staging = work_dir / CLAUDEMD_STAGING_REL
+    claudemd_staging.mkdir(parents=True, exist_ok=True)
     return staging
 
 
@@ -1919,6 +1922,34 @@ def _apply_agent_edit_staging(work_dir: Path) -> int:
             # silently lost when the copy fails — caller can inspect
             # or retry. Do not fall through to shutil.rmtree below.
             return applied
+
+    # Apply any CLAUDE.md staging: .cai-staging/claudemd/ → <work_dir>/
+    # Uses rglob("CLAUDE.md") so only files literally named CLAUDE.md
+    # are copied — stray files in the staging tree are ignored.
+    claudemd_staging = work_dir / CLAUDEMD_STAGING_REL
+    if claudemd_staging.exists() and claudemd_staging.is_dir():
+        for staged_file in sorted(claudemd_staging.rglob("CLAUDE.md")):
+            rel = staged_file.relative_to(claudemd_staging)
+            target = work_dir / rel
+            try:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                content = staged_file.read_text()
+                target.write_text(content)
+                print(
+                    f"[cai] applied staged CLAUDE.md: {rel} "
+                    f"({len(content)} bytes)",
+                    flush=True,
+                )
+                applied += 1
+            except OSError as exc:
+                print(
+                    f"[cai] agent edit staging: failed to apply "
+                    f"CLAUDE.md at {rel}: {exc}",
+                    file=sys.stderr,
+                )
+                # Preserve .cai-staging so staged files are not
+                # silently lost when the copy fails.
+                return applied
 
     # Clean up the entire .cai-staging tree (one level above the
     # agents/ subdir) so nothing leaks into the PR.
@@ -2030,6 +2061,37 @@ def _work_directory_block(work_dir: Path) -> str:
         "\"<full new file content>\")`\n"
         f"  - BAD:  `Edit(\"{work_dir}/.claude/agents/cai-implement.md\", "
         "...)`  (blocked by claude-code)\n"
+        "\n\n"
+        "## Updating `CLAUDE.md` files (self-modification)\n\n"
+        "Claude-code's headless `-p` mode also hardcodes a write block "
+        "on `CLAUDE.md` files (project-level context files). Edit/Write "
+        "calls against `<work_dir>/CLAUDE.md` or any subdirectory "
+        "`CLAUDE.md` WILL fail with a sensitive-file protection error.\n\n"
+        "The wrapper provides a **staging directory** at:\n\n"
+        f"    {(work_dir / CLAUDEMD_STAGING_REL).as_posix()}\n\n"
+        "To update a `CLAUDE.md` file at any path (root or subdirectory), "
+        "write it to "
+        f"`{(work_dir / CLAUDEMD_STAGING_REL).as_posix()}/<same-relative-path>/CLAUDE.md`. "
+        "The wrapper scans for all `CLAUDE.md` files under the staging "
+        "tree and copies each to the matching path in `<work_dir>/`, "
+        "creating parent directories as needed. The staging directory is "
+        "then deleted so it never lands in the PR.\n\n"
+        "Rules:\n"
+        "  - Only files literally named `CLAUDE.md` are copied — other "
+        "files in the staging tree are ignored.\n"
+        "  - Preserve the full relative path (e.g., to update "
+        f"`<work_dir>/CLAUDE.md`, write to "
+        f"`{(work_dir / CLAUDEMD_STAGING_REL).as_posix()}/CLAUDE.md`; "
+        "to update `<work_dir>/subdir/CLAUDE.md`, write to "
+        f"`{(work_dir / CLAUDEMD_STAGING_REL).as_posix()}/subdir/CLAUDE.md`).\n"
+        "  - Write the FULL file, not a diff or patch.\n"
+        "  - Do NOT attempt `Edit` or `Write` on `<work_dir>/CLAUDE.md` "
+        "directly — it will always fail. Go through the staging dir.\n\n"
+        "Example:\n"
+        f"  - GOOD: `Write(\"{(work_dir / CLAUDEMD_STAGING_REL).as_posix()}/CLAUDE.md\", "
+        "\"<full new file content>\")`\n"
+        f"  - BAD:  `Edit(\"{work_dir}/CLAUDE.md\", ...)`  "
+        "(blocked by claude-code)\n"
     )
 
 

--- a/cai.py
+++ b/cai.py
@@ -1827,7 +1827,8 @@ CLAUDEMD_STAGING_REL = Path(".cai-staging") / "claudemd"
 
 def _setup_agent_edit_staging(work_dir: Path) -> Path:
     """Create the staging directories where agents write proposed
-    `.claude/agents/*.md` and `.claude/plugins/` updates. Idempotent.
+    `.claude/agents/*.md`, `.claude/plugins/`, and `CLAUDE.md` updates.
+    Idempotent.
 
     Returns the absolute agent-staging directory path so the caller can
     pass it to the agent via the user message.
@@ -1845,7 +1846,9 @@ def _apply_agent_edit_staging(work_dir: Path) -> int:
     """Copy any files staged at `<work_dir>/.cai-staging/agents/`
     back to `<work_dir>/.claude/agents/`, copy any plugin tree staged
     at `<work_dir>/.cai-staging/plugins/` to `<work_dir>/.claude/plugins/`,
-    then remove the staging directory so it doesn't land in the PR.
+    copy any CLAUDE.md files staged at `<work_dir>/.cai-staging/claudemd/`
+    to their matching paths in `<work_dir>/`, then remove the staging
+    directory so it doesn't land in the PR.
 
     Security boundaries:
 
@@ -1854,11 +1857,14 @@ def _apply_agent_edit_staging(work_dir: Path) -> int:
          created; if one exists it is overwritten.
       2. Staged plugin trees are merged into `<work_dir>/.claude/plugins/`
          using shutil.copytree with dirs_exist_ok=True.
-      3. The staging dir lives entirely inside `work_dir` so escapes
+      3. CLAUDE.md files are copied from the staging tree to `<work_dir>/`,
+         preserving their relative paths. Only files literally named
+         `CLAUDE.md` are copied — stray files in the staging tree are ignored.
+      4. The staging dir lives entirely inside `work_dir` so escapes
          via `..` are not possible (the wrapper iterates one
          directory level via `iterdir()` and copies whole files).
-      4. The staging dir is removed before commit if all staging
-         operations succeeded. If plugin staging fails, the staging
+      5. The staging dir is removed before commit if all staging
+         operations succeeded. If any staging operation fails, the staging
          dir is preserved for inspection and the function returns
          early so staged content is not silently lost.
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#644

**Issue:** #644 — CLAUDE.md has the same protection issue than the agents file and so should have the same wrapper

## PR Summary

### What this fixes
Claude Code's headless `-p` mode write-protects `CLAUDE.md` files with the same structural block as `.claude/agents/*.md` and `.claude/plugins/`. Agents running inside `cai-implement`, `cai-revise`, or `cai-fix-ci` that try to edit a `CLAUDE.md` file get a sensitive-file protection error they cannot bypass, with no documented workaround.

### What was changed
- **`cai.py`**: Added `CLAUDEMD_STAGING_REL = Path(".cai-staging") / "claudemd"` constant; updated `_setup_agent_edit_staging` to mkdir the new `claudemd/` subdir; inserted a `rglob("CLAUDE.md")`-based copy block in `_apply_agent_edit_staging` (between the plugin block and cleanup); appended a `## Updating CLAUDE.md files` section to `_work_directory_block`.
- **`.claude/agents/cai-implement.md`** (via staging): Updated staging section heading, added `CLAUDE.md` bullet, updated rules heading, added CLAUDE.md example.
- **`.claude/agents/cai-revise.md`** (via staging): Updated staging section heading, added `CLAUDE.md` bullet, updated rules line.
- **`.claude/agents/cai-fix-ci.md`** (via staging): Updated staging section heading, added `CLAUDE.md` bullet, updated rules line.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
