### PR TITLE
fix(_run): allow callers to override check= instead of forcing False

### DIFF
--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -10,8 +10,16 @@ from cai_lib.logging_utils import log_cost
 
 
 def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
-    """Thin wrapper around subprocess.run with text mode and check=False."""
-    return subprocess.run(cmd, text=True, check=False, **kwargs)
+    """Thin wrapper around subprocess.run with text mode; defaults check=False.
+
+    ``check`` is overridable — callers that want the stdlib raise-on-nonzero
+    semantics can pass ``check=True``. Previously we hard-coded ``check=False``
+    and then also forwarded ``**kwargs`` into ``subprocess.run``, which raised
+    ``TypeError: got multiple values for keyword argument 'check'`` whenever
+    a caller tried to opt in (e.g. `actions/triage.py` on the body-edit path).
+    """
+    kwargs.setdefault("check", False)
+    return subprocess.run(cmd, text=True, **kwargs)
 
 
 def _run_claude_p(


### PR DESCRIPTION
## Summary
- `_run` hard-coded `check=False` and then forwarded `**kwargs`, so any caller passing `check=True` (e.g. `actions/triage.py:294,320`) raised `TypeError: got multiple values for keyword argument 'check'` and crashed the handler mid-dispatch.
- Switch to `kwargs.setdefault("check", False)` so the default stays permissive but callers can still opt in to raise-on-nonzero.
- Spotted via the #657 dispatcher guard (now merged) — the queue survived because `dispatch_drain` caught the traceback, but the triage attempt itself was lost.

## Test plan
- [x] `python -m unittest discover tests` — 129 pass, 1 skipped
- [ ] Next cycle: confirm `handle_triage` completes the body-edit path without a TypeError.