### PR TITLE
refactor: move verify and audit out of cmd_cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ targeted invocation, `cai.py dispatch --issue N` and
 
 | Subcommand | Default schedule | What it does |
 |---|---|---|
-| `cai.py cycle` | `0 * * * *` (hourly, startup, manual) | One dispatcher tick: restart-recover → verify → audit → `dispatch_oldest_actionable()` (runs the handler for whatever state the oldest actionable issue or PR is in). A flock serializes overlapping runs; the entrypoint also runs this once synchronously at `docker compose up -d` so startup logs are immediate |
+| `cai.py cycle` | `0 * * * *` (hourly, startup, manual) | One dispatcher tick: restart-recovery + `dispatch_oldest_actionable()` (runs the handler for whatever state the oldest actionable issue or PR is in). A flock serializes overlapping runs; the entrypoint also runs this once synchronously at `docker compose up -d` so startup logs are immediate |
+| `cai.py verify` | `15 * * * *` (hourly @15) | Label-state reconciliation — keeps `:pr-open` / `:merged` / etc. consistent with actual GitHub state |
 | `cai.py dispatch [--issue N \| --pr N]` | _(manual/on-demand)_ | Direct entry into the FSM dispatcher for a specific issue or PR (or the oldest actionable item when no target is given) |
 | `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` (6-hour TTL) and `:revising` (1-hour TTL) locks and stale `:no-action` issues, flags stale `:merged` issues for human review, recovers `:pr-open` issues whose linked PR was closed (rolls back to `:refined`), deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `audit:raised` issues (Sonnet) |
@@ -76,7 +77,7 @@ targeted invocation, `cai.py dispatch --issue N` and
 | `cai.py health-report` | `0 7 * * 1` (weekly Monday 07:00 UTC) | Automated pipeline health report with anomaly detection. Aggregates cost trends (last 7d vs prior 7d WoW delta), issue queue counts per label state, pipeline stalls, and fix quality metrics. Posts a GitHub-flavored markdown report with 🔴/🟡/🟢 traffic-light indicators as a `health-report` labelled issue. Use `--dry-run` to print to stdout without posting. |
 | `cai.py cost-optimize` | `0 5 * * 0` (weekly Sunday 05:00 UTC) | Weekly cost-reduction agent — loads 14 days of cost data, computes per-agent WoW deltas and cache hit rates, and proposes one concrete optimization targeting the most expensive agent or workflow. Alternates with evaluating previous proposals to track effectiveness. Files proposals as `auto-improve:raised` issues. |
 | `cai.py check-workflows` | `0 */6 * * *` (every 6 hours) | GitHub Actions failure monitor — fetches recent failed workflow runs (last 24 h), filters out bot branches, and runs a Haiku agent to group related failures and identify root causes; findings are published as `check-workflows` namespace issues. |
-| `cai.py verify` / `audit` / `unblock` | _(invoked by `cycle`; also manual/on-demand)_ | Housekeeping subcommands that are not FSM handlers. Per-state handlers (triage, refine, plan, implement, explore, confirm, review-pr, revise, review-docs, fix-ci, merge) are no longer standalone subcommands — invoke them via `cai.py dispatch`. |
+| `cai.py verify` / `audit` / `unblock` | _(own cron schedules; also manual/on-demand)_ | Housekeeping subcommands that are not FSM handlers. Per-state handlers (triage, refine, plan, implement, explore, confirm, review-pr, revise, review-docs, fix-ci, merge) are no longer standalone subcommands — invoke them via `cai.py dispatch`. |
 | `cai.py test` | _(manual/on-demand)_ | Runs the project test suite (`python -m unittest discover` under `tests/`) |
 
 On `docker compose up -d` the entrypoint templates the crontab from
@@ -84,7 +85,7 @@ the env vars (`CAI_CYCLE_SCHEDULE`, `CAI_ANALYZER_SCHEDULE`,
 `CAI_AUDIT_SCHEDULE`, `CAI_AUDIT_TRIAGE_SCHEDULE`,
 `CAI_CODE_AUDIT_SCHEDULE`, `CAI_PROPOSE_SCHEDULE`,
 `CAI_UPDATE_CHECK_SCHEDULE`, `CAI_HEALTH_REPORT_SCHEDULE`,
-`CAI_COST_OPTIMIZE_SCHEDULE`, `CAI_CHECK_WORKFLOWS_SCHEDULE`, `CAI_FIX_CI_SCHEDULE`),
+`CAI_COST_OPTIMIZE_SCHEDULE`, `CAI_CHECK_WORKFLOWS_SCHEDULE`, `CAI_VERIFY_SCHEDULE`),
 runs `cai.py cycle` once synchronously so the issue-solving pipeline
 produces immediate logs, then execs supercronic. Orthogonal tasks
 (analyze, audit, propose, update-check, health-report, cost-optimize,

--- a/cai.py
+++ b/cai.py
@@ -2530,7 +2530,11 @@ def cmd_cycle(args) -> int:
 
 
 def _cmd_cycle_inner(args) -> int:
-    """One cycle tick: recover stale locks, housekeep, dispatch one action."""
+    """One cycle tick: restart-recovery + dispatch one actionable issue/PR.
+
+    Verify and audit run on their own cron cadences (CAI_VERIFY_SCHEDULE,
+    CAI_AUDIT_SCHEDULE) — the cycle is purely restart-recovery + dispatch.
+    """
     print("[cai cycle] starting cycle tick", flush=True)
     t0 = time.monotonic()
     all_results: dict[str, int] = {}
@@ -2544,14 +2548,7 @@ def _cmd_cycle_inner(args) -> int:
         print(f"[cai cycle] recovered {len(rolled_back)} stale lock(s): {nums}",
               flush=True)
 
-    # Phase 2: housekeeping that doesn't belong to any FSM state.
-    for step_name, handler in [("verify", cmd_verify), ("audit", cmd_audit)]:
-        rc = _run_step(step_name, handler, args)
-        all_results[step_name] = rc
-        if rc != 0:
-            had_failure = True
-
-    # Phase 3: dispatch a single actionable issue/PR via the FSM dispatcher.
+    # Phase 2: dispatch a single actionable issue/PR via the FSM dispatcher.
     rc = _run_step("dispatch", lambda _a: dispatch_oldest_actionable(), args)
     all_results["dispatch"] = rc
     if rc != 0:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,8 @@ services:
       # upstream refine → plan flow that turns :raised/:refined
       # issues into :planned for humans to approve. The remaining
       # schedules are for orthogonal tasks that run independently.
-      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — fix pipeline on auto-improve:plan-approved
-      CAI_PLAN_ALL_SCHEDULE: "30 * * * *"   # hourly @30 — drain :raised/:refined into :planned
+      CAI_CYCLE_SCHEDULE: "0 * * * *"        # hourly — restart-recovery + dispatch one actionable issue/PR
+      CAI_VERIFY_SCHEDULE: "15 * * * *"     # hourly @15 — label-state reconciliation (cmd_verify)
       CAI_ANALYZER_SCHEDULE: "0 0 * * *"   # daily at 00:00 UTC (LLM call)
       CAI_AUDIT_SCHEDULE: "0 */6 * * *"     # every 6h (Sonnet: LLM audit + deterministic cleanup; see README)
       CAI_AUDIT_TRIAGE_SCHEDULE: "10 */6 * * *" # every 6h at :10 (triage raised findings)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,14 +65,14 @@ Issues still enter the pipeline the same way: `cai analyze`, `cai propose`, `cai
 
 ## The Cycle Command
 
-`cai cycle` is one tick of the dispatcher loop. The implementation is deliberately minimal — there is no per-phase ordering anymore:
+`cai cycle` is one tick of the dispatcher loop. The implementation is deliberately minimal:
 
 1. **Restart recovery** — roll back `:in-progress` and `:revising` locks past their stale-timeout.
-2. **Verify** — sync label state with actual PR/issue state (merged → `:merged`, closed → `:raised`, etc.).
-3. **Audit** — run the queue/PR consistency audit.
-4. **Dispatch** — call `dispatch_oldest_actionable()`, which lists every open issue and PR whose state has a registered handler, picks the oldest by `createdAt`, and runs that handler.
+2. **Dispatch** — call `dispatch_oldest_actionable()`, which lists every open issue and PR whose state has a registered handler, picks the oldest by `createdAt`, and runs that handler.
 
 A flock serializes overlapping runs so two cron ticks cannot dispatch the same item concurrently.
+
+Verify (`cai verify`) and audit (`cai audit`) are **independent cron jobs** — they run on their own schedules (`CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`) rather than inside the cycle. Verify syncs label state with actual PR/issue state (merged → `:merged`, closed → `:raised`, etc.); audit runs the queue/PR consistency audit.
 
 ## Agent Execution Modes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,11 +16,12 @@
 
 Cron schedules are configurable via environment variables. Default values are set in `entrypoint.sh`; most are also explicitly configured in `docker-compose.yml`.
 
-`CAI_CYCLE_SCHEDULE` drives the unified dispatcher: each tick runs restart-recover → verify → audit → `dispatch_oldest_actionable()`, which picks the oldest open issue or PR whose lifecycle state has a handler and runs the matching handler in `cai_lib/actions/`. A flock serializes overlapping runs. The planner confidence gate is unchanged — HIGH auto-promotes to `:plan-approved`; MEDIUM / LOW / missing diverts to `:human-needed` with a pending marker, where an admin comment resumes it via `cai unblock`. `cai dispatch --issue N` / `cai dispatch --pr N` remains callable manually or from GitHub Actions for targeted retries.
+`CAI_CYCLE_SCHEDULE` drives the unified dispatcher: each tick runs restart-recover → `dispatch_oldest_actionable()`, which picks the oldest open issue or PR whose lifecycle state has a handler and runs the matching handler in `cai_lib/actions/`. A flock serializes overlapping runs. The planner confidence gate is unchanged — HIGH auto-promotes to `:plan-approved`; MEDIUM / LOW / missing diverts to `:human-needed` with a pending marker, where an admin comment resumes it via `cai unblock`. `cai dispatch --issue N` / `cai dispatch --pr N` remains callable manually or from GitHub Actions for targeted retries. Verify and audit run on their own independent cron schedules (`CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`).
 
 | Variable | Default | Description |
 |---|---|---|
-| `CAI_CYCLE_SCHEDULE` | `0 * * * *` | Hourly FSM dispatcher tick (flock-serialized) |
+| `CAI_CYCLE_SCHEDULE` | `0 * * * *` | Restart-recovery + dispatch one actionable issue/PR |
+| `CAI_VERIFY_SCHEDULE` | `15 * * * *` | Label-state reconciliation (cmd_verify) — keeps :pr-open / :merged / etc. consistent with actual GitHub state. |
 | `CAI_ANALYZER_SCHEDULE` | `0 0 * * *` | Daily transcript analysis and issue raising |
 | `CAI_AUDIT_SCHEDULE` | `0 */6 * * *` | Every 6 hours — queue/PR lifecycle audit |
 | `CAI_AUDIT_TRIAGE_SCHEDULE` | `10 */6 * * *` | Every 6 hours — resolve `audit:raised` findings |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,19 +5,15 @@
 #
 # 1. Template the crontab from env vars. Tasks fall into two groups:
 #
-#    Pipeline (issue-solving) — a `cai.py cycle` line drives the
-#    fix → revise → review-pr → merge → confirm flow on
-#    auto-improve:plan-approved issues, while a separate `cai.py plan-all` line
-#    drives :raised and :refined issues through refine → plan → :planned
-#    so humans can review and approve plans out-of-band. A flock in
-#    cmd_cycle guarantees at most one cycle runs at a time, so issues
-#    are processed serially (one full cycle per issue from fix through
-#    merge). This replaces the older per-stage cron lines (fix, refine,
-#    plan, revise, review-pr, merge, verify, confirm) which
-#    could interleave stages across different issues.
+#    Pipeline (issue-solving) — a `cai.py cycle` line runs restart-recovery
+#    plus a single dispatch via `dispatch_oldest_actionable()`, which picks
+#    the oldest open issue/PR whose lifecycle state has a registered handler
+#    and runs that handler. A flock in cmd_cycle guarantees at most one cycle
+#    runs at a time, so issues are processed serially.
 #
 #    Orthogonal (independent) tasks — not part of the fix pipeline,
 #    so they keep their own schedules:
+#      - verify:         label-state reconciliation with GitHub
 #      - analyze:        parse own transcripts, raise findings as issues
 #      - audit:          periodic queue/PR consistency checks
 #      - audit-triage:   resolve audit:raised findings
@@ -41,7 +37,7 @@
 set -euo pipefail
 
 CAI_CYCLE_SCHEDULE="${CAI_CYCLE_SCHEDULE:-0 * * * *}"
-CAI_PLAN_ALL_SCHEDULE="${CAI_PLAN_ALL_SCHEDULE:-30 * * * *}"
+CAI_VERIFY_SCHEDULE="${CAI_VERIFY_SCHEDULE:-15 * * * *}"
 CAI_ANALYZER_SCHEDULE="${CAI_ANALYZER_SCHEDULE:-0 0 * * *}"
 CAI_AUDIT_SCHEDULE="${CAI_AUDIT_SCHEDULE:-0 */6 * * *}"
 CAI_AUDIT_TRIAGE_SCHEDULE="${CAI_AUDIT_TRIAGE_SCHEDULE:-10 */6 * * *}"
@@ -51,7 +47,6 @@ CAI_UPDATE_CHECK_SCHEDULE="${CAI_UPDATE_CHECK_SCHEDULE:-0 4 * * 1}"
 CAI_HEALTH_REPORT_SCHEDULE="${CAI_HEALTH_REPORT_SCHEDULE:-0 7 * * 1}"
 CAI_COST_OPTIMIZE_SCHEDULE="${CAI_COST_OPTIMIZE_SCHEDULE:-0 5 * * 0}"
 CAI_CHECK_WORKFLOWS_SCHEDULE="${CAI_CHECK_WORKFLOWS_SCHEDULE:-0 */6 * * *}"
-CAI_FIX_CI_SCHEDULE="${CAI_FIX_CI_SCHEDULE:-50 * * * *}"
 
 CRONTAB_PATH=/tmp/crontab
 
@@ -60,7 +55,7 @@ cat > "$CRONTAB_PATH" <<CRONTAB
 # The single cycle line drives the full issue-solving pipeline;
 # other lines are orthogonal tasks with their own cadence.
 $CAI_CYCLE_SCHEDULE python /app/cai.py cycle
-$CAI_PLAN_ALL_SCHEDULE python /app/cai.py plan-all
+$CAI_VERIFY_SCHEDULE python /app/cai.py verify
 $CAI_ANALYZER_SCHEDULE python /app/cai.py analyze
 $CAI_AUDIT_SCHEDULE python /app/cai.py audit
 $CAI_AUDIT_TRIAGE_SCHEDULE python /app/cai.py audit-triage
@@ -70,7 +65,6 @@ $CAI_UPDATE_CHECK_SCHEDULE python /app/cai.py update-check
 $CAI_HEALTH_REPORT_SCHEDULE python /app/cai.py health-report
 $CAI_COST_OPTIMIZE_SCHEDULE python /app/cai.py cost-optimize
 $CAI_CHECK_WORKFLOWS_SCHEDULE python /app/cai.py check-workflows
-$CAI_FIX_CI_SCHEDULE python /app/cai.py fix-ci
 CRONTAB
 
 echo "[entrypoint] crontab:"


### PR DESCRIPTION
## Summary
- `_cmd_cycle_inner` is now restart-recovery + `dispatch_oldest_actionable()` only.
- `cmd_verify` and `cmd_audit` are no longer called from inside the cycle — both run on their own cron schedules.
- New `CAI_VERIFY_SCHEDULE` env var (default `15 * * * *`) for the verify cron.
- Existing `CAI_AUDIT_SCHEDULE` (default `0 */6 * * *`) is now the only place audit runs — was being doubled previously (cycle + cron).
- Drops dead `CAI_PLAN_ALL_SCHEDULE` and `CAI_FIX_CI_SCHEDULE` entries (subcommands removed in #646).

## Why
The dispatcher model means cycle's only job is "pick oldest actionable, run handler". Bundling housekeeping into cycle re-entangled what the refactor untangled — and double-charging for `cai-audit` agent runs was real money.

## Test plan
- [x] `python -m unittest discover -s tests -t .` — 113 pass.
- [x] `bash -n entrypoint.sh` — syntax-clean.
- [ ] Verify in staging that the new `verify` cron line fires at :15 and the cycle line at :00.