### PR TITLE
fix(dispatcher): recover from handler crash/non-advance (#657)

### DIFF
--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -426,6 +426,23 @@ def handle_plan_gate(issue: dict) -> int:
         current_labels=[LABEL_PLANNED],
         log_prefix="cai plan",
     )
+    if not ok:
+        # Transition or divert refused (e.g. state drift, label-edit failure).
+        # Returning 0 here would leave the issue at :planned and cause the
+        # dispatcher to re-pick the same target every cycle (#657). Report
+        # failure so the cycle's worst_rc reflects the stall.
+        dur = f"{int(time.monotonic() - t0)}s"
+        conf_name = plan_confidence.name if plan_confidence else "MISSING"
+        print(
+            f"[cai plan] #{issue_number} gate refused — state did not advance",
+            file=sys.stderr,
+            flush=True,
+        )
+        log_run("plan", repo=REPO, issue=issue_number,
+                duration=dur, result="gate_refused",
+                confidence=conf_name, diverted=int(diverted),
+                exit=1)
+        return 1
     if diverted:
         # Append a pending marker so cai-unblock knows what we were
         # trying to do when the admin comments. Re-read the body so the

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -248,14 +248,21 @@ def dispatch_pr(pr_number: int) -> int:
     return handler(pr)
 
 
-def _pick_oldest_actionable_target() -> Optional[tuple[str, int]]:
+def _pick_oldest_actionable_target(
+    skip: Optional[set[tuple[str, int]]] = None,
+) -> Optional[tuple[str, int]]:
     """Return ``(kind, number)`` of the oldest open issue/PR in a state with
     a registered handler, or ``None`` if the queue is empty.
 
     ``kind`` is ``"issue"`` or ``"pr"``. Sort key is the GitHub
     ``createdAt`` timestamp (oldest first), so PRs that have been around
     longer get the next tick — keeps in-flight work ahead of fresh intake.
+
+    ``skip`` is an optional set of ``(kind, number)`` tuples to exclude — used
+    by :func:`dispatch_drain` to move past a target whose handler already
+    failed in the current drain pass so the rest of the queue can still run.
     """
+    skip = skip or set()
     issue_states = actionable_issue_states()
     pr_states = actionable_pr_states()
 
@@ -291,11 +298,15 @@ def _pick_oldest_actionable_target() -> Optional[tuple[str, int]]:
         label_names = [lb["name"] for lb in issue.get("labels", [])]
         state = get_issue_state(label_names)
         if state is not None and state in issue_states:
+            if ("issue", issue["number"]) in skip:
+                continue
             candidates.append((issue.get("createdAt", ""), "issue", issue["number"]))
 
     for pr in prs:
         state = get_pr_state(pr)
         if state in pr_states:
+            if ("pr", pr["number"]) in skip:
+                continue
             candidates.append((pr.get("createdAt", ""), "pr", pr["number"]))
 
     if not candidates:
@@ -327,11 +338,14 @@ def dispatch_drain(max_iter: int = _DEFAULT_DRAIN_MAX_ITER) -> int:
     Returns the worst exit code seen across handlers (0 if every dispatch
     succeeded or the queue was empty from the start).
     """
+    import traceback
+
     last_target: Optional[tuple[str, int]] = None
+    failed_targets: set[tuple[str, int]] = set()
     worst_rc = 0
 
     for i in range(max_iter):
-        target = _pick_oldest_actionable_target()
+        target = _pick_oldest_actionable_target(skip=failed_targets)
         if target is None:
             print(f"[cai dispatch] drain complete after {i} dispatch(es): "
                   "queue empty", flush=True)
@@ -342,14 +356,27 @@ def dispatch_drain(max_iter: int = _DEFAULT_DRAIN_MAX_ITER) -> int:
             return worst_rc
 
         kind, number = target
-        if kind == "issue":
-            rc = dispatch_issue(number)
-        else:
-            rc = dispatch_pr(number)
-        if rc != 0 and worst_rc == 0:
-            worst_rc = rc
-        elif rc > worst_rc:
-            worst_rc = rc
+        try:
+            if kind == "issue":
+                rc = dispatch_issue(number)
+            else:
+                rc = dispatch_pr(number)
+        except Exception:  # noqa: BLE001 — keep draining the queue
+            # Handler crashed. Record failure, skip this target for the rest
+            # of this drain pass (#657 — one crashing item must not stall
+            # the cycle), and continue with the next actionable target.
+            traceback.print_exc()
+            print(f"[cai dispatch] handler for {kind} #{number} raised; "
+                  "skipping this target for the remainder of the drain",
+                  flush=True)
+            failed_targets.add(target)
+            worst_rc = max(worst_rc, 1)
+            last_target = target
+            continue
+        if rc != 0:
+            failed_targets.add(target)
+            if rc > worst_rc:
+                worst_rc = rc
         last_target = target
 
     print(f"[cai dispatch] hit drain cap (max_iter={max_iter}); remaining "

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -465,5 +465,69 @@ class TestDispatchDrain(unittest.TestCase):
         self.assertEqual(rc, 2)
 
 
+    def test_handler_exception_skips_target_and_continues_drain(self):
+        """A crashing handler must not stall the queue — drain skips it and
+        processes the rest of the actionable items (#657)."""
+        pool = [
+            {"number": 10, "createdAt": "2024-01-01T00:00:00Z",
+             "labels": [{"name": "auto-improve:refining"}]},
+            {"number": 20, "createdAt": "2024-01-02T00:00:00Z",
+             "labels": [{"name": "auto-improve:in-progress"}]},
+        ]
+
+        def fake_gh_json(cmd):
+            if "issue" in cmd and "list" in cmd:
+                return pool
+            return []
+
+        calls: list[int] = []
+
+        def fake_di(n):
+            calls.append(n)
+            if n == 10:
+                raise RuntimeError("boom")
+            pool[:] = [i for i in pool if i["number"] != n]
+            return 0
+
+        with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json), \
+             patch.object(dispatcher, "dispatch_issue", side_effect=fake_di):
+            rc = dispatcher.dispatch_drain()
+
+        # Crash on #10 is recorded as worst_rc=1, but #20 still ran.
+        self.assertEqual(rc, 1)
+        self.assertEqual(calls, [10, 20])
+
+    def test_nonzero_handler_skips_target_and_continues_drain(self):
+        """A handler that returns nonzero is also skipped so the drain can
+        still reach the next actionable target in the same pass."""
+        pool = [
+            {"number": 10, "createdAt": "2024-01-01T00:00:00Z",
+             "labels": [{"name": "auto-improve:refining"}]},
+            {"number": 20, "createdAt": "2024-01-02T00:00:00Z",
+             "labels": [{"name": "auto-improve:in-progress"}]},
+        ]
+
+        def fake_gh_json(cmd):
+            if "issue" in cmd and "list" in cmd:
+                return pool
+            return []
+
+        calls: list[int] = []
+
+        def fake_di(n):
+            calls.append(n)
+            if n == 10:
+                return 1  # non-advancing failure — don't shrink pool
+            pool[:] = [i for i in pool if i["number"] != n]
+            return 0
+
+        with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json), \
+             patch.object(dispatcher, "dispatch_issue", side_effect=fake_di):
+            rc = dispatcher.dispatch_drain()
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(calls, [10, 20])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Closes #657 — dispatcher cycle exits nonzero in a loop when a single item crashes or refuses to advance.
- `handle_plan_gate` now checks the `ok` return from `apply_transition_with_confidence` and returns 1 on refusal instead of silently re-queuing the same issue.
- `dispatch_drain` wraps handler calls in try/except and skips failed `(kind, number)` targets for the rest of the drain pass so one bad item can't starve the queue.

## Test plan
- [x] `python -m unittest tests.test_dispatcher tests.test_fsm` — 89 tests pass
- [ ] Watch the next cycle run against a refused-divert issue to confirm the cycle now exits 1 once (on the bad item) but still drains the rest.