### PR TITLE
Wire PR-side human:solved unblock into FSM

### DIFF
--- a/.claude/agents/cai-unblock.md
+++ b/.claude/agents/cai-unblock.md
@@ -61,14 +61,15 @@ maps to a `pr_human_to_<state>` transition defined in
 
 | State              | Admin intent (examples)                                   |
 |--------------------|-----------------------------------------------------------|
-| `REVIEWING`        | "re-run the automated review" / ambiguous comment         |
+| `REVIEWING_CODE`   | "re-run the automated review" / ambiguous comment         |
+| `REVIEWING_DOCS`   | "just re-check docs — code is fine"                       |
 | `REVISION_PENDING` | "revise this PR per my comments"                          |
 | `APPROVED`         | "looks good — queue for merge"                            |
 
 (`MERGED` is not a valid resume target — PRs must funnel back
-through `REVIEWING` / `REVISION_PENDING` / `APPROVED` before the
-merge pipeline takes over. Pick `APPROVED` if the admin greenlights
-the merge.)
+through `REVIEWING_CODE` / `REVIEWING_DOCS` / `REVISION_PENDING` /
+`APPROVED` before the merge pipeline takes over. Pick `APPROVED` if
+the admin greenlights the merge.)
 
 ## Fallback
 
@@ -76,7 +77,7 @@ If the admin's comment is unrelated to the pending decision or you
 cannot decide with confidence:
 
 - For `Kind: issue`, emit `ResumeTo: RAISED` with `Confidence: LOW`.
-- For `Kind: pr`, emit `ResumeTo: REVIEWING` with `Confidence: LOW`.
+- For `Kind: pr`, emit `ResumeTo: REVIEWING_CODE` with `Confidence: LOW`.
 
 Either restarts the relevant submachine without pretending certainty.
 

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,7 +5,6 @@
 
 | File | Purpose |
 |------|---------|
-| `.cai/pr-context.md` | Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `auto-improve:raised` + `audit` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |

--- a/cai_lib/cmd_unblock.py
+++ b/cai_lib/cmd_unblock.py
@@ -1,24 +1,20 @@
 """cai_lib.cmd_unblock — label-gated FSM resume.
 
-Scans issues parked at ``auto-improve:human-needed`` that the admin
-has marked ready for resume by applying the ``human:solved`` label.
-Picking up on the *label* (rather than any fresh admin comment) means:
+Scans issues parked at ``auto-improve:human-needed`` and PRs parked at
+``auto-improve:pr-human-needed`` that the admin has marked ready for
+resume by applying the ``human:solved`` label. Picking up on the
+*label* (rather than any fresh admin comment) means:
 
-- An admin can discuss or ask questions on the issue without the
+- An admin can discuss or ask questions on the issue/PR without the
   automation prematurely deciding the divert is resolved.
-- The resume loop skips parked issues entirely until the admin opts in,
+- The resume loop skips parked targets entirely until the admin opts in,
   so we don't re-run the classifier every cycle on every open
-  :human-needed issue.
+  parked issue/PR.
 
-For each gated issue carrying a pending-transition marker, invokes the
-``cai-unblock`` Haiku agent to classify the admin's reply into a resume
-target, fires the matching ``human_to_<state>`` transition via
-:func:`cai_lib.fsm.apply_transition`, and finally removes the
-``human:solved`` label so the signal is one-shot.
-
-PR-side unblock (``auto-improve:pr-human-needed``) is handled in a
-follow-up — the PR submachine needs a PR-labelling counterpart to
-``_set_labels`` before it can be wired symmetrically.
+For each gated target, invokes the ``cai-unblock`` Haiku agent to
+classify the admin's reply into a resume target, fires the matching
+``human_to_<state>`` / ``pr_human_to_<state>`` transition, and finally
+removes the ``human:solved`` label so the signal is one-shot.
 """
 from __future__ import annotations
 
@@ -30,19 +26,22 @@ from typing import Optional
 from cai_lib.config import (
     REPO,
     LABEL_HUMAN_NEEDED,
+    LABEL_PR_HUMAN_NEEDED,
     LABEL_HUMAN_SOLVED,
     is_admin_login,
 )
 from cai_lib.fsm import (
     Confidence,
     apply_transition,
+    apply_pr_transition,
     parse_confidence,
     parse_pending_marker,
     parse_resume_target,
     resume_transition_for,
+    resume_pr_transition_for,
     strip_pending_marker,
 )
-from cai_lib.github import _gh_json, _set_labels
+from cai_lib.github import _gh_json, _set_pr_labels
 from cai_lib.logging_utils import log_run
 from cai_lib.subprocess_utils import _run, _run_claude_p
 
@@ -87,16 +86,25 @@ def _build_unblock_message(
     *,
     kind: str,
     issue: dict,
-    marker: dict,
+    marker: Optional[dict],
     admin_comments: list[dict],
 ) -> str:
-    """Format the user message for the cai-unblock agent."""
-    marker_line = (
-        f"transition={marker.get('transition', '?')} "
-        f"from={marker.get('from', '?')} "
-        f"intended={marker.get('intended', '?')} "
-        f"conf={marker.get('conf', '?')}"
-    )
+    """Format the user message for the cai-unblock agent.
+
+    ``marker`` may be ``None`` — PRs are parked without a pending
+    marker written to their body (the ``approved_to_human`` path in
+    ``cai merge`` doesn't emit one), so the agent gets "(no marker)"
+    and relies solely on the admin comment plus PR body for context.
+    """
+    if marker is None:
+        marker_line = "(no marker — target was parked without one)"
+    else:
+        marker_line = (
+            f"transition={marker.get('transition', '?')} "
+            f"from={marker.get('from', '?')} "
+            f"intended={marker.get('intended', '?')} "
+            f"conf={marker.get('conf', '?')}"
+        )
     body = issue.get("body") or "(no body)"
     comments_block = ""
     for c in admin_comments:
@@ -256,12 +264,162 @@ def handle_human_needed(issue: dict) -> int:
     return 1 if tag == "agent_failed" else 0
 
 
+def _list_pr_human_needed_prs() -> list[dict]:
+    """PR-side counterpart to :func:`_list_human_needed_issues`.
+
+    Returns open PRs carrying BOTH ``auto-improve:pr-human-needed`` and
+    ``human:solved``. PRs lacking ``human:solved`` stay parked and are
+    ignored by this pass.
+    """
+    try:
+        return _gh_json([
+            "pr", "list",
+            "--repo", REPO,
+            "--label", LABEL_PR_HUMAN_NEEDED,
+            "--label", LABEL_HUMAN_SOLVED,
+            "--state", "open",
+            "--json", "number,title,body,labels,updatedAt,comments",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(
+            f"[cai unblock] gh pr list failed:\n{e.stderr}",
+            file=sys.stderr,
+        )
+        return []
+
+
+def _try_unblock_pr(pr: dict) -> Optional[str]:
+    """Attempt to resume *pr* from :pr-human-needed. Returns the result tag.
+
+    Mirrors :func:`_try_unblock_issue` with two differences:
+
+    - PR bodies are not expected to carry a pending marker (the
+      ``approved_to_human`` path in ``cai merge`` doesn't write one),
+      so the absence of a marker is not a skip condition.
+    - Resume target → ``pr_human_to_<state>`` transition via
+      :func:`resume_pr_transition_for`, applied with
+      :func:`apply_pr_transition`.
+
+    Result tags mirror the issue side; ``no_marker`` cannot occur here.
+    """
+    pr_number = pr["number"]
+    body = pr.get("body") or ""
+    marker = parse_pending_marker(body)  # may be None — informational only
+
+    admin_comments = _extract_admin_comments(pr)
+    if not admin_comments:
+        return "no_admin_comment"
+
+    user_message = _build_unblock_message(
+        kind="pr", issue=pr, marker=marker, admin_comments=admin_comments,
+    )
+    result = _run_claude_p(
+        ["claude", "-p", "--agent", "cai-unblock",
+         "--dangerously-skip-permissions"],
+        category="unblock",
+        agent="cai-unblock",
+        input=user_message,
+    )
+    if result.returncode != 0:
+        print(
+            f"[cai unblock] PR #{pr_number} agent failed "
+            f"(exit {result.returncode}):\n{result.stderr}",
+            file=sys.stderr,
+        )
+        return "agent_failed"
+
+    stdout = result.stdout
+    print(stdout, flush=True)
+
+    target = parse_resume_target(stdout)
+    confidence = parse_confidence(stdout)
+    if confidence != Confidence.HIGH:
+        print(
+            f"[cai unblock] PR #{pr_number} confidence="
+            f"{confidence.name if confidence else 'MISSING'}; leaving parked",
+            flush=True,
+        )
+        return "low_confidence"
+
+    if not target:
+        print(f"[cai unblock] PR #{pr_number} no ResumeTo target; leaving parked",
+              flush=True)
+        return "no_target"
+
+    transition = resume_pr_transition_for(target)
+    if transition is None:
+        print(
+            f"[cai unblock] PR #{pr_number} unknown resume target {target!r}; "
+            f"leaving parked",
+            flush=True,
+        )
+        return "no_target"
+
+    # The transition already clears :pr-human-needed via labels_remove.
+    # The human:solved label needs an explicit removal pass — unlike the
+    # issue-side helper, apply_pr_transition has no ``extra_remove`` kw.
+    ok = apply_pr_transition(
+        pr_number, transition.name,
+        log_prefix="cai unblock",
+    )
+    if not ok:
+        return "agent_failed"
+
+    if not _set_pr_labels(
+        pr_number, remove=[LABEL_HUMAN_SOLVED], log_prefix="cai unblock",
+    ):
+        # The state transition landed; failing to clear :solved will make
+        # the next pass re-pick this PR and loop on the same decision.
+        # Log and surface as a non-fatal agent_failed so the wrapper can
+        # retry or a human can intervene.
+        print(
+            f"[cai unblock] PR #{pr_number} resumed via {transition.name} "
+            f"but failed to clear {LABEL_HUMAN_SOLVED}",
+            file=sys.stderr,
+        )
+        return "agent_failed"
+
+    print(
+        f"[cai unblock] PR #{pr_number} resumed via {transition.name} "
+        f"→ {transition.to_state.name}",
+        flush=True,
+    )
+    return "resumed"
+
+
+def handle_pr_human_needed(pr: dict) -> int:
+    """Dispatcher handler for :class:`PRState.PR_HUMAN_NEEDED` PRs.
+
+    Mirrors :func:`handle_human_needed`. Only fires ``_try_unblock_pr``
+    when the admin has applied ``human:solved``; otherwise returns 0 so
+    the inner driver treats the PR as blocked. The dispatcher's picker
+    already filters PRs lacking ``human:solved``, so this branch is a
+    belt-and-braces guard against a race with label removal.
+    """
+    labels = [
+        (lb.get("name") if isinstance(lb, dict) else lb)
+        for lb in pr.get("labels", [])
+    ]
+    if LABEL_HUMAN_SOLVED not in labels:
+        print(
+            f"[cai dispatch] PR #{pr['number']} parked at :pr-human-needed "
+            f"without {LABEL_HUMAN_SOLVED} — leaving parked",
+            flush=True,
+        )
+        return 0
+    tag = _try_unblock_pr(pr) or "skipped"
+    print(f"[cai dispatch] auto-unblock PR #{pr['number']}: {tag}", flush=True)
+    return 1 if tag == "agent_failed" else 0
+
+
 def cmd_unblock(args) -> int:
-    """Scan :human-needed issues and attempt FSM resume via cai-unblock."""
+    """Scan :human-needed issues and PRs and attempt FSM resume via cai-unblock."""
     t0 = time.monotonic()
     issues = _list_human_needed_issues()
-    if not issues:
-        print("[cai unblock] no :human-needed issues; nothing to do",
+    prs = _list_pr_human_needed_prs()
+    if not issues and not prs:
+        print("[cai unblock] no :human-needed issues or PRs; nothing to do",
               flush=True)
         log_run("unblock", repo=REPO, result="no_targets", exit=0)
         return 0
@@ -269,7 +427,10 @@ def cmd_unblock(args) -> int:
     counters: dict[str, int] = {}
     for issue in issues:
         tag = _try_unblock_issue(issue) or "skipped"
-        counters[tag] = counters.get(tag, 0) + 1
+        counters[f"issue_{tag}"] = counters.get(f"issue_{tag}", 0) + 1
+    for pr in prs:
+        tag = _try_unblock_pr(pr) or "skipped"
+        counters[f"pr_{tag}"] = counters.get(f"pr_{tag}", 0) + 1
 
     dur = f"{int(time.monotonic() - t0)}s"
     summary = ", ".join(f"{k}={v}" for k, v in sorted(counters.items()))

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -57,7 +57,7 @@ from cai_lib.github import _gh_json
 # entry (apply the raise_to_triaging transition first) or a resume
 # (skip the entry transition).
 #
-# States with no handler (SOLVED, PR_HUMAN_NEEDED, MERGED on the PR
+# States with no handler (SOLVED, MERGED on the PR
 # side) are terminal or parked and the dispatcher returns without doing
 # anything. HUMAN_NEEDED has a handler that auto-resumes the FSM when
 # the admin has applied ``human:solved`` and no-ops otherwise.
@@ -105,6 +105,7 @@ def _build_pr_registry() -> dict[PRState, PRHandler]:
     from cai_lib.actions.fix_ci      import handle_fix_ci
     from cai_lib.actions.merge       import handle_merge
     from cai_lib.actions.rebase      import handle_rebase
+    from cai_lib.cmd_unblock          import handle_pr_human_needed
 
     return {
         PRState.OPEN:             handle_open_to_review,
@@ -114,14 +115,18 @@ def _build_pr_registry() -> dict[PRState, PRHandler]:
         PRState.APPROVED:         handle_merge,
         PRState.REBASING:         handle_rebase,
         PRState.CI_FAILING:       handle_fix_ci,
-        # MERGED, PR_HUMAN_NEEDED → no handler
+        # PR_HUMAN_NEEDED is actionable via handle_pr_human_needed —
+        # the picker filters to only those PRs carrying ``human:solved``
+        # so parked-waiting PRs stay out of the queue.
+        PRState.PR_HUMAN_NEEDED:  handle_pr_human_needed,
+        # MERGED → no handler (terminal)
     }
 
 
 # Pre-merge PR states from which the dispatcher can divert into REBASING
 # when it sees ``mergeable == "CONFLICTING"`` / ``mergeStateStatus == "DIRTY"``.
 # Maps each from-state to the canonical ``*_to_rebasing`` transition name.
-# REBASING itself, MERGED, PR_HUMAN_NEEDED, and OPEN are intentionally
+# REBASING itself, MERGED, and OPEN are intentionally
 # excluded — REBASING is already running it; OPEN doesn't have a label
 # so apply_pr_transition wouldn't have one to remove.
 _REBASE_ENTRY_TRANSITIONS: dict[PRState, str] = {
@@ -355,6 +360,16 @@ def _pick_oldest_actionable_target(
         if state in pr_states:
             if ("pr", pr["number"]) in skip:
                 continue
+            # PR_HUMAN_NEEDED is actionable only when the admin has
+            # signalled ready-to-resume via ``human:solved``. Mirrors
+            # the issue-side gate above.
+            if state == PRState.PR_HUMAN_NEEDED:
+                pr_label_names = [
+                    (lb.get("name") if isinstance(lb, dict) else lb)
+                    for lb in pr.get("labels", [])
+                ]
+                if LABEL_HUMAN_SOLVED not in pr_label_names:
+                    continue
             candidates.append((pr.get("createdAt", ""), "pr", pr["number"]))
 
     if not candidates:
@@ -466,7 +481,8 @@ def _drive_target_to_completion(
     The inner loop:
       1. Fetches the entity's current state.
       2. Returns when the state has no registered handler (terminal like
-         SOLVED / HUMAN_NEEDED / PR_HUMAN_NEEDED / MERGED).
+         SOLVED / MERGED; or HUMAN_NEEDED / PR_HUMAN_NEEDED without
+         ``human:solved``, which the picker filters out).
       3. Otherwise calls the registered handler (via :func:`dispatch_issue`
          or :func:`dispatch_pr`).
       4. Re-fetches state to detect progress.
@@ -603,8 +619,8 @@ def dispatch_drain(max_iter: int = _DEFAULT_DRAIN_MAX_ITER) -> int:
 
     Each tick picks the oldest actionable target, then drives it through
     its state transitions (following issue↔PR hops) until it reaches a
-    terminal state (SOLVED), a parked state (HUMAN_NEEDED /
-    PR_HUMAN_NEEDED), or is genuinely blocked (handler ran without
+    terminal state (SOLVED), a parked state without ``human:solved``
+    (HUMAN_NEEDED / PR_HUMAN_NEEDED), or is genuinely blocked (handler ran without
     advancing state, and for PRs, CI isn't pending). Then moves to the
     next actionable target.
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -52,10 +52,13 @@ class TestActionableStateSets(unittest.TestCase):
             PRState.APPROVED,
             PRState.REBASING,
             PRState.CI_FAILING,
+            # PR_HUMAN_NEEDED is actionable via handle_pr_human_needed —
+            # the picker filters to only those PRs carrying ``human:solved``
+            # so parked-waiting PRs stay out of the queue.
+            PRState.PR_HUMAN_NEEDED,
         }
         self.assertEqual(dispatcher.actionable_pr_states(), expected)
         self.assertNotIn(PRState.MERGED, dispatcher.actionable_pr_states())
-        self.assertNotIn(PRState.PR_HUMAN_NEEDED, dispatcher.actionable_pr_states())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_unblock.py
+++ b/tests/test_unblock.py
@@ -236,5 +236,106 @@ class TestHandleHumanNeeded(unittest.TestCase):
         self.assertEqual(rc, 1)
 
 
+class TestListPrHumanNeededFiltersByLabel(unittest.TestCase):
+    """PR-side picker must require BOTH :pr-human-needed and human:solved."""
+
+    def test_queries_both_labels(self):
+        captured: list[list[str]] = []
+
+        def fake_gh(args):
+            captured.append(args)
+            return []
+
+        with mock.patch.object(U, "_gh_json", side_effect=fake_gh):
+            U._list_pr_human_needed_prs()
+
+        self.assertEqual(len(captured), 1)
+        args = captured[0]
+        label_flags = [args[i + 1] for i, a in enumerate(args) if a == "--label"]
+        self.assertIn("auto-improve:pr-human-needed", label_flags)
+        self.assertIn("human:solved", label_flags)
+        self.assertEqual(len(label_flags), 2)
+
+
+class TestTryUnblockPrSkips(unittest.TestCase):
+    """The no-op branches on PR resume do not invoke claude."""
+
+    def test_no_admin_comment(self):
+        pr = {"number": 700, "title": "t", "body": "pr body", "labels": [],
+              "comments": [{"author": {"login": "stranger"}, "body": "hi"}]}
+        with mock.patch.object(U, "_run_claude_p") as fake:
+            result = U._try_unblock_pr(pr)
+        self.assertEqual(result, "no_admin_comment")
+        fake.assert_not_called()
+
+    def test_resumed_clears_human_solved(self):
+        pr = {
+            "number": 701,
+            "title": "t",
+            "body": "pr body without marker",
+            "labels": [
+                {"name": "auto-improve:pr-human-needed"},
+                {"name": "human:solved"},
+            ],
+            "comments": [
+                {"author": {"login": "alice"},
+                 "createdAt": "2026-04-15T12:00:00Z",
+                 "body": "looks good, merge it"},
+            ],
+        }
+        agent_stdout = "ResumeTo: APPROVED\nConfidence: HIGH\n"
+        fake_agent = mock.MagicMock()
+        fake_agent.returncode = 0
+        fake_agent.stdout = agent_stdout
+        fake_agent.stderr = ""
+
+        transitions: list[str] = []
+
+        def fake_pr_transition(pr_number, transition_name, **kwargs):
+            transitions.append(transition_name)
+            return True
+
+        set_label_calls: list[dict] = []
+
+        def fake_set_pr_labels(pr_number, *, add=(), remove=(), log_prefix=""):
+            set_label_calls.append({"add": list(add), "remove": list(remove)})
+            return True
+
+        with mock.patch.object(U, "_run_claude_p", return_value=fake_agent), \
+             mock.patch.object(U, "apply_pr_transition", side_effect=fake_pr_transition), \
+             mock.patch.object(U, "_set_pr_labels", side_effect=fake_set_pr_labels):
+            result = U._try_unblock_pr(pr)
+
+        self.assertEqual(result, "resumed")
+        self.assertEqual(transitions, ["pr_human_to_approved"])
+        self.assertTrue(
+            any("human:solved" in c["remove"] for c in set_label_calls),
+            f"human:solved not cleared: {set_label_calls}",
+        )
+
+
+class TestHandlePrHumanNeeded(unittest.TestCase):
+
+    def test_noop_without_human_solved(self):
+        pr = {"number": 1, "labels": [{"name": "auto-improve:pr-human-needed"}]}
+        with mock.patch.object(U, "_try_unblock_pr") as fake:
+            rc = U.handle_pr_human_needed(pr)
+        self.assertEqual(rc, 0)
+        fake.assert_not_called()
+
+    def test_delegates_when_human_solved_present(self):
+        pr = {
+            "number": 2,
+            "labels": [
+                {"name": "auto-improve:pr-human-needed"},
+                {"name": "human:solved"},
+            ],
+        }
+        with mock.patch.object(U, "_try_unblock_pr", return_value="resumed") as fake:
+            rc = U.handle_pr_human_needed(pr)
+        self.assertEqual(rc, 0)
+        fake.assert_called_once_with(pr)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Fills the dead-end where PRs with `auto-improve:pr-human-needed` + `human:solved` were ignored by the dispatcher (e.g. PR #696).
- Registers `handle_pr_human_needed` in the PR registry, mirroring the issue-side `handle_human_needed` gate on `human:solved`.
- Extends `cmd_unblock` to scan parked PRs and classify admin comments via `cai-unblock`, firing the matching `pr_human_to_<state>` transition.
- Fixes the `cai-unblock.md` PR resume table — \`REVIEWING\` was not a real `PRState` member; replaced with `REVIEWING_CODE` / `REVIEWING_DOCS`.

## Test plan
- [x] \`python -m unittest discover tests\` — 164 tests pass
- [ ] Live: re-check PR #696 on next cycle tick after merge