### PR TITLE
feat(staging): add CLAUDE.md staging directory

### DIFF
--- a/.claude/agents/cai-fix-ci.md
+++ b/.claude/agents/cai-fix-ci.md
@@ -27,19 +27,24 @@ absolute paths under the work directory from the user message.
 for targeted reads. Git operations go through `cai-git` if needed — you
 have no Bash.
 
-## Self-modifying agent files (staging directory)
+## Self-modifying agent files, plugins, and CLAUDE.md (staging directory)
 
-Claude-code blocks `Edit`/`Write` on `.claude/agents/*.md` paths.
-Use the staging directory the wrapper pre-creates:
+Claude-code blocks `Edit`/`Write` on `.claude/agents/*.md`,
+`.claude/plugins/`, and `CLAUDE.md` paths. Use the staging directory
+the wrapper pre-creates:
 
 - **Agent files:** Write the FULL new file to
   `<work_dir>/.cai-staging/agents/<basename>.md`. The wrapper copies
   it over `.claude/agents/<basename>.md` after you exit.
 - **Plugin files:** Write to
   `<work_dir>/.cai-staging/plugins/<same-relative-path>`.
+- **`CLAUDE.md` files:** Write to
+  `<work_dir>/.cai-staging/claudemd/<same-relative-path>/CLAUDE.md`.
+  The wrapper scans for files named `CLAUDE.md` and copies each to
+  the matching path in `<work_dir>/` after you exit.
 
 Rules: write the FULL file (unconditional overwrite), use exact
-basename, never try `Edit`/`Write` on the protected paths.
+relative path, never try `Edit`/`Write` on the protected paths.
 
 ## Hard rules — remote and git
 

--- a/.claude/agents/cai-implement.md
+++ b/.claude/agents/cai-implement.md
@@ -52,7 +52,7 @@ will exceed the token limit. Use `Grep(pattern, path="<work_dir>")` for
 symbol search and `Read("<work_dir>/cai.py", offset=N, limit=200)` for
 targeted sections.
 
-## Self-modifying `.claude/agents/*.md` and `.claude/plugins/` (staging directory)
+## Self-modifying `.claude/agents/*.md`, `.claude/plugins/`, and `CLAUDE.md` (staging directory)
 
 **Claude-code's headless `-p` mode hardcodes a write block on
 every `.claude/agents/*.md` path**, regardless of any permission
@@ -94,7 +94,20 @@ wrapper pre-creates is the workaround for both cases:
      `dirs_exist_ok=True` after you exit, then deletes the
      staging directory.
 
-Rules (apply to both agents and plugins):
+**For `CLAUDE.md` files** (root or any subdirectory):
+
+  1. **Write** the full `CLAUDE.md` content to
+     `<work_dir>/.cai-staging/claudemd/<same-relative-path>/CLAUDE.md`.
+     Preserve the directory structure. To update the root
+     `CLAUDE.md`, write to `.cai-staging/claudemd/CLAUDE.md`. To
+     update `subdir/CLAUDE.md`, write to
+     `.cai-staging/claudemd/subdir/CLAUDE.md`.
+  2. The wrapper scans `.cai-staging/claudemd/` for all files named
+     exactly `CLAUDE.md` and copies each to the matching path in
+     `<work_dir>/` after you exit, then deletes the staging
+     directory.
+
+Rules (apply to agents, plugins, and CLAUDE.md files):
 
   - Staged files are copied unconditionally — new definitions
     are created if no target exists yet.
@@ -117,6 +130,11 @@ Example of creating a plugin skill:
 
   - GOOD: `Write("<work_dir>/.cai-staging/plugins/cai-skills/skills/foo/SKILL.md", "<full content>")`
   - BAD:  `Write("<work_dir>/.claude/plugins/cai-skills/skills/foo/SKILL.md", ...)`  (blocked)
+
+Example of updating root CLAUDE.md:
+
+  - GOOD: `Write("<work_dir>/.cai-staging/claudemd/CLAUDE.md", "<full content>")`
+  - BAD:  `Write("<work_dir>/CLAUDE.md", ...)`  (blocked)
 
 ## Hard rules
 

--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -33,18 +33,23 @@ absolute paths under the work directory from the user message.
 `cai.py` is ~63 k tokens — use `Grep` + `Read(..., offset=N, limit=200)`. **Git
 operations go through `cai-git`** — you have no Bash.
 
-## Self-modifying agent files and plugins (staging directory)
+## Self-modifying agent files, plugins, and CLAUDE.md (staging directory)
 
-Claude-code blocks `Edit`/`Write` on `.claude/agents/*.md` and `.claude/plugins/`
-paths. Use the staging directory the wrapper pre-creates:
+Claude-code blocks `Edit`/`Write` on `.claude/agents/*.md`, `.claude/plugins/`,
+and `CLAUDE.md` paths. Use the staging directory the wrapper pre-creates:
 
 - **Agent files:** Write the FULL new file to
   `<work_dir>/.cai-staging/agents/<basename>.md`. The wrapper copies it over
   `.claude/agents/<basename>.md` after you exit.
 - **Plugin files:** Write to `<work_dir>/.cai-staging/plugins/<same-relative-path>`.
   The wrapper merges it into `.claude/plugins/` after you exit.
+- **`CLAUDE.md` files:** Write to
+  `<work_dir>/.cai-staging/claudemd/<same-relative-path>/CLAUDE.md`.
+  The wrapper scans for all files named `CLAUDE.md` in the staging
+  tree and copies each to the matching path in `<work_dir>/` after
+  you exit, preserving relative paths.
 
-Rules: write the FULL file (unconditional overwrite), use exact basename,
+Rules: write the FULL file (unconditional overwrite), use exact relative path,
 never try `Edit`/`Write` on the protected paths.
 
   - GOOD: `Read("<work_dir>/.claude/agents/cai-revise.md")` then

--- a/cai_lib/cmd_helpers.py
+++ b/cai_lib/cmd_helpers.py
@@ -24,6 +24,7 @@ from cai_lib.subprocess_utils import _run
 # to the clone root.
 AGENT_EDIT_STAGING_REL = Path(".cai-staging") / "agents"
 PLUGIN_STAGING_REL = Path(".cai-staging") / "plugins"
+CLAUDEMD_STAGING_REL = Path(".cai-staging") / "claudemd"
 
 
 # IMPORTANT: only "no-action" / "summary" bot comments belong here.
@@ -172,6 +173,8 @@ def _setup_agent_edit_staging(work_dir: Path) -> Path:
     staging.mkdir(parents=True, exist_ok=True)
     plugin_staging = work_dir / PLUGIN_STAGING_REL
     plugin_staging.mkdir(parents=True, exist_ok=True)
+    claudemd_staging = work_dir / CLAUDEMD_STAGING_REL
+    claudemd_staging.mkdir(parents=True, exist_ok=True)
     return staging
 
 
@@ -257,6 +260,34 @@ def _apply_agent_edit_staging(work_dir: Path) -> int:
             # or retry. Do not fall through to shutil.rmtree below.
             return applied
 
+    # Apply any CLAUDE.md staging: .cai-staging/claudemd/ → <work_dir>/.
+    # Use rglob("CLAUDE.md") so only files literally named CLAUDE.md
+    # are copied — stray files in the staging tree are ignored.
+    claudemd_staging = work_dir / CLAUDEMD_STAGING_REL
+    if claudemd_staging.exists() and claudemd_staging.is_dir():
+        for staged_file in sorted(claudemd_staging.rglob("CLAUDE.md")):
+            rel = staged_file.relative_to(claudemd_staging)
+            target = work_dir / rel
+            try:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                content = staged_file.read_text()
+                target.write_text(content)
+                print(
+                    f"[cai] applied staged CLAUDE.md: {rel} "
+                    f"({len(content)} bytes)",
+                    flush=True,
+                )
+                applied += 1
+            except OSError as exc:
+                print(
+                    f"[cai] agent edit staging: failed to apply "
+                    f"CLAUDE.md at {rel}: {exc}",
+                    file=sys.stderr,
+                )
+                # Preserve .cai-staging so staged files are not
+                # silently lost when the copy fails.
+                return applied
+
     # Clean up the entire .cai-staging tree (one level above the
     # agents/ subdir) so nothing leaks into the PR.
     cai_staging_root = work_dir / ".cai-staging"
@@ -308,6 +339,7 @@ def _work_directory_block(work_dir: Path) -> str:
     """
     staging_rel = AGENT_EDIT_STAGING_REL.as_posix()
     staging_abs = (work_dir / AGENT_EDIT_STAGING_REL).as_posix()
+    claudemd_abs = (work_dir / CLAUDEMD_STAGING_REL).as_posix()
     return (
         "## Work directory\n\n"
         "You are running with cwd `/app` so your declarative agent "
@@ -367,6 +399,36 @@ def _work_directory_block(work_dir: Path) -> str:
         "\"<full new file content>\")`\n"
         f"  - BAD:  `Edit(\"{work_dir}/.claude/agents/cai-implement.md\", "
         "...)`  (blocked by claude-code)\n"
+        "\n"
+        "## Updating `CLAUDE.md` files (self-modification)\n\n"
+        "Claude-code's headless `-p` mode also hardcodes a write block "
+        "on `CLAUDE.md` files (project-level context files). Edit/Write "
+        f"calls against `{work_dir}/CLAUDE.md` or any subdirectory "
+        "`CLAUDE.md` WILL fail with a sensitive-file protection error.\n\n"
+        "The wrapper provides a **staging directory** at:\n\n"
+        f"    {claudemd_abs}\n\n"
+        "To update a `CLAUDE.md` file at any path (root or subdirectory), "
+        f"write it to `{claudemd_abs}/<same-relative-path>/CLAUDE.md`. "
+        "The wrapper scans for all files named exactly `CLAUDE.md` under "
+        f"the staging tree and copies each to the matching path in "
+        f"`{work_dir}/`, creating parent directories as needed. The "
+        "staging directory is then deleted so it never lands in the PR.\n\n"
+        "Rules:\n"
+        "  - Only files literally named `CLAUDE.md` are copied — other "
+        "files in the staging tree are ignored.\n"
+        "  - Preserve the full relative path (e.g., to update "
+        f"`{work_dir}/CLAUDE.md`, write to "
+        f"`{claudemd_abs}/CLAUDE.md`; to update "
+        f"`{work_dir}/subdir/CLAUDE.md`, write to "
+        f"`{claudemd_abs}/subdir/CLAUDE.md`).\n"
+        "  - Write the FULL file, not a diff or patch.\n"
+        f"  - Do NOT attempt `Edit` or `Write` on `{work_dir}/CLAUDE.md` "
+        "directly — it will always fail. Go through the staging dir.\n\n"
+        "Example:\n"
+        f"  - GOOD: `Write(\"{claudemd_abs}/CLAUDE.md\", "
+        "\"<full new file content>\")`\n"
+        f"  - BAD:  `Edit(\"{work_dir}/CLAUDE.md\", ...)`  "
+        "(blocked by claude-code)\n"
     )
 
 


### PR DESCRIPTION
## Summary
- Extends the `.cai-staging/` pattern to cover `CLAUDE.md` files (root and nested), which claude-code's headless `-p` mode write-protects alongside `.claude/agents/*.md` and `.claude/plugins/`.
- Adds `CLAUDEMD_STAGING_REL = .cai-staging/claudemd`; `_setup_agent_edit_staging` pre-creates it and `_apply_agent_edit_staging` scans `rglob("CLAUDE.md")` and copies each match to the matching path in `work_dir`, ignoring stray files and preserving staging on failure.
- Documents the new path in `_work_directory_block` and in the staging sections of `cai-implement.md`, `cai-revise.md`, and `cai-fix-ci.md`.

Closes #644

## Test plan
- [x] Local roundtrip: `_setup_agent_edit_staging` creates the dir; staging a root + nested `CLAUDE.md` plus a stray file → both `CLAUDE.md` files copied, stray ignored, `.cai-staging/` cleaned up.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)