### PR TITLE
feat(unblock): gate FSM resume on explicit human:solved label

### DIFF
--- a/.claude/agents/cai-unblock.md
+++ b/.claude/agents/cai-unblock.md
@@ -12,8 +12,9 @@ You are the unblock agent for `robotsix-cai`. Either an auto-improve
 issue is parked in `auto-improve:human-needed`, or an auto-improve
 pull request is parked in `auto-improve:pr-human-needed`, because an
 earlier agent could not move forward with high confidence. An admin
-has now commented. Your job is to read the comment and decide which
-state the FSM should resume from.
+has commented AND applied the `human:solved` label to signal they
+consider the divert resolved and want the FSM to resume. Your job is
+to read the comment and decide which state the FSM should resume from.
 
 ## What you receive
 

--- a/cai_lib/cmd_unblock.py
+++ b/cai_lib/cmd_unblock.py
@@ -1,10 +1,20 @@
-"""cai_lib.cmd_unblock — admin-comment-driven FSM resume.
+"""cai_lib.cmd_unblock — label-gated FSM resume.
 
-Scans issues parked at ``auto-improve:human-needed``. For each one
-carrying a pending-transition marker and at least one admin comment,
-invokes the ``cai-unblock`` Haiku agent to classify the admin's reply
-into a resume target, then fires the matching ``human_to_<state>``
-transition via :func:`cai_lib.fsm.apply_transition`.
+Scans issues parked at ``auto-improve:human-needed`` that the admin
+has marked ready for resume by applying the ``human:solved`` label.
+Picking up on the *label* (rather than any fresh admin comment) means:
+
+- An admin can discuss or ask questions on the issue without the
+  automation prematurely deciding the divert is resolved.
+- The resume loop skips parked issues entirely until the admin opts in,
+  so we don't re-run the classifier every cycle on every open
+  :human-needed issue.
+
+For each gated issue carrying a pending-transition marker, invokes the
+``cai-unblock`` Haiku agent to classify the admin's reply into a resume
+target, fires the matching ``human_to_<state>`` transition via
+:func:`cai_lib.fsm.apply_transition`, and finally removes the
+``human:solved`` label so the signal is one-shot.
 
 PR-side unblock (``auto-improve:pr-human-needed``) is handled in a
 follow-up — the PR submachine needs a PR-labelling counterpart to
@@ -20,6 +30,7 @@ from typing import Optional
 from cai_lib.config import (
     REPO,
     LABEL_HUMAN_NEEDED,
+    LABEL_HUMAN_SOLVED,
     is_admin_login,
 )
 from cai_lib.fsm import (
@@ -31,18 +42,25 @@ from cai_lib.fsm import (
     resume_transition_for,
     strip_pending_marker,
 )
-from cai_lib.github import _gh_json
+from cai_lib.github import _gh_json, _set_labels
 from cai_lib.logging_utils import log_run
 from cai_lib.subprocess_utils import _run, _run_claude_p
 
 
 def _list_human_needed_issues() -> list[dict]:
-    """Return open issues labelled ``auto-improve:human-needed``."""
+    """Return open issues parked at ``:human-needed`` that the admin has
+    marked ready for resume via ``human:solved``.
+
+    Passing ``--label`` twice to ``gh issue list`` ANDs the filters, so
+    we only get issues that carry BOTH labels. Everything else stays
+    parked and is ignored by this pass.
+    """
     try:
         return _gh_json([
             "issue", "list",
             "--repo", REPO,
             "--label", LABEL_HUMAN_NEEDED,
+            "--label", LABEL_HUMAN_SOLVED,
             "--state", "open",
             "--json", "number,title,body,labels,updatedAt,comments",
             "--limit", "100",
@@ -126,10 +144,11 @@ def _try_unblock_issue(issue: dict) -> Optional[str]:
 
     Result tags (used for logging):
       - ``"no_marker"``        — no pending marker in body, left parked
-      - ``"no_admin_comment"`` — no admin has commented yet
+      - ``"no_admin_comment"`` — ``human:solved`` applied but no admin
+        comment yet — the classifier has nothing to read
       - ``"low_confidence"``   — agent's Confidence < HIGH, left parked
       - ``"no_target"``        — agent emitted no valid ResumeTo target
-      - ``"resumed"``          — transition fired, marker cleared
+      - ``"resumed"``          — transition fired, marker + solved label cleared
       - ``"agent_failed"``     — claude invocation returned non-zero
     """
     issue_number = issue["number"]
@@ -140,6 +159,10 @@ def _try_unblock_issue(issue: dict) -> Optional[str]:
 
     admin_comments = _extract_admin_comments(issue)
     if not admin_comments:
+        # Admin applied human:solved without leaving any comment. The
+        # classifier would have nothing to read, so leave the issue parked
+        # rather than guess. The label stays on so we retry once a comment
+        # lands.
         return "no_admin_comment"
 
     user_message = _build_unblock_message(
@@ -188,9 +211,12 @@ def _try_unblock_issue(issue: dict) -> Optional[str]:
         return "no_target"
 
     current_labels = [l["name"] for l in issue.get("labels", [])]  # noqa: E741
+    # The transition already clears :human-needed; also drop the
+    # human:solved signal so the label is one-shot.
     ok = apply_transition(
         issue_number, transition.name,
         current_labels=current_labels,
+        extra_remove=[LABEL_HUMAN_SOLVED],
         log_prefix="cai unblock",
     )
     if not ok:

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -73,6 +73,12 @@ LABEL_APPLYING = "auto-improve:applying"
 LABEL_APPLIED  = "auto-improve:applied"
 LABEL_HUMAN_NEEDED    = "auto-improve:human-needed"    # IssueState.HUMAN_NEEDED
 LABEL_PR_HUMAN_NEEDED = "auto-improve:pr-human-needed" # PRState.PR_HUMAN_NEEDED
+# Explicit "admin is done, resume the FSM" signal. An issue/PR parked at
+# :human-needed is only considered for resume when this label is *also*
+# present — the admin applies it once their comment(s) fully address the
+# divert. Replaces the previous "any admin comment triggers resume" model,
+# which fired on incidental questions and ambiguous replies.
+LABEL_HUMAN_SOLVED = "human:solved"
 LABEL_TRIAGING         = "auto-improve:triaging"
 LABEL_KIND_CODE        = "kind:code"
 LABEL_KIND_MAINTENANCE = "kind:maintenance"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,7 @@ Handler registry (PR states):
 
 Terminal / parked states (`SOLVED`, `HUMAN_NEEDED`, `PR_HUMAN_NEEDED`, PR `MERGED`) have no handler; the dispatcher returns without doing anything.
 
-Issues still enter the pipeline the same way: `cai analyze`, `cai propose`, `cai code-audit`, `cai audit`, or a human files an issue labeled `auto-improve:raised`. Low-confidence planner outcomes still park at `:human-needed`, and an admin's comment is still resumed via `cai unblock`.
+Issues still enter the pipeline the same way: `cai analyze`, `cai propose`, `cai code-audit`, `cai audit`, or a human files an issue labeled `auto-improve:raised`. Low-confidence planner outcomes still park at `:human-needed`; the admin resolves the issue in comments and then applies the `human:solved` label, which `cai unblock` picks up to resume the FSM.
 
 ## Lifecycle Labels
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -94,7 +94,7 @@ No arguments.
 
 ## unblock
 
-Scan open issues labelled `auto-improve:human-needed` and attempt to resume the FSM via admin comments. For each issue with a pending-transition marker in its body and at least one comment from an admin login (`CAI_ADMIN_LOGINS`), invokes the `cai-unblock` Haiku agent to classify the comment into a `ResumeTo:` target, then fires the matching `human_to_<state>` transition and strips the marker. Confidence below `HIGH` leaves the issue parked.
+Scan open issues parked at `auto-improve:human-needed` that an admin has explicitly marked ready for resume by applying the `human:solved` label. For each such issue with a pending-transition marker in its body and at least one comment from an admin login (`CAI_ADMIN_LOGINS`), invokes the `cai-unblock` Haiku agent to classify the comment into a `ResumeTo:` target, then fires the matching `human_to_<state>` transition, strips the marker, and removes the `human:solved` label. Confidence below `HIGH` leaves the issue parked (label stays on so the admin can iterate). Issues without `human:solved` are ignored entirely — the admin is free to discuss or ask questions without waking the classifier.
 
 PR-side (`auto-improve:pr-human-needed`) is not yet wired — follow-up.
 

--- a/tests/test_unblock.py
+++ b/tests/test_unblock.py
@@ -123,5 +123,81 @@ class TestTryUnblockIssueSkips(unittest.TestCase):
         fake.assert_not_called()
 
 
+class TestListHumanNeededIssuesFiltersByLabel(unittest.TestCase):
+    """_list_human_needed_issues must require BOTH :human-needed and human:solved.
+
+    The label-gated handoff is the whole point of PR 3 — if this query
+    regresses to a single --label filter the classifier will start
+    firing on every parked issue again.
+    """
+
+    def test_queries_both_labels(self):
+        captured: list[list[str]] = []
+
+        def fake_gh(args):
+            captured.append(args)
+            return []
+
+        with mock.patch.object(U, "_gh_json", side_effect=fake_gh):
+            U._list_human_needed_issues()
+
+        self.assertEqual(len(captured), 1)
+        args = captured[0]
+        # --label appears twice, once for each required label.
+        label_flags = [args[i + 1] for i, a in enumerate(args) if a == "--label"]
+        self.assertIn("auto-improve:human-needed", label_flags)
+        self.assertIn("human:solved", label_flags)
+        self.assertEqual(len(label_flags), 2)
+
+
+class TestResumeStripsHumanSolvedLabel(unittest.TestCase):
+    """A successful resume must remove human:solved so the signal is one-shot."""
+
+    def test_apply_transition_receives_human_solved_in_extra_remove(self):
+        body = (
+            "issue text\n\n"
+            "<!-- cai-fsm-pending transition=refining_to_refined "
+            "from=REFINING intended=REFINED conf=MEDIUM -->\n"
+        )
+        issue = {
+            "number": 77,
+            "title": "t",
+            "body": body,
+            "labels": [
+                {"name": "auto-improve:human-needed"},
+                {"name": "human:solved"},
+            ],
+            "comments": [
+                {"author": {"login": "alice"},
+                 "createdAt": "2026-04-14T12:00:00Z",
+                 "body": "please retry"},
+            ],
+        }
+
+        agent_stdout = "ResumeTo: REFINING\nConfidence: HIGH\n"
+        fake_agent = mock.MagicMock()
+        fake_agent.returncode = 0
+        fake_agent.stdout = agent_stdout
+        fake_agent.stderr = ""
+
+        captured: dict = {}
+
+        def fake_apply(issue_number, transition_name, **kwargs):
+            captured["issue_number"] = issue_number
+            captured["transition_name"] = transition_name
+            captured["kwargs"] = kwargs
+            return True
+
+        with mock.patch.object(U, "_run_claude_p", return_value=fake_agent), \
+             mock.patch.object(U, "apply_transition", side_effect=fake_apply), \
+             mock.patch.object(U, "_clear_pending_marker_on_body", return_value=True):
+            result = U._try_unblock_issue(issue)
+
+        self.assertEqual(result, "resumed")
+        self.assertEqual(captured["issue_number"], 77)
+        self.assertEqual(captured["transition_name"], "human_to_refining")
+        self.assertIn("human:solved", captured["kwargs"].get("extra_remove", []))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `cai unblock` now only considers `:human-needed` issues that also carry the new `human:solved` label. The admin explicitly signals "I'm done, resume" by applying the label, replacing the prior "any admin comment triggers resume" model.
- `_list_human_needed_issues` filters on both labels (`--label` twice → AND).
- Successful resume passes `human:solved` via `extra_remove` so the label clears atomically with the FSM state change — one-shot signal.
- Docs + `cai-unblock` agent guidance updated.

## Test plan
- [x] `python -m unittest discover tests` — 129 pass, 1 skipped
- [x] New `TestListHumanNeededIssuesFiltersByLabel` asserts both labels are required.
- [x] New `TestResumeStripsHumanSolvedLabel` asserts `human:solved` appears in `extra_remove` on a successful resume.
- [ ] Manually: park an issue at `:human-needed`, comment, apply `human:solved`, run `cai unblock`, confirm resume + label removal.