### PR TITLE
auto-improve: all auto-impro, audit labels should be in the orkflow to remove them if not set by accepted list

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,31 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#628
+
+## Files touched
+- `cai.py`:187 — added `_ALL_MANAGED_ISSUE_LABELS` frozenset and `_MANAGED_ISSUE_PREFIXES` tuple constants after `_STALE_NO_ACTION_DAYS` import block
+- `cai.py`:653 — added `_issue_label_sweep()` function before `cmd_verify()`
+- `cai.py`:703 — wired `_issue_label_sweep()` call into `cmd_verify()` before `try:` block
+- `cai.py`:2819 — wired `_issue_label_sweep()` call into `_cmd_cycle_inner()` as Phase 0.5
+
+## Files read (not touched) that matter
+- `cai.py`:186 — wildcard import `from cai_lib.config import *` brings all `LABEL_*` constants into scope before the new frozenset
+
+## Key symbols
+- `_ALL_MANAGED_ISSUE_LABELS` (`cai.py`:196) — frozenset of all valid cai-managed issue labels; stale detection compares against this
+- `_MANAGED_ISSUE_PREFIXES` (`cai.py`:208) — tuple of prefix strings identifying cai-owned labels; no trailing colons
+- `_issue_label_sweep` (`cai.py`:653) — main sweep function; returns (issues_scanned, labels_removed)
+- `_set_labels` (imported from `cai_lib.github`) — used to remove stale labels; already available
+
+## Design decisions
+- Used `lbl == p or lbl.startswith(p + ":")` matching — avoids false positives (e.g., `"kind"` prefix won't match `"kindness"`)
+- Three separate `gh issue list` calls (one per base label) with dedup via `seen` dict — simpler than a combined query
+- `_issue_label_sweep()` returns counts tuple — allows callers to log or react to results
+- Rejected: modifying `cai_lib/config.py` or `publish.py` — scope guardrails explicitly forbid it
+
+## Out of scope / known gaps
+- PR objects are NOT swept — `_issue_label_sweep` only calls `gh issue list`; PR label lifecycle remains separate
+- `LABEL_PR_*` labels (pr:reviewing-code etc.) are absent from `_ALL_MANAGED_ISSUE_LABELS` intentionally — they are valid on PRs but stale if found on issues, and `"pr"` prefix in `_MANAGED_ISSUE_PREFIXES` handles removal
+
+## Invariants this change relies on
+- `from cai_lib.config import *` (line 186) precedes the `_ALL_MANAGED_ISSUE_LABELS` frozenset definition — all `LABEL_*` names must be in scope at module parse time
+- `_set_labels` signature accepts `remove=` kwarg and `log_prefix=` kwarg — no changes made to it

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -36,6 +36,20 @@ Refs: robotsix/robotsix-cai#628
 ### New gaps / deferred
 - None
 
+## Revision 2 (2026-04-15)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py`:205 — added `"check-workflows:raised"` to `_ALL_MANAGED_ISSUE_LABELS` frozenset
+
+### Decisions this revision
+- `"check-workflows:raised"` is created by `ensure_all_labels()` (via `CHECK_WORKFLOWS_LABELS` in publish.py) but had no corresponding `LABEL_*` constant in `cai_lib/config.py`, so the string literal was added directly to the frozenset alongside the three base labels on line 205
+
+### New gaps / deferred
+- `category:workflow_*` labels from `CHECK_WORKFLOWS_LABELS` are not swept (prefix `"category"` is not in `_MANAGED_ISSUE_PREFIXES`) — intentional, same as existing `LABEL_KIND_*` pattern
+
 ## Out of scope / known gaps
 - PR objects are NOT swept — `_issue_label_sweep` only calls `gh issue list`; PR label lifecycle remains separate
 - `LABEL_PR_*` labels (pr:reviewing-code etc.) are absent from `_ALL_MANAGED_ISSUE_LABELS` intentionally — they are valid on PRs but stale if found on issues, and `"pr"` prefix in `_MANAGED_ISSUE_PREFIXES` handles removal

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -22,6 +22,20 @@ Refs: robotsix/robotsix-cai#628
 - `_issue_label_sweep()` returns counts tuple — allows callers to log or react to results
 - Rejected: modifying `cai_lib/config.py` or `publish.py` — scope guardrails explicitly forbid it
 
+## Revision 1 (2026-04-15)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `publish.py`:340 — added `CHECK_WORKFLOWS_LABELS` to `ensure_all_labels()` label-set tuple
+
+### Decisions this revision
+- Reviewer requested publish.py change; scope guardrail was about not sourcing accepted-label set from publish.py, not an absolute prohibition on touching it — pre-existing omission of CHECK_WORKFLOWS_LABELS from ensure_all_labels() is a legitimate co-change
+
+### New gaps / deferred
+- None
+
 ## Out of scope / known gaps
 - PR objects are NOT swept — `_issue_label_sweep` only calls `gh issue list`; PR label lifecycle remains separate
 - `LABEL_PR_*` labels (pr:reviewing-code etc.) are absent from `_ALL_MANAGED_ISSUE_LABELS` intentionally — they are valid on PRs but stale if found on issues, and `"pr"` prefix in `_MANAGED_ISSUE_PREFIXES` handles removal

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ targeted invocation, `cai.py dispatch --issue N` and
 | Subcommand | Default schedule | What it does |
 |---|---|---|
 | `cai.py cycle` | `0 * * * *` (hourly, startup, manual) | One dispatcher tick: restart-recovery + `dispatch_oldest_actionable()` (runs the handler for whatever state the oldest actionable issue or PR is in). A flock serializes overlapping runs; the entrypoint also runs this once synchronously at `docker compose up -d` so startup logs are immediate |
-| `cai.py verify` | `15 * * * *` (hourly @15) | Label-state reconciliation — keeps `:pr-open` / `:merged` / etc. consistent with actual GitHub state |
+| `cai.py verify` | `15 * * * *` (hourly @15) | Label-state reconciliation — removes deprecated cai-managed labels from open issues, then keeps `:pr-open` / `:merged` / etc. consistent with actual GitHub state |
 | `cai.py dispatch [--issue N \| --pr N]` | _(manual/on-demand)_ | Direct entry into the FSM dispatcher for a specific issue or PR (or the oldest actionable item when no target is given) |
 | `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` (6-hour TTL), `:revising` (1-hour TTL), and `:applying` (2-hour TTL) locks, and stale `:no-action` issues, flags stale `:merged` issues for human review, recovers `:pr-open` issues whose linked PR was closed (rolls back to `:refined`), deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, and label corruption as `auto-improve:raised` + `audit` findings (Sonnet) |

--- a/cai.py
+++ b/cai.py
@@ -202,7 +202,7 @@ _ALL_MANAGED_ISSUE_LABELS: frozenset[str] = frozenset({
     LABEL_HUMAN_NEEDED, LABEL_PR_HUMAN_NEEDED,
     LABEL_TRIAGING, LABEL_MERGE_BLOCKED,
     LABEL_HUMAN_SOLVED, LABEL_KIND_CODE, LABEL_KIND_MAINTENANCE,
-    "auto-improve", "audit", "check-workflows",
+    "auto-improve", "audit", "check-workflows", "check-workflows:raised",
 })
 
 # Prefixes that identify a label as cai-owned on an issue.

--- a/cai.py
+++ b/cai.py
@@ -188,6 +188,36 @@ from cai_lib.config import (  # noqa: E402
     _STALE_NO_ACTION_DAYS, _STALE_MERGED_DAYS,
 )
 
+# ---------------------------------------------------------------------------
+# Canonical set of valid cai-managed labels on issues.  Any cai-owned label
+# found on an open issue that is NOT in this set is considered stale and will
+# be removed by _issue_label_sweep().
+# ---------------------------------------------------------------------------
+_ALL_MANAGED_ISSUE_LABELS: frozenset[str] = frozenset({
+    LABEL_RAISED, LABEL_IN_PROGRESS, LABEL_PR_OPEN,
+    LABEL_MERGED, LABEL_SOLVED, LABEL_NO_ACTION,
+    LABEL_NEEDS_EXPLORATION, LABEL_REFINED, LABEL_REVISING,
+    LABEL_PARENT, LABEL_PLANNED, LABEL_PLAN_APPROVED,
+    LABEL_REFINING, LABEL_PLANNING, LABEL_APPLYING, LABEL_APPLIED,
+    LABEL_HUMAN_NEEDED, LABEL_PR_HUMAN_NEEDED,
+    LABEL_TRIAGING, LABEL_MERGE_BLOCKED,
+    LABEL_HUMAN_SOLVED, LABEL_KIND_CODE, LABEL_KIND_MAINTENANCE,
+    "auto-improve", "audit", "check-workflows",
+})
+
+# Prefixes that identify a label as cai-owned on an issue.
+# NO trailing colons — matching uses `lbl == p or lbl.startswith(p + ":")`.
+_MANAGED_ISSUE_PREFIXES: tuple[str, ...] = (
+    "auto-improve",
+    "audit",
+    "check-workflows",
+    "merge-blocked",
+    "human",          # matches human:solved (and any future human:* labels)
+    "kind",           # matches kind:code, kind:maintenance
+    "pr",             # pr:* labels are PR-only; stale if found on an issue
+    "needs-human-review",
+)
+
 
 from cai_lib.logging_utils import (  # noqa: E402
     log_run, log_cost,  # noqa: F401
@@ -620,9 +650,57 @@ def _find_linked_pr(issue_number: int):
     return prs[0]
 
 
+def _issue_label_sweep() -> tuple[int, int]:
+    """Remove stale/deprecated cai-managed labels from open issues.
+
+    Fetches open issues bearing 'auto-improve', 'audit', or 'check-workflows'
+    labels, identifies any cai-owned label not in _ALL_MANAGED_ISSUE_LABELS,
+    and removes those stale labels via _set_labels().
+
+    Returns (issues_scanned, labels_removed).
+    """
+    seen: dict[int, list[str]] = {}
+    for base_label in ("auto-improve", "audit", "check-workflows"):
+        try:
+            batch = _gh_json([
+                "issue", "list",
+                "--repo", REPO,
+                "--label", base_label,
+                "--state", "open",
+                "--json", "number,labels",
+                "--limit", "200",
+            ]) or []
+        except subprocess.CalledProcessError as e:
+            print(f"[cai sweep] gh issue list failed for {base_label!r}:\n{e.stderr}",
+                  file=sys.stderr)
+            continue
+        for issue in batch:
+            num = issue["number"]
+            if num not in seen:
+                seen[num] = [lbl["name"] for lbl in issue.get("labels", [])]
+
+    issues_scanned = len(seen)
+    labels_removed = 0
+    for num, label_names in seen.items():
+        stale = [
+            lbl for lbl in label_names
+            if any(lbl == p or lbl.startswith(p + ":") for p in _MANAGED_ISSUE_PREFIXES)
+            and lbl not in _ALL_MANAGED_ISSUE_LABELS
+        ]
+        if stale:
+            _set_labels(num, remove=stale, log_prefix="cai sweep")
+            labels_removed += len(stale)
+            print(f"[cai sweep] #{num}: removed stale label(s) {stale}", flush=True)
+
+    print(f"[cai sweep] scanned {issues_scanned} issue(s), removed {labels_removed} stale label(s)",
+          flush=True)
+    return issues_scanned, labels_removed
+
+
 def cmd_verify(args) -> int:
     """Walk :pr-open issues and transition labels based on PR state."""
     print("[cai verify] checking pr-open issues", flush=True)
+    _issue_label_sweep()
     try:
         issues = _gh_json([
             "issue", "list",
@@ -2735,6 +2813,12 @@ def _cmd_cycle_inner(args) -> int:
         nums = ", ".join(f"#{n}" for n in migrated)
         print(f"[cai cycle] migrated {len(migrated)} audit:raised issue(s) to auto-improve:raised: {nums}",
               flush=True)
+
+    # Phase 0.5: stale label sweep — remove any deprecated/renamed cai-managed
+    # labels from open issues so orphaned labels don't accumulate over time.
+    _sweep_scanned, _sweep_removed = _issue_label_sweep()
+    print(f"[cai cycle] label sweep: scanned {_sweep_scanned} issue(s), removed {_sweep_removed} stale label(s)",
+          flush=True)
 
     # Phase 1: restart recovery — force-rollback any stuck locks left
     # behind by a previous run that crashed mid-handler.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ Issues still enter the pipeline the same way: `cai analyze`, `cai propose`, `cai
 
 A flock serializes overlapping runs so two cron ticks cannot dispatch the same item concurrently.
 
-Verify (`cai verify`) and audit (`cai audit`) are **independent cron jobs** — they run on their own schedules (`CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`) rather than inside the cycle. Verify syncs label state with actual PR/issue state (merged → `:merged`, closed → `:raised`, etc.); audit runs the queue/PR consistency audit. Maintain operations (Phase 3) are drained within the cycle rather than on a separate schedule because they are transient states that should unblock quickly.
+Verify (`cai verify`) and audit (`cai audit`) are **independent cron jobs** — they run on their own schedules (`CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`) rather than inside the cycle. Verify removes deprecated cai-managed labels from open issues, then syncs label state with actual PR/issue state (merged → `:merged`, closed → `:raised`, etc.); audit runs the queue/PR consistency audit. Maintain operations (Phase 3) are drained within the cycle rather than on a separate schedule because they are transient states that should unblock quickly.
 
 ## Agent Execution Modes
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -114,6 +114,6 @@ No arguments.
 
 ## verify
 
-Walk `auto-improve:pr-open` issues and transition labels based on actual PR state (merged → `:merged`, closed → `:raised`, etc.).
+Remove deprecated cai-managed labels from open issues, then walk `auto-improve:pr-open` issues and transition labels based on actual PR state (merged → `:merged`, closed → `:raised`, etc.).
 
 No arguments.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ Cron schedules are configurable via environment variables. Default values are se
 | Variable | Default | Description |
 |---|---|---|
 | `CAI_CYCLE_SCHEDULE` | `0 * * * *` | Restart-recovery + dispatch one actionable issue/PR |
-| `CAI_VERIFY_SCHEDULE` | `15 * * * *` | Label-state reconciliation (cmd_verify) — keeps :pr-open / :merged / etc. consistent with actual GitHub state. |
+| `CAI_VERIFY_SCHEDULE` | `15 * * * *` | Label-state reconciliation (cmd_verify) — removes deprecated cai-managed labels from open issues, then keeps :pr-open / :merged / etc. consistent with actual GitHub state. |
 | `CAI_ANALYZER_SCHEDULE` | `0 0 * * *` | Daily transcript analysis and issue raising |
 | `CAI_AUDIT_SCHEDULE` | `0 */6 * * *` | Every 6 hours — queue/PR lifecycle audit |
 | `CAI_AUDIT_TRIAGE_SCHEDULE` | `10 */6 * * *` | Every 6 hours — resolve `auto-improve:raised` + `audit` findings |

--- a/publish.py
+++ b/publish.py
@@ -337,7 +337,7 @@ def ensure_all_labels() -> None:
     and CODE_AUDIT_LABELS).
     """
     seen: set[str] = set()
-    for label_set in (LABELS, AUDIT_LABELS, CODE_AUDIT_LABELS, UPDATE_CHECK_LABELS):
+    for label_set in (LABELS, AUDIT_LABELS, CODE_AUDIT_LABELS, UPDATE_CHECK_LABELS, CHECK_WORKFLOWS_LABELS):
         for name, color, description in label_set:
             if name in seen:
                 continue


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#628

**Issue:** #628 — all auto-impro, audit labels should be in the orkflow to remove them if not set by accepted list

## PR Summary

### What this fixes
Open issues could accumulate stale or deprecated cai-managed labels (e.g., `auto-improve:merge-blocked`, `auto-improve:in-pr`) with no mechanism to remove them, since no sweep validated issue labels against the current accepted set.

### What was changed
- **`cai.py`** (after `_STALE_NO_ACTION_DAYS` import block): Added `_ALL_MANAGED_ISSUE_LABELS` frozenset constant containing all valid cai-managed issue labels, and `_MANAGED_ISSUE_PREFIXES` tuple for identifying cai-owned labels by prefix.
- **`cai.py`** (before `cmd_verify`): Added `_issue_label_sweep()` function that fetches open issues with `auto-improve`/`audit`/`check-workflows` labels, identifies stale cai-owned labels not in `_ALL_MANAGED_ISSUE_LABELS`, and removes them via `_set_labels()`. Returns `(issues_scanned, labels_removed)`.
- **`cai.py`** (`cmd_verify`): Wired `_issue_label_sweep()` call immediately before the existing `try:` block.
- **`cai.py`** (`_cmd_cycle_inner`): Wired `_issue_label_sweep()` as "Phase 0.5" after the audit migration block and before Phase 1.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
