### PR TITLE
fix(dispatcher): make drain loop guard state-aware

### DIFF
--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -250,13 +250,17 @@ def dispatch_pr(pr_number: int) -> int:
 
 def _pick_oldest_actionable_target(
     skip: Optional[set[tuple[str, int]]] = None,
-) -> Optional[tuple[str, int]]:
-    """Return ``(kind, number)`` of the oldest open issue/PR in a state with
-    a registered handler, or ``None`` if the queue is empty.
+) -> Optional[tuple[str, int, str]]:
+    """Return ``(kind, number, state_name)`` of the oldest open issue/PR in a
+    state with a registered handler, or ``None`` if the queue is empty.
 
-    ``kind`` is ``"issue"`` or ``"pr"``. Sort key is the GitHub
-    ``createdAt`` timestamp (oldest first), so PRs that have been around
-    longer get the next tick — keeps in-flight work ahead of fresh intake.
+    ``kind`` is ``"issue"`` or ``"pr"``. ``state_name`` is the ``.name`` of
+    the :class:`IssueState` / :class:`PRState` the target is currently in —
+    callers use it to distinguish "same item, new state" (legitimate
+    handler-driven progression across drain iterations) from "same item,
+    same state" (true loop). Sort key is the GitHub ``createdAt`` timestamp
+    (oldest first), so PRs that have been around longer get the next tick —
+    keeps in-flight work ahead of fresh intake.
 
     ``skip`` is an optional set of ``(kind, number)`` tuples to exclude — used
     by :func:`dispatch_drain` to move past a target whose handler already
@@ -292,7 +296,7 @@ def _pick_oldest_actionable_target(
         print(f"[cai dispatch] gh pr list failed:\n{e.stderr}", file=sys.stderr)
         prs = []
 
-    candidates: list[tuple[str, str, int]] = []
+    candidates: list[tuple[str, str, int, str]] = []
 
     for issue in issues:
         label_names = [lb["name"] for lb in issue.get("labels", [])]
@@ -300,21 +304,25 @@ def _pick_oldest_actionable_target(
         if state is not None and state in issue_states:
             if ("issue", issue["number"]) in skip:
                 continue
-            candidates.append((issue.get("createdAt", ""), "issue", issue["number"]))
+            candidates.append(
+                (issue.get("createdAt", ""), "issue", issue["number"], state.name)
+            )
 
     for pr in prs:
         state = get_pr_state(pr)
         if state in pr_states:
             if ("pr", pr["number"]) in skip:
                 continue
-            candidates.append((pr.get("createdAt", ""), "pr", pr["number"]))
+            candidates.append(
+                (pr.get("createdAt", ""), "pr", pr["number"], state.name)
+            )
 
     if not candidates:
         return None
 
     candidates.sort(key=lambda c: c[0])
-    _, kind, number = candidates[0]
-    return (kind, number)
+    _, kind, number, state_name = candidates[0]
+    return (kind, number, state_name)
 
 
 # Default cap on how many handlers a single drain pass will run. The
@@ -329,9 +337,12 @@ def dispatch_drain(max_iter: int = _DEFAULT_DRAIN_MAX_ITER) -> int:
 
     Stops when one of:
       - the queue is empty (no actionable issues or PRs left),
-      - the same ``(kind, number)`` is picked twice in a row (loop guard
-        — should not happen with idempotent handlers, but defends against
-        a regression),
+      - the same ``(kind, number, state)`` is picked twice in a row (loop
+        guard — should not happen with idempotent handlers, but defends
+        against a regression). State is part of the key so that a handler
+        which legitimately advances its target to another actionable state
+        (e.g. implement: PLAN_APPROVED → PR, plan_gate: PLANNED →
+        PLAN_APPROVED) isn't mistaken for a loop,
       - ``max_iter`` iterations have run (defense against systemic
         non-advancing handlers; the cycle's flock prevents overlap).
 
@@ -340,7 +351,7 @@ def dispatch_drain(max_iter: int = _DEFAULT_DRAIN_MAX_ITER) -> int:
     """
     import traceback
 
-    last_target: Optional[tuple[str, int]] = None
+    last_target: Optional[tuple[str, int, str]] = None
     failed_targets: set[tuple[str, int]] = set()
     worst_rc = 0
 
@@ -352,10 +363,12 @@ def dispatch_drain(max_iter: int = _DEFAULT_DRAIN_MAX_ITER) -> int:
             return worst_rc
         if target == last_target:
             print(f"[cai dispatch] same target {target!r} picked twice in a "
-                  "row; stopping drain to avoid loop", flush=True)
+                  "row with no state change; stopping drain to avoid loop",
+                  flush=True)
             return worst_rc
 
-        kind, number = target
+        kind, number, _state_name = target
+        target_key = (kind, number)
         try:
             if kind == "issue":
                 rc = dispatch_issue(number)
@@ -369,12 +382,12 @@ def dispatch_drain(max_iter: int = _DEFAULT_DRAIN_MAX_ITER) -> int:
             print(f"[cai dispatch] handler for {kind} #{number} raised; "
                   "skipping this target for the remainder of the drain",
                   flush=True)
-            failed_targets.add(target)
+            failed_targets.add(target_key)
             worst_rc = max(worst_rc, 1)
             last_target = target
             continue
         if rc != 0:
-            failed_targets.add(target)
+            failed_targets.add(target_key)
             if rc > worst_rc:
                 worst_rc = rc
         last_target = target

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -403,6 +403,61 @@ class TestDispatchDrain(unittest.TestCase):
         self.assertEqual(rc, 0)
         di.assert_called_once_with(10)
 
+    def test_loop_guard_allows_same_target_across_state_change(self):
+        """Same (kind, number) but a new state is legitimate progression, not a loop.
+
+        Regression for the case where ``handle_implement`` advances an
+        issue from ``:plan-approved`` to ``:pr-open``. Before the fix the
+        loop guard keyed on ``(kind, number)`` only and aborted the drain
+        after one dispatch even though the state had legitimately
+        advanced; now it keys on state too.
+        """
+        # Issue #10: first seen at :plan-approved, then at :pr-open after the
+        # implement handler ran. Both states are actionable (handle_implement
+        # and handle_pr_bounce respectively).
+        state = {"label": "auto-improve:plan-approved"}
+
+        def fake_gh_json(cmd):
+            if "issue" in cmd and "list" in cmd:
+                return [{
+                    "number": 10,
+                    "createdAt": "2024-01-01T00:00:00Z",
+                    "labels": [{"name": state["label"]}],
+                }]
+            return []
+
+        di_calls: list[int] = []
+
+        def fake_di(n):
+            di_calls.append(n)
+            # First call simulates implement advancing the label.
+            if state["label"] == "auto-improve:plan-approved":
+                state["label"] = "auto-improve:pr-open"
+                return 0
+            # Second call simulates pr_bounce clearing the label (queue empties).
+            state["label"] = "none"
+            return 0
+
+        def fake_gh_json_stateful(cmd):
+            if "issue" in cmd and "list" in cmd:
+                if state["label"] == "none":
+                    return []
+                return [{
+                    "number": 10,
+                    "createdAt": "2024-01-01T00:00:00Z",
+                    "labels": [{"name": state["label"]}],
+                }]
+            return []
+
+        with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json_stateful), \
+             patch.object(dispatcher, "dispatch_issue", side_effect=fake_di):
+            rc = dispatcher.dispatch_drain(max_iter=10)
+
+        # Both iterations ran — the guard didn't abort on the state
+        # transition, and the drain only stopped when the queue emptied.
+        self.assertEqual(rc, 0)
+        self.assertEqual(di_calls, [10, 10])
+
     def test_max_iter_cap(self):
         """A pool that keeps providing distinct targets stops at max_iter."""
         # Generate as many distinct issues as we want and never shrink.


### PR DESCRIPTION
## Summary
- The drain loop guard in `cai_lib/dispatcher.py` keyed on `(kind, number)` only, so when a handler legitimately advanced an issue to a new actionable state within the same drain pass (e.g. `handle_implement` transitioning an issue from `PLAN_APPROVED` → `PR` after opening a PR), the next pick aborted the drain as a false-positive loop. The follow-up handler (e.g. `handle_pr_bounce` on `:pr-open`) was deferred to the next cron tick, silently losing throughput.
- Fix: include the state name in the loop-guard key. "Same item, new state" is now recognized as forward progress. True loops (same item + same state, twice in a row) still trip the guard. `max_iter=50` remains the ultimate backstop.

Observed in production on issue #620 (PR #668 context): `[cai dispatch] same target ('issue', 620) picked twice in a row; stopping drain to avoid loop` fired even though the handler had successfully advanced state from `:plan-approved` to `:pr-open`.

## Test plan
- [x] Added regression test `test_loop_guard_allows_same_target_across_state_change` simulating implement → pr_bounce on the same issue across iterations.
- [x] Existing loop-guard test (`test_loop_guard_breaks_on_repeat_target`) still passes — same state twice in a row still aborts.
- [x] Full test suite: `python -m unittest discover tests -q` → 145 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)