### PR TITLE
fix: drop invalid `merged` JSON field from gh pr calls

### DIFF
--- a/cai_lib/actions/fix_ci.py
+++ b/cai_lib/actions/fix_ci.py
@@ -282,7 +282,7 @@ def handle_fix_ci(pr: dict) -> int:
     try:
         pr_now = _gh_json([
             "pr", "view", str(pr_number),
-            "--repo", REPO, "--json", "labels,merged,mergedAt,state",
+            "--repo", REPO, "--json", "labels,mergedAt,state",
         ])
     except subprocess.CalledProcessError:
         pr_now = {}

--- a/cai_lib/actions/revise.py
+++ b/cai_lib/actions/revise.py
@@ -941,7 +941,7 @@ def handle_revise(pr: dict) -> int:
             try:
                 pr_now = _gh_json([
                     "pr", "view", str(pr_number),
-                    "--repo", REPO, "--json", "labels,merged,mergedAt,state",
+                    "--repo", REPO, "--json", "labels,mergedAt,state",
                 ])
             except subprocess.CalledProcessError:
                 pr_now = {}

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -183,7 +183,7 @@ def dispatch_pr(pr_number: int) -> int:
             "--repo", REPO,
             "--json",
             "number,title,headRefName,headRefOid,labels,state,mergeable,"
-            "merged,mergedAt,comments,reviews",
+            "mergedAt,comments,reviews",
         ])
     except subprocess.CalledProcessError as e:
         print(
@@ -233,7 +233,7 @@ def dispatch_oldest_actionable() -> int:
             "--repo", REPO,
             "--state", "open",
             "--base", "main",
-            "--json", "number,createdAt,labels,merged,mergedAt",
+            "--json", "number,createdAt,labels,mergedAt",
             "--limit", "100",
         ]) or []
     except subprocess.CalledProcessError as e:

--- a/cai_lib/fsm.py
+++ b/cai_lib/fsm.py
@@ -419,7 +419,7 @@ def get_pr_state(pr: dict) -> PRState:
     applies a ``*_to_ci_failing`` transition. Keeping derivation pure
     lets tests stub PR dicts without checkrollup data.
     """
-    if pr.get("merged") or pr.get("mergedAt") or pr.get("state") == "MERGED":
+    if pr.get("mergedAt") or pr.get("state") == "MERGED":
         return PRState.MERGED
     labels_raw = pr.get("labels", [])
     label_set = {

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -534,7 +534,11 @@ class TestPRStateShape(unittest.TestCase):
             self.assertEqual(get_pr_state(pr), expected, f"labels={labels}")
 
         self.assertEqual(
-            get_pr_state({"merged": True, "labels": [{"name": LABEL_PR_REVIEWING_CODE}]}),
+            get_pr_state({"state": "MERGED", "labels": [{"name": LABEL_PR_REVIEWING_CODE}]}),
+            PRState.MERGED,
+        )
+        self.assertEqual(
+            get_pr_state({"mergedAt": "2026-04-01T00:00:00Z", "labels": []}),
             PRState.MERGED,
         )
         both = [{"name": LABEL_PR_REVIEWING_CODE}, {"name": LABEL_PR_CI_FAILING}]


### PR DESCRIPTION
## Summary
`gh pr` doesn't expose a `merged` JSON field — only `mergedAt` and `state`. The dispatcher (and two handler post-push state re-checks) were requesting `merged` and gh was returning a non-zero exit on every call. Live cron ticks were logging:

> [cai dispatch] gh pr list failed: Unknown JSON field: "merged"
> [cai dispatch] gh pr view #643 failed: Unknown JSON field: "merged"

Fix: drop `merged` from `--json` arg lists; use `mergedAt`/`state` only. Same cleanup in `get_pr_state`.

## Test plan
- [x] `python -m unittest discover -s tests -t .` — 113 pass.
- [ ] Watch the next cycle tick in staging — `[cai dispatch] gh pr list failed` line should disappear.