### PR TITLE
auto-improve: Dispatcher: skip Step N+1 when Step N of same parent is unresolved

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,23 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#664
+
+## Files touched
+- docs/architecture.md:32 — added one-line note about multi-step sequential processing after the terminal states description
+
+## Files read (not touched) that matter
+- cai_lib/dispatcher.py — already contained full implementation: `_SUB_ISSUE_TITLE_RE`, `_parse_sub_issue_step`, `open_sub_steps` set, and filtering logic in `_pick_oldest_actionable_target`
+- tests/test_dispatcher.py — already contained `TestSubIssueStepOrderingGate` with all three required test cases
+
+## Key symbols
+- `_parse_sub_issue_step` (cai_lib/dispatcher.py:34) — extracts (parent_num, step) from `[#N Step X/Y]` titles
+- `open_sub_steps` (cai_lib/dispatcher.py:307) — set built from all open issue titles for O(1) predecessor lookup
+- `TestSubIssueStepOrderingGate` (tests/test_dispatcher.py:594) — covers the three required test cases
+
+## Design decisions
+- Only added the missing docs line; code and tests were already fully implemented in the repo
+
+## Out of scope / known gaps
+- No FSM changes; filter-only approach as specified
+
+## Invariants this change relies on
+- The docs line placement assumes the architecture.md dispatcher section is between the PR handler table and Lifecycle Labels section

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,6 +5,7 @@
 
 | File | Purpose |
 |------|---------|
+| `.cai/pr-context.md` | Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `auto-improve:raised` + `audit` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,6 +31,8 @@ Handler registry (PR states):
 
 Terminal / parked states (`SOLVED`, `HUMAN_NEEDED`, `PR_HUMAN_NEEDED`, PR `MERGED`) have no handler; the dispatcher returns without doing anything.
 
+Multi-step sequences (titled `[#N Step X/Y]`) are processed sequentially; Step N+1 is deferred if Step N is still open.
+
 Issues still enter the pipeline the same way: `cai analyze`, `cai propose`, `cai code-audit`, `cai audit`, or a human files an issue labeled `auto-improve:raised`. Low-confidence planner outcomes still park at `:human-needed`; the admin resolves the issue in comments and then applies the `human:solved` label, which `cai unblock` picks up to resume the FSM.
 
 ## Lifecycle Labels


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#664

**Issue:** #664 — Dispatcher: skip Step N+1 when Step N of same parent is unresolved

## PR Summary

### What this fixes
The dispatcher lacked dependency-aware filtering for multi-step issue sequences (titled `[#N Step X/Y]`), allowing Step N+1 to be picked while Step N was still open, wasting triage/plan/implement cycles.

### What was changed
- `docs/architecture.md`: Added one line to the dispatcher section noting that multi-step sequences are processed sequentially and Step N+1 is deferred while Step N is still open.

Note: The core implementation (`cai_lib/dispatcher.py` — regex, `_parse_sub_issue_step` helper, `open_sub_steps` set, and filtering loop) and tests (`tests/test_dispatcher.py` — `TestSubIssueStepOrderingGate` class with all three required cases) were already fully implemented in the repository. Only the documentation note was missing.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
