### PR TITLE
feat(dispatcher): drain mode — pick all actionable items per tick

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -200,7 +200,7 @@ from cai_lib.actions.confirm import (  # noqa: E402
     _parse_verdicts,
     _update_parent_checklist_item,
 )
-from cai_lib.dispatcher import dispatch_oldest_actionable  # noqa: E402
+from cai_lib.dispatcher import dispatch_drain  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -2549,7 +2549,7 @@ def _cmd_cycle_inner(args) -> int:
               flush=True)
 
     # Phase 2: dispatch a single actionable issue/PR via the FSM dispatcher.
-    rc = _run_step("dispatch", lambda _a: dispatch_oldest_actionable(), args)
+    rc = _run_step("dispatch", lambda _a: dispatch_drain(), args)
     all_results["dispatch"] = rc
     if rc != 0:
         had_failure = True
@@ -2565,19 +2565,20 @@ def _cmd_cycle_inner(args) -> int:
 def cmd_dispatch(args) -> int:
     """Dispatch one or more FSM actions.
 
-    With no args, picks the oldest actionable issue/PR across all
-    states with a handler and dispatches it. With --issue N, fetches
-    issue N, derives its FSM state, and runs the matching handler.
-    With --pr N, same for a PR.
+    With no args, drains the actionable queue: repeatedly picks the
+    oldest actionable issue/PR and dispatches it until the queue is
+    empty (or a loop-guard / max-iter cap fires). With --issue N,
+    fetches issue N, derives its FSM state, and runs the matching
+    handler exactly once. With --pr N, same for a PR.
     """
     from cai_lib.dispatcher import (
-        dispatch_issue, dispatch_pr, dispatch_oldest_actionable,
+        dispatch_issue, dispatch_pr, dispatch_drain,
     )
     if getattr(args, "issue", None) is not None:
         return dispatch_issue(args.issue)
     if getattr(args, "pr", None) is not None:
         return dispatch_pr(args.pr)
-    return dispatch_oldest_actionable()
+    return dispatch_drain()
 
 
 

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -248,16 +248,17 @@ def dispatch_pr(pr_number: int) -> int:
     return handler(pr)
 
 
-def dispatch_oldest_actionable() -> int:
-    """List every open issue and PR in a state that has a registered handler;
-    pick the oldest (by ``createdAt``) and dispatch it.
+def _pick_oldest_actionable_target() -> Optional[tuple[str, int]]:
+    """Return ``(kind, number)`` of the oldest open issue/PR in a state with
+    a registered handler, or ``None`` if the queue is empty.
 
-    Returns the handler's exit code, or 0 if the queue is empty.
+    ``kind`` is ``"issue"`` or ``"pr"``. Sort key is the GitHub
+    ``createdAt`` timestamp (oldest first), so PRs that have been around
+    longer get the next tick — keeps in-flight work ahead of fresh intake.
     """
     issue_states = actionable_issue_states()
     pr_states = actionable_pr_states()
 
-    # Fetch all open auto-improve issues with their current labels.
     try:
         issues = _gh_json([
             "issue", "list",
@@ -284,7 +285,7 @@ def dispatch_oldest_actionable() -> int:
         print(f"[cai dispatch] gh pr list failed:\n{e.stderr}", file=sys.stderr)
         prs = []
 
-    candidates: list[tuple[str, str, int]] = []  # (createdAt, kind, number)
+    candidates: list[tuple[str, str, int]] = []
 
     for issue in issues:
         label_names = [lb["name"] for lb in issue.get("labels", [])]
@@ -298,11 +299,66 @@ def dispatch_oldest_actionable() -> int:
             candidates.append((pr.get("createdAt", ""), "pr", pr["number"]))
 
     if not candidates:
-        print("[cai dispatch] no actionable issues or PRs", flush=True)
-        return 0
+        return None
 
-    candidates.sort(key=lambda c: c[0])  # oldest first
+    candidates.sort(key=lambda c: c[0])
     _, kind, number = candidates[0]
-    if kind == "issue":
-        return dispatch_issue(number)
-    return dispatch_pr(number)
+    return (kind, number)
+
+
+# Default cap on how many handlers a single drain pass will run. The
+# cron tick interval (CAI_CYCLE_SCHEDULE) is the wall-clock rate limit;
+# this cap is the loop-detection backstop in case a handler keeps
+# re-picking itself without advancing state.
+_DEFAULT_DRAIN_MAX_ITER = 50
+
+
+def dispatch_drain(max_iter: int = _DEFAULT_DRAIN_MAX_ITER) -> int:
+    """Drain the actionable queue: pick oldest, dispatch, repeat.
+
+    Stops when one of:
+      - the queue is empty (no actionable issues or PRs left),
+      - the same ``(kind, number)`` is picked twice in a row (loop guard
+        — should not happen with idempotent handlers, but defends against
+        a regression),
+      - ``max_iter`` iterations have run (defense against systemic
+        non-advancing handlers; the cycle's flock prevents overlap).
+
+    Returns the worst exit code seen across handlers (0 if every dispatch
+    succeeded or the queue was empty from the start).
+    """
+    last_target: Optional[tuple[str, int]] = None
+    worst_rc = 0
+
+    for i in range(max_iter):
+        target = _pick_oldest_actionable_target()
+        if target is None:
+            print(f"[cai dispatch] drain complete after {i} dispatch(es): "
+                  "queue empty", flush=True)
+            return worst_rc
+        if target == last_target:
+            print(f"[cai dispatch] same target {target!r} picked twice in a "
+                  "row; stopping drain to avoid loop", flush=True)
+            return worst_rc
+
+        kind, number = target
+        if kind == "issue":
+            rc = dispatch_issue(number)
+        else:
+            rc = dispatch_pr(number)
+        if rc != 0 and worst_rc == 0:
+            worst_rc = rc
+        elif rc > worst_rc:
+            worst_rc = rc
+        last_target = target
+
+    print(f"[cai dispatch] hit drain cap (max_iter={max_iter}); remaining "
+          "actionable items will run on the next cycle tick", flush=True)
+    return worst_rc
+
+
+# Back-compat alias: dispatcher tests + cmd_dispatch still call
+# `dispatch_oldest_actionable`. Now drains.
+def dispatch_oldest_actionable() -> int:
+    """Alias for :func:`dispatch_drain` — drains the actionable queue."""
+    return dispatch_drain()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,7 +69,7 @@ Issues still enter the pipeline the same way: `cai analyze`, `cai propose`, `cai
 `cai cycle` is one tick of the dispatcher loop. The implementation is deliberately minimal:
 
 1. **Restart recovery** — roll back `:in-progress` and `:revising` locks past their stale-timeout.
-2. **Dispatch** — call `dispatch_oldest_actionable()`, which lists every open issue and PR whose state has a registered handler, picks the oldest by `createdAt`, and runs that handler.
+2. **Drain** — call `dispatch_drain()`, which loops `pick oldest actionable → dispatch handler` until the queue is empty (no more issues/PRs in any handler-backed state). A loop guard breaks if the same target gets picked twice in a row, and a `max_iter=50` cap defends against systemic non-advancing handlers; the cron interval is the wall-clock rate limit and the flock prevents overlapping ticks.
 
 A flock serializes overlapping runs so two cron ticks cannot dispatch the same item concurrently.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,7 +48,7 @@ Print a human-readable cost report from `/var/log/cai/cai-cost.jsonl`.
 
 ## cycle
 
-One cycle tick: restart-recover stale locks → verify label state against PR/issue reality → run the periodic audit → dispatch a single actionable issue or PR via the FSM dispatcher. A flock serializes overlapping runs. No explicit per-phase ordering — the FSM label is the source of truth and the dispatcher picks the handler for whichever state the oldest actionable item is in.
+One cycle tick: restart-recover stale locks → drain the actionable queue. The drain loops "pick oldest actionable issue/PR → run its state handler" until the queue is empty (or a loop guard / max-iter cap fires). A flock serializes overlapping runs. No explicit per-phase ordering — the FSM label is the source of truth and the dispatcher picks the handler for whichever state the oldest actionable item is in. Verify and audit run on their own crons (`CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`).
 
 No arguments.
 
@@ -60,7 +60,7 @@ Three modes:
 
 | Invocation | Behavior |
 |---|---|
-| `cai dispatch` | Dispatch the oldest actionable open issue or PR (used by `cai cycle`). |
+| `cai dispatch` | Drain the actionable queue: dispatch the oldest open issue/PR, repeat until empty (used by `cai cycle`). |
 | `cai dispatch --issue N` | Dispatch a specific issue by number. |
 | `cai dispatch --pr N` | Dispatch a specific PR by number. |
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -243,11 +243,17 @@ class TestDispatchPR(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# dispatch_oldest_actionable
+# dispatch_drain (and the dispatch_oldest_actionable alias)
 # ---------------------------------------------------------------------------
 
 class TestDispatchOldestActionable(unittest.TestCase):
-    """Picks the oldest (by createdAt) across issues + PRs."""
+    """Picks the oldest (by createdAt) across issues + PRs.
+
+    These cover the *single-pick* behavior — the alias is wired into
+    dispatch_drain, so when both pools return the same data on every
+    iteration the drain breaks on the same-target loop guard after one
+    dispatch.
+    """
 
     def test_picks_oldest_across_issues_and_prs(self):
         # Two issues + one PR; issue #10 is oldest.
@@ -319,6 +325,144 @@ class TestDispatchOldestActionable(unittest.TestCase):
         self.assertEqual(rc, 0)
         di.assert_not_called()
         dp.assert_not_called()
+
+
+class TestDispatchDrain(unittest.TestCase):
+    """dispatch_drain loops pick+dispatch until empty / loop-guard / cap."""
+
+    def test_drains_multiple_distinct_targets(self):
+        """Each iteration picks a different oldest until queue is empty."""
+        # Simulate the queue shrinking each tick: handler "advances state"
+        # (we drop the dispatched item from the next pool snapshot).
+        remaining = [
+            ("issue", 10, "2024-01-01T00:00:00Z", "auto-improve:refining"),
+            ("issue", 20, "2024-01-02T00:00:00Z", "auto-improve:in-progress"),
+            ("pr",    99, "2024-01-03T00:00:00Z", "pr:reviewing-code"),
+        ]
+
+        def snapshot_issues():
+            return [
+                {"number": n, "createdAt": ca, "labels": [{"name": lb}]}
+                for k, n, ca, lb in remaining if k == "issue"
+            ]
+
+        def snapshot_prs():
+            return [
+                {"number": n, "createdAt": ca, "labels": [{"name": lb}],
+                 "merged": False, "mergedAt": None}
+                for k, n, ca, lb in remaining if k == "pr"
+            ]
+
+        def fake_gh_json(cmd):
+            if "issue" in cmd and "list" in cmd:
+                return snapshot_issues()
+            if "pr" in cmd and "list" in cmd:
+                return snapshot_prs()
+            raise AssertionError(f"unexpected _gh_json call: {cmd}")
+
+        di_calls: list[int] = []
+        dp_calls: list[int] = []
+
+        def fake_di(n):
+            di_calls.append(n)
+            remaining[:] = [t for t in remaining if not (t[0] == "issue" and t[1] == n)]
+            return 0
+
+        def fake_dp(n):
+            dp_calls.append(n)
+            remaining[:] = [t for t in remaining if not (t[0] == "pr" and t[1] == n)]
+            return 0
+
+        with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json), \
+             patch.object(dispatcher, "dispatch_issue", side_effect=fake_di), \
+             patch.object(dispatcher, "dispatch_pr", side_effect=fake_dp):
+            rc = dispatcher.dispatch_drain()
+
+        self.assertEqual(rc, 0)
+        # Drained in oldest-first order, queue emptied.
+        self.assertEqual(di_calls, [10, 20])
+        self.assertEqual(dp_calls, [99])
+
+    def test_loop_guard_breaks_on_repeat_target(self):
+        """Same target picked twice in a row stops the drain even with budget left."""
+        # Pool never shrinks → loop guard must catch on iteration 2.
+        issues = [
+            {"number": 10, "createdAt": "2024-01-01T00:00:00Z",
+             "labels": [{"name": "auto-improve:refining"}]},
+        ]
+
+        def fake_gh_json(cmd):
+            if "issue" in cmd and "list" in cmd:
+                return issues
+            return []
+
+        with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json), \
+             patch.object(dispatcher, "dispatch_issue", return_value=0) as di:
+            rc = dispatcher.dispatch_drain(max_iter=10)
+
+        self.assertEqual(rc, 0)
+        di.assert_called_once_with(10)
+
+    def test_max_iter_cap(self):
+        """A pool that keeps providing distinct targets stops at max_iter."""
+        # Generate as many distinct issues as we want and never shrink.
+        all_issues = [
+            {"number": n, "createdAt": f"2024-01-{n:02d}T00:00:00Z",
+             "labels": [{"name": "auto-improve:refining"}]}
+            for n in range(1, 21)
+        ]
+
+        def fake_gh_json(cmd):
+            if "issue" in cmd and "list" in cmd:
+                return all_issues
+            return []
+
+        # dispatch_issue does NOT shrink the pool — but each call advances
+        # the pool's "next oldest" via a counter so targets differ.
+        # Simpler: give each issue a unique createdAt and remove it after dispatch.
+        pool = list(all_issues)
+
+        def fake_di(n):
+            pool[:] = [i for i in pool if i["number"] != n]
+            return 0
+
+        def fake_gh_json2(cmd):
+            if "issue" in cmd and "list" in cmd:
+                return pool
+            return []
+
+        with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json2), \
+             patch.object(dispatcher, "dispatch_issue", side_effect=fake_di) as di:
+            rc = dispatcher.dispatch_drain(max_iter=3)
+
+        self.assertEqual(rc, 0)
+        # Cap stopped us at 3 dispatches even though more remain.
+        self.assertEqual(di.call_count, 3)
+        self.assertEqual(len(pool), 17)
+
+    def test_returns_worst_exit_code(self):
+        """If any handler returns non-zero, drain returns the worst code."""
+        issues_pool = [
+            {"number": 10, "createdAt": "2024-01-01T00:00:00Z",
+             "labels": [{"name": "auto-improve:refining"}]},
+            {"number": 20, "createdAt": "2024-01-02T00:00:00Z",
+             "labels": [{"name": "auto-improve:in-progress"}]},
+        ]
+
+        def fake_gh_json(cmd):
+            if "issue" in cmd and "list" in cmd:
+                return issues_pool
+            return []
+
+        def fake_di(n):
+            issues_pool[:] = [i for i in issues_pool if i["number"] != n]
+            return 0 if n == 10 else 2
+
+        with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json), \
+             patch.object(dispatcher, "dispatch_issue", side_effect=fake_di):
+            rc = dispatcher.dispatch_drain()
+
+        self.assertEqual(rc, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
`cmd_cycle` and `cai dispatch` (no args) now drain: loop `pick oldest actionable → dispatch handler` until the queue is empty. Previously each tick ran exactly one handler, so a PR transitioning REVIEWING_DOCS → APPROVED would have to wait a full cron interval before the merge handler picked it up.

## Drain semantics
`dispatch_drain(max_iter=50)` stops on any of:
- queue empty (no actionable issues/PRs left in any handler-backed state),
- the same `(kind, number)` picked twice in a row — loop guard against a regression where a handler doesn't advance state,
- `max_iter` reached — last-resort cap; the cycle's flock prevents overlapping ticks if a drain runs long.

Returns the worst exit code seen.

## Why
With idempotent state-advancing handlers (the recent refactor), pipeline progress was bottlenecked by the cron interval. PR #643 in production:
\`\`\`
[cai dispatch] PR #643 at REVIEWING_DOCS → handle_review_docs
[cai review-docs] PR #643: cached clean review at ca42a43c — advancing to APPROVED
[cai cycle] done in 4.4s — dispatch=0
\`\`\`
Now: same tick continues, picks #643 (now at APPROVED), routes to merge handler.

## Test plan
- [x] \`python -m unittest discover -s tests -t .\` — 120 pass.
- [ ] In staging: confirm a single tick can advance a PR through REVIEWING_DOCS → APPROVED → MERGED if the merge handler doesn't gate on confidence.