### PR TITLE
chore(cai-triage): downgrade to haiku-4-5

### DIFF
--- a/.claude/agents/cai-triage.md
+++ b/.claude/agents/cai-triage.md
@@ -2,7 +2,7 @@
 name: cai-triage
 description: Triage `auto-improve:raised` issues one at a time — classify as REFINE, DISMISS_DUPLICATE, DISMISS_RESOLVED, PLAN_APPROVE, APPLY, or HUMAN. Inline-only — full issue body plus context are provided in the user message. No tool use needed.
 tools: Read
-model: claude-sonnet-4-6
+model: claude-haiku-4-5-20251001
 memory: project
 ---
 


### PR DESCRIPTION
## Summary
- `cai-triage` is inline-only: fixed decision set (REFINE / DISMISS_* / PLAN_APPROVE / APPLY / HUMAN), no tools, no code-reading. That's a haiku-shaped job, not sonnet.
- Every raised issue pays this cost, so the savings compound.
- Only the `model:` frontmatter line changes; prompt body is unchanged.

## Test plan
- [ ] Next cycle: watch a raised issue get triaged by haiku-4-5 and confirm the verdict lands in the expected set.
- [ ] Compare a few verdicts against what sonnet would have emitted — flag if haiku is visibly less accurate on ambiguous duplicates.