### PR TITLE
chore: standardize agent model aliases and soften inline descriptions

### DIFF
--- a/.claude/agents/cai-analyze.md
+++ b/.claude/agents/cai-analyze.md
@@ -2,7 +2,7 @@
 name: cai-analyze
 description: Analyze parsed signals from the cai container's own Claude Code session transcripts and raise auto-improve findings for code, prompt, or workflow issues. Read-only — the wrapper publishes findings as GitHub issues after the agent exits.
 tools: Read, Grep, Glob, Skill
-model: claude-sonnet-4-6
+model: sonnet
 memory: project
 ---
 

--- a/.claude/agents/cai-audit-triage.md
+++ b/.claude/agents/cai-audit-triage.md
@@ -1,8 +1,8 @@
 ---
 name: cai-audit-triage
-description: Triage `auto-improve:raised` + `audit` findings and emit structured verdicts (close_duplicate / close_resolved / passthrough / escalate). Inline-only — all the state (raised issues, other open issues, recent PRs) is provided in the user message. No tool use needed.
+description: Triage `auto-improve:raised` + `audit` findings and emit structured verdicts (close_duplicate / close_resolved / passthrough / escalate). Inline-only — all the state (raised issues, other open issues, recent PRs) is provided in the user message. Minimal tool use.
 tools: Read
-model: claude-sonnet-4-6
+model: sonnet
 memory: project
 ---
 

--- a/.claude/agents/cai-audit.md
+++ b/.claude/agents/cai-audit.md
@@ -2,7 +2,7 @@
 name: cai-audit
 description: Audit the current GitHub issue queue, recent PRs, and log tail to find inconsistencies in the auto-improve lifecycle state machine. Report-only — findings go to humans for triage, not to the implement subagent.
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: sonnet
 memory: project
 ---
 

--- a/.claude/agents/cai-code-audit.md
+++ b/.claude/agents/cai-code-audit.md
@@ -2,7 +2,7 @@
 name: cai-code-audit
 description: Read-only audit of the `robotsix-cai` source tree for concrete inconsistencies, dead code, and missing cross-file references the session-based analyzer cannot catch. Runs in a fresh clone and emits `### Finding:` blocks plus a memory update for the next run.
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: sonnet
 memory: project
 ---
 

--- a/.claude/agents/cai-confirm.md
+++ b/.claude/agents/cai-confirm.md
@@ -2,7 +2,7 @@
 name: cai-confirm
 description: Verify whether each `auto-improve:merged` issue has actually been resolved by checking the merged PR's diff against the issue's remediation and the recent parsed transcript signals against the issue's evidence. Produces exactly one verdict per issue — no new findings, no remediations.
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: sonnet
 memory: project
 ---
 

--- a/.claude/agents/cai-cost-optimize.md
+++ b/.claude/agents/cai-cost-optimize.md
@@ -2,7 +2,7 @@
 name: cai-cost-optimize
 description: Weekly cost-reduction agent — analyzes spending trends and proposes one optimization per run.
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: sonnet
 memory: project
 ---
 

--- a/.claude/agents/cai-dup-check.md
+++ b/.claude/agents/cai-dup-check.md
@@ -1,8 +1,8 @@
 ---
 name: cai-dup-check
-description: Check whether an issue is a duplicate of another open issue or has already been resolved by a recent commit/PR. Inline-only — all context (target issue, other open issues, recent commits/PRs) is provided in the user message. No tool use needed.
+description: Check whether an issue is a duplicate of another open issue or has already been resolved by a recent commit/PR. Inline-only — all context (target issue, other open issues, recent commits/PRs) is provided in the user message. Minimal tool use.
 tools: Read
-model: claude-haiku-4-5
+model: haiku
 ---
 
 # Issue Duplicate / Resolved Check

--- a/.claude/agents/cai-explore.md
+++ b/.claude/agents/cai-explore.md
@@ -2,7 +2,7 @@
 name: cai-explore
 description: Autonomous exploration and benchmarking agent. Investigates open-ended questions by running concrete measurements, then feeds findings directly back into the auto-improve pipeline with structured outcomes (Findings, Refined Issue, or Blocked).
 tools: Read, Grep, Glob, Bash, Agent, Write, Edit
-model: claude-opus-4-6
+model: opus
 memory: project
 ---
 

--- a/.claude/agents/cai-fix-ci.md
+++ b/.claude/agents/cai-fix-ci.md
@@ -2,7 +2,7 @@
 name: cai-fix-ci
 description: Diagnose and fix failing CI checks on an open auto-improve PR. Receives a CI failure log section in the user message, identifies the root cause (test, lint, build, or type error), locates the relevant source in the clone, and makes the minimal targeted fix. Leaves edits uncommitted for the wrapper to commit and push.
 tools: Read, Edit, Write, Grep, Glob, Agent
-model: claude-sonnet-4-6
+model: sonnet
 memory: project
 ---
 

--- a/.claude/agents/cai-git.md
+++ b/.claude/agents/cai-git.md
@@ -2,7 +2,7 @@
 name: cai-git
 description: Lightweight haiku subagent that executes git operations on behalf of other subagents. Accepts a work directory and a set of git commands to run. Never modifies code — only runs git commands.
 tools: Bash
-model: claude-haiku-4-5
+model: haiku
 ---
 
 # Git Operations Subagent

--- a/.claude/agents/cai-implement.md
+++ b/.claude/agents/cai-implement.md
@@ -2,7 +2,7 @@
 name: cai-implement
 description: Autonomous code-editing subagent for `robotsix-cai`. Makes the smallest targeted change that addresses an auto-improve issue handed by the wrapper. Cannot run git or gh — the wrapper handles all remote state and PR opening.
 tools: Read, Edit, Write, Grep, Glob, TodoWrite
-model: claude-sonnet-4-6
+model: sonnet
 memory: project
 ---
 

--- a/.claude/agents/cai-merge.md
+++ b/.claude/agents/cai-merge.md
@@ -1,8 +1,8 @@
 ---
 name: cai-merge
-description: Assess whether a pull request correctly implements its linked issue and emit a structured merge verdict (confidence + action). Inline-only — the issue body, PR changes, and PR comments all arrive as the user message. No tool use needed.
+description: Assess whether a pull request correctly implements its linked issue and emit a structured merge verdict (confidence + action). Inline-only — the issue body, PR changes, and PR comments all arrive as the user message. Minimal tool use.
 tools: Read
-model: claude-opus-4-6
+model: opus
 memory: project
 ---
 

--- a/.claude/agents/cai-plan.md
+++ b/.claude/agents/cai-plan.md
@@ -2,7 +2,7 @@
 name: cai-plan
 description: Generate a detailed fix plan for an auto-improve issue. Read-only — examines the codebase and produces a structured plan that the fix agent will implement. First of two serial planners — the second receives this plan and proposes an alternative. Output is evaluated by cai-select.
 tools: Read, Grep, Glob, Agent
-model: claude-sonnet-4-6
+model: sonnet
 ---
 
 # Plan Generator

--- a/.claude/agents/cai-propose-review.md
+++ b/.claude/agents/cai-propose-review.md
@@ -2,7 +2,7 @@
 name: cai-propose-review
 description: Review agent that evaluates creative improvement proposals for feasibility and value before they are submitted as issues for human review.
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: sonnet
 memory: project
 ---
 

--- a/.claude/agents/cai-propose.md
+++ b/.claude/agents/cai-propose.md
@@ -2,7 +2,7 @@
 name: cai-propose
 description: Weekly creative agent that explores the codebase and proposes ambitious improvements — from small wins to full architectural reworks.
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: sonnet
 memory: project
 ---
 

--- a/.claude/agents/cai-rebase.md
+++ b/.claude/agents/cai-rebase.md
@@ -2,7 +2,7 @@
 name: cai-rebase
 description: Lightweight rebase-only conflict resolution agent. Resolves merge conflicts in a rebase-in-progress worktree and drives the rebase to completion. No review-comment logic, no memory tracking. Used by the revise handler when a PR only needs a rebase with no unaddressed review comments.
 tools: Read, Edit, Write, Grep, Glob, Agent
-model: claude-haiku-4-5
+model: haiku
 ---
 
 # Rebase-Only Conflict Resolution Agent

--- a/.claude/agents/cai-refine.md
+++ b/.claude/agents/cai-refine.md
@@ -2,7 +2,7 @@
 name: cai-refine
 description: Rewrite human-filed issues into structured auto-improve plans with problem, steps, verification, scope guardrails, and likely files.
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: sonnet
 memory: project
 ---
 

--- a/.claude/agents/cai-review-docs.md
+++ b/.claude/agents/cai-review-docs.md
@@ -2,7 +2,7 @@
 name: cai-review-docs
 description: Pre-merge documentation review for an open PR. Checks whether changes to user-facing behavior, CLI interface, configuration, or architecture require updates to files in /docs, and directly fixes any stale documentation it finds.
 tools: Read, Grep, Glob, Agent, Edit, Write
-model: claude-haiku-4-5
+model: haiku
 memory: project
 ---
 

--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -2,7 +2,7 @@
 name: cai-review-pr
 description: Pre-merge ripple-effect review for an open PR. Walks the changed files in the clone, searches the broader codebase for inconsistencies the PR introduced but didn't update, and emits `### Finding:` blocks the wrapper posts as a PR comment. Read-only.
 tools: Read, Grep, Glob
-model: claude-haiku-4-5
+model: haiku
 memory: project
 ---
 

--- a/.claude/agents/cai-revise.md
+++ b/.claude/agents/cai-revise.md
@@ -2,7 +2,7 @@
 name: cai-revise
 description: Handle review comments on an auto-improve PR — resolve any in-progress rebase against main AND address unaddressed reviewer comments, in one session. Only invoked by the wrapper when there are unaddressed review comments. (Conflict-only runs go to `cai-rebase`.)
 tools: Read, Edit, Write, Grep, Glob, Agent
-model: claude-sonnet-4-6
+model: sonnet
 memory: project
 ---
 

--- a/.claude/agents/cai-select.md
+++ b/.claude/agents/cai-select.md
@@ -1,8 +1,8 @@
 ---
 name: cai-select
-description: Evaluate multiple fix plans for an auto-improve issue and select the best one. Inline-only — all plans arrive in the user message. No tool use needed.
+description: Evaluate multiple fix plans for an auto-improve issue and select the best one. Inline-only — all plans arrive in the user message. Minimal tool use.
 tools: Read
-model: claude-opus-4-6
+model: opus
 ---
 
 # Plan Selector

--- a/.claude/agents/cai-triage.md
+++ b/.claude/agents/cai-triage.md
@@ -1,8 +1,8 @@
 ---
 name: cai-triage
-description: Triage `auto-improve:raised` issues one at a time — classify as REFINE, PLAN_APPROVE, APPLY, or HUMAN. Inline-only — full issue body is provided in the user message. No tool use needed.
+description: Triage `auto-improve:raised` issues one at a time — classify as REFINE, PLAN_APPROVE, APPLY, or HUMAN. Inline-only — full issue body is provided in the user message. Minimal tool use.
 tools: Read
-model: claude-haiku-4-5-20251001
+model: haiku
 memory: project
 ---
 

--- a/.claude/agents/cai-unblock.md
+++ b/.claude/agents/cai-unblock.md
@@ -2,7 +2,7 @@
 name: cai-unblock
 description: Classify an admin's GitHub comment on an issue or PR parked in the human-needed state into a FSM resume target so the auto-improve pipeline can continue.
 tools: Read
-model: claude-haiku-4-5-20251001
+model: haiku
 memory: project
 ---
 

--- a/.claude/agents/cai-update-check.md
+++ b/.claude/agents/cai-update-check.md
@@ -2,7 +2,7 @@
 name: cai-update-check
 description: Periodic Claude Code release checker that compares the current pinned version against the latest releases and emits findings for new versions, feature adoptions, deprecations, and best-practice changes.
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: sonnet
 memory: project
 ---
 


### PR DESCRIPTION
## Summary
- Switch all 24 versioned `model:` fields in `.claude/agents/*.md` to bare aliases (`haiku`/`sonnet`/`opus`), matching `cai-maintain` and `cai-check-workflows`.
- Replace "No tool use needed" with "Minimal tool use" in the 5 inline-only agent descriptions (cai-merge, cai-select, cai-triage, cai-audit-triage, cai-dup-check), which all declare the `Read` tool.

Outcome of an agent-frontmatter audit — no behavior change.

## Test plan
- [ ] CI green