### PR TITLE
auto-improve: Add cross-reference check step to cai-implement before finishing

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,21 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#649
+
+## Files touched
+- .claude/agents/cai-implement.md:54 — Added new hard rule 7 requiring cross-reference Grep before exiting with a non-zero diff
+
+## Files read (not touched) that matter
+- .claude/agents/cai-implement.md — The agent definition being modified; read to verify current rule numbering and insertion point
+
+## Key symbols
+- Hard rule 7 (.claude/agents/cai-implement.md:54) — New rule mandating cross-file reference checks for renamed/added symbols before PR exit
+
+## Design decisions
+- Inserted as rule 7 immediately after rule 6 (Stay inside the repo) — preserves logical grouping of hard constraints before efficiency guidance
+- Anchored scope with "within the minimal-change scope" phrase — prevents rule from becoming a license for unbounded edits
+
+## Out of scope / known gaps
+- Did not add corresponding guidance to cai-revise.md or other agents — only cai-implement was identified in the issue
+
+## Invariants this change relies on
+- The staging path `.cai-staging/agents/` is copied over `.claude/agents/` by the wrapper after the session exits

--- a/.claude/agents/cai-implement.md
+++ b/.claude/agents/cai-implement.md
@@ -51,6 +51,7 @@ and label transitions — so you only need to focus on the code.
    directory. Don't modify `.github/workflows/` files unless the
    issue is specifically about them — if in doubt, exit without
    changes.
+7. **Cross-reference check before exiting.** Before exiting with a non-zero diff, Grep for the name of every function, class, config key, or CLI flag you renamed or added, across the entire work directory. If callers or references exist in files you have not edited, assess whether they also need updating. If they do, edit them now (within the minimal-change scope); if not, note them under "Out of scope / known gaps" in the PR context dossier.
 
 ## Efficiency guidance
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#649

**Issue:** #649 — Add cross-reference check step to cai-implement before finishing

## PR Summary

### What this fixes
The `cai-implement` agent had no step requiring it to check for cross-file references to symbols it renamed or added, causing 14 ripple-effect findings across 5 PRs in 30 days where callers in unedited files were left stale.

### What was changed
- `.claude/agents/cai-implement.md` (via staging): Added new hard rule 7 — "Cross-reference check before exiting" — requiring the agent to Grep for every renamed/added function, class, config key, or CLI flag across the entire work directory before submitting a non-zero diff, and either update found callers (within minimal-change scope) or document them under "Out of scope / known gaps" in the PR context dossier.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
