### PR TITLE
fix(dispatcher): dispatch each target at most once per drain pass

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,7 +5,6 @@
 
 | File | Purpose |
 |------|---------|
-| `.cai/pr-context.md` | Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `audit:raised` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -317,41 +317,48 @@ def _pick_oldest_actionable_target(
     return (kind, number)
 
 
-# Default cap on how many handlers a single drain pass will run. The
-# cron tick interval (CAI_CYCLE_SCHEDULE) is the wall-clock rate limit;
-# this cap is the sole backstop against a runaway loop (e.g. a handler
-# that keeps re-picking the same target without advancing state, or a
-# routing handler like pr_bounce repeatedly delegating to a PR that's
-# already done). Handler-level idempotence + ``failed_targets`` skipping
-# of any nonzero/crashing handler are the primary safety nets.
+# Default cap on how many handlers a single drain pass will run. With
+# per-target dedup (each ``(kind, number)`` dispatches at most once per
+# drain) this cap bounds the work pass to ``max_iter`` distinct targets;
+# the cron tick interval (CAI_CYCLE_SCHEDULE) is the wall-clock rate
+# limit; ``dispatched_targets`` skipping is the per-drain loop backstop.
 _DEFAULT_DRAIN_MAX_ITER = 50
 
 
 def dispatch_drain(max_iter: int = _DEFAULT_DRAIN_MAX_ITER) -> int:
     """Drain the actionable queue: pick oldest, dispatch, repeat.
 
+    Each ``(kind, number)`` is dispatched **at most once per drain pass**.
+    After a dispatch (success, nonzero, or crash), the target is added
+    to a per-drain skip set so the picker moves on to the next oldest.
+    This kills the class of loop where a routing handler (``pr_bounce``)
+    or an idempotent no-op handler keeps returning 0 on a target whose
+    underlying state never changes (e.g. PR parked at ``PR_HUMAN_NEEDED``,
+    merge handler short-circuiting on "already evaluated at this SHA").
+
     Stops when one of:
       - the queue is empty (no actionable issues or PRs left),
-      - ``max_iter`` iterations have run (defense against systemic
-        non-advancing handlers; the cycle's flock prevents overlap).
+      - ``max_iter`` iterations have run (hard upper bound; the cycle's
+        flock prevents overlap).
 
-    No same-target loop guard: routing handlers like ``pr_bounce`` make
-    legitimate progress on a *delegated* target (the linked PR) without
-    changing the picked issue's own state, so a same-target guard
-    produces false positives that abort the drain mid-pipeline. The
-    ``max_iter`` cap plus ``failed_targets`` skipping handle the
-    regression cases the guard was meant to catch.
+    A side effect of per-drain dedup: when a handler legitimately advances
+    state and the same item is now actionable in a *new* state (e.g.
+    implement advancing PLAN_APPROVED → PR), the follow-up handler fires
+    on the next cron tick rather than in the same drain pass. The cron
+    interval is the wall-clock rate limit anyway, so this is just a
+    one-tick deferral — cheap insurance against the no-op-loop class of
+    bugs.
 
     Returns the worst exit code seen across handlers (0 if every dispatch
     succeeded or the queue was empty from the start).
     """
     import traceback
 
-    failed_targets: set[tuple[str, int]] = set()
+    dispatched_targets: set[tuple[str, int]] = set()
     worst_rc = 0
 
     for i in range(max_iter):
-        target = _pick_oldest_actionable_target(skip=failed_targets)
+        target = _pick_oldest_actionable_target(skip=dispatched_targets)
         if target is None:
             print(f"[cai dispatch] drain complete after {i} dispatch(es): "
                   "queue empty", flush=True)
@@ -364,20 +371,21 @@ def dispatch_drain(max_iter: int = _DEFAULT_DRAIN_MAX_ITER) -> int:
             else:
                 rc = dispatch_pr(number)
         except Exception:  # noqa: BLE001 — keep draining the queue
-            # Handler crashed. Record failure, skip this target for the rest
-            # of this drain pass (#657 — one crashing item must not stall
-            # the cycle), and continue with the next actionable target.
+            # Handler crashed. Record dispatch, skip this target for the
+            # rest of this drain pass (#657 — one crashing item must not
+            # stall the cycle), and continue with the next actionable target.
             traceback.print_exc()
             print(f"[cai dispatch] handler for {kind} #{number} raised; "
                   "skipping this target for the remainder of the drain",
                   flush=True)
-            failed_targets.add(target)
+            dispatched_targets.add(target)
             worst_rc = max(worst_rc, 1)
             continue
-        if rc != 0:
-            failed_targets.add(target)
-            if rc > worst_rc:
-                worst_rc = rc
+        # Every dispatch — success or failure — counts. No target runs
+        # twice in the same drain.
+        dispatched_targets.add(target)
+        if rc > worst_rc:
+            worst_rc = rc
 
     print(f"[cai dispatch] hit drain cap (max_iter={max_iter}); remaining "
           "actionable items will run on the next cycle tick", flush=True)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,7 +69,7 @@ Issues still enter the pipeline the same way: `cai analyze`, `cai propose`, `cai
 `cai cycle` is one tick of the dispatcher loop. The implementation has three phases:
 
 1. **Restart recovery** — roll back `:in-progress`, `:revising`, and `:applying` locks past their stale-timeout.
-2. **Drain** — call `dispatch_drain()`, which loops `pick oldest actionable → dispatch handler` until the queue is empty (no more issues/PRs in any handler-backed state). A `max_iter=50` cap is the sole loop backstop — handlers that return nonzero or raise are added to a per-drain skip set so one bad target can't stall the queue. The cron interval is the wall-clock rate limit and the flock prevents overlapping ticks.
+2. **Drain** — call `dispatch_drain()`, which loops `pick oldest actionable → dispatch handler` until the queue is empty (no more issues/PRs in any handler-backed state). Each `(kind, number)` target is dispatched at most once per drain pass — after dispatch (success or failure) it's added to a per-drain skip set so the picker moves on. A `max_iter=50` cap is the hard upper bound. The cron interval is the wall-clock rate limit and the flock prevents overlapping ticks.
 3. **Maintenance apply** — if any `:applying` issues remain (transient state during maintenance operations), call `cai maintain` to drain them by executing the declared operations and transitioning to `:applied` or `:human-needed` based on Confidence.
 
 A flock serializes overlapping runs so two cron ticks cannot dispatch the same item concurrently.

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -414,12 +414,17 @@ class TestDispatchDrain(unittest.TestCase):
         self.assertEqual(di_calls, [10, 20])
         self.assertEqual(dp_calls, [99])
 
-    def test_idempotent_repeat_picks_capped_by_max_iter(self):
-        """A non-advancing handler that keeps re-picking the same target is
-        bounded by ``max_iter`` (the only loop backstop now that the
-        same-target guard has been removed — it produced false positives
-        on routing handlers like ``pr_bounce`` that advance state on a
-        delegated target rather than the picked one)."""
+    def test_target_dispatched_at_most_once_per_drain(self):
+        """Each ``(kind, number)`` runs at most once per drain, even when
+        the handler returns 0 and the pool never shrinks.
+
+        Regression for the loop class where a routing handler
+        (``pr_bounce``) or an idempotent no-op handler
+        (``handle_merge`` short-circuiting on "already evaluated")
+        returns 0 on a target whose underlying state never changes.
+        Before per-drain dedup, this ran the full ``max_iter`` cap
+        every tick; now the drain empties cleanly after one pass.
+        """
         issues = [
             {"number": 10, "createdAt": "2024-01-01T00:00:00Z",
              "labels": [{"name": "auto-improve:refining"}]},
@@ -432,11 +437,14 @@ class TestDispatchDrain(unittest.TestCase):
 
         with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json), \
              patch.object(dispatcher, "dispatch_issue", return_value=0) as di:
-            rc = dispatcher.dispatch_drain(max_iter=4)
+            rc = dispatcher.dispatch_drain(max_iter=10)
 
         self.assertEqual(rc, 0)
-        # Pool never shrinks, handler always returns 0 → runs the full cap.
-        self.assertEqual(di.call_count, 4)
+        # Exactly one call even though pool never shrinks and we gave
+        # max_iter=10 headroom — per-drain dedup adds the target to the
+        # skip set after the first dispatch so the picker returns None
+        # on the next iteration.
+        di.assert_called_once_with(10)
 
     def test_max_iter_cap(self):
         """A pool that keeps providing distinct targets stops at max_iter."""


### PR DESCRIPTION
## Summary
- After the loop guard was dropped in #674, the drain still burned the full `max_iter=50` whenever a handler returned 0 on a target whose underlying state never changed.
- Two concrete loops observed in production:
  1. `handle_pr_bounce` → delegates to a PR parked at `PR_HUMAN_NEEDED` → no handler → rc=0. Next pick returns the same issue. 50× per drain.
  2. `handle_merge` short-circuiting on "already evaluated at this SHA" → rc=0 while PR still carried `pr:approved` (fixed separately in #676, but other rc=0 no-ops remain).
- Root cause: `failed_targets` only caught **nonzero/crashing** handlers. rc=0 no-op loops slipped through.
- Fix: rename `failed_targets` → `dispatched_targets` and add every target after one dispatch **regardless of return code**. Each `(kind, number)` runs at most once per drain pass.
- Trade-off: when a handler legitimately advances state and the same item is actionable in a new state (e.g. `implement` advancing `PLAN_APPROVED → PR`), the follow-up handler fires on the **next cron tick** rather than in the same drain. Cron is the wall-clock rate limit anyway, so one-tick deferral is cheap insurance against the no-op-loop class.

Log before fix:
```
[cai dispatch] issue #624 at PR → handle_pr_bounce
[cai dispatch] PR #677 at PR_HUMAN_NEEDED — no handler (terminal / parked)
... (×50) ...
[cai dispatch] hit drain cap (max_iter=50); remaining actionable items will run on the next cycle tick
```

## Test plan
- [x] Replaced `test_idempotent_repeat_picks_capped_by_max_iter` with `test_target_dispatched_at_most_once_per_drain` — asserts one call even with pool never shrinking and max_iter headroom.
- [x] Existing `test_handler_exception_skips_target_and_continues_drain` and `test_nonzero_handler_skips_target_and_continues_drain` still pass (the behavior for failure paths is unchanged: skip on dispatch).
- [x] `docs/architecture.md` updated.
- [x] Full suite: `python -m unittest discover tests -q` → 144 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)