### PR TITLE
fix(pr_bounce): recover orphaned :pr-open issues; gate by close actor

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -89,6 +89,7 @@
 | `tests/test_lint.py` | Lint check: ruff must report zero violations |
 | `tests/test_multistep.py` | Tests for multi-step plan support |
 | `tests/test_parse.py` | Tests for parse.py signal extraction |
+| `tests/test_pr_bounce.py` | TODO: add description |
 | `tests/test_publish.py` | Tests for publish.py issue publishing |
 | `tests/test_rollback.py` | Tests for rollback functionality |
 | `tests/test_unblock.py` | Tests for cai_lib.cmd_unblock — admin-comment filtering and agent input formatting |

--- a/cai_lib/actions/pr_bounce.py
+++ b/cai_lib/actions/pr_bounce.py
@@ -1,52 +1,233 @@
-"""Handler for issues in IssueState.PR — bounces to the PR submachine.
+"""Handler for issues in IssueState.PR — bounces to the PR submachine
+or recovers from an orphaned ``:pr-open`` label.
 
 An issue is in ``:pr-open`` state while its linked PR is being processed
-by the PR pipeline. The issue-side handler looks up the linked PR and
-dispatches it; the issue itself has no work to do until the PR merges
-(at which point the ``pr_to_merged`` / ``merged_to_solved`` transitions
-advance it).
+by the PR pipeline. The handler:
+
+  1. Looks for an open PR with branch ``auto-improve/<issue_number>-*``
+     and dispatches it (the normal happy path).
+  2. If no open PR exists, scans recent closed PRs for the same branch:
+     - Closed-merged but issue still at ``:pr-open`` → apply
+       ``pr_to_merged`` so :func:`cai_lib.actions.confirm.handle_confirm`
+       runs on the next tick.
+     - Closed-unmerged: inspect *who* closed it via the issue timeline
+       event. If a human (or bot account other than ours) closed it, the
+       PR was rejected on purpose — divert to ``pr_to_human_needed`` so
+       a human decides next steps. If the cai container itself closed
+       it (matched on ``gh api user``'s login), apply ``pr_to_refined``
+       so the issue re-flows through plan / implement.
+  3. If no PR (open or recently closed) is found at all → apply
+     ``pr_to_human_needed``. The label was applied without provenance
+     and only a human can decide what to do.
+
+Step (2) and (3) replace the old behavior of returning 0 silently, which
+left the issue stuck at ``:pr-open`` forever and starved the dispatcher
+loop guard.
 """
-import re
 import subprocess
 import sys
+from typing import Optional
 
 from cai_lib.config import REPO
+from cai_lib.fsm import apply_transition
 from cai_lib.github import _gh_json
 
 
-def handle_pr_bounce(issue: dict) -> int:
-    """Find the PR linked to *issue* and dispatch it.
+_BRANCH_PREFIX_TEMPLATE = "auto-improve/{n}-"
 
-    Called when an issue is at :pr-open. The linked PR's branch is
-    ``auto-improve/<issue_number>-*``; we fetch the open PR with that
-    head and hand it off to :func:`cai_lib.dispatcher.dispatch_pr`.
+
+def _our_gh_login() -> Optional[str]:
+    """Return the authenticated GitHub login (the cai container's identity)."""
+    try:
+        out = _gh_json(["api", "user", "--jq", ".login"])
+    except subprocess.CalledProcessError as e:
+        print(
+            f"[cai dispatch] gh api user failed (cannot determine our login):\n"
+            f"{e.stderr}",
+            file=sys.stderr,
+        )
+        return None
+    if isinstance(out, str):
+        return out.strip() or None
+    if isinstance(out, dict):
+        return (out.get("login") or "").strip() or None
+    return None
+
+
+def _pr_close_actor(pr_number: int) -> Optional[str]:
+    """Return the GitHub login of whoever last closed PR #pr_number, or None.
+
+    Walks the issue timeline newest-first and returns the actor of the
+    most recent ``closed`` event. ``None`` means we couldn't determine —
+    callers should treat that as "unknown actor".
     """
-    from cai_lib.dispatcher import dispatch_pr  # local to avoid import cycle
+    try:
+        events = _gh_json([
+            "api",
+            f"repos/{REPO}/issues/{pr_number}/timeline",
+            "--paginate",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(
+            f"[cai dispatch] gh api timeline failed for PR #{pr_number}:\n"
+            f"{e.stderr}",
+            file=sys.stderr,
+        )
+        return None
+    if not isinstance(events, list):
+        return None
+    closed_events = [e for e in events if (e.get("event") == "closed")]
+    if not closed_events:
+        return None
+    latest = closed_events[-1]
+    actor = latest.get("actor") or {}
+    login = actor.get("login")
+    return login or None
 
-    issue_number = issue["number"]
-    prefix = f"auto-improve/{issue_number}-"
+
+def _find_open_linked_pr(issue_number: int) -> dict | None:
+    """Return the first open PR whose head branch starts with ``auto-improve/<N>-``."""
+    prefix = _BRANCH_PREFIX_TEMPLATE.format(n=issue_number)
     try:
         prs = _gh_json([
             "pr", "list",
             "--repo", REPO,
             "--state", "open",
             "--json", "number,headRefName",
-            "--limit", "50",
+            "--limit", "100",
         ]) or []
     except subprocess.CalledProcessError as e:
         print(
-            f"[cai dispatch] gh pr list failed for issue #{issue_number}:\n{e.stderr}",
+            f"[cai dispatch] gh pr list (open) failed for issue #{issue_number}:\n"
+            f"{e.stderr}",
             file=sys.stderr,
         )
-        return 1
+        return None
 
-    linked = [p for p in prs if p.get("headRefName", "").startswith(prefix)]
-    if not linked:
+    for pr in prs:
+        if pr.get("headRefName", "").startswith(prefix):
+            return pr
+    return None
+
+
+def _find_recent_closed_linked_pr(issue_number: int) -> dict | None:
+    """Return the most recent closed PR whose branch matches ``auto-improve/<N>-``.
+
+    Includes ``state`` and ``mergedAt`` so the caller can tell merged vs
+    closed-unmerged apart.
+    """
+    prefix = _BRANCH_PREFIX_TEMPLATE.format(n=issue_number)
+    try:
+        prs = _gh_json([
+            "pr", "list",
+            "--repo", REPO,
+            "--state", "closed",
+            "--json", "number,headRefName,state,mergedAt,closedAt",
+            "--limit", "200",
+        ]) or []
+    except subprocess.CalledProcessError as e:
         print(
-            f"[cai dispatch] issue #{issue_number} at :pr-open has no linked open PR; "
-            "nothing to dispatch",
-            flush=True,
+            f"[cai dispatch] gh pr list (closed) failed for issue #{issue_number}:\n"
+            f"{e.stderr}",
+            file=sys.stderr,
         )
-        return 0
+        return None
 
-    return dispatch_pr(linked[0]["number"])
+    matches = [pr for pr in prs if pr.get("headRefName", "").startswith(prefix)]
+    if not matches:
+        return None
+    # Pick the most recent — by closedAt desc; mergedAt as fallback.
+    matches.sort(
+        key=lambda pr: pr.get("closedAt") or pr.get("mergedAt") or "",
+        reverse=True,
+    )
+    return matches[0]
+
+
+def _was_merged(pr: dict) -> bool:
+    return bool(pr.get("mergedAt")) or pr.get("state") == "MERGED"
+
+
+def handle_pr_bounce(issue: dict) -> int:
+    """Bounce to the linked PR if open; otherwise recover the issue's state.
+
+    See module docstring for the recovery decision tree.
+    """
+    from cai_lib.dispatcher import dispatch_pr  # local to avoid import cycle
+
+    issue_number = issue["number"]
+    label_names = [lb["name"] for lb in issue.get("labels", [])]
+
+    # 1. Open PR? Bounce to it.
+    open_pr = _find_open_linked_pr(issue_number)
+    if open_pr is not None:
+        return dispatch_pr(open_pr["number"])
+
+    # 2. No open PR. Check recently closed PRs to choose a recovery path.
+    closed_pr = _find_recent_closed_linked_pr(issue_number)
+    if closed_pr is not None:
+        if _was_merged(closed_pr):
+            print(
+                f"[cai dispatch] issue #{issue_number}: linked PR "
+                f"#{closed_pr['number']} merged but issue still at :pr-open — "
+                f"advancing pr_to_merged",
+                flush=True,
+            )
+            ok = apply_transition(
+                issue_number, "pr_to_merged",
+                current_labels=label_names,
+                log_prefix="cai dispatch",
+            )
+            return 0 if ok else 1
+
+        # Closed unmerged — inspect who closed it. If it's us (the bot),
+        # safely re-plan. If it's a human or another account, the close
+        # was a deliberate decision and a human owns the next move.
+        close_actor = _pr_close_actor(closed_pr["number"])
+        our_login = _our_gh_login()
+        bot_closed = (
+            close_actor is not None
+            and our_login is not None
+            and close_actor == our_login
+        )
+        if bot_closed:
+            print(
+                f"[cai dispatch] issue #{issue_number}: linked PR "
+                f"#{closed_pr['number']} closed unmerged by us "
+                f"({close_actor}) — reverting pr_to_refined",
+                flush=True,
+            )
+            ok = apply_transition(
+                issue_number, "pr_to_refined",
+                current_labels=label_names,
+                log_prefix="cai dispatch",
+            )
+        else:
+            actor_str = close_actor or "unknown"
+            print(
+                f"[cai dispatch] issue #{issue_number}: linked PR "
+                f"#{closed_pr['number']} closed unmerged by {actor_str} "
+                f"(our login: {our_login or 'unknown'}) — diverting "
+                f"pr_to_human_needed",
+                flush=True,
+            )
+            ok = apply_transition(
+                issue_number, "pr_to_human_needed",
+                current_labels=label_names,
+                log_prefix="cai dispatch",
+            )
+        return 0 if ok else 1
+
+    # 3. No PR found at all — orphaned :pr-open label, needs a human.
+    print(
+        f"[cai dispatch] issue #{issue_number}: no PR found (open or recently "
+        f"closed) for branch auto-improve/{issue_number}-* — diverting "
+        f"pr_to_human_needed",
+        flush=True,
+    )
+    ok = apply_transition(
+        issue_number, "pr_to_human_needed",
+        current_labels=label_names,
+        log_prefix="cai dispatch",
+    )
+    return 0 if ok else 1

--- a/cai_lib/fsm.py
+++ b/cai_lib/fsm.py
@@ -250,6 +250,14 @@ ISSUE_TRANSITIONS: list[Transition] = [
                labels_remove=[LABEL_IN_PROGRESS],       labels_add=[LABEL_PR_OPEN]),
     Transition("pr_to_merged",               IssueState.PR,                IssueState.MERGED,
                labels_remove=[LABEL_PR_OPEN],             labels_add=[LABEL_MERGED]),
+    # Recovery paths out of PR when the linked PR was closed unmerged
+    # (re-plan from scratch) or never existed (orphan — needs a human).
+    # Fired by handle_pr_bounce after inspecting recent closed PRs for
+    # the issue's branch.
+    Transition("pr_to_refined",              IssueState.PR,                IssueState.REFINED,
+               labels_remove=[LABEL_PR_OPEN],             labels_add=[LABEL_REFINED]),
+    Transition("pr_to_human_needed",         IssueState.PR,                IssueState.HUMAN_NEEDED,
+               labels_remove=[LABEL_PR_OPEN],             labels_add=[LABEL_HUMAN_NEEDED]),
     Transition("merged_to_solved",           IssueState.MERGED,            IssueState.SOLVED,
                labels_remove=[LABEL_MERGED],            labels_add=[LABEL_SOLVED]),
 

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -35,6 +35,8 @@ stateDiagram-v2
     PLAN_APPROVED --> IN_PROGRESS : approved_to_in_progress [≥HIGH]
     IN_PROGRESS --> PR : in_progress_to_pr [≥HIGH]
     PR --> MERGED : pr_to_merged [≥HIGH]
+    PR --> REFINED : pr_to_refined [≥HIGH]
+    PR --> HUMAN_NEEDED : pr_to_human_needed [≥HIGH]
     MERGED --> SOLVED : merged_to_solved [≥HIGH]
     HUMAN_NEEDED --> RAISED : human_to_raised [≥HIGH]
     HUMAN_NEEDED --> REFINING : human_to_refining [≥HIGH]

--- a/tests/test_pr_bounce.py
+++ b/tests/test_pr_bounce.py
@@ -1,0 +1,148 @@
+"""Tests for cai_lib.actions.pr_bounce.handle_pr_bounce.
+
+Covers the three branches:
+  1. Open linked PR exists → calls dispatch_pr.
+  2. No open PR + closed-merged PR found → applies pr_to_merged.
+  3. No open PR + closed-unmerged PR found → applies pr_to_refined.
+  4. No PR found at all → applies pr_to_human_needed.
+"""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.actions import pr_bounce
+
+
+def _issue(number: int, label: str = "auto-improve:pr-open") -> dict:
+    return {
+        "number": number,
+        "title": "t",
+        "body": "b",
+        "labels": [{"name": label}],
+        "createdAt": "2024-01-01T00:00:00Z",
+    }
+
+
+class TestHandlePrBounce(unittest.TestCase):
+
+    def test_open_pr_routes_to_dispatch_pr(self):
+        issue = _issue(620)
+        open_pr = {"number": 643, "headRefName": "auto-improve/620-foo"}
+        with patch.object(pr_bounce, "_find_open_linked_pr", return_value=open_pr), \
+             patch.object(pr_bounce, "_find_recent_closed_linked_pr") as closed_lookup, \
+             patch.object(pr_bounce, "apply_transition") as apply_t, \
+             patch("cai_lib.dispatcher.dispatch_pr", return_value=0) as dpr:
+            rc = pr_bounce.handle_pr_bounce(issue)
+        self.assertEqual(rc, 0)
+        dpr.assert_called_once_with(643)
+        closed_lookup.assert_not_called()
+        apply_t.assert_not_called()
+
+    def test_closed_merged_pr_advances_to_merged(self):
+        issue = _issue(620)
+        closed_pr = {
+            "number": 643, "headRefName": "auto-improve/620-foo",
+            "state": "MERGED", "mergedAt": "2024-01-02T00:00:00Z",
+            "closedAt": "2024-01-02T00:00:00Z",
+        }
+        with patch.object(pr_bounce, "_find_open_linked_pr", return_value=None), \
+             patch.object(pr_bounce, "_find_recent_closed_linked_pr",
+                          return_value=closed_pr), \
+             patch.object(pr_bounce, "apply_transition", return_value=True) as apply_t, \
+             patch("cai_lib.dispatcher.dispatch_pr") as dpr:
+            rc = pr_bounce.handle_pr_bounce(issue)
+        self.assertEqual(rc, 0)
+        dpr.assert_not_called()
+        apply_t.assert_called_once()
+        args, kwargs = apply_t.call_args
+        self.assertEqual(args[0], 620)
+        self.assertEqual(args[1], "pr_to_merged")
+
+    def test_closed_unmerged_by_bot_reverts_to_refined(self):
+        issue = _issue(644)
+        closed_pr = {
+            "number": 645, "headRefName": "auto-improve/644-foo",
+            "state": "CLOSED", "mergedAt": None,
+            "closedAt": "2024-01-02T00:00:00Z",
+        }
+        with patch.object(pr_bounce, "_find_open_linked_pr", return_value=None), \
+             patch.object(pr_bounce, "_find_recent_closed_linked_pr",
+                          return_value=closed_pr), \
+             patch.object(pr_bounce, "_pr_close_actor", return_value="cai-bot"), \
+             patch.object(pr_bounce, "_our_gh_login", return_value="cai-bot"), \
+             patch.object(pr_bounce, "apply_transition", return_value=True) as apply_t, \
+             patch("cai_lib.dispatcher.dispatch_pr") as dpr:
+            rc = pr_bounce.handle_pr_bounce(issue)
+        self.assertEqual(rc, 0)
+        dpr.assert_not_called()
+        apply_t.assert_called_once()
+        self.assertEqual(apply_t.call_args[0][1], "pr_to_refined")
+
+    def test_closed_unmerged_by_human_diverts_to_human_needed(self):
+        issue = _issue(644)
+        closed_pr = {
+            "number": 645, "headRefName": "auto-improve/644-foo",
+            "state": "CLOSED", "mergedAt": None,
+            "closedAt": "2024-01-02T00:00:00Z",
+        }
+        with patch.object(pr_bounce, "_find_open_linked_pr", return_value=None), \
+             patch.object(pr_bounce, "_find_recent_closed_linked_pr",
+                          return_value=closed_pr), \
+             patch.object(pr_bounce, "_pr_close_actor",
+                          return_value="damien-robotsix"), \
+             patch.object(pr_bounce, "_our_gh_login", return_value="cai-bot"), \
+             patch.object(pr_bounce, "apply_transition", return_value=True) as apply_t, \
+             patch("cai_lib.dispatcher.dispatch_pr") as dpr:
+            rc = pr_bounce.handle_pr_bounce(issue)
+        self.assertEqual(rc, 0)
+        dpr.assert_not_called()
+        apply_t.assert_called_once()
+        self.assertEqual(apply_t.call_args[0][1], "pr_to_human_needed")
+
+    def test_closed_unmerged_unknown_actor_diverts_to_human_needed(self):
+        """When timeline lookup fails, default to human-needed (safer)."""
+        issue = _issue(644)
+        closed_pr = {
+            "number": 645, "headRefName": "auto-improve/644-foo",
+            "state": "CLOSED", "mergedAt": None,
+            "closedAt": "2024-01-02T00:00:00Z",
+        }
+        with patch.object(pr_bounce, "_find_open_linked_pr", return_value=None), \
+             patch.object(pr_bounce, "_find_recent_closed_linked_pr",
+                          return_value=closed_pr), \
+             patch.object(pr_bounce, "_pr_close_actor", return_value=None), \
+             patch.object(pr_bounce, "_our_gh_login", return_value="cai-bot"), \
+             patch.object(pr_bounce, "apply_transition", return_value=True) as apply_t, \
+             patch("cai_lib.dispatcher.dispatch_pr") as dpr:
+            rc = pr_bounce.handle_pr_bounce(issue)
+        self.assertEqual(rc, 0)
+        self.assertEqual(apply_t.call_args[0][1], "pr_to_human_needed")
+
+    def test_no_pr_diverts_to_human_needed(self):
+        issue = _issue(700)
+        with patch.object(pr_bounce, "_find_open_linked_pr", return_value=None), \
+             patch.object(pr_bounce, "_find_recent_closed_linked_pr",
+                          return_value=None), \
+             patch.object(pr_bounce, "apply_transition", return_value=True) as apply_t, \
+             patch("cai_lib.dispatcher.dispatch_pr") as dpr:
+            rc = pr_bounce.handle_pr_bounce(issue)
+        self.assertEqual(rc, 0)
+        dpr.assert_not_called()
+        apply_t.assert_called_once()
+        self.assertEqual(apply_t.call_args[0][1], "pr_to_human_needed")
+
+    def test_apply_transition_failure_returns_one(self):
+        issue = _issue(700)
+        with patch.object(pr_bounce, "_find_open_linked_pr", return_value=None), \
+             patch.object(pr_bounce, "_find_recent_closed_linked_pr",
+                          return_value=None), \
+             patch.object(pr_bounce, "apply_transition", return_value=False):
+            rc = pr_bounce.handle_pr_bounce(issue)
+        self.assertEqual(rc, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
`handle_pr_bounce` no longer returns 0 silently when an issue is at `:pr-open` with no open linked PR. It scans recent closed PRs and routes the issue based on what happened:

| Closed PR state | Closer | New transition |
|---|---|---|
| Merged | (any) | `pr_to_merged` |
| Closed unmerged | Bot (us) | `pr_to_refined` (re-plan) |
| Closed unmerged | Human | `pr_to_human_needed` (deliberate close — let human decide) |
| Closed unmerged | Unknown | `pr_to_human_needed` (safer default) |
| No PR found at all | n/a | `pr_to_human_needed` |

## Why the close-actor gate matters
A human closing a PR is making a decision: "this approach was wrong, don't try the same thing again." Auto-resetting to `:refined` would loop the issue through plan/implement and likely produce another rejected PR. Diverting to `:human-needed` respects the close as a stop signal.

## Production evidence
The latest `cai cycle` log:
\`\`\`
[cai dispatch] issue #620 at PR → handle_pr_bounce
[cai dispatch] issue #620 at :pr-open has no linked open PR; nothing to dispatch
[cai dispatch] same target ('issue', 620) picked twice in a row; stopping drain to avoid loop
[cai cycle] done in 4.0s — dispatch=0
\`\`\`
The drain stopped because handle_pr_bounce's no-op left issue #620 stuck. Other actionable issues (#628, #627, #624 at `:planning`) never got a turn.

## New FSM transitions
- `pr_to_refined` (PR → REFINED)
- `pr_to_human_needed` (PR → HUMAN_NEEDED)

Both are deterministic — the dispatcher applies them based on inspected state, not agent confidence.

## Test plan
- [x] `python -m unittest discover -s tests -t .` — 127 pass (6 new in tests/test_pr_bounce.py).
- [ ] Run a cycle in staging on the current queue (issues #620 / #644 with closed-unmerged PRs); confirm both divert to `:human-needed` (since the closing actor is presumably you, not the cai bot user).