### PR TITLE
feat(fsm): post reason comment when diverting to :human-needed

### DIFF
--- a/cai_lib/fsm.py
+++ b/cai_lib/fsm.py
@@ -604,6 +604,39 @@ def apply_transition(
     )
 
 
+def _render_human_divert_reason(
+    *,
+    transition_name: str,
+    transition: "Transition",
+    confidence: Optional[Confidence],
+    extra: str = "",
+) -> str:
+    """Render the user-visible reason for a confidence-gated divert.
+
+    Kept close to the divert call sites so a future change to gate
+    semantics only needs to touch one formatter.
+    """
+    conf_name = confidence.name if confidence is not None else "MISSING"
+    required = transition.min_confidence.name
+    lines = [
+        "**🙋 Human attention needed**",
+        "",
+        f"Automation paused `{transition_name}` because the confidence gate "
+        f"was not met.",
+        "",
+        f"- Required confidence: `{required}`",
+        f"- Reported confidence: `{conf_name}`",
+    ]
+    if extra:
+        lines.extend(["", extra.rstrip()])
+    lines.extend([
+        "",
+        "See the pending marker in the body for how the automation intends "
+        "to resume once an admin responds.",
+    ])
+    return "\n".join(lines)
+
+
 def apply_transition_with_confidence(
     issue_number: int,
     transition_name: str,
@@ -613,6 +646,8 @@ def apply_transition_with_confidence(
     extra_remove: Sequence[str] = (),
     log_prefix: str = "cai",
     set_labels=None,
+    post_comment=None,
+    reason_extra: str = "",
 ) -> tuple[bool, bool]:
     """Apply an issue FSM transition gated on *confidence*.
 
@@ -626,6 +661,12 @@ def apply_transition_with_confidence(
       where the automation stopped — see :func:`render_pending_marker`.
     - When confidence meets the threshold, delegates to
       :func:`apply_transition` and returns ``(ok, False)``.
+
+    On a successful divert, also posts a comment on the issue explaining
+    the reason (the failing transition and confidence gate). ``post_comment``
+    is injectable for tests; defaults to ``cai_lib.github._post_issue_comment``.
+    ``reason_extra`` lets the caller append handler-specific context (e.g. a
+    failed-transition name when the divert is not driven by confidence).
     """
     transition = find_transition(transition_name, ISSUE_TRANSITIONS)
 
@@ -667,6 +708,19 @@ def apply_transition_with_confidence(
         remove=list(transition.labels_remove) + list(extra_remove),
         log_prefix=log_prefix,
     )
+    if ok:
+        if post_comment is None:
+            from cai_lib.github import _post_issue_comment as post_comment  # local import — avoids cycle
+        post_comment(
+            issue_number,
+            _render_human_divert_reason(
+                transition_name=transition_name,
+                transition=transition,
+                confidence=confidence,
+                extra=reason_extra,
+            ),
+            log_prefix=log_prefix,
+        )
     return ok, True
 
 
@@ -738,8 +792,15 @@ def apply_pr_transition_with_confidence(
     current_pr: Optional[dict] = None,
     log_prefix: str = "cai",
     set_pr_labels=None,
+    post_comment=None,
+    reason_extra: str = "",
 ) -> tuple[bool, bool]:
-    """Confidence-gated PR transition. Mirrors ``apply_transition_with_confidence``."""
+    """Confidence-gated PR transition. Mirrors ``apply_transition_with_confidence``.
+
+    On successful divert, posts a comment on the PR with the failing
+    transition / confidence values. ``post_comment`` is injectable for tests;
+    defaults to ``cai_lib.github._post_pr_comment``.
+    """
     transition = find_transition(transition_name, PR_TRANSITIONS)
 
     if transition.accepts(confidence):
@@ -778,6 +839,19 @@ def apply_pr_transition_with_confidence(
         remove=list(transition.labels_remove),
         log_prefix=log_prefix,
     )
+    if ok:
+        if post_comment is None:
+            from cai_lib.github import _post_pr_comment as post_comment  # local import — avoids cycle
+        post_comment(
+            pr_number,
+            _render_human_divert_reason(
+                transition_name=transition_name,
+                transition=transition,
+                confidence=confidence,
+                extra=reason_extra,
+            ),
+            log_prefix=log_prefix,
+        )
     return ok, True
 
 

--- a/cai_lib/github.py
+++ b/cai_lib/github.py
@@ -125,6 +125,43 @@ def _set_pr_labels(pr_number: int, *, add: list[str] = (), remove: list[str] = (
     return True
 
 
+def _post_issue_comment(issue_number: int, body: str, *, log_prefix: str = "cai") -> bool:
+    """Post a comment on an issue. Returns True on success.
+
+    Kept permissive — a failure here is logged but does not abort the
+    caller's state transition. The comment is informational context for
+    the admin.
+    """
+    result = _run(
+        ["gh", "issue", "comment", str(issue_number),
+         "--repo", REPO, "--body", body],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"[{log_prefix}] failed to post comment on #{issue_number}:\n{result.stderr}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def _post_pr_comment(pr_number: int, body: str, *, log_prefix: str = "cai") -> bool:
+    """Post a comment on a PR. Returns True on success. See :func:`_post_issue_comment`."""
+    result = _run(
+        ["gh", "pr", "comment", str(pr_number),
+         "--repo", REPO, "--body", body],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"[{log_prefix}] failed to post comment on PR #{pr_number}:\n{result.stderr}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
 def _issue_has_label(issue_number: int, label: str) -> bool:
     """Re-fetch an issue's labels and check for *label*. Avoids stale-snapshot races."""
     try:

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -190,51 +190,83 @@ class TestApplyTransitionWithConfidence(unittest.TestCase):
             return True
         return calls, _fake
 
+    def _recording_post_comment(self):
+        calls = []
+        def _fake(issue_number, body, *, log_prefix="cai"):
+            calls.append({
+                "issue_number": issue_number,
+                "body": body,
+                "log_prefix": log_prefix,
+            })
+            return True
+        return calls, _fake
+
     def test_high_confidence_applies_nominal_transition(self):
         calls, fake = self._recording_set_labels()
+        comments, fake_comment = self._recording_post_comment()
         ok, diverted = apply_transition_with_confidence(
             11, "refining_to_refined", Confidence.HIGH,
             current_labels=[LABEL_REFINING],
             set_labels=fake,
+            post_comment=fake_comment,
         )
         self.assertTrue(ok)
         self.assertFalse(diverted)
         self.assertIn(LABEL_REFINED, calls[0]["add"])
+        # No divert → no human-needed comment should be posted.
+        self.assertEqual(comments, [])
 
     def test_medium_confidence_diverts_to_human(self):
         calls, fake = self._recording_set_labels()
+        comments, fake_comment = self._recording_post_comment()
         ok, diverted = apply_transition_with_confidence(
             12, "refining_to_refined", Confidence.MEDIUM,
             current_labels=[LABEL_REFINING],
             set_labels=fake,
+            post_comment=fake_comment,
         )
         self.assertTrue(ok)
         self.assertTrue(diverted)
         self.assertIn(LABEL_HUMAN_NEEDED, calls[0]["add"])
         self.assertIn(LABEL_REFINING, calls[0]["remove"])
         self.assertNotIn(LABEL_REFINED, calls[0]["add"])
+        # Divert → a reason comment must be posted with the failing transition
+        # and confidence values so the admin knows why they were summoned.
+        self.assertEqual(len(comments), 1)
+        body = comments[0]["body"]
+        self.assertIn("refining_to_refined", body)
+        self.assertIn("MEDIUM", body)
+        self.assertIn("HIGH", body)
 
     def test_missing_confidence_diverts_to_human(self):
         calls, fake = self._recording_set_labels()
+        comments, fake_comment = self._recording_post_comment()
         ok, diverted = apply_transition_with_confidence(
             13, "refining_to_refined", None,
             current_labels=[LABEL_REFINING],
             set_labels=fake,
+            post_comment=fake_comment,
         )
         self.assertTrue(ok)
         self.assertTrue(diverted)
         self.assertIn(LABEL_HUMAN_NEEDED, calls[0]["add"])
+        self.assertEqual(len(comments), 1)
+        self.assertIn("MISSING", comments[0]["body"])
 
     def test_divert_respects_from_state_mismatch(self):
         calls, fake = self._recording_set_labels()
+        comments, fake_comment = self._recording_post_comment()
         ok, diverted = apply_transition_with_confidence(
             14, "refining_to_refined", None,
             current_labels=[LABEL_REFINED],  # wrong state
             set_labels=fake,
+            post_comment=fake_comment,
         )
         self.assertFalse(ok)
         self.assertFalse(diverted)
         self.assertEqual(calls, [])
+        # State mismatch aborts before the divert → no comment either.
+        self.assertEqual(comments, [])
 
 
 class TestPendingMarker(unittest.TestCase):


### PR DESCRIPTION
## Summary
- When the confidence gate routes an issue/PR to `:human-needed`, also post a comment explaining the reason (failing transition, required vs. reported confidence). Previously only a pending marker was appended to the body.
- Adds `_post_issue_comment` / `_post_pr_comment` helpers in `cai_lib/github.py` and wires them into both `apply_transition_with_confidence` and `apply_pr_transition_with_confidence`.
- `post_comment` is injectable; `reason_extra` lets callers append handler-specific context.

## Test plan
- [x] `python -m unittest discover tests` — 127 tests pass (skipped=1)
- [x] Updated fsm divert tests assert the comment body names the transition and both confidence levels.
- [ ] Observe a real divert on the next cycle and check the issue/PR timeline shows the new comment.