### PR TITLE
fix(select): parse markdown-wrapped Confidence line (closes #685)

### DIFF
--- a/.claude/agents/cai-select.md
+++ b/.claude/agents/cai-select.md
@@ -40,11 +40,13 @@ Assess each plan on these criteria, in order of importance:
 Output **only** the chosen plan — paste it exactly as provided with
 no modifications. Do not emit any selection metadata, plan numbers,
 reasoning, or wrapper headings. The plan text must be followed by
-exactly one trailing line:
+exactly one trailing line that names a single level. For example:
 
-```
-Confidence: HIGH | MEDIUM | LOW
-```
+    Confidence: HIGH
+
+Pick exactly one of `HIGH`, `MEDIUM`, or `LOW`. Do not bold the
+label, do not bold the level, do not add trailing punctuation, and
+do not list multiple levels or alternatives on that line.
 
 That confidence line drives the FSM. At **HIGH**, the wrapper
 auto-approves the plan and sends the issue straight into the

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,7 +5,6 @@
 
 | File | Purpose |
 |------|---------|
-| `.cai/pr-context.md` | Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `auto-improve:raised` + `audit` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |

--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -226,7 +226,7 @@ def _run_plan_select_pipeline(
     # Strip the trailing ``Confidence: X`` line so the stored plan is
     # clean — the confidence drives the FSM transition, not the plan body.
     plan_text = re.sub(
-        r"(?im)^\s*Confidence\s*[:=]\s*(LOW|MEDIUM|HIGH)\s*$",
+        r"(?im)^[^\w\n]*Confidence[^\w\n]*[:=][^\w\n]*(LOW|MEDIUM|HIGH)[^\w\n]*$",
         "",
         selection,
     ).rstrip() + "\n"

--- a/cai_lib/fsm.py
+++ b/cai_lib/fsm.py
@@ -58,7 +58,7 @@ class Confidence(Enum):
 
 
 _CONFIDENCE_RE = re.compile(
-    r"^\s*Confidence\s*[:=]\s*(LOW|MEDIUM|HIGH)\s*$",
+    r"^[^\w\n]*Confidence[^\w\n]*[:=][^\w\n]*(LOW|MEDIUM|HIGH)[^\w\n]*$",
     re.IGNORECASE | re.MULTILINE,
 )
 

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -104,6 +104,22 @@ class TestConfidenceEnum(unittest.TestCase):
         self.assertIsNone(parse_confidence("no confidence line here"))
         self.assertIsNone(parse_confidence("Confidence: BOGUS"))
 
+    def test_parse_tolerates_markdown_and_punctuation(self):
+        # Bolded label, bolded level, trailing period — all common
+        # markdown variants the select agent may emit. See issue #685.
+        self.assertEqual(parse_confidence("**Confidence:** HIGH"), Confidence.HIGH)
+        self.assertEqual(parse_confidence("Confidence: **HIGH**"), Confidence.HIGH)
+        self.assertEqual(parse_confidence("**Confidence:** **MEDIUM**"), Confidence.MEDIUM)
+        self.assertEqual(parse_confidence("Confidence: HIGH."), Confidence.HIGH)
+
+    def test_parse_rejects_pipe_menu_echo(self):
+        # The agent echoing the template verbatim must NOT count as a
+        # valid confidence line — that would pick whichever level the
+        # regex happens to land on and bypass the human gate.
+        self.assertIsNone(
+            parse_confidence("Confidence: HIGH | MEDIUM | LOW")
+        )
+
     def test_transition_accepts(self):
         t = find_transition("refining_to_refined")
         # default threshold is HIGH


### PR DESCRIPTION
## Summary
- Loosen `_CONFIDENCE_RE` in `cai_lib/fsm.py` (and the mirrored strip regex in `cai_lib/actions/plan.py`) to tolerate bolded labels/levels and trailing punctuation, while still rejecting the pipe-menu echo.
- Rewrite the cai-select prompt so the agent stops seeing `HIGH | MEDIUM | LOW` as a valid emit shape.
- Add unit tests in `tests/test_fsm.py` for the new tolerant cases and the rejected pipe-menu case.

Fixes #685 — every planned issue was diverting to `:human-needed` because the strict parser rejected the marker the select agent actually emitted.

## Test plan
- [x] `python -m unittest discover -s tests` — 151 tests pass
- [ ] After deploy, confirm some plans reach `:plan-approved` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)