### PR TITLE
fix(review-docs): always advance to APPROVED, no re-review bounce

### DIFF
--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -56,10 +56,6 @@ _MERGE_THRESHOLD = os.environ.get("CAI_MERGE_CONFIDENCE_THRESHOLD", "high").lowe
 
 _CONFIDENCE_RANKS = {"high": 3, "medium": 2, "low": 1}
 
-# Heading of the docs-review "clean" marker used to verify the docs
-# review that earned APPROVED is still valid at the current HEAD.
-_DOCS_REVIEW_COMMENT_HEADING_CLEAN = "## cai docs review (clean)"
-
 # Bot-PR branch prefix regex. Only PRs on ``auto-improve/<issue>-…``
 # branches are eligible for auto-merge.
 _BOT_BRANCH_RE = re.compile(r"^auto-improve/(\d+)-")
@@ -76,8 +72,6 @@ def handle_merge(pr: dict) -> int:
     ``PRState.APPROVED``. This handler either:
 
     * merges the PR (``approved_to_merged``), or
-    * diverts back to code review when new commits have arrived
-      (``approved_to_reviewing_code``), or
     * applies ``approved_to_human`` (clears ``pr:approved``, sets
       ``pr:human-needed``) when the merge agent refuses / yields low
       confidence / merge itself fails on a still-open PR. Parking is
@@ -200,34 +194,14 @@ def handle_merge(pr: dict) -> int:
                 result="wrong_state", exit=0)
         return 0
 
-    # New-commits-arrived check: the clean docs-review comment that
-    # earned APPROVED was pinned to a specific HEAD SHA. If no clean
-    # comment exists for the *current* HEAD, the branch has advanced
-    # since APPROVED was applied — divert back to code review so the
-    # pipeline re-enters review on the new SHA.
-    docs_clean_at_head = False
-    for comment in pr.get("comments", []):
-        body_line = (comment.get("body") or "").split("\n", 1)[0]
-        if (
-            body_line.startswith(_DOCS_REVIEW_COMMENT_HEADING_CLEAN)
-            and head_sha in body_line
-        ):
-            docs_clean_at_head = True
-            break
-    if not docs_clean_at_head:
-        print(
-            f"[cai merge] PR #{pr_number}: new commits since APPROVED "
-            f"(HEAD {head_sha[:8]} has no clean docs review); "
-            f"diverting to reviewing-code",
-            flush=True,
-        )
-        apply_pr_transition(
-            pr_number, "approved_to_reviewing_code",
-            log_prefix="cai merge",
-        )
-        log_run("merge", repo=REPO, pr=pr_number,
-                result="new_commits_divert", exit=0)
-        return 0
+    # NOTE: the previous SHA gate that diverted APPROVED → REVIEWING_CODE
+    # when the current HEAD had no `(clean)` docs-review comment caused
+    # ping-pong with the docs-review push path: every doc fix advanced
+    # HEAD, the gate fired, code review re-ran on doc-only changes, and
+    # docs-review ran again. Docs-review now always advances to APPROVED
+    # (push or no push), so this handler trusts the FSM label and lets
+    # the unaddressed-comments / CI / merge-agent gates below catch
+    # anything that genuinely needs another look.
 
     # Safety filter 3: unaddressed review comments → let revise handle.
     # Mirror the revise subcommand's filter logic via the shared helper

--- a/cai_lib/actions/review_docs.py
+++ b/cai_lib/actions/review_docs.py
@@ -71,20 +71,21 @@ def handle_review_docs(pr: dict) -> int:
                     result="cached_clean_advanced", exit=0)
             return 0
         if first_line.startswith(_DOCS_REVIEW_COMMENT_HEADING_APPLIED):
-            # A docs-fix push happened at this SHA; the new code needs
-            # re-review. Bounce back to REVIEWING_CODE so the next tick
-            # picks up handle_review_pr.
+            # A docs-fix push happened at this SHA. Docs review is the
+            # last gate before merge; we do not bounce back to code
+            # review just because doc files changed (the merge handler
+            # is the final gatekeeper).
             print(
                 f"[cai review-docs] PR #{pr_number}: cached applied-fix at "
-                f"{head_sha[:8]} — bouncing to REVIEWING_CODE",
+                f"{head_sha[:8]} — advancing to APPROVED",
                 flush=True,
             )
             apply_pr_transition(
-                pr_number, "reviewing_docs_to_reviewing_code",
+                pr_number, "reviewing_docs_to_approved",
                 log_prefix="cai review-docs",
             )
             log_run("review_docs", repo=REPO, pr=pr_number,
-                    result="cached_applied_bounced", exit=0)
+                    result="cached_applied_advanced", exit=0)
             return 0
         # Heading prefix matched but suffix is unfamiliar — fall through
         # to a fresh review rather than guess.
@@ -236,23 +237,19 @@ def handle_review_docs(pr: dict) -> int:
             capture_output=True,
         )
 
-        # Advance FSM state based on docs review outcome.
+        # Advance FSM state. Docs review is the final pre-merge gate:
+        # whether or not it pushed doc fixes, the PR moves to APPROVED
+        # and the merge handler decides whether to merge. Bouncing back
+        # to REVIEWING_CODE on a doc push caused review/docs ping-pong
+        # loops that produced no new code findings.
+        apply_pr_transition(
+            pr_number, "reviewing_docs_to_approved",
+            log_prefix="cai review-docs",
+        )
         if has_doc_changes:
-            # Docs fix pushed — re-enter code review on the new HEAD.
-            apply_pr_transition(
-                pr_number, "reviewing_docs_to_reviewing_code",
-                log_prefix="cai review-docs",
-            )
             result_word = "fixes pushed"
             result_tag = "fixes_pushed"
         else:
-            # Clean — mark the PR :approved so actions/merge can own
-            # the final approved_to_merged step. (Replaces the old
-            # terminal reviewing_docs_to_merged transition.)
-            apply_pr_transition(
-                pr_number, "reviewing_docs_to_approved",
-                log_prefix="cai review-docs",
-            )
             result_word = "clean"
             result_tag = "clean"
 


### PR DESCRIPTION
## Summary
- Docs review now always advances `REVIEWING_DOCS → APPROVED` whether or not it pushed doc fixes, instead of bouncing back to `REVIEWING_CODE` on a push.
- The merge handler's HEAD-SHA divert (`approved_to_reviewing_code` when no `(clean)` docs comment exists at HEAD) is removed.

## Why
On PR #680 the lifecycle ran review-pr 4× and review-docs 3× because every doc-fix push triggered a fresh code review, which finished clean and re-triggered docs review. Docs review is the last gate before the merge handler — the merge agent, CI gate, and unaddressed-comments gate remain as the final guards, so a docs push doesn't need to re-enter code review.

## Test plan
- [ ] Watch the next bot PR that requires a docs fix and confirm it advances `REVIEWING_DOCS → APPROVED → MERGED` without re-entering `REVIEWING_CODE`.