### PR TITLE
auto-improve: Add contradictory-rules check to cai-implement for config/prompt edits

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,21 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#650
+
+## Files touched
+- .claude/agents/cai-implement.md:57-65 — added hard rule #8 requiring contradiction-check Grep before adding rules/config to prompt or settings files
+
+## Files read (not touched) that matter
+- .claude/agents/cai-implement.md — source file; rule 7 already existed (cross-reference check), so the new rule became #8
+
+## Key symbols
+- Hard rule 8 (.claude/agents/cai-implement.md:57) — new contradiction-checking rule added to ## Hard rules section
+
+## Design decisions
+- Numbered as rule 8 (not 7) — rule 7 already existed for cross-reference checks; inserting as 8 preserves existing rules without renumbering
+- Rejected: renumbering existing rules — would be a larger diff and break any external references to rule numbers
+
+## Out of scope / known gaps
+- Other agent files not updated — the new rule is self-contained guidance for cai-implement only
+
+## Invariants this change relies on
+- The staging path `.cai-staging/agents/cai-implement.md` is picked up by the wrapper and copied to `.claude/agents/cai-implement.md`

--- a/.claude/agents/cai-implement.md
+++ b/.claude/agents/cai-implement.md
@@ -52,6 +52,15 @@ and label transitions — so you only need to focus on the code.
    issue is specifically about them — if in doubt, exit without
    changes.
 7. **Cross-reference check before exiting.** Before exiting with a non-zero diff, Grep for the name of every function, class, config key, or CLI flag you renamed or added, across the entire work directory. If callers or references exist in files you have not edited, assess whether they also need updating. If they do, edit them now (within the minimal-change scope); if not, note them under "Out of scope / known gaps" in the PR context dossier.
+8. **Check for contradictions before adding rules or config.**
+   If your change adds a new rule, constraint, or config value to a
+   prompt or settings file (`.claude/agents/*.md`, `settings.json`,
+   or workflow YAML), Grep the **same file** for keywords related to
+   your addition and confirm no existing rule contradicts it. If the
+   target is a `.claude/agents/*.md` file, also Grep the other agent
+   files in that directory for the same keywords. If you find a
+   contradiction, resolve it — either update the conflicting rule or
+   adjust your addition — rather than leaving both in place.
 
 ## Efficiency guidance
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#650

**Issue:** #650 — Add contradictory-rules check to cai-implement for config/prompt edits

## PR Summary

### What this fixes
`cai-implement` had no guidance to check for contradictions when adding new rules or config values to agent prompt files or settings files, leading to a recurring `contradictory_rules` ripple-effect pattern (9 occurrences across 5 PRs in the last 30 days).

### What was changed
- `.claude/agents/cai-implement.md` (via `.cai-staging/agents/cai-implement.md`): Added hard rule **#8** — "Check for contradictions before adding rules or config" — requiring the agent to Grep the same file (and sibling agent files when editing `.claude/agents/*.md`) for related keywords before committing any addition, and to resolve any contradiction found rather than leaving both rules in place.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
