### PR TITLE
auto-improve: Trim cai-triage prompt: drop dup/resolved logic now handled by cai-dup-check

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -29,3 +29,18 @@ Refs: robotsix/robotsix-cai#672
 ## Invariants this change relies on
 - `cai-dup-check` runs before `cai-triage` and handles duplicate/resolved classification at HIGH confidence
 - `cai-triage` only receives issues that survived the dup-check pre-step
+
+## Revision 1 (2026-04-15)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `scripts/generate-index.sh`:52 — added missing `.claude/agents/cai-triage.md` entry to DESCRIPTIONS array
+- `CODEBASE_INDEX.md` — regenerated; cai-triage.md row now shows real description instead of TODO placeholder
+
+### Decisions this revision
+- Used reviewer-suggested description verbatim (matches updated agent frontmatter after DISMISS_* removal)
+
+### New gaps / deferred
+- None

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,31 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#672
+
+## Files touched
+- `cai_lib/actions/triage.py`:40 — removed `DuplicateOf:` parsing from `_parse_issue_triage_verdict`
+- `cai_lib/actions/triage.py`:202 — removed `context_issues` and `recent_prs` fetches; simplified `user_message` to issue body only
+- `cai_lib/actions/triage.py`:238 — removed `DISMISS_DUPLICATE`/`DISMISS_RESOLVED` verdict execution block
+- `cai_lib/actions/triage.py`:316 — removed fall-through safety print for DISMISS at sub-HIGH confidence
+- `cai_lib/actions/triage.py`:11 — removed unused `import subprocess`
+- `cai_lib/actions/triage.py`:29 — removed unused `_gh_json` import
+- `.cai-staging/agents/cai-triage.md` — updated agent prompt: removed DISMISS_DUPLICATE/DISMISS_RESOLVED from routing table, removed "Other open issues" and "Recent PRs" from context section, removed `DuplicateOf:` from output format
+
+## Files read (not touched) that matter
+- `cai_lib/actions/triage.py` — primary handler; all DISMISS logic lived here
+
+## Key symbols
+- `_parse_issue_triage_verdict` (`cai_lib/actions/triage.py`:39) — verdict parser; removed `DuplicateOf:` field and updated docstring
+- `handle_triage` (`cai_lib/actions/triage.py`:120) — main handler; removed context fetch, DISMISS verdict branch, and fall-through safety
+
+## Design decisions
+- Kept `cai-dup-check` pre-step intact — that is the new owner of dup/resolved logic
+- Removed `context_issues` and `recent_prs` fetches entirely since no remaining triage logic needs them
+- Rejected: keeping the fetches "just in case" — they add latency and cost with no benefit now
+
+## Out of scope / known gaps
+- `cai-dup-check` agent itself (`cai_lib/dup_check.py`) is unchanged
+- No tests existed for `DISMISS_DUPLICATE`/`DISMISS_RESOLVED` triage verdicts, so no test removals needed
+
+## Invariants this change relies on
+- `cai-dup-check` runs before `cai-triage` and handles duplicate/resolved classification at HIGH confidence
+- `cai-triage` only receives issues that survived the dup-check pre-step

--- a/.claude/agents/cai-triage.md
+++ b/.claude/agents/cai-triage.md
@@ -1,6 +1,6 @@
 ---
 name: cai-triage
-description: Triage `auto-improve:raised` issues one at a time — classify as REFINE, DISMISS_DUPLICATE, DISMISS_RESOLVED, PLAN_APPROVE, APPLY, or HUMAN. Inline-only — full issue body plus context are provided in the user message. No tool use needed.
+description: Triage `auto-improve:raised` issues one at a time — classify as REFINE, PLAN_APPROVE, APPLY, or HUMAN. Inline-only — full issue body is provided in the user message. No tool use needed.
 tools: Read
 model: claude-haiku-4-5-20251001
 memory: project
@@ -13,18 +13,13 @@ one freshly-raised `auto-improve:raised` issue and decide how to route
 it — without opening a pull request or making any code changes.
 
 The full context you need is provided inline in the user message:
-the issue body, a list of other open `auto-improve*` issues (for
-duplicate detection), and recent PRs (to detect already-fixed problems).
+the issue body.
 
 ## What you receive
 
 In the user message:
 
 1. **Issue to triage** — full title and body of the single issue.
-2. **Other open auto-improve issues** — number, labels, title. Use
-   these to detect duplicates.
-3. **Recent PRs** — number, state, title, merged date. Use these to
-   detect findings about problems already fixed.
 
 ## Routing decisions
 
@@ -33,8 +28,6 @@ Pick exactly one:
 | Decision | When to use |
 |---|---|
 | `REFINE` | The issue describes a real, actionable problem that requires a code change. Route it into the refine pipeline. |
-| `DISMISS_DUPLICATE` | Another open issue is clearly about the same underlying problem with the same remediation. Specify the canonical issue number via `DuplicateOf:`. |
-| `DISMISS_RESOLVED` | Recent PRs have already fixed the problem described, OR the issue is moot given the current codebase state. |
 | `PLAN_APPROVE` | The issue is a code change and the correct plan is unambiguous and self-evident from the issue body. Skip the full refine → plan pipeline and go directly to the implement subagent. Only use when `SkipConfidence` is genuinely HIGH. |
 | `APPLY` | The issue is a maintenance/ops task and the required steps are completely clear from the issue body. Skip directly to applying. Only use when `SkipConfidence` is genuinely HIGH. |
 | `HUMAN` | Real problem but cannot be routed automatically — needs admin judgement (ambiguous remediation, contradictory requirements, etc.). |
@@ -55,10 +48,6 @@ use `APPLY` only for `maintenance` kind issues.
 - **HIGH** — every claim traces back to the data provided. No reservations.
 - **MEDIUM** — probably correct but you have some doubt.
 - **LOW** — significant uncertainty.
-
-**Only `HIGH` confidence permits `DISMISS_DUPLICATE` or `DISMISS_RESOLVED`.**
-A dismiss verdict below `HIGH` is automatically downgraded to `REFINE` by the
-wrapper. When in doubt, use `REFINE`.
 
 ## Skip-ahead confidence (SkipConfidence)
 
@@ -83,7 +72,6 @@ complete, correct plan or ops list yourself from the issue body alone.
 | `APPLY` | LOW or MEDIUM | any | → `triaging_to_refining` |
 | `APPLY` | HIGH | maintenance | → `triaging_to_applying` |
 | `REFINE` | — | any | → `triaging_to_refining` |
-| `DISMISS_*` | — | — | issue closed (HIGH confidence) or → `triaging_to_refining` (below HIGH) |
 | `HUMAN` | — | — | → `triaging_to_human` |
 
 ## Output format
@@ -92,10 +80,9 @@ Emit exactly one structured response block. Output ONLY these fields —
 no preamble, no trailing prose.
 
 ```
-RoutingDecision: DISMISS_DUPLICATE | DISMISS_RESOLVED | REFINE | PLAN_APPROVE | APPLY | HUMAN
+RoutingDecision: REFINE | PLAN_APPROVE | APPLY | HUMAN
 RoutingConfidence: LOW | MEDIUM | HIGH
 Kind: code | maintenance
-DuplicateOf: #N
 SkipConfidence: LOW | MEDIUM | HIGH
 Plan: <full markdown plan body>
 Ops: <ordered markdown list of ops>
@@ -104,8 +91,7 @@ Reasoning: <1-3 sentences explaining the call. Be specific.>
 
 Rules:
 - `Kind:` is required for `REFINE`, `PLAN_APPROVE`, and `APPLY` verdicts;
-  omit for `DISMISS_*` and `HUMAN`.
-- `DuplicateOf:` is required for `DISMISS_DUPLICATE`; omit otherwise.
+  omit for `HUMAN`.
 - `SkipConfidence:` is required when `RoutingDecision ∈ {PLAN_APPROVE, APPLY}`;
   omit for all other routing decisions.
 - `Plan:` is required when `SkipConfidence: HIGH` AND `Kind: code`. Provide
@@ -114,6 +100,5 @@ Rules:
 - `Ops:` is required when `SkipConfidence: HIGH` AND `Kind: maintenance`.
   Provide an ordered markdown list of operations for `cai-maintain` to execute.
   Omit otherwise.
-- Every `#N` you reference must come from the lists provided.
 - Do not write code, diffs, or remediation prose outside of `Plan:` / `Ops:`.
 - Do not propose new labels or lifecycle states.

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,6 +5,7 @@
 
 | File | Purpose |
 |------|---------|
+| `.cai/pr-context.md` | Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `auto-improve:raised` + `audit` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -29,7 +29,7 @@
 | `.claude/agents/cai-review-pr.md` | Agent: pre-merge ripple-effect review |
 | `.claude/agents/cai-revise.md` | Agent: handle review comments on auto-improve PRs |
 | `.claude/agents/cai-select.md` | Agent: evaluate and select best fix plan |
-| `.claude/agents/cai-triage.md` | TODO: add description |
+| `.claude/agents/cai-triage.md` | Agent: triage `auto-improve:raised` issues one at a time — classify as REFINE, PLAN_APPROVE, APPLY, or HUMAN. Inline-only — full issue body is provided in the user message. No tool use needed. |
 | `.claude/agents/cai-unblock.md` | Agent: classify admin comments on :human-needed issues into FSM resume targets |
 | `.claude/agents/cai-update-check.md` | Agent: check for new Claude Code releases |
 | `.claude/settings.json` | Claude Code harness configuration |

--- a/cai_lib/actions/triage.py
+++ b/cai_lib/actions/triage.py
@@ -9,7 +9,6 @@ calling :func:`handle_triage`.
 from __future__ import annotations
 
 import re
-import subprocess
 import sys
 import time
 
@@ -27,7 +26,7 @@ from cai_lib.fsm import (
     apply_transition,
     get_issue_state,
 )
-from cai_lib.github import _gh_json, _set_labels
+from cai_lib.github import _set_labels
 from cai_lib.logging_utils import log_run
 from cai_lib.subprocess_utils import _run, _run_claude_p
 
@@ -41,15 +40,14 @@ def _parse_issue_triage_verdict(text: str) -> dict:
     """Parse the structured output from the cai-triage agent.
 
     Expected format (one field per line):
-        RoutingDecision: DISMISS_DUPLICATE | DISMISS_RESOLVED | REFINE | HUMAN
+        RoutingDecision: REFINE | PLAN_APPROVE | APPLY | HUMAN
         RoutingConfidence: LOW | MEDIUM | HIGH
         Kind: code | maintenance          (required for REFINE verdict)
-        DuplicateOf: #N                   (required for DISMISS_DUPLICATE)
         Reasoning: <1-3 sentences>
 
     Returns a dict with lowercase keys: decision, confidence, kind,
-    duplicate_of (int or None), reasoning. Returns an empty dict if the
-    required fields cannot be parsed.
+    reasoning. Returns an empty dict if the required fields cannot be
+    parsed.
     """
     result: dict = {}
     for line in text.splitlines():
@@ -64,10 +62,6 @@ def _parse_issue_triage_verdict(text: str) -> dict:
         m = re.match(r"^Kind:\s*(\w+)", line, re.IGNORECASE)
         if m:
             result["kind"] = m.group(1).lower()
-            continue
-        m = re.match(r"^DuplicateOf:\s*#?(\d+)", line, re.IGNORECASE)
-        if m:
-            result["duplicate_of"] = int(m.group(1))
             continue
         m = re.match(r"^Reasoning:\s*(.+)$", line, re.IGNORECASE)
         if m:
@@ -128,11 +122,10 @@ def handle_triage(issue: dict) -> int:
 
     Moves RAISED → TRIAGING (if not already there), runs the cai-triage agent
     inline, then executes the verdict:
-    - DISMISS_DUPLICATE / DISMISS_RESOLVED at HIGH confidence → close issue.
     - PLAN_APPROVE with HIGH skip-confidence + code kind → TRIAGING → PLAN_APPROVED
       (embedded plan in issue body).
     - APPLY with HIGH skip-confidence + maintenance kind → TRIAGING → APPLYING.
-    - REFINE (or DISMISS/PLAN_APPROVE/APPLY at non-HIGH confidence) →
+    - REFINE (or PLAN_APPROVE/APPLY at non-HIGH confidence) →
       TRIAGING → REFINING + kind label.
     - HUMAN → TRIAGING → HUMAN_NEEDED.
     """
@@ -199,50 +192,14 @@ def handle_triage(issue: dict) -> int:
             file=sys.stderr,
         )
 
-    # 2. Gather context: other open auto-improve* issues + recent PRs.
-    try:
-        context_issues = _gh_json([
-            "issue", "list", "--repo", REPO,
-            "--label", "auto-improve",
-            "--state", "open",
-            "--json", "number,title,labels,body",
-            "--limit", "100",
-        ]) or []
-    except subprocess.CalledProcessError:
-        context_issues = []
-
-    try:
-        recent_prs = _gh_json([
-            "pr", "list", "--repo", REPO,
-            "--state", "all",
-            "--json", "number,title,state,mergedAt",
-            "--limit", "30",
-        ]) or []
-    except subprocess.CalledProcessError:
-        recent_prs = []
-
-    # Exclude the issue being triaged from context.
-    context_issues = [ci for ci in context_issues if ci["number"] != issue_number]
-
-    # 3. Build user message.
-    ci_lines = "\n".join(
-        f"  #{ci['number']} [{', '.join(lb['name'] for lb in ci.get('labels', []))}] {ci['title']}"
-        for ci in context_issues[:50]
-    )
-    pr_lines = "\n".join(
-        f"  #{pr['number']} [{pr['state']}] {pr['title']}"
-        + (f" (merged {pr['mergedAt'][:10]})" if pr.get("mergedAt") else "")
-        for pr in recent_prs
-    )
+    # 2. Build user message.
     user_message = (
         f"## Issue to triage: #{issue_number}\n\n"
         f"**Title:** {title}\n\n"
-        f"**Body:**\n{issue.get('body', '')}\n\n"
-        f"## Other open auto-improve issues\n{ci_lines or '(none)'}\n\n"
-        f"## Recent PRs\n{pr_lines or '(none)'}\n"
+        f"**Body:**\n{issue.get('body', '')}\n"
     )
 
-    # 4. Run cai-triage agent.
+    # 3. Run cai-triage agent.
     result = _run_claude_p(
         ["claude", "-p", "--agent", "cai-triage",
          "--dangerously-skip-permissions"],
@@ -268,7 +225,6 @@ def handle_triage(issue: dict) -> int:
     decision   = verdict.get("decision", "")
     confidence = verdict.get("confidence", "")
     kind       = verdict.get("kind", "code")
-    dup_of     = verdict.get("duplicate_of")
     reasoning  = verdict.get("reasoning", "(no reasoning)")
 
     print(
@@ -280,28 +236,7 @@ def handle_triage(issue: dict) -> int:
     dur = f"{int(time.monotonic() - t0)}s"
 
     # 6. Execute verdict.
-    if decision in ("DISMISS_DUPLICATE", "DISMISS_RESOLVED") and confidence == "HIGH":
-        reason_flag = "not-planned"
-        if decision == "DISMISS_DUPLICATE" and dup_of:
-            comment = f"Closed as duplicate of #{dup_of} by cai-triage. Reasoning: {reasoning}"
-        else:
-            comment = f"Closed as resolved by cai-triage. Reasoning: {reasoning}"
-        close_res = _run(
-            ["gh", "issue", "close", str(issue_number),
-             "--repo", REPO,
-             "--reason", reason_flag,
-             "--comment", comment],
-            capture_output=True,
-        )
-        if close_res.returncode != 0:
-            print(f"[cai triage] gh issue close failed:\n{close_res.stderr}", file=sys.stderr)
-            log_run("triage", repo=REPO, issue=issue_number,
-                    duration=dur, result="close_failed", exit=1)
-            return 1
-        # Remove the triaging label (issue is closed but label cleanup is tidy).
-        _set_labels(issue_number, remove=[LABEL_TRIAGING], log_prefix="cai triage")
-        action_taken = decision.lower()
-    elif decision == "HUMAN":
+    if decision == "HUMAN":
         apply_transition(
             issue_number, "triaging_to_human",
             current_labels=[LABEL_TRIAGING],
@@ -379,13 +314,7 @@ def handle_triage(issue: dict) -> int:
             )
             action_taken = "applying"
     else:
-        # REFINE, or DISMISS at sub-HIGH confidence → fall through to REFINE.
-        if decision in ("DISMISS_DUPLICATE", "DISMISS_RESOLVED"):
-            print(
-                f"[cai triage] #{issue_number}: dismiss at {confidence} confidence "
-                f"— downgrading to REFINE",
-                flush=True,
-            )
+        # REFINE or any unrecognised decision → fall through to REFINE.
         apply_transition(
             issue_number, "triaging_to_refining",
             current_labels=[LABEL_TRIAGING],

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ Handler registry (issue states):
 
 | State | Handler file | Role |
 |---|---|---|
-| `RAISED` / `TRIAGING` | `cai_lib/actions/triage.py` | Classify the issue (REFINE / DISMISS / PLAN_APPROVE / APPLY / HUMAN). DISMISS at HIGH closes; PLAN_APPROVE / APPLY at HIGH skips ahead to `:plan-approved` or `:applying`. |
+| `RAISED` / `TRIAGING` | `cai_lib/actions/triage.py` | Pre-check for duplicates/resolved issues via `cai-dup-check` (closes at HIGH confidence). Then classify the issue (REFINE / PLAN_APPROVE / APPLY / HUMAN). PLAN_APPROVE / APPLY at HIGH SkipConfidence skips ahead to `:plan-approved` or `:applying`. |
 | `REFINING` | `cai_lib/actions/refine.py` | Rewrite the issue into a structured plan with steps, verification, and scope guardrails. |
 | `NEEDS_EXPLORATION` | `cai_lib/actions/explore.py` | Run `cai-explore` to investigate an under-specified issue and route back to `:refining`. |
 | `REFINED` / `PLANNING` / `PLANNED` | `cai_lib/actions/plan.py` | Run plan + select, store the plan in the issue body, then apply the confidence gate: HIGH auto-promotes to `:plan-approved`; MEDIUM / LOW / missing diverts to `:human-needed` with a pending marker. |

--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -50,6 +50,7 @@ declare -A DESCRIPTIONS=(
   [".claude/agents/cai-review-pr.md"]="Agent: pre-merge ripple-effect review"
   [".claude/agents/cai-revise.md"]="Agent: handle review comments on auto-improve PRs"
   [".claude/agents/cai-select.md"]="Agent: evaluate and select best fix plan"
+  [".claude/agents/cai-triage.md"]="Agent: triage \`auto-improve:raised\` issues one at a time — classify as REFINE, PLAN_APPROVE, APPLY, or HUMAN. Inline-only — full issue body is provided in the user message. No tool use needed."
   [".claude/agents/cai-unblock.md"]="Agent: classify admin comments on :human-needed issues into FSM resume targets"
   [".claude/agents/cai-update-check.md"]="Agent: check for new Claude Code releases"
   [".github/workflows/admin-only-label.yml"]="CI: restrict auto-improve:requested label to admins"


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#672

**Issue:** #672 — Trim cai-triage prompt: drop dup/resolved logic now handled by cai-dup-check

## PR Summary

### What this fixes
`cai-triage` was still emitting `DISMISS_DUPLICATE` and `DISMISS_RESOLVED` verdicts and fetching context issues/recent PRs for duplicate detection, even though PR #669 added `cai-dup-check` as a dedicated haiku pre-step that handles this upstream. The duplicated logic wasted prompt tokens and added latency on every triage run.

### What was changed
- **`cai_lib/actions/triage.py`**: Removed `DuplicateOf:` field parsing from `_parse_issue_triage_verdict`; removed `context_issues` and `recent_prs` fetches (steps 2a/2b); simplified `user_message` to issue body only; removed the `DISMISS_DUPLICATE`/`DISMISS_RESOLVED` verdict execution block; removed the fall-through safety print for sub-HIGH dismiss verdicts; removed now-unused `import subprocess` and `_gh_json` import.
- **`.claude/agents/cai-triage.md`** (via staging): Removed `DISMISS_DUPLICATE`/`DISMISS_RESOLVED` from routing decisions table, behavior matrix, and output format spec; removed "Other open auto-improve issues" and "Recent PRs" from "What you receive"; removed `DuplicateOf:` field and related rules; updated frontmatter description to list only the four remaining verdicts (`REFINE`, `PLAN_APPROVE`, `APPLY`, `HUMAN`).

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
