### PR TITLE
auto-improve: Issue #647 plan body present but label is still `:raised`

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,31 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#658
+
+## Files touched
+- `cai_lib/actions/plan.py:282` — replaced silent fallthrough comment with explicit `else` block that logs and returns 1
+- `cai_lib/actions/plan.py:376` — captured return value of `apply_transition("planning_to_planned")` and propagated failure as return 1
+- `tests/test_plan.py` — new test file verifying unexpected-state early exit
+
+## Files read (not touched) that matter
+- `cai_lib/actions/plan.py` — main action handler, lines 270–395
+
+## Key symbols
+- `handle_plan()` (`cai_lib/actions/plan.py:~240`) — the action handler being fixed
+- `apply_transition()` (`cai_lib/fsm.py`) — returns bool; false on failure
+- `IssueState` (`cai_lib/fsm.py`) — enum; RAISED, REFINED, PLANNING etc.
+- `log_run` (`cai_lib/actions/plan.py`) — already imported, reused in new else block
+
+## Design decisions
+- Early exit logs and returns 1 without calling `apply_transition` — for `:raised` state there is no valid transition
+- Capture `ok` from `apply_transition("planning_to_planned")` to surface label-edit failures as non-zero exit
+- Rejected: calling `planning_to_human` in the else block — would produce noise/errors for states that have no valid planning transition
+
+## Out of scope / known gaps
+- Operational fix for issue #647 (removing stale `:raised` label via `gh issue edit`) — must be done manually
+- `handle_plan_gate()` — not modified, its hardcoded labels are correct
+- `apply_transition()` in `fsm.py` — not modified
+
+## Invariants this change relies on
+- `apply_transition()` returns a truthy bool on success and falsy on failure
+- The `else` branch fires only for states that are neither REFINED nor PLANNING
+- The early return happens before `work_dir` is created, so the `finally` cleanup block safely skips `shutil.rmtree`

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -95,6 +95,7 @@
 | `tests/test_maintain.py` | TODO: add description |
 | `tests/test_multistep.py` | Tests for multi-step plan support |
 | `tests/test_parse.py` | Tests for parse.py signal extraction |
+| `tests/test_plan.py` | TODO: add description |
 | `tests/test_pr_bounce.py` | TODO: add description |
 | `tests/test_publish.py` | Tests for publish.py issue publishing |
 | `tests/test_rollback.py` | Tests for rollback functionality |

--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -279,8 +279,15 @@ def handle_plan(issue: dict) -> int:
             f"[cai plan] resuming #{issue_number} already at :planning",
             flush=True,
         )
-    # Any other state is the dispatcher's bug, not ours — proceed as if
-    # we are at :planning so the pipeline still runs.
+    else:
+        print(
+            f"[cai plan] #{issue_number} unexpected state {state!r} "
+            f"— aborting to prevent label corruption",
+            file=sys.stderr, flush=True,
+        )
+        log_run("plan", repo=REPO, issue=issue_number,
+                result="unexpected_state", exit=1)
+        return 1
 
     # 2. Clone repo (plan agents need to read the codebase).
     _uid = uuid.uuid4().hex[:8]
@@ -373,11 +380,16 @@ def handle_plan(issue: dict) -> int:
         issue["_cai_plan_confidence"] = plan_confidence
 
         # 6. Transition labels: :planning → :planned (waypoint).
-        apply_transition(
+        ok = apply_transition(
             issue_number, "planning_to_planned",
             current_labels=[LABEL_PLANNING],
             log_prefix="cai plan",
         )
+        if not ok:
+            dur = f"{int(time.monotonic() - t0)}s"
+            log_run("plan", repo=REPO, issue=issue_number,
+                    duration=dur, result="label_update_failed", exit=1)
+            return 1
 
         dur = f"{int(time.monotonic() - t0)}s"
         conf_name = plan_confidence.name if plan_confidence else "MISSING"

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,35 @@
+"""Tests for cai_lib.actions.plan — handle_plan() behaviour."""
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.fsm import IssueState
+
+
+class TestHandlePlanUnexpectedState(unittest.TestCase):
+    """handle_plan() must abort immediately for any state other than REFINED or PLANNING."""
+
+    @patch("cai_lib.actions.plan._run_plan_select_pipeline")
+    @patch("cai_lib.actions.plan.log_run")
+    @patch("cai_lib.actions.plan.get_issue_state", return_value=IssueState.RAISED)
+    def test_raised_state_returns_1_without_pipeline(
+        self, mock_state, mock_log_run, mock_pipeline
+    ):
+        from cai_lib.actions.plan import handle_plan
+
+        issue = {"number": 42, "title": "test issue", "labels": [], "body": ""}
+        result = handle_plan(issue)
+
+        self.assertEqual(result, 1)
+        mock_pipeline.assert_not_called()
+        mock_log_run.assert_called_once()
+        # Confirm the log_run was for unexpected_state
+        call_kwargs = mock_log_run.call_args
+        self.assertIn("unexpected_state", str(call_kwargs))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#658

**Issue:** #658 — Issue #647 plan body present but label is still `:raised`

## PR Summary

### What this fixes
`handle_plan()` silently proceeded when an issue was in an unexpected state (e.g. `:raised`), writing the plan body and applying `planning_to_planned` with hardcoded labels — corrupting the label set and causing the dispatcher to loop endlessly. Additionally, if the `planning_to_planned` transition failed, no error was surfaced.

### What was changed
- **`cai_lib/actions/plan.py`** (line ~282): Replaced the silent fallthrough comment with an explicit `else` block that prints an error to stderr, calls `log_run` with `result="unexpected_state"`, and returns `1` — preventing label corruption for issues in unexpected states.
- **`cai_lib/actions/plan.py`** (line ~376): Captured the return value of `apply_transition("planning_to_planned")` into `ok`; if falsy, logs `result="label_update_failed"` and returns `1` so the dispatcher observes a non-zero exit.
- **`tests/test_plan.py`** (new file): Added a unit test that patches `get_issue_state` to return `IssueState.RAISED`, calls `handle_plan()`, and asserts it returns `1` without calling `_run_plan_select_pipeline`.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
