### PR TITLE
auto-improve: gate_ok path still misparses plan confidence after PR #687 fix

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,25 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#698
+
+## Files touched
+- `cai_lib/actions/plan.py:342` — added `conf_name` variable and embedded `Confidence: {conf_name}` line inside the `plan_block` string
+
+## Files read (not touched) that matter
+- `cai_lib/actions/plan.py` — contains `handle_plan` (writes plan block to issue body) and `handle_plan_gate` (re-reads body and calls `parse_confidence`)
+
+## Key symbols
+- `handle_plan` (`cai_lib/actions/plan.py:~280`) — builds and stores the plan block in the issue body
+- `plan_block` (`cai_lib/actions/plan.py:342`) — the string written between `<!-- cai-plan-start -->` and `<!-- cai-plan-end -->`
+- `parse_confidence` / `_CONFIDENCE_RE` (`cai_lib/fsm.py`) — regex that reads `Confidence: HIGH/MEDIUM/LOW` from the stored body in `handle_plan_gate`
+
+## Design decisions
+- Embed `Confidence: {conf_name}` as a plain text line just before `<!-- cai-plan-end -->` — visible to humans reviewing the issue body and parseable by the existing `_CONFIDENCE_RE`
+- If `plan_confidence` is `None`, write `Confidence: MISSING` — `parse_confidence` returns `None` for that value, correctly diverting to `:human-needed`
+
+## Out of scope / known gaps
+- Manual re-labeling of stuck issues (#626, #628, #649, #650, #670, #671, #675, #679) from `:human-needed` back to `:refined` — operational task, not a code change
+- `handle_plan_gate` and `parse_confidence` / `_CONFIDENCE_RE` are unchanged — already fixed by PR #687
+
+## Invariants this change relies on
+- `_CONFIDENCE_RE` in `cai_lib/fsm.py` matches `Confidence: HIGH|MEDIUM|LOW` (with optional markdown bold wrapping) — fixed by PR #687
+- `_strip_stored_plan_block` strips the *old* plan block before this new one is built, so no double-embedding

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,6 +5,7 @@
 
 | File | Purpose |
 |------|---------|
+| `.cai/pr-context.md` | Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `auto-improve:raised` + `audit` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |

--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -339,10 +339,12 @@ def handle_plan(issue: dict) -> int:
         # upcoming confidence gate (handle_plan_gate) will re-add one if
         # it diverts.
         current_body = strip_pending_marker(current_body)
+        conf_name = plan_confidence.name if plan_confidence else "MISSING"
         plan_block = (
             "<!-- cai-plan-start -->\n"
             "## Selected Implementation Plan\n\n"
             f"{selected_plan}\n"
+            f"Confidence: {conf_name}\n"
             "<!-- cai-plan-end -->"
         )
         new_body = f"{plan_block}\n\n{current_body}"


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#698

**Issue:** #698 — gate_ok path still misparses plan confidence after PR #687 fix

## PR Summary

### What this fixes
After PR #687, `handle_plan_gate` still mis-parsed the confidence level because the stored plan block written by `handle_plan` never included a `Confidence:` line — so when the gate ran in a separate process and fell back to re-parsing the issue body, `parse_confidence` always returned `None`, incorrectly diverting HIGH-confidence plans to `:human-needed`.

### What was changed
- **`cai_lib/actions/plan.py`** (`handle_plan`, around line 342): added `conf_name = plan_confidence.name if plan_confidence else "MISSING"` and appended `f"Confidence: {conf_name}\n"` to the `plan_block` string, so the existing `parse_confidence` / `_CONFIDENCE_RE` in `handle_plan_gate` reliably finds the confidence level when reading back the stored issue body.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
