### PR TITLE
fix(merge): park APPROVED PRs via FSM state, not orthogonal flag

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,7 +5,6 @@
 
 | File | Purpose |
 |------|---------|
-| `.cai/pr-context.md` | Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `audit:raised` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -5,8 +5,10 @@ verified its state is ``PRState.APPROVED``. Runs the ``cai-merge``
 agent to obtain a confidence-gated verdict and, on a high-enough
 merge verdict, squash-merges via ``gh pr merge``. On new commits
 arriving since the APPROVED label was set, diverts back to code
-review. On low-confidence / refusal / merge failure, tags the PR
-with ``needs-human-review``.
+review. On low-confidence / refusal / merge failure on a still-open
+PR, transitions the PR out of APPROVED into ``PR_HUMAN_NEEDED``
+(``approved_to_human``) so the dispatcher parks it instead of
+re-routing back to ``handle_merge`` every drain tick.
 """
 from __future__ import annotations
 
@@ -76,11 +78,41 @@ def handle_merge(pr: dict) -> int:
     * merges the PR (``approved_to_merged``), or
     * diverts back to code review when new commits have arrived
       (``approved_to_reviewing_code``), or
-    * tags the PR ``needs-human-review`` when the merge agent
-      refuses / yields low confidence / merge itself fails.
+    * applies ``approved_to_human`` (clears ``pr:approved``, sets
+      ``pr:human-needed``) when the merge agent refuses / yields low
+      confidence / merge itself fails on a still-open PR. Parking is
+      done via FSM transition so the PR has exactly one state — the
+      old behavior of layering a ``needs-human-review`` flag on top of
+      ``pr:approved`` made the dispatcher loop on the same PR every
+      drain tick.
     """
     print("[cai merge] evaluating APPROVED PR", flush=True)
     t0 = time.monotonic()
+
+    # Legacy self-heal: an older code path tagged held / failed PRs with
+    # the orthogonal ``needs-human-review`` label while leaving them at
+    # ``pr:approved``. The dispatcher would re-route to handle_merge
+    # every drain tick only to short-circuit on "already evaluated at
+    # this SHA". Transition such PRs into the proper PR_HUMAN_NEEDED
+    # state so they park cleanly.
+    pr_label_names = [
+        (lb.get("name") if isinstance(lb, dict) else lb)
+        for lb in pr.get("labels", [])
+    ]
+    if LABEL_PR_NEEDS_HUMAN in pr_label_names:
+        print(
+            f"[cai merge] PR #{pr['number']}: legacy "
+            f"`{LABEL_PR_NEEDS_HUMAN}` flag while at :pr-approved — "
+            f"migrating to PR_HUMAN_NEEDED",
+            flush=True,
+        )
+        apply_pr_transition(
+            pr["number"], "approved_to_human",
+            log_prefix="cai merge",
+        )
+        log_run("merge", repo=REPO, pr=pr["number"],
+                result="legacy_park_migration", exit=0)
+        return 0
 
     if _MERGE_THRESHOLD == "disabled":
         print(
@@ -445,7 +477,10 @@ def handle_merge(pr: dict) -> int:
                         f"— issue may be stuck without a lifecycle label",
                         file=sys.stderr, flush=True,
                     )
-                    _pr_set_needs_human(pr_number, True)
+                    apply_pr_transition(
+                        pr_number, "approved_to_human",
+                        log_prefix="cai merge",
+                    )
                     log_run("merge", repo=REPO, pr=pr_number,
                             duration=dur(), result="close_label_failed",
                             exit=0)
@@ -471,7 +506,10 @@ def handle_merge(pr: dict) -> int:
                         f"after close failure on PR #{pr_number}",
                         file=sys.stderr, flush=True,
                     )
-            _pr_set_needs_human(pr_number, True)
+            apply_pr_transition(
+                pr_number, "approved_to_human",
+                log_prefix="cai merge",
+            )
             log_run("merge", repo=REPO, pr=pr_number,
                     duration=dur(), result="close_failed", exit=0)
             return 0
@@ -516,6 +554,10 @@ def handle_merge(pr: dict) -> int:
                         f"issue may be stuck without a lifecycle label",
                         file=sys.stderr, flush=True,
                     )
+                    # PR is already merged on GitHub side (gh merge
+                    # returned 0). State has moved to MERGED — no loop
+                    # risk, but flag for human attention so the
+                    # orphaned issue label is fixed up.
                     _pr_set_needs_human(pr_number, True)
                     log_run("merge", repo=REPO, pr=pr_number,
                             duration=dur(),
@@ -535,7 +577,10 @@ def handle_merge(pr: dict) -> int:
                 f"{merge_result.stderr}",
                 file=sys.stderr,
             )
-            _pr_set_needs_human(pr_number, True)
+            apply_pr_transition(
+                pr_number, "approved_to_human",
+                log_prefix="cai merge",
+            )
             log_run("merge", repo=REPO, pr=pr_number,
                     duration=dur(), result="merge_failed", exit=0)
             return 0
@@ -556,7 +601,10 @@ def handle_merge(pr: dict) -> int:
                     f"label to #{issue_number} for held PR #{pr_number}",
                     file=sys.stderr, flush=True,
                 )
-        _pr_set_needs_human(pr_number, True)
+        apply_pr_transition(
+            pr_number, "approved_to_human",
+            log_prefix="cai merge",
+        )
         log_run("merge", repo=REPO, pr=pr_number,
                 duration=dur(), result="held", exit=0)
         return 0

--- a/cai_lib/fsm.py
+++ b/cai_lib/fsm.py
@@ -406,6 +406,19 @@ PR_TRANSITIONS: list[Transition] = [
                labels_remove=[LABEL_PR_REVIEWING_CODE],
                labels_add=[LABEL_PR_HUMAN_NEEDED],
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    # Merge handler park: when the merge agent's verdict is below the
+    # configured confidence threshold, or when a recovery action (close /
+    # merge) failed, the PR must leave APPROVED so the dispatcher stops
+    # re-routing it to handle_merge. Without this transition the PR
+    # carried a parallel ``needs-human-review`` flag while still labelled
+    # ``pr:approved`` — two states disagreeing — and the merge handler
+    # was re-invoked every drain tick only to short-circuit on its
+    # "already evaluated at this SHA" guard.
+    Transition("approved_to_human",
+               PRState.APPROVED, PRState.PR_HUMAN_NEEDED,
+               labels_remove=[LABEL_PR_APPROVED],
+               labels_add=[LABEL_PR_HUMAN_NEEDED],
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
     Transition("pr_human_to_reviewing_code",
                PRState.PR_HUMAN_NEEDED, PRState.REVIEWING_CODE,
                labels_remove=[LABEL_PR_HUMAN_NEEDED],

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -69,6 +69,7 @@ stateDiagram-v2
     CI_FAILING --> REBASING : ci_failing_to_rebasing [≥HIGH]
     REBASING --> REVIEWING_CODE : rebasing_to_reviewing_code [≥HIGH]
     REVIEWING_CODE --> PR_HUMAN_NEEDED : reviewing_code_to_human [≥HIGH]
+    APPROVED --> PR_HUMAN_NEEDED : approved_to_human [≥HIGH]
     PR_HUMAN_NEEDED --> REVIEWING_CODE : pr_human_to_reviewing_code [≥HIGH]
     PR_HUMAN_NEEDED --> REVISION_PENDING : pr_human_to_revision_pending [≥HIGH]
     PR_HUMAN_NEEDED --> REVIEWING_DOCS : pr_human_to_reviewing_docs [≥HIGH]

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -545,6 +545,19 @@ class TestPRStateShape(unittest.TestCase):
             if t.from_state == PRState.APPROVED
         }
         self.assertIn(PRState.MERGED, approved_dests)
+        # APPROVED must also be able to reach PR_HUMAN_NEEDED so the
+        # merge handler's "hold" / recovery paths can park the PR
+        # cleanly instead of layering an orthogonal needs-human-review
+        # flag on top of pr:approved (which made the dispatcher loop).
+        self.assertIn(PRState.PR_HUMAN_NEEDED, approved_dests)
+        approved_to_human = next(
+            (t for t in PR_TRANSITIONS if t.name == "approved_to_human"),
+            None,
+        )
+        self.assertIsNotNone(approved_to_human)
+        from cai_lib.config import LABEL_PR_APPROVED, LABEL_PR_HUMAN_NEEDED
+        self.assertIn(LABEL_PR_APPROVED, approved_to_human.labels_remove)
+        self.assertIn(LABEL_PR_HUMAN_NEEDED, approved_to_human.labels_add)
 
     def test_get_pr_state_from_labels(self):
         """get_pr_state derives from pipeline labels (post-redesign)."""


### PR DESCRIPTION
## Summary
- `handle_merge`'s "hold" / still-open-PR recovery paths used to add the orthogonal `needs-human-review` label while leaving the PR at `pr:approved`. The dispatcher derives state from `pr:approved` → routes to `handle_merge` → handler short-circuits on "already evaluated at this SHA" → rc=0 → loop. The 50-iter `max_iter` cap was the only thing preventing an infinite spin.
- Fix: introduce `approved_to_human` (PRState.APPROVED → PRState.PR_HUMAN_NEEDED) and apply it from the merge handler's hold and APPROVED-state recovery paths instead. The PR ends up in exactly one state — `pr:human-needed` — and the dispatcher cleanly returns "no handler" so the PR drops out of the queue. Existing `pr_human_to_*` resume transitions handle unparking when an admin acts.
- Kept `_pr_set_needs_human` in the post-merge label-failed recovery path: there the PR is already merged on GitHub side (state moves to MERGED, no loop risk) and the orthogonal flag is the right signal for the orphaned issue label.
- Added a one-shot legacy self-heal at the top of `handle_merge`: any PR currently stuck with the old `(pr:approved + needs-human-review)` combo (e.g. PR #668) transitions itself to PR_HUMAN_NEEDED on the next tick.

Observed log before this fix (issue #620 / PR #668):
```
[cai dispatch] issue #620 at PR → handle_pr_bounce
[cai dispatch] PR #668 at APPROVED → handle_merge
[cai merge] PR #668: already evaluated at 9f08d5e3; skipping
... (×50 per drain) ...
```

## Test plan
- [x] Extended `test_reviewing_docs_to_approved` in `tests/test_fsm.py` to assert `approved_to_human` exists, lands on PR_HUMAN_NEEDED, and removes `pr:approved` while adding `pr:human-needed`.
- [x] Full suite: `python -m unittest discover tests -q` → 144 tests pass.
- [ ] Post-merge: container restart picks up the legacy migration; PR #668 should transition out of `pr:approved` on the next dispatcher tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)