### PR TITLE
auto-improve: Fix unenforced tool restriction letting review agents call Bash

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,31 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#648
+
+## Files touched
+- `cai_lib/actions/review_pr.py`:289–298 — added `"--allowedTools", "Read,Grep,Glob"` to `_run_claude_p` invocation
+- `cai_lib/actions/review_docs.py`:166–175 — added `"--allowedTools", "Read,Grep,Glob,Edit,Write"` to `_run_claude_p` invocation
+- `.claude/agents/cai-review-pr.md` (via staging) — added Hard rule 9: no Bash
+- `.claude/agents/cai-review-docs.md` (via staging) — removed Agent from frontmatter tools, removed "Use Agent for broad exploration" guidance, added Hard rule 6: no Bash
+
+## Files read (not touched) that matter
+- `cai_lib/actions/review_pr.py` — identified the `_run_claude_p` invocation site
+- `cai_lib/actions/review_docs.py` — identified the `_run_claude_p` invocation site
+- `.claude/agents/cai-review-pr.md` — verified existing Hard rules, read full content for staging rewrite
+- `.claude/agents/cai-review-docs.md` — verified existing Hard rules and Agent usage, read full content for staging rewrite
+
+## Key symbols
+- `_run_claude_p` (`cai_lib/actions/review_pr.py`:289, `review_docs.py`:166) — subprocess wrapper; `--allowedTools` flag inserted here
+- `--allowedTools` — Claude CLI flag that enforces tool restrictions at process level, overriding any frontmatter-only constraints
+
+## Design decisions
+- `cai-review-pr` gets `Read,Grep,Glob` only — matches its frontmatter and read-only contract
+- `cai-review-docs` gets `Read,Grep,Glob,Edit,Write` (no Agent) — per human commenter's suggestion to remove Agent; the agent can use Read/Grep/Glob for exploration instead of spawning sub-agents
+- `Agent` removed from `cai-review-docs` frontmatter tools and "Use Agent for broad exploration" guidance removed to stay consistent with the process-level restriction
+- Rejected: keeping Agent for review-docs — commenter asked whether it was needed; since it's an optimization (not essential) and tightens the cost/security boundary, it was dropped
+
+## Out of scope / known gaps
+- Prior fix #382 that was "already merged but didn't work" — the root cause was `--permission-mode acceptEdits` not enforcing frontmatter tool restrictions; this PR fixes it at the CLI level
+
+## Invariants this change relies on
+- `--allowedTools` CLI flag takes precedence over `--permission-mode acceptEdits` and frontmatter tool declarations in Claude Code
+- `cai-review-docs` can fulfill its job (grep for renames, edit stale docs) using only Read/Grep/Glob/Edit/Write without needing to spawn sub-agents

--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -23,6 +23,26 @@ Refs: robotsix-cai/robotsix-cai#648
 - `Agent` removed from `cai-review-docs` frontmatter tools and "Use Agent for broad exploration" guidance removed to stay consistent with the process-level restriction
 - Rejected: keeping Agent for review-docs — commenter asked whether it was needed; since it's an optimization (not essential) and tightens the cost/security boundary, it was dropped
 
+## Revision 1 (2026-04-15)
+
+### Rebase
+- clean
+
+### Files touched this revision
+- `cai.py`:1932 — added `"--allowedTools", "Read,Grep,Glob"` to cai-cost-optimize invocation
+- `cai.py`:2121 — added `"--allowedTools", "Read,Grep,Glob"` to cai-propose invocation
+- `cai.py`:2182 — added `"--allowedTools", "Read,Grep,Glob"` to cai-propose-review invocation
+- `cai.py`:2366 — added `"--allowedTools", "Read,Grep,Glob"` to cai-code-audit invocation
+- `cai.py`:2499 — added `"--allowedTools", "Read,Grep,Glob"` to cai-update-check invocation
+- `cai.py`:3283 — added `"--allowedTools", "Read,Grep,Glob"` to cai-check-workflows invocation
+
+### Decisions this revision
+- All six agents declare `tools: Read, Grep, Glob` in frontmatter — `--allowedTools "Read,Grep,Glob"` is the correct restriction for all of them
+- Pattern matches exactly what was done for cai-review-pr in the original PR
+
+### New gaps / deferred
+- None
+
 ## Out of scope / known gaps
 - Prior fix #382 that was "already merged but didn't work" — the root cause was `--permission-mode acceptEdits` not enforcing frontmatter tool restrictions; this PR fixes it at the CLI level
 

--- a/.claude/agents/cai-review-docs.md
+++ b/.claude/agents/cai-review-docs.md
@@ -1,7 +1,7 @@
 ---
 name: cai-review-docs
 description: Pre-merge documentation review for an open PR. Checks whether changes to user-facing behavior, CLI interface, configuration, or architecture require updates to files in /docs, and directly fixes any stale documentation it finds.
-tools: Read, Grep, Glob, Agent, Edit, Write
+tools: Read, Grep, Glob, Edit, Write
 model: haiku
 memory: project
 ---
@@ -155,10 +155,27 @@ give the replacement>
    skip it entirely.
 5. **Keep fixes short.** Update only the specific stale content, preserving
    all other text.
+6. **Do not use Bash.** You have `Read`, `Grep`, `Glob`, `Edit`, and `Write` —
+   use them exclusively. Bash is not available and all Bash calls will be
+   rejected by the sandbox.
 
 ## Agent-specific efficiency guidance
 
-1. **Use Agent for broad exploration.** When you need to search broadly, use
-   `Agent(subagent_type="Explore", model="haiku", ...)` rather than many
-   sequential Grep or Read calls. **Do NOT delegate decisions** — only
-   reading and search.
+1. **Grep before Read.** Use Grep to locate the relevant file(s)
+   and line numbers before opening them with Read. Do not
+   sequentially Read files to search for content — reserve Read for
+   files whose paths and relevance are already known.
+2. **Verify paths with Glob before Read.** When a file path is
+   constructed or inferred (not hard-coded), confirm the file exists
+   using Glob before attempting to Read it. If a Read fails, do not
+   retry the same path — use Glob to find the correct filename
+   first.
+3. **Batch independent Read calls.** When you need to read multiple
+   files and the reads are independent, issue all Read calls in a
+   single turn rather than one at a time.
+4. **Batch Grep calls.** When searching for multiple patterns or
+   across multiple paths, combine them into a single Grep call using
+   regex alternation (`pat1|pat2`) or issue independent Grep calls
+   in parallel rather than sequentially. Use Glob first to narrow
+   the file set, then Grep the results, instead of running
+   exploratory Grep calls one at a time.

--- a/.claude/agents/cai-review-pr.md
+++ b/.claude/agents/cai-review-pr.md
@@ -142,6 +142,9 @@ GitHub issue will be created automatically instead.
    PR, emit an `## Out-of-scope Issue` block (see Output format)
    rather than a `### Finding:` block. Do not block the PR on work
    that belongs in a separate issue.
+9. **Do not use Bash.** You have `Read`, `Grep`, and `Glob` — use
+   them exclusively. Bash is not available and all Bash calls will be
+   rejected by the sandbox.
 
 ## Agent-specific efficiency guidance
 

--- a/cai.py
+++ b/cai.py
@@ -1930,7 +1930,8 @@ def cmd_cost_optimize(args) -> int:
     print("[cai cost-optimize] running agent", flush=True)
     result = _run_claude_p(
         ["claude", "-p", "--agent", "cai-cost-optimize",
-         "--permission-mode", "acceptEdits"],
+         "--permission-mode", "acceptEdits",
+         "--allowedTools", "Read,Grep,Glob"],
         category="cost-optimize",
         agent="cai-cost-optimize",
         input=user_message,
@@ -2120,6 +2121,7 @@ def cmd_propose(args) -> int:
     creative = _run_claude_p(
         ["claude", "-p", "--agent", "cai-propose",
          "--permission-mode", "acceptEdits",
+         "--allowedTools", "Read,Grep,Glob",
          "--add-dir", str(work_dir)],
         category="propose",
         agent="cai-propose",
@@ -2181,6 +2183,7 @@ def cmd_propose(args) -> int:
     review = _run_claude_p(
         ["claude", "-p", "--agent", "cai-propose-review",
          "--permission-mode", "acceptEdits",
+         "--allowedTools", "Read,Grep,Glob",
          "--add-dir", str(work_dir)],
         category="propose",
         agent="cai-propose-review",
@@ -2365,6 +2368,7 @@ def cmd_code_audit(args) -> int:
     agent = _run_claude_p(
         ["claude", "-p", "--agent", "cai-code-audit",
          "--permission-mode", "acceptEdits",
+         "--allowedTools", "Read,Grep,Glob",
          "--add-dir", str(work_dir)],
         category="code-audit",
         agent="cai-code-audit",
@@ -2498,6 +2502,7 @@ def cmd_update_check(args) -> int:
     agent = _run_claude_p(
         ["claude", "-p", "--agent", "cai-update-check",
          "--permission-mode", "acceptEdits",
+         "--allowedTools", "Read,Grep,Glob",
          "--add-dir", str(work_dir)],
         category="update-check",
         agent="cai-update-check",
@@ -3282,7 +3287,8 @@ def cmd_check_workflows(args) -> int:
     agent = _run_claude_p(
         ["claude", "-p", "--agent", "cai-check-workflows",
          "--max-turns", "3",
-         "--permission-mode", "acceptEdits"],
+         "--permission-mode", "acceptEdits",
+         "--allowedTools", "Read,Grep,Glob"],
         category="check-workflows",
         agent="cai-check-workflows",
         input=user_message,

--- a/cai_lib/actions/review_docs.py
+++ b/cai_lib/actions/review_docs.py
@@ -167,6 +167,7 @@ def handle_review_docs(pr: dict) -> int:
             ["claude", "-p", "--agent", "cai-review-docs",
              "--permission-mode", "acceptEdits",
              "--max-budget-usd", "0.50",
+             "--allowedTools", "Read,Grep,Glob,Edit,Write",
              "--add-dir", str(work_dir)],
             category="review-docs",
             agent="cai-review-docs",

--- a/cai_lib/actions/review_pr.py
+++ b/cai_lib/actions/review_pr.py
@@ -290,6 +290,7 @@ def handle_review_pr(pr: dict) -> int:
             ["claude", "-p", "--agent", "cai-review-pr",
              "--permission-mode", "acceptEdits",
              "--max-budget-usd", "0.50",
+             "--allowedTools", "Read,Grep,Glob",
              "--add-dir", str(work_dir)],
             category="review-pr",
             agent="cai-review-pr",

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -21,7 +21,7 @@ Agents are defined in `.claude/agents/*.md` with YAML frontmatter (`name`, `desc
 | `cai-propose-review` | Evaluate creative proposals for feasibility and value before filing issues | Read, Grep, Glob | sonnet | Worktree |
 | `cai-rebase` | Lightweight rebase conflict resolution for PRs with no unaddressed review comments | Read, Edit, Write, Grep, Glob, Agent | haiku | Worktree |
 | `cai-refine` | Rewrite human-filed issues into structured plans with steps, verification, and scope guardrails | Read, Grep, Glob | sonnet | Read-only |
-| `cai-review-docs` | Pre-merge documentation review — checks whether PR changes require `/docs` updates, directly fixes stale documentation, and posts findings for issues that cannot be fixed automatically | Read, Grep, Glob, Agent, Edit, Write | haiku | Worktree |
+| `cai-review-docs` | Pre-merge documentation review — checks whether PR changes require `/docs` updates, directly fixes stale documentation, and posts findings for issues that cannot be fixed automatically | Read, Grep, Glob, Edit, Write | haiku | Worktree |
 | `cai-review-pr` | Pre-merge ripple-effect review — finds inconsistencies the PR introduced but didn't update | Read, Grep, Glob | haiku | Worktree |
 | `cai-revise` | Handle PR review comments: resolve rebase conflicts AND address unaddressed reviewer comments | Read, Edit, Write, Grep, Glob, Agent | sonnet | Worktree |
 | `cai-select` | Evaluate two fix plans and select the better one | Read | opus | Worktree |


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#648

**Issue:** #648 — Fix unenforced tool restriction letting review agents call Bash

## PR Summary

### What this fixes
Review agents (`cai-review-pr` and `cai-review-docs`) were able to call Bash at runtime despite frontmatter declaring restricted tool sets, because `--permission-mode acceptEdits` does not enforce frontmatter tool restrictions. This caused a 14.4% Bash error rate (33/229 calls) in review sessions as sandbox rejections blocked git and grep-via-Bash attempts.

### What was changed
- **`cai_lib/actions/review_pr.py`**: Added `"--allowedTools", "Read,Grep,Glob"` to the `claude -p` subprocess invocation so tool restrictions are enforced at the process level.
- **`cai_lib/actions/review_docs.py`**: Added `"--allowedTools", "Read,Grep,Glob,Edit,Write"` to the `claude -p` subprocess invocation. `Agent` was excluded per the human commenter's suggestion — the agent can explore using `Read`/`Grep`/`Glob` directly.
- **`.claude/agents/cai-review-pr.md`** (via staging): Added Hard rule 9 explicitly forbidding Bash.
- **`.claude/agents/cai-review-docs.md`** (via staging): Removed `Agent` from the frontmatter `tools:` line, removed the "Use Agent for broad exploration" guidance (now inconsistent with the process-level restriction), and added Hard rule 6 explicitly forbidding Bash.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
