### PR TITLE
auto-improve: [#621 Step 5/6] Migrate check-workflows pipeline into unified FSM

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,40 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#626
+
+## Files touched
+- `publish.py`:141 — added `"check-workflows:raised"` to `LABELS_TO_DELETE`
+- `publish.py`:178-185 — replaced `("check-workflows:raised", ...)` with `("auto-improve", ...)` and `("auto-improve:raised", ...)` in `CHECK_WORKFLOWS_LABELS`
+- `publish.py`:340 — added `CHECK_WORKFLOWS_LABELS` to `ensure_all_labels` loop
+- `publish.py`:435-440 — changed `create_issue` check-workflows branch to emit `auto-improve,auto-improve:raised,check-workflows` instead of `check-workflows,check-workflows:raised`
+- `cai_lib/watchdog.py`:215-267 — added `_migrate_check_workflows_raised()` migration helper
+- `cai.py`:211 — extended watchdog import to include `_migrate_check_workflows_raised`
+- `cai.py`:3206-3216 — added migration call at top of `cmd_check_workflows`
+- `tests/test_publish.py`:10 — added `CHECK_WORKFLOWS_LABELS`, `LABELS_TO_DELETE` to imports
+- `tests/test_publish.py`:140-159 — added `TestCheckWorkflowsLabels` test class
+
+## Files read (not touched) that matter
+- `cai_lib/watchdog.py` — migration helper pattern copied from `_migrate_audit_raised_labels`
+- `publish.py` lines 120-185 — label constants and `LABELS_TO_DELETE`
+- `publish.py` lines 332-360 — `ensure_all_labels` loop
+- `publish.py` lines 428-458 — `create_issue` label-building logic
+
+## Key symbols
+- `_migrate_check_workflows_raised` (`cai_lib/watchdog.py`:215) — migration helper that relabels open `check-workflows:raised` issues to `auto-improve:raised + check-workflows`
+- `CHECK_WORKFLOWS_LABELS` (`publish.py`:178) — now includes `auto-improve` and `auto-improve:raised`, excludes `check-workflows:raised`
+- `LABELS_TO_DELETE` (`publish.py`:124) — now includes `"check-workflows:raised"` for cleanup
+
+## Design decisions
+- Placed migration helper in `cai_lib/watchdog.py` alongside `_migrate_audit_raised_labels` — avoids creating a new module; mirrors the same pattern exactly
+- Did NOT add `LABEL_CHECK_WORKFLOWS_RAISED` to config.py — the string literal `"check-workflows:raised"` is only used in the migration helper and `LABELS_TO_DELETE`; a constant is not needed for such limited use
+- Rejected: creating `cai_lib/cmd_lifecycle.py` (as suggested in detailed issue plan) — the Selected Implementation Plan explicitly chose `watchdog.py` as the location
+
+## Out of scope / known gaps
+- Did not touch `cai_lib/fsm.py` or any FSM transition logic (per scope guardrails)
+- Did not touch `cmd_audit_triage` or `audit:raised` path (per scope guardrails)
+- Did not retire `auto-improve:no-action` (that is Step 6)
+- `check-workflows` source label retained on all new findings so `--label check-workflows` dedup queries still work
+
+## Invariants this change relies on
+- `_gh_json`, `_set_labels`, `LABEL_RAISED`, `REPO`, `log_run` are already imported in `cai_lib/watchdog.py`
+- `cmd_check_workflows` prints before calling `t0 = time.monotonic()` — migration call inserted between the initial print and `t0`
+- `auto-improve` and `auto-improve:raised` labels already exist in `LABELS` (used in the dedup) — adding them to `CHECK_WORKFLOWS_LABELS` just ensures idempotent creation via `ensure_all_labels`

--- a/cai.py
+++ b/cai.py
@@ -208,7 +208,7 @@ from cai_lib.github import (  # noqa: E402
     _set_labels, _set_pr_labels, _issue_has_label, _build_issue_block,
     _build_implement_user_message, _fetch_linked_issue_block,
 )
-from cai_lib.watchdog import _rollback_stale_in_progress, _migrate_audit_raised_labels  # noqa: E402
+from cai_lib.watchdog import _rollback_stale_in_progress, _migrate_audit_raised_labels, _migrate_check_workflows_raised  # noqa: E402
 from cai_lib.cmd_unblock import cmd_unblock  # noqa: E402
 from cai_lib.actions.confirm import (  # noqa: E402
     _parse_verdicts,
@@ -3206,6 +3206,15 @@ def cmd_health_report(args) -> int:
 def cmd_check_workflows(args) -> int:
     """Check GitHub Actions for recent workflow failures and raise findings."""
     print("[cai check-workflows] running workflow check", flush=True)
+    # Idempotent migration: relabel any open check-workflows:raised issues to
+    # auto-improve:raised + check-workflows so they flow through the unified pipeline.
+    migrated = _migrate_check_workflows_raised()
+    if migrated:
+        nums = ", ".join(f"#{n}" for n in migrated)
+        print(
+            f"[cai check-workflows] migrated {len(migrated)} check-workflows:raised issue(s) to auto-improve:raised: {nums}",
+            flush=True,
+        )
     t0 = time.monotonic()
 
     # 1. Fetch recent failed runs from GitHub Actions.

--- a/cai_lib/watchdog.py
+++ b/cai_lib/watchdog.py
@@ -211,3 +211,60 @@ def _migrate_audit_raised_labels() -> list[int]:
             )
 
     return migrated
+
+
+def _migrate_check_workflows_raised() -> list[int]:
+    """Idempotent one-time migration: relabel open ``check-workflows:raised`` issues.
+
+    Finds open issues that still carry the retired ``check-workflows:raised``
+    label and adds ``auto-improve`` + ``auto-improve:raised`` while removing
+    ``check-workflows:raised``.  The ``check-workflows`` source tag is left in
+    place so check-workflows-originated issues remain filterable.
+
+    Safe to call on every cycle iteration — issues that have already been
+    migrated (no ``check-workflows:raised`` label) are simply not returned by
+    the ``gh issue list`` query.
+
+    Returns the list of issue numbers that were migrated in this call.
+    """
+    try:
+        stale_issues = _gh_json([
+            "issue", "list",
+            "--repo", REPO,
+            "--label", "check-workflows:raised",
+            "--state", "open",
+            "--json", "number,title",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(
+            f"[cai migrate] gh issue list (check-workflows:raised) failed:\n{e.stderr}",
+            file=sys.stderr,
+        )
+        return []
+
+    if not stale_issues:
+        return []
+
+    migrated: list[int] = []
+    for issue in stale_issues:
+        n = issue["number"]
+        ok = _set_labels(
+            n,
+            add=["auto-improve", LABEL_RAISED],
+            remove=["check-workflows:raised"],
+            log_prefix="cai migrate",
+        )
+        if ok:
+            migrated.append(n)
+            log_run(
+                "migrate",
+                action="check_workflows_raised_migration",
+                issue=n,
+            )
+            print(
+                f"[cai migrate] #{n} migrated: check-workflows:raised → auto-improve:raised + check-workflows",
+                flush=True,
+            )
+
+    return migrated

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -7,6 +7,7 @@ Agents are defined in `.claude/agents/*.md` with YAML frontmatter (`name`, `desc
 | `cai-analyze` | Analyze parsed transcript signals and raise auto-improve findings | Read, Grep, Glob, Skill | sonnet | Read-only |
 | `cai-audit` | Audit issue queue and PRs for lifecycle state-machine inconsistencies | Read, Grep, Glob | sonnet | Read-only |
 | `cai-audit-triage` | Triage `auto-improve:raised` + `audit` findings and emit close/passthrough/escalate verdicts | Read | sonnet | Inline-only |
+| `cai-check-workflows` | Analyze recent GitHub Actions workflow failures and emit structured findings for new, unreported failures | Read, Grep, Glob | haiku | Read-only |
 | `cai-code-audit` | Read-only source tree audit for inconsistencies, dead code, and missing cross-file references | Read, Grep, Glob | sonnet | Worktree |
 | `cai-confirm` | Verify each `auto-improve:merged` issue is actually resolved | Read, Grep, Glob | sonnet | Read-only |
 | `cai-cost-optimize` | Weekly cost-reduction agent — analyzes spending trends, proposes one optimization | Read, Grep, Glob | sonnet | Read-only |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,12 @@ Clone the repo and run `cai-code-audit` to find concrete inconsistencies, dead c
 
 No arguments.
 
+## check-workflows
+
+Monitor GitHub Actions for recent workflow failures and publish findings as issues. Fetches recent failed workflow runs (last 24 hours), filters out bot branches, and runs a Haiku agent to identify and group related failures. Findings are published with the `check-workflows` namespace and integrated into the unified auto-improve pipeline.
+
+No arguments.
+
 ## cost-optimize
 
 Run the weekly `cai-cost-optimize` agent to analyze spending trends and propose one cost-reduction optimization.

--- a/publish.py
+++ b/publish.py
@@ -138,6 +138,9 @@ LABELS_TO_DELETE = [
     "audit:raised",
     "audit:needs-human",
     "audit:solved",
+    # Retired check-workflows state label — unified into auto-improve:raised + check-workflows source tag.
+    # Migration: _migrate_check_workflows_raised in cai_lib/watchdog.py relabels existing issues.
+    "check-workflows:raised",
 ]
 
 AUDIT_LABELS = [
@@ -176,8 +179,9 @@ UPDATE_CHECK_LABELS = [
 ]
 
 CHECK_WORKFLOWS_LABELS = [
-    ("check-workflows", "e11d48", "GitHub Actions workflow failure finding"),
-    ("check-workflows:raised", "d73a4a", "Workflow failure freshly raised"),
+    ("auto-improve", "ededed", "Self-improvement finding raised by the analyzer"),
+    ("auto-improve:raised", "0e8a16", "Awaiting structured refinement before implement subagent picks it up"),
+    ("check-workflows", "e11d48", "GitHub Actions workflow failure finding (source tag)"),
     ("category:workflow_failure", "b60205", "GitHub Actions run failed"),
     ("category:workflow_flake", "fbca04", "Flaky or intermittent workflow failure"),
     ("category:workflow_config_error", "0075ca", "Workflow YAML misconfiguration"),
@@ -337,7 +341,7 @@ def ensure_all_labels() -> None:
     and CODE_AUDIT_LABELS).
     """
     seen: set[str] = set()
-    for label_set in (LABELS, AUDIT_LABELS, CODE_AUDIT_LABELS, UPDATE_CHECK_LABELS):
+    for label_set in (LABELS, AUDIT_LABELS, CODE_AUDIT_LABELS, UPDATE_CHECK_LABELS, CHECK_WORKFLOWS_LABELS):
         for name, color, description in label_set:
             if name in seen:
                 continue
@@ -434,8 +438,9 @@ def create_issue(f: Finding, namespace: str = "auto-improve") -> int:
         ])
     elif namespace == "check-workflows":
         labels = ",".join([
+            "auto-improve",
+            "auto-improve:raised",
             "check-workflows",
-            "check-workflows:raised",
             f"category:{f.category}",
         ])
     else:

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -7,7 +7,7 @@ import unittest
 # regardless of how the test runner is invoked.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from publish import parse_findings, Finding  # noqa: E402
+from publish import parse_findings, Finding, CHECK_WORKFLOWS_LABELS, LABELS_TO_DELETE  # noqa: E402
 
 
 def _finding_block(title, category, key, confidence, evidence, remediation):
@@ -134,6 +134,28 @@ class TestParseFindings(unittest.TestCase):
         findings = parse_findings(text, valid_categories={"custom_cat"})
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0].category, "custom_cat")
+
+
+class TestCheckWorkflowsLabels(unittest.TestCase):
+
+    def test_check_workflows_raised_not_in_labels(self):
+        """check-workflows:raised must NOT appear in CHECK_WORKFLOWS_LABELS (retired label)."""
+        label_names = [name for name, _, _ in CHECK_WORKFLOWS_LABELS]
+        self.assertNotIn("check-workflows:raised", label_names)
+
+    def test_check_workflows_in_labels(self):
+        """check-workflows source tag must remain in CHECK_WORKFLOWS_LABELS."""
+        label_names = [name for name, _, _ in CHECK_WORKFLOWS_LABELS]
+        self.assertIn("check-workflows", label_names)
+
+    def test_auto_improve_raised_in_check_workflows_labels(self):
+        """auto-improve:raised must be in CHECK_WORKFLOWS_LABELS so new findings enter the FSM."""
+        label_names = [name for name, _, _ in CHECK_WORKFLOWS_LABELS]
+        self.assertIn("auto-improve:raised", label_names)
+
+    def test_check_workflows_raised_in_labels_to_delete(self):
+        """check-workflows:raised must be in LABELS_TO_DELETE so it gets cleaned up on publish runs."""
+        self.assertIn("check-workflows:raised", LABELS_TO_DELETE)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#626

**Issue:** #626 — [#621 Step 5/6] Migrate check-workflows pipeline into unified FSM

## PR Summary

### What this fixes
`check-workflows` findings were being published with `check-workflows:raised` labels instead of entering the unified `auto-improve` FSM. This meant workflow-failure findings bypassed the standard TRIAGE → REFINE → PLAN → IMPLEMENT pipeline that all other findings use.

### What was changed
- **`publish.py`**: Added `"check-workflows:raised"` to `LABELS_TO_DELETE`; replaced `("check-workflows:raised", ...)` in `CHECK_WORKFLOWS_LABELS` with `("auto-improve", ...)` and `("auto-improve:raised", ...)`; added `CHECK_WORKFLOWS_LABELS` to the `ensure_all_labels` loop; changed the `create_issue` check-workflows branch to emit `auto-improve,auto-improve:raised,check-workflows,category:{f.category}` instead of `check-workflows,check-workflows:raised,category:{f.category}`
- **`cai_lib/watchdog.py`**: Added `_migrate_check_workflows_raised()` helper (mirroring `_migrate_audit_raised_labels`) that relabels open `check-workflows:raised` issues to `auto-improve:raised + check-workflows`
- **`cai.py`**: Extended the `from cai_lib.watchdog import` line to include `_migrate_check_workflows_raised`; added a call to it at the top of `cmd_check_workflows` so existing issues are migrated on each run
- **`tests/test_publish.py`**: Added `TestCheckWorkflowsLabels` test class with four assertions verifying `check-workflows:raised` is absent from `CHECK_WORKFLOWS_LABELS`, `check-workflows` source tag is present, `auto-improve:raised` is present, and `check-workflows:raised` is in `LABELS_TO_DELETE`

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
