### PR TITLE
fix(dispatcher): gate sub-issues on prior step being closed

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,7 +5,6 @@
 
 | File | Purpose |
 |------|---------|
-| `.cai/pr-context.md` | Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `auto-improve:raised` + `audit` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -21,9 +21,25 @@ without creating an import cycle.
 """
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from typing import Callable, Optional
+
+
+# Matches sub-issue titles produced by cai_lib.actions.refine:
+# ``[#123 Step 2/5] Do the thing``. Group 1 = parent number, group 2 = step.
+_SUB_ISSUE_TITLE_RE = re.compile(r"^\[#(\d+)\s+Step\s+(\d+)/\d+\]")
+
+
+def _parse_sub_issue_step(title: str) -> Optional[tuple[int, int]]:
+    """Return ``(parent_number, step)`` when *title* is a sub-issue title, else None."""
+    if not title:
+        return None
+    m = _SUB_ISSUE_TITLE_RE.match(title)
+    if not m:
+        return None
+    return int(m.group(1)), int(m.group(2))
 
 from cai_lib.config import REPO
 from cai_lib.fsm import (
@@ -272,12 +288,23 @@ def _pick_oldest_actionable_target(
             "--repo", REPO,
             "--label", "auto-improve",
             "--state", "open",
-            "--json", "number,createdAt,labels",
+            "--json", "number,createdAt,labels,title",
             "--limit", "200",
         ]) or []
     except subprocess.CalledProcessError as e:
         print(f"[cai dispatch] gh issue list failed:\n{e.stderr}", file=sys.stderr)
         issues = []
+
+    # Build the set of (parent, step) pairs whose sub-issue is still open.
+    # A sub-issue at step N > 1 is gated on (parent, N-1) being absent from
+    # this set — i.e. the prior step has already been closed (its PR merged
+    # and confirm ran, or a human closed it). See the "ordering gate"
+    # referenced in cai_lib/actions/refine.py::_create_sub_issues.
+    open_sub_steps: set[tuple[int, int]] = set()
+    for issue in issues:
+        parsed = _parse_sub_issue_step(issue.get("title", ""))
+        if parsed is not None:
+            open_sub_steps.add(parsed)
 
     try:
         prs = _gh_json([
@@ -300,6 +327,17 @@ def _pick_oldest_actionable_target(
         if state is not None and state in issue_states:
             if ("issue", issue["number"]) in skip:
                 continue
+            parsed = _parse_sub_issue_step(issue.get("title", ""))
+            if parsed is not None:
+                parent, step = parsed
+                if step > 1 and (parent, step - 1) in open_sub_steps:
+                    print(
+                        f"[cai dispatch] issue #{issue['number']} is "
+                        f"[#{parent} Step {step}/...]; prior step still open — "
+                        f"skipping until previous step is merged",
+                        flush=True,
+                    )
+                    continue
             candidates.append((issue.get("createdAt", ""), "issue", issue["number"]))
 
     for pr in prs:

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -542,5 +542,61 @@ class TestDispatchDrain(unittest.TestCase):
         self.assertEqual(di_calls, [10, 20])
 
 
+class TestSubIssueStepOrderingGate(unittest.TestCase):
+    """Sub-issues like ``[#P Step N/T]`` must wait until the step N-1
+    sub-issue has been closed (typically by its PR merging and confirm
+    closing it)."""
+
+    def _pick(self, issues):
+        def fake_gh_json(cmd):
+            if "issue" in cmd and "list" in cmd:
+                return issues
+            if "pr" in cmd and "list" in cmd:
+                return []
+            raise AssertionError(f"unexpected _gh_json call: {cmd}")
+
+        with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json):
+            return dispatcher._pick_oldest_actionable_target()
+
+    def test_later_step_skipped_while_prior_step_open(self):
+        issues = [
+            {"number": 50, "createdAt": "2024-01-01T00:00:00Z",
+             "title": "[#621 Step 4/6] Previous step",
+             "labels": [{"name": "auto-improve:in-progress"}]},
+            {"number": 51, "createdAt": "2024-01-02T00:00:00Z",
+             "title": "[#621 Step 5/6] Migrate check-workflows",
+             "labels": [{"name": "auto-improve:refined"}]},
+        ]
+        target = self._pick(issues)
+        self.assertEqual(target, ("issue", 50))
+
+    def test_later_step_picked_when_prior_step_closed(self):
+        # Step 4 absent from the open list → it was closed → step 5 is allowed.
+        issues = [
+            {"number": 51, "createdAt": "2024-01-02T00:00:00Z",
+             "title": "[#621 Step 5/6] Migrate check-workflows",
+             "labels": [{"name": "auto-improve:refined"}]},
+        ]
+        target = self._pick(issues)
+        self.assertEqual(target, ("issue", 51))
+
+    def test_step_one_never_gated(self):
+        issues = [
+            {"number": 51, "createdAt": "2024-01-02T00:00:00Z",
+             "title": "[#621 Step 1/6] First step",
+             "labels": [{"name": "auto-improve:refined"}]},
+        ]
+        target = self._pick(issues)
+        self.assertEqual(target, ("issue", 51))
+
+    def test_parse_sub_issue_step(self):
+        self.assertEqual(
+            dispatcher._parse_sub_issue_step("[#123 Step 2/5] Do a thing"),
+            (123, 2),
+        )
+        self.assertIsNone(dispatcher._parse_sub_issue_step("Just a normal title"))
+        self.assertIsNone(dispatcher._parse_sub_issue_step(""))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- The dispatcher was picking sub-issues like `[#621 Step 5/6]` while earlier steps (e.g. Step 4) were still open. The ordering-gate referenced in `cai_lib/actions/refine.py::_create_sub_issues` was never implemented.
- `_pick_oldest_actionable_target` now parses the `[#P Step N/T]` title prefix, builds the set of open `(parent, step)` pairs from the same issue listing, and skips any candidate at step N>1 whose `(parent, N-1)` is still open.
- Step 1 sub-issues and non-sub-issues are never gated. Closing the prior step (merge + confirm, or manual close) unblocks the next.

## Test plan
- [x] `python -m unittest discover -s tests -q` — 153 tests pass
- [x] New `TestSubIssueStepOrderingGate` covers skip-when-prior-open, pick-when-prior-closed, step-1-never-gated, and the title parser

🤖 Generated with Claude Code