### PR TITLE
fix(implement): restore _extract_stored_plan after dispatcher refactor

### DIFF
--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -50,6 +50,7 @@ from cai_lib.cmd_helpers import (
     _setup_agent_edit_staging,
     _apply_agent_edit_staging,
     _build_attempt_history_block,
+    _extract_stored_plan,
 )
 from cai_lib.fsm import (
     apply_transition,
@@ -81,10 +82,6 @@ def _get_plan_for_fix(issue: dict) -> str | None:
     called after that gate, so the plan should always be present; the
     None branch is kept as a defensive WARNING rather than a hard abort.
     """
-    # Local import avoids a circular dependency: cai.py imports from
-    # this module once the dispatcher wires handle_implement in.
-    from cai import _extract_stored_plan
-
     plan = _extract_stored_plan(issue.get("body", ""))
     if plan:
         print(f"[cai implement] using stored plan from issue body ({len(plan)} chars)", flush=True)
@@ -284,10 +281,6 @@ def handle_implement(issue: dict) -> int:
     ``in_progress_to_pr``; on pre-screen ``spike`` / subagent "Needs
     Spike" marker we divert to ``:human-needed``.
     """
-    # Local import of _extract_stored_plan lives inside _get_plan_for_fix
-    # (circular-import guard).  Here we need it too for the pre-lock gate.
-    from cai import _extract_stored_plan
-
     issue_number = issue["number"]
     title = issue["title"]
     label_names = [lbl["name"] for lbl in issue.get("labels", [])]

--- a/cai_lib/cmd_helpers.py
+++ b/cai_lib/cmd_helpers.py
@@ -147,6 +147,21 @@ def _build_attempt_history_block(attempts: list[dict]) -> str:
     return block
 
 
+def _extract_stored_plan(issue_body: str) -> str | None:
+    """Extract the stored plan from an issue body, or None if not present."""
+    start_marker = "<!-- cai-plan-start -->"
+    end_marker = "<!-- cai-plan-end -->"
+    start = issue_body.find(start_marker)
+    end = issue_body.find(end_marker)
+    if start == -1 or end == -1 or end <= start:
+        return None
+    content = issue_body[start + len(start_marker):end].strip()
+    heading = "## Selected Implementation Plan"
+    if content.startswith(heading):
+        content = content[len(heading):].strip()
+    return content if content else None
+
+
 def _strip_stored_plan_block(issue_body: str) -> str:
     """Remove an existing cai-plan block from the issue body, if present."""
     start_marker = "<!-- cai-plan-start -->"


### PR DESCRIPTION
## Summary
- Restores `_extract_stored_plan` (removed in 94e84c4) as `cai_lib/cmd_helpers._extract_stored_plan`.
- Fixes `cai_lib/actions/implement.py` imports that still referenced `cai._extract_stored_plan` — every PLAN_APPROVED issue was crashing the dispatcher with ImportError and breaking `cai cycle`.

## Test plan
- [x] `python -c "from cai_lib.actions.implement import handle_implement"` loads without ImportError
- [ ] Next cycle tick dispatches a PLAN_APPROVED issue without crashing

Generated with [Claude Code](https://claude.com/claude-code)