### PR TITLE
fix(dispatcher): drop same-target loop guard, rely on max_iter

### DIFF
--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -250,17 +250,13 @@ def dispatch_pr(pr_number: int) -> int:
 
 def _pick_oldest_actionable_target(
     skip: Optional[set[tuple[str, int]]] = None,
-) -> Optional[tuple[str, int, str]]:
-    """Return ``(kind, number, state_name)`` of the oldest open issue/PR in a
-    state with a registered handler, or ``None`` if the queue is empty.
+) -> Optional[tuple[str, int]]:
+    """Return ``(kind, number)`` of the oldest open issue/PR in a state with
+    a registered handler, or ``None`` if the queue is empty.
 
-    ``kind`` is ``"issue"`` or ``"pr"``. ``state_name`` is the ``.name`` of
-    the :class:`IssueState` / :class:`PRState` the target is currently in —
-    callers use it to distinguish "same item, new state" (legitimate
-    handler-driven progression across drain iterations) from "same item,
-    same state" (true loop). Sort key is the GitHub ``createdAt`` timestamp
-    (oldest first), so PRs that have been around longer get the next tick —
-    keeps in-flight work ahead of fresh intake.
+    ``kind`` is ``"issue"`` or ``"pr"``. Sort key is the GitHub
+    ``createdAt`` timestamp (oldest first), so PRs that have been around
+    longer get the next tick — keeps in-flight work ahead of fresh intake.
 
     ``skip`` is an optional set of ``(kind, number)`` tuples to exclude — used
     by :func:`dispatch_drain` to move past a target whose handler already
@@ -296,7 +292,7 @@ def _pick_oldest_actionable_target(
         print(f"[cai dispatch] gh pr list failed:\n{e.stderr}", file=sys.stderr)
         prs = []
 
-    candidates: list[tuple[str, str, int, str]] = []
+    candidates: list[tuple[str, str, int]] = []
 
     for issue in issues:
         label_names = [lb["name"] for lb in issue.get("labels", [])]
@@ -304,31 +300,30 @@ def _pick_oldest_actionable_target(
         if state is not None and state in issue_states:
             if ("issue", issue["number"]) in skip:
                 continue
-            candidates.append(
-                (issue.get("createdAt", ""), "issue", issue["number"], state.name)
-            )
+            candidates.append((issue.get("createdAt", ""), "issue", issue["number"]))
 
     for pr in prs:
         state = get_pr_state(pr)
         if state in pr_states:
             if ("pr", pr["number"]) in skip:
                 continue
-            candidates.append(
-                (pr.get("createdAt", ""), "pr", pr["number"], state.name)
-            )
+            candidates.append((pr.get("createdAt", ""), "pr", pr["number"]))
 
     if not candidates:
         return None
 
     candidates.sort(key=lambda c: c[0])
-    _, kind, number, state_name = candidates[0]
-    return (kind, number, state_name)
+    _, kind, number = candidates[0]
+    return (kind, number)
 
 
 # Default cap on how many handlers a single drain pass will run. The
 # cron tick interval (CAI_CYCLE_SCHEDULE) is the wall-clock rate limit;
-# this cap is the loop-detection backstop in case a handler keeps
-# re-picking itself without advancing state.
+# this cap is the sole backstop against a runaway loop (e.g. a handler
+# that keeps re-picking the same target without advancing state, or a
+# routing handler like pr_bounce repeatedly delegating to a PR that's
+# already done). Handler-level idempotence + ``failed_targets`` skipping
+# of any nonzero/crashing handler are the primary safety nets.
 _DEFAULT_DRAIN_MAX_ITER = 50
 
 
@@ -337,21 +332,21 @@ def dispatch_drain(max_iter: int = _DEFAULT_DRAIN_MAX_ITER) -> int:
 
     Stops when one of:
       - the queue is empty (no actionable issues or PRs left),
-      - the same ``(kind, number, state)`` is picked twice in a row (loop
-        guard — should not happen with idempotent handlers, but defends
-        against a regression). State is part of the key so that a handler
-        which legitimately advances its target to another actionable state
-        (e.g. implement: PLAN_APPROVED → PR, plan_gate: PLANNED →
-        PLAN_APPROVED) isn't mistaken for a loop,
       - ``max_iter`` iterations have run (defense against systemic
         non-advancing handlers; the cycle's flock prevents overlap).
+
+    No same-target loop guard: routing handlers like ``pr_bounce`` make
+    legitimate progress on a *delegated* target (the linked PR) without
+    changing the picked issue's own state, so a same-target guard
+    produces false positives that abort the drain mid-pipeline. The
+    ``max_iter`` cap plus ``failed_targets`` skipping handle the
+    regression cases the guard was meant to catch.
 
     Returns the worst exit code seen across handlers (0 if every dispatch
     succeeded or the queue was empty from the start).
     """
     import traceback
 
-    last_target: Optional[tuple[str, int, str]] = None
     failed_targets: set[tuple[str, int]] = set()
     worst_rc = 0
 
@@ -361,14 +356,8 @@ def dispatch_drain(max_iter: int = _DEFAULT_DRAIN_MAX_ITER) -> int:
             print(f"[cai dispatch] drain complete after {i} dispatch(es): "
                   "queue empty", flush=True)
             return worst_rc
-        if target == last_target:
-            print(f"[cai dispatch] same target {target!r} picked twice in a "
-                  "row with no state change; stopping drain to avoid loop",
-                  flush=True)
-            return worst_rc
 
-        kind, number, _state_name = target
-        target_key = (kind, number)
+        kind, number = target
         try:
             if kind == "issue":
                 rc = dispatch_issue(number)
@@ -382,15 +371,13 @@ def dispatch_drain(max_iter: int = _DEFAULT_DRAIN_MAX_ITER) -> int:
             print(f"[cai dispatch] handler for {kind} #{number} raised; "
                   "skipping this target for the remainder of the drain",
                   flush=True)
-            failed_targets.add(target_key)
+            failed_targets.add(target)
             worst_rc = max(worst_rc, 1)
-            last_target = target
             continue
         if rc != 0:
-            failed_targets.add(target_key)
+            failed_targets.add(target)
             if rc > worst_rc:
                 worst_rc = rc
-        last_target = target
 
     print(f"[cai dispatch] hit drain cap (max_iter={max_iter}); remaining "
           "actionable items will run on the next cycle tick", flush=True)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,7 +69,7 @@ Issues still enter the pipeline the same way: `cai analyze`, `cai propose`, `cai
 `cai cycle` is one tick of the dispatcher loop. The implementation is deliberately minimal:
 
 1. **Restart recovery** — roll back `:in-progress` and `:revising` locks past their stale-timeout.
-2. **Drain** — call `dispatch_drain()`, which loops `pick oldest actionable → dispatch handler` until the queue is empty (no more issues/PRs in any handler-backed state). A loop guard breaks if the same target gets picked twice in a row, and a `max_iter=50` cap defends against systemic non-advancing handlers; the cron interval is the wall-clock rate limit and the flock prevents overlapping ticks.
+2. **Drain** — call `dispatch_drain()`, which loops `pick oldest actionable → dispatch handler` until the queue is empty (no more issues/PRs in any handler-backed state). A `max_iter=50` cap is the sole loop backstop — handlers that return nonzero or raise are added to a per-drain skip set so one bad target can't stall the queue. The cron interval is the wall-clock rate limit and the flock prevents overlapping ticks.
 
 A flock serializes overlapping runs so two cron ticks cannot dispatch the same item concurrently.
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -249,10 +249,9 @@ class TestDispatchPR(unittest.TestCase):
 class TestDispatchOldestActionable(unittest.TestCase):
     """Picks the oldest (by createdAt) across issues + PRs.
 
-    These cover the *single-pick* behavior — the alias is wired into
-    dispatch_drain, so when both pools return the same data on every
-    iteration the drain breaks on the same-target loop guard after one
-    dispatch.
+    These cover the *single-pick* selection by simulating an
+    advancing handler (each dispatch removes the picked item from the
+    pool snapshot, so the drain naturally empties after one pick).
     """
 
     def test_picks_oldest_across_issues_and_prs(self):
@@ -260,31 +259,48 @@ class TestDispatchOldestActionable(unittest.TestCase):
         issues = [
             {"number": 10, "createdAt": "2024-01-01T00:00:00Z",
              "labels": [{"name": "auto-improve:refining"}]},
-            {"number": 20, "createdAt": "2024-02-01T00:00:00Z",
-             "labels": [{"name": "auto-improve:in-progress"}]},
         ]
-        prs = [
-            {"number": 99, "createdAt": "2024-01-15T00:00:00Z",
-             "labels": [{"name": "pr:reviewing-code"}],
-             "merged": False, "mergedAt": None},
-        ]
+        prs: list[dict] = []
 
         def fake_gh_json(cmd):
-            # cmd is a list; distinguish issue vs pr list.
             if "issue" in cmd and "list" in cmd:
                 return issues
             if "pr" in cmd and "list" in cmd:
                 return prs
             raise AssertionError(f"unexpected _gh_json call: {cmd}")
 
+        # Add a second issue and PR to the snapshot but make dispatch_issue
+        # remove the dispatched item — so we observe which one was picked
+        # first without having the drain process the rest.
+        issues.append({"number": 20, "createdAt": "2024-02-01T00:00:00Z",
+                       "labels": [{"name": "auto-improve:in-progress"}]})
+        prs.append({"number": 99, "createdAt": "2024-01-15T00:00:00Z",
+                    "labels": [{"name": "pr:reviewing-code"}],
+                    "merged": False, "mergedAt": None})
+
+        di_calls: list[int] = []
+
+        def fake_di(n):
+            di_calls.append(n)
+            issues[:] = [i for i in issues if i["number"] != n]
+            return 0
+
+        dp_calls: list[int] = []
+
+        def fake_dp(n):
+            dp_calls.append(n)
+            prs[:] = [p for p in prs if p["number"] != n]
+            return 0
+
         with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json), \
-             patch.object(dispatcher, "dispatch_issue", return_value=0) as di, \
-             patch.object(dispatcher, "dispatch_pr", return_value=0) as dp:
+             patch.object(dispatcher, "dispatch_issue", side_effect=fake_di), \
+             patch.object(dispatcher, "dispatch_pr", side_effect=fake_dp):
             rc = dispatcher.dispatch_oldest_actionable()
 
         self.assertEqual(rc, 0)
-        di.assert_called_once_with(10)
-        dp.assert_not_called()
+        # Oldest first: issue #10 (Jan 1) before PR #99 (Jan 15) before issue #20 (Feb 1).
+        self.assertEqual(di_calls, [10, 20])
+        self.assertEqual(dp_calls, [99])
 
     def test_picks_oldest_when_pr_wins(self):
         issues = [
@@ -304,14 +320,29 @@ class TestDispatchOldestActionable(unittest.TestCase):
                 return prs
             raise AssertionError(f"unexpected _gh_json call: {cmd}")
 
+        di_calls: list[int] = []
+
+        def fake_di(n):
+            di_calls.append(n)
+            issues[:] = [i for i in issues if i["number"] != n]
+            return 0
+
+        dp_calls: list[int] = []
+
+        def fake_dp(n):
+            dp_calls.append(n)
+            prs[:] = [p for p in prs if p["number"] != n]
+            return 0
+
         with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json), \
-             patch.object(dispatcher, "dispatch_issue", return_value=0) as di, \
-             patch.object(dispatcher, "dispatch_pr", return_value=0) as dp:
+             patch.object(dispatcher, "dispatch_issue", side_effect=fake_di), \
+             patch.object(dispatcher, "dispatch_pr", side_effect=fake_dp):
             rc = dispatcher.dispatch_oldest_actionable()
 
         self.assertEqual(rc, 0)
-        dp.assert_called_once_with(99)
-        di.assert_not_called()
+        # Oldest first: PR #99 (Jan 15) before issue #20 (Mar 1).
+        self.assertEqual(dp_calls, [99])
+        self.assertEqual(di_calls, [20])
 
     def test_empty_pools_returns_zero(self):
         def fake_gh_json(cmd):
@@ -383,9 +414,12 @@ class TestDispatchDrain(unittest.TestCase):
         self.assertEqual(di_calls, [10, 20])
         self.assertEqual(dp_calls, [99])
 
-    def test_loop_guard_breaks_on_repeat_target(self):
-        """Same target picked twice in a row stops the drain even with budget left."""
-        # Pool never shrinks → loop guard must catch on iteration 2.
+    def test_idempotent_repeat_picks_capped_by_max_iter(self):
+        """A non-advancing handler that keeps re-picking the same target is
+        bounded by ``max_iter`` (the only loop backstop now that the
+        same-target guard has been removed — it produced false positives
+        on routing handlers like ``pr_bounce`` that advance state on a
+        delegated target rather than the picked one)."""
         issues = [
             {"number": 10, "createdAt": "2024-01-01T00:00:00Z",
              "labels": [{"name": "auto-improve:refining"}]},
@@ -398,65 +432,11 @@ class TestDispatchDrain(unittest.TestCase):
 
         with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json), \
              patch.object(dispatcher, "dispatch_issue", return_value=0) as di:
-            rc = dispatcher.dispatch_drain(max_iter=10)
+            rc = dispatcher.dispatch_drain(max_iter=4)
 
         self.assertEqual(rc, 0)
-        di.assert_called_once_with(10)
-
-    def test_loop_guard_allows_same_target_across_state_change(self):
-        """Same (kind, number) but a new state is legitimate progression, not a loop.
-
-        Regression for the case where ``handle_implement`` advances an
-        issue from ``:plan-approved`` to ``:pr-open``. Before the fix the
-        loop guard keyed on ``(kind, number)`` only and aborted the drain
-        after one dispatch even though the state had legitimately
-        advanced; now it keys on state too.
-        """
-        # Issue #10: first seen at :plan-approved, then at :pr-open after the
-        # implement handler ran. Both states are actionable (handle_implement
-        # and handle_pr_bounce respectively).
-        state = {"label": "auto-improve:plan-approved"}
-
-        def fake_gh_json(cmd):
-            if "issue" in cmd and "list" in cmd:
-                return [{
-                    "number": 10,
-                    "createdAt": "2024-01-01T00:00:00Z",
-                    "labels": [{"name": state["label"]}],
-                }]
-            return []
-
-        di_calls: list[int] = []
-
-        def fake_di(n):
-            di_calls.append(n)
-            # First call simulates implement advancing the label.
-            if state["label"] == "auto-improve:plan-approved":
-                state["label"] = "auto-improve:pr-open"
-                return 0
-            # Second call simulates pr_bounce clearing the label (queue empties).
-            state["label"] = "none"
-            return 0
-
-        def fake_gh_json_stateful(cmd):
-            if "issue" in cmd and "list" in cmd:
-                if state["label"] == "none":
-                    return []
-                return [{
-                    "number": 10,
-                    "createdAt": "2024-01-01T00:00:00Z",
-                    "labels": [{"name": state["label"]}],
-                }]
-            return []
-
-        with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json_stateful), \
-             patch.object(dispatcher, "dispatch_issue", side_effect=fake_di):
-            rc = dispatcher.dispatch_drain(max_iter=10)
-
-        # Both iterations ran — the guard didn't abort on the state
-        # transition, and the drain only stopped when the queue emptied.
-        self.assertEqual(rc, 0)
-        self.assertEqual(di_calls, [10, 10])
+        # Pool never shrinks, handler always returns 0 → runs the full cap.
+        self.assertEqual(di.call_count, 4)
 
     def test_max_iter_cap(self):
         """A pool that keeps providing distinct targets stops at max_iter."""


### PR DESCRIPTION
## Summary
- Follow-up to #673. Making the loop-guard key state-aware was not enough: routing handlers like `handle_pr_bounce` advance state on a *delegated* target (the linked PR), not on the picked issue, so a same-target guard keeps producing false positives.
- Observed: issue #620 at `:pr-open` → `pr_bounce` dispatches PR #668 → PR advances OPEN → REVIEWING_CODE → next pick sees same `(issue, 620, PR)` triple → guard fires → drain stops with `handle_review_pr` still pending. Lost throughput, no real loop.
- Fix: drop the loop guard. The `max_iter=50` cap is the sole runaway backstop, supplemented by `failed_targets` skipping any handler that returns nonzero or raises. The cron flock continues to prevent overlapping ticks.

## Test plan
- [x] Replaced `test_loop_guard_breaks_on_repeat_target` and `test_loop_guard_allows_same_target_across_state_change` with `test_idempotent_repeat_picks_capped_by_max_iter` covering the new behavior (non-advancing handler + non-shrinking pool → bounded by `max_iter`).
- [x] Updated `TestDispatchOldestActionable` picker tests to advance the pool (since the drain no longer short-circuits on the second identical pick).
- [x] `docs/architecture.md` updated to remove the loop-guard mention.
- [x] Full suite: `python -m unittest discover tests -q` → 144 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)