### PR TITLE
auto-improve: Close issues #635 and #587 without terminal lifecycle labels

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -24,6 +24,20 @@ Refs: robotsix/robotsix-cai#647
 - `deterministic_section` entry added after `:pr-open` recovery block, consistent with existing pattern
 - Rejected: applying labels only to a hardcoded exempt list — the structural fix (auto-apply on every audit run) is more robust
 
+## Revision 1 (2026-04-15)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `.claude/agents/cai-audit.md:83` — added `auto-improve:solved` to the terminal states list in the "What to check" table row for `workflow_anomaly`
+
+### Decisions this revision
+- Minimal single-word addition to bring the table description in sync with the three-element `terminal_labels` set in `cai.py:945` and the notes at lines 144-146
+
+### New gaps / deferred
+- None
+
 ## Out of scope / known gaps
 - Does not backfill issues closed before this PR ships — only processes the last 30 on each audit run
 - Does not check whether the closed issue was actually resolved; `:no-action` is used as "human manually closed, pipeline acknowledges"

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,33 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#647
+
+## Files touched
+- `cai.py:940` — added `_apply_no_action_to_unlabeled_closed()` helper function before `cmd_audit()`
+- `cai.py:986` — added Step 1f call to `_apply_no_action_to_unlabeled_closed()` in `cmd_audit()`
+- `cai.py:1107` — added `no_action_applied` results to `deterministic_section`
+- `.claude/agents/cai-audit.md` — added Note explaining the retroactive `:no-action` step and guardrail against re-raising `workflow_anomaly` for already-handled issues
+
+## Files read (not touched) that matter
+- `cai_lib/config.py` — defines LABEL_MERGED, LABEL_SOLVED, LABEL_NO_ACTION constants
+- `cai.py:247` — `_fetch_closed_auto_improve_issues()` return shape (dict with `number`, `title`, `labels` as list of strings, `closedAt`)
+
+## Key symbols
+- `_apply_no_action_to_unlabeled_closed()` (`cai.py:940`) — new helper; fetches last 30 closed issues, filters to those lacking any terminal label, applies `:no-action`
+- `_fetch_closed_auto_improve_issues()` (`cai.py:247`) — existing helper that returns closed issues with labels as plain string lists
+- `_set_labels()` (`cai_lib/github.py`) — applies/removes labels via gh CLI
+- `log_run()` (`cai_lib/logging_utils.py`) — writes structured log entry
+
+## Design decisions
+- Used `limit=30` (not 50) to match the plan spec and focus on recently closed issues
+- Terminal label set: `{LABEL_MERGED, LABEL_SOLVED, LABEL_NO_ACTION}` — all three defined in `cai_lib/config.py`
+- Inserted Step 1f before Step 2 so the closed-issues list seen by the LLM already has terminal labels applied
+- `deterministic_section` entry added after `:pr-open` recovery block, consistent with existing pattern
+- Rejected: applying labels only to a hardcoded exempt list — the structural fix (auto-apply on every audit run) is more robust
+
+## Out of scope / known gaps
+- Does not backfill issues closed before this PR ships — only processes the last 30 on each audit run
+- Does not check whether the closed issue was actually resolved; `:no-action` is used as "human manually closed, pipeline acknowledges"
+
+## Invariants this change relies on
+- `_fetch_closed_auto_improve_issues()` returns `labels` as a list of plain label name strings (not dicts)
+- `LABEL_MERGED`, `LABEL_SOLVED`, `LABEL_NO_ACTION` are all importable via `from cai_lib.config import *` (already used in `cai.py`)

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -38,6 +38,21 @@ Refs: robotsix/robotsix-cai#647
 ### New gaps / deferred
 - None
 
+## Revision 2 (2026-04-15)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py:1172` — added `no_action_applied=len(no_action_applied)` to failure-case `log_run` call
+- `cai.py:1188` — added `no_action_applied=len(no_action_applied)` to success-case `log_run` call
+
+### Decisions this revision
+- Reviewer correctly identified the count was absent from both `log_run` calls while all other deterministic step counts were logged; minimal two-line fix for observability parity
+
+### New gaps / deferred
+- None
+
 ## Out of scope / known gaps
 - Does not backfill issues closed before this PR ships — only processes the last 30 on each audit run
 - Does not check whether the closed issue was actually resolved; `:no-action` is used as "human manually closed, pipeline acknowledges"

--- a/.claude/agents/cai-audit.md
+++ b/.claude/agents/cai-audit.md
@@ -80,7 +80,7 @@ stale `:merged` issues are flagged with `needs-human-review`.)
 | Multiple rules in `.claude/agents/cai-implement.md` that contradict each other | `prompt_contradiction` |
 | Tracking-only issue (no state label) older than 30 days with no human activity | `forgotten_backlog` |
 | A single `claude -p` invocation in the cost summary whose `cost` is >3× the mean cost of its category, OR a category whose `total cost (share)` exceeds 50% of the window total | `cost_outlier` |
-| Closed issue whose labels don't include a terminal state (`auto-improve:merged` or `auto-improve:no-action`) — may indicate manual close without proper resolution | `workflow_anomaly` |
+| Closed issue whose labels don't include a terminal state (`auto-improve:merged`, `auto-improve:no-action`, or `auto-improve:solved`) — may indicate manual close without proper resolution | `workflow_anomaly` |
 | Merged PR whose linked `auto-improve` issue is still open (check recent PRs for matching branch/title against open issues) | `workflow_anomaly` |
 | Closed-unmerged PR whose linked issue is not rolled back to `:refined` | `workflow_anomaly` |
 | A category in the outcome statistics table flagged ⚠ (success rate <40% with ≥3 outcomes in 90 days) | `fix_loop_efficiency` |

--- a/.claude/agents/cai-audit.md
+++ b/.claude/agents/cai-audit.md
@@ -141,6 +141,17 @@ appears in the log as the `pr_open_recovered` field on the `[audit]`
 log line. You will NOT see these issues as `:pr-open`; they have
 already been rolled back before your context is assembled.
 
+**Note:** recently closed `auto-improve` issues that lack a terminal
+label (`auto-improve:merged`, `auto-improve:no-action`,
+`auto-improve:solved`) are automatically tagged with `:no-action`
+deterministically before you run. This covers issues closed manually by
+a human without going through the normal pipeline (e.g., superseded work,
+direct implementation). These appear in the log as
+`[audit] action=no_action_applied_retroactively`. Do NOT raise
+`workflow_anomaly` findings for issues that appear in the
+"Closed issues with :no-action applied retroactively this run" section
+of your input — they have already been handled.
+
 ## Categories
 
 | Category | Description |

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,6 +5,7 @@
 
 | File | Purpose |
 |------|---------|
+| `.cai/pr-context.md` | Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `auto-improve:raised` + `audit` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |

--- a/README.md
+++ b/README.md
@@ -200,23 +200,28 @@ Audit categories: `stale_lifecycle`, `lock_corruption`, `loop_stuck`,
 `prompt_contradiction`, `topic_duplicate`, `silent_failure`, `forgotten_backlog`,
 `cost_outlier`, `workflow_anomaly`, `fix_loop_efficiency`.
 
-There are five exceptions to "report-only": stale lock rollback,
+There are six exceptions to "report-only": stale lock rollback,
 stale `:no-action` rollback, stale `:merged` flagging,
-orphaned-branch cleanup, and `:pr-open` recovery. Three lock types are
-rolled back: `:in-progress` issues after 6 hours with no recent fix
-activity, `:revising` issues after 1 hour with no recent revise
-activity, and `:applying` issues after 2 hours with no recent maintain
-activity — `:in-progress` and `:revising` are rolled back to `:refined`,
-while `:applying` is rolled back to `:raised`. Stale
-`:no-action` issues (7+ days) are rolled back to `:raised` so the `refine`
-agent (and subsequently the implement agent) can retry with new context. Stale `:merged` issues (14+ days)
-are flagged with `needs-human-review` since the automation cannot
-determine whether the fix worked. Additionally, remote `auto-improve/*`
+orphaned-branch cleanup, `:pr-open` recovery, and retroactive `:no-action`
+application. Three lock types are rolled back: `:in-progress` issues after
+6 hours with no recent fix activity, `:revising` issues after 1 hour with no
+recent revise activity, and `:applying` issues after 2 hours with no recent
+maintain activity — `:in-progress` and `:revising` are rolled back to
+`:refined`, while `:applying` is rolled back to `:raised`. Stale `:no-action`
+issues (7+ days) are rolled back to `:raised` so the `refine` agent (and
+subsequently the implement agent) can retry with new context. Stale `:merged`
+issues (14+ days) are flagged with `needs-human-review` since the automation
+cannot determine whether the fix worked. Additionally, remote `auto-improve/*`
 branches with no open PR — including branches for merged/closed PRs and
 branches pushed by the implement agent that never had a PR opened — are deleted
-automatically. Finally, `:pr-open` issues whose linked PR was closed without
-merging are rolled back to `:refined` to restart the refinement and planning
-cycle before a human can re-approve them for the implement subagent.
+automatically. `:pr-open` issues whose linked PR was closed without merging
+are rolled back to `:refined` to restart the refinement and planning cycle
+before a human can re-approve them for the implement subagent. Finally, recently
+closed `auto-improve` issues that lack a terminal label
+(`auto-improve:merged`, `auto-improve:no-action`, `auto-improve:solved`)
+are automatically tagged with `:no-action` — this covers issues closed manually
+by a human without going through the normal pipeline (e.g., superseded work,
+direct implementation).
 
 ### Comment-driven PR iteration
 

--- a/cai.py
+++ b/cai.py
@@ -939,6 +939,31 @@ def _flag_stale_merged() -> list[dict]:
     return flagged
 
 
+def _apply_no_action_to_unlabeled_closed() -> list[dict]:
+    """Apply :no-action to recently closed auto-improve issues that lack a terminal label."""
+    closed_issues = _fetch_closed_auto_improve_issues(limit=30)
+    terminal_labels = {LABEL_MERGED, LABEL_SOLVED, LABEL_NO_ACTION}
+    labeled = []
+    for issue in closed_issues:
+        issue_labels = set(issue["labels"])
+        if issue_labels & terminal_labels:
+            continue
+        issue_num = issue["number"]
+        ok = _set_labels(issue_num, add=[LABEL_NO_ACTION], log_prefix="cai audit")
+        if ok:
+            labeled.append(issue)
+            log_run(
+                "audit",
+                action="no_action_applied_retroactively",
+                issue=issue_num,
+            )
+            print(
+                f"[cai audit] applied :no-action to #{issue_num} (closed without terminal label)",
+                flush=True,
+            )
+    return labeled
+
+
 def cmd_audit(args) -> int:
     """Run the periodic queue/PR consistency audit."""
     print("[cai audit] running audit", flush=True)
@@ -975,6 +1000,9 @@ def cmd_audit(args) -> int:
     except subprocess.CalledProcessError:
         pr_open_issues = []
     recovered_pr_open = _recover_stale_pr_open(pr_open_issues, log_prefix="cai audit")
+
+    # Step 1f: Apply :no-action to closed issues that lack a terminal label.
+    no_action_applied = _apply_no_action_to_unlabeled_closed()
 
     # Step 2: Gather GitHub state for the claude-driven semantic checks.
 
@@ -1083,6 +1111,11 @@ def cmd_audit(args) -> int:
         deterministic_section += "## Stale :pr-open issues recovered (closed-unmerged PR) this run\n\n"
         for ri in recovered_pr_open:
             deterministic_section += f"- #{ri['number']}: {ri['title']}\n"
+        deterministic_section += "\n"
+    if no_action_applied:
+        deterministic_section += "## Closed issues with :no-action applied retroactively this run\n\n"
+        for ci in no_action_applied:
+            deterministic_section += f"- #{ci['number']}: {ci['title']}\n"
         deterministic_section += "\n"
 
     # Cost summary so the audit agent can flag cost outliers — same

--- a/cai.py
+++ b/cai.py
@@ -1170,6 +1170,7 @@ def cmd_audit(args) -> int:
                 branches_cleaned=len(deleted_orphaned),
                 no_action_unstuck=len(unstuck_no_action),
                 merged_flagged=len(flagged_merged),
+                no_action_applied=len(no_action_applied),
                 exit=audit.returncode)
         return audit.returncode
 
@@ -1185,6 +1186,7 @@ def cmd_audit(args) -> int:
             branches_cleaned=len(deleted_orphaned),
             no_action_unstuck=len(unstuck_no_action),
             merged_flagged=len(flagged_merged),
+            no_action_applied=len(no_action_applied),
             duration=dur, exit=published.returncode)
     return published.returncode
 

--- a/cai.py
+++ b/cai.py
@@ -44,12 +44,17 @@ Subcommands:
 
     python cai.py audit     Periodic queue/PR consistency audit.
                             Deterministically rolls back stale
-                            `:in-progress` issues (>6h with no fix
-                            activity), then runs a Sonnet-driven
-                            semantic check for duplicates, stuck loops,
-                            label corruption, etc. Findings are
-                            published as `auto-improve:raised` + `audit`
-                            issues in the unified label scheme.
+                            `:in-progress` (>6h), `:revising` (>1h),
+                            and `:applying` (>2h) locks; unsticks stale
+                            `:no-action` issues; flags stale `:merged`
+                            issues; recovers `:pr-open` issues with closed
+                            PRs; cleans up orphaned branches; applies
+                            `:no-action` to closed issues lacking terminal
+                            labels; then runs a Sonnet-driven semantic
+                            check for duplicates, stuck loops, label
+                            corruption, etc. Findings are published as
+                            `auto-improve:raised` + `audit` issues in the
+                            unified label scheme.
 
     python cai.py revise    Watch `:pr-open` PRs for new comments and
                             let the implement subagent iterate on the same

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,7 +14,7 @@ No arguments.
 
 ## audit
 
-Run the periodic queue/PR consistency audit: roll back stale `:in-progress` locks, clean up orphaned branches, unstick stale `:no-action` issues, recover closed-PR issues, and invoke the `cai-audit` agent for a full state-machine review.
+Run the periodic queue/PR consistency audit: roll back stale `:in-progress` locks, clean up orphaned branches, unstick stale `:no-action` issues, recover closed-PR issues, apply `:no-action` to closed issues lacking terminal labels, and invoke the `cai-audit` agent for a full state-machine review.
 
 No arguments.
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#647

**Issue:** #647 — Close issues #635 and #587 without terminal lifecycle labels

## PR Summary

### What this fixes
Human-closed `auto-improve` issues (e.g., superseded work or direct implementation) were being closed without a terminal label, causing the audit agent to repeatedly raise `workflow_anomaly` findings for the same issues on every audit run.

### What was changed
- **`cai.py`**: Added `_apply_no_action_to_unlabeled_closed()` helper function that fetches the 30 most recently closed `auto-improve` issues, filters to those lacking any terminal label (`auto-improve:merged`, `auto-improve:solved`, `auto-improve:no-action`), applies `auto-improve:no-action` to each, and logs the action. Called as Step 1f in `cmd_audit()` and its results are surfaced in `deterministic_section` passed to the LLM.
- **`.claude/agents/cai-audit.md`** (via staging): Added a "Note" explaining that this deterministic step runs before the LLM audit, and a guardrail instructing the agent not to raise `workflow_anomaly` findings for issues already handled by this step.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
