### PR TITLE
feat(cycle): auto-unblock :human-needed issues on dispatch

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,7 +5,6 @@
 
 | File | Purpose |
 |------|---------|
-| `.cai/pr-context.md` | Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `auto-improve:raised` + `audit` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |

--- a/cai_lib/cmd_unblock.py
+++ b/cai_lib/cmd_unblock.py
@@ -231,6 +231,31 @@ def _try_unblock_issue(issue: dict) -> Optional[str]:
     return "resumed"
 
 
+def handle_human_needed(issue: dict) -> int:
+    """Dispatcher handler for :class:`IssueState.HUMAN_NEEDED` issues.
+
+    Picked up by :func:`cai_lib.dispatcher.dispatch_issue` when the cycle
+    selects a parked issue. Delegates to :func:`_try_unblock_issue` only
+    when the admin has applied ``human:solved``; otherwise returns 0 so
+    the inner driver treats the issue as blocked and moves on. The
+    picker in :func:`_pick_oldest_actionable_target` skips parked
+    issues lacking ``human:solved`` so this branch is rarely hit, but
+    it keeps manual ``cai dispatch --issue N`` safe against a
+    race with label removal.
+    """
+    labels = [l["name"] for l in issue.get("labels", [])]  # noqa: E741
+    if LABEL_HUMAN_SOLVED not in labels:
+        print(
+            f"[cai dispatch] #{issue['number']} parked at :human-needed "
+            f"without {LABEL_HUMAN_SOLVED} — leaving parked",
+            flush=True,
+        )
+        return 0
+    tag = _try_unblock_issue(issue) or "skipped"
+    print(f"[cai dispatch] auto-unblock #{issue['number']}: {tag}", flush=True)
+    return 1 if tag == "agent_failed" else 0
+
+
 def cmd_unblock(args) -> int:
     """Scan :human-needed issues and attempt FSM resume via cai-unblock."""
     t0 = time.monotonic()

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -26,7 +26,6 @@ import subprocess
 import sys
 from typing import Callable, Optional
 
-
 # Matches sub-issue titles produced by cai_lib.actions.refine:
 # ``[#123 Step 2/5] Do the thing``. Group 1 = parent number, group 2 = step.
 _SUB_ISSUE_TITLE_RE = re.compile(r"^\[#(\d+)\s+Step\s+(\d+)/\d+\]")
@@ -41,7 +40,7 @@ def _parse_sub_issue_step(title: str) -> Optional[tuple[int, int]]:
         return None
     return int(m.group(1)), int(m.group(2))
 
-from cai_lib.config import REPO
+from cai_lib.config import LABEL_HUMAN_SOLVED, REPO
 from cai_lib.fsm import (
     IssueState, PRState,
     get_issue_state, get_pr_state,
@@ -58,9 +57,10 @@ from cai_lib.github import _gh_json
 # entry (apply the raise_to_triaging transition first) or a resume
 # (skip the entry transition).
 #
-# States with no handler (SOLVED, HUMAN_NEEDED, PR_HUMAN_NEEDED, MERGED
-# on the PR side) are terminal or parked and the dispatcher returns
-# without doing anything.
+# States with no handler (SOLVED, PR_HUMAN_NEEDED, MERGED on the PR
+# side) are terminal or parked and the dispatcher returns without doing
+# anything. HUMAN_NEEDED has a handler that auto-resumes the FSM when
+# the admin has applied ``human:solved`` and no-ops otherwise.
 
 IssueHandler = Callable[[dict], int]
 PRHandler    = Callable[[dict], int]
@@ -76,6 +76,7 @@ def _build_issue_registry() -> dict[IssueState, IssueHandler]:
     from cai_lib.actions.implement import handle_implement
     from cai_lib.actions.confirm   import handle_confirm
     from cai_lib.actions.pr_bounce import handle_pr_bounce
+    from cai_lib.cmd_unblock       import handle_human_needed
 
     return {
         IssueState.RAISED:            handle_triage,
@@ -89,7 +90,10 @@ def _build_issue_registry() -> dict[IssueState, IssueHandler]:
         IssueState.IN_PROGRESS:       handle_implement,   # resume
         IssueState.PR:                handle_pr_bounce,
         IssueState.MERGED:            handle_confirm,
-        # SOLVED, HUMAN_NEEDED → no handler
+        # HUMAN_NEEDED is only picked up when the admin has applied
+        # ``human:solved`` (see filter in _pick_oldest_actionable_target).
+        IssueState.HUMAN_NEEDED:      handle_human_needed,
+        # SOLVED → no handler (terminal)
     }
 
 
@@ -338,6 +342,12 @@ def _pick_oldest_actionable_target(
                         flush=True,
                     )
                     continue
+            # HUMAN_NEEDED is actionable only when the admin has signalled
+            # ready-to-resume via ``human:solved``. Other parked issues
+            # stay out of the queue so we don't spin on them each tick.
+            if (state == IssueState.HUMAN_NEEDED
+                    and LABEL_HUMAN_SOLVED not in label_names):
+                continue
             candidates.append((issue.get("createdAt", ""), "issue", issue["number"]))
 
     for pr in prs:

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -34,10 +34,13 @@ class TestActionableStateSets(unittest.TestCase):
             IssueState.IN_PROGRESS,
             IssueState.PR,
             IssueState.MERGED,
+            # HUMAN_NEEDED is actionable via handle_human_needed — the
+            # picker filters to only those issues carrying ``human:solved``
+            # so parked-waiting ones stay out of the queue.
+            IssueState.HUMAN_NEEDED,
         }
         self.assertEqual(dispatcher.actionable_issue_states(), expected)
-        # HUMAN_NEEDED and SOLVED are explicitly not actionable.
-        self.assertNotIn(IssueState.HUMAN_NEEDED, dispatcher.actionable_issue_states())
+        # SOLVED is terminal and must not be dispatched.
         self.assertNotIn(IssueState.SOLVED, dispatcher.actionable_issue_states())
 
     def test_actionable_pr_states(self):
@@ -311,6 +314,52 @@ class TestDispatchOldestActionable(unittest.TestCase):
         # Oldest first: issue #10 (Jan 1), PR #99 (Jan 15), issue #20 (Feb 1).
         self.assertEqual(di_calls, [10, 20])
         self.assertEqual(dp_calls, [99])
+
+    def test_human_needed_picked_only_with_human_solved(self):
+        """HUMAN_NEEDED issues are only pickable when the admin has
+        applied ``human:solved``. Parked-waiting issues must stay out of
+        the drain queue so the cycle doesn't spin on them each tick.
+        """
+        from cai_lib.config import LABEL_HUMAN_SOLVED
+        issues = [
+            # Parked, no solved label → must be ignored.
+            {"number": 30, "createdAt": "2024-01-01T00:00:00Z",
+             "labels": [{"name": "auto-improve:human-needed"}]},
+            # Parked with solved label → pickable.
+            {"number": 31, "createdAt": "2024-01-02T00:00:00Z",
+             "labels": [{"name": "auto-improve:human-needed"},
+                        {"name": LABEL_HUMAN_SOLVED}]},
+        ]
+
+        def fake_pool(cmd):
+            if "issue" in cmd and "list" in cmd:
+                return issues
+            if "pr" in cmd and "list" in cmd:
+                return []
+            raise AssertionError(f"unexpected _gh_json call: {cmd}")
+
+        di_calls: list[int] = []
+
+        def fake_fetch_issue_state(n):
+            if n in di_calls:
+                issues[:] = [i for i in issues if i["number"] != n]
+                return None
+            return dispatcher.IssueState.HUMAN_NEEDED
+
+        def fake_di(n):
+            di_calls.append(n)
+            return 0
+
+        with patch.object(dispatcher, "_gh_json", side_effect=fake_pool), \
+             patch.object(dispatcher, "_fetch_issue_state",
+                          side_effect=fake_fetch_issue_state), \
+             patch.object(dispatcher, "dispatch_issue", side_effect=fake_di), \
+             patch.object(dispatcher, "dispatch_pr") as dp:
+            rc = dispatcher.dispatch_oldest_actionable()
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(di_calls, [31])
+        dp.assert_not_called()
 
     def test_empty_pools_returns_zero(self):
         def fake_gh_json(cmd):

--- a/tests/test_unblock.py
+++ b/tests/test_unblock.py
@@ -199,5 +199,42 @@ class TestResumeStripsHumanSolvedLabel(unittest.TestCase):
         self.assertIn("human:solved", captured["kwargs"].get("extra_remove", []))
 
 
+class TestHandleHumanNeeded(unittest.TestCase):
+    """Dispatcher hook — gated on ``human:solved`` to avoid spinning on
+    parked-waiting issues each cycle tick."""
+
+    def test_noop_without_human_solved(self):
+        issue = {"number": 1, "labels": [{"name": "auto-improve:human-needed"}]}
+        with mock.patch.object(U, "_try_unblock_issue") as fake:
+            rc = U.handle_human_needed(issue)
+        self.assertEqual(rc, 0)
+        fake.assert_not_called()
+
+    def test_delegates_when_human_solved_present(self):
+        issue = {
+            "number": 2,
+            "labels": [
+                {"name": "auto-improve:human-needed"},
+                {"name": "human:solved"},
+            ],
+        }
+        with mock.patch.object(U, "_try_unblock_issue", return_value="resumed") as fake:
+            rc = U.handle_human_needed(issue)
+        self.assertEqual(rc, 0)
+        fake.assert_called_once_with(issue)
+
+    def test_agent_failed_returns_nonzero(self):
+        issue = {
+            "number": 3,
+            "labels": [
+                {"name": "auto-improve:human-needed"},
+                {"name": "human:solved"},
+            ],
+        }
+        with mock.patch.object(U, "_try_unblock_issue", return_value="agent_failed"):
+            rc = U.handle_human_needed(issue)
+        self.assertEqual(rc, 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Registers `handle_human_needed` for `IssueState.HUMAN_NEEDED` in the FSM dispatcher so that the cycle auto-resumes parked issues when the admin has applied `human:solved`, delegating to the existing `_try_unblock_issue` flow.
- Picker filters out parked issues lacking `human:solved` so the drain doesn't spin on them each tick.
- Closes the gap where `cai unblock` existed as a CLI command but was not wired into `cmd_cycle` or any cron, leaving solved-labelled issues (e.g. #626, #628, #648) stuck until manually invoked.

## Test plan
- [x] `python -m unittest discover -s tests -q` (159 pass, 1 skipped)
- [ ] Live: next cycle tick should pick up #626 / #628 / #648 (all carry `auto-improve:human-needed` + `human:solved`) and run `cai-unblock` against them.