### PR TITLE
auto-improve: Issue #648 stuck at `:planned` with MEDIUM-confidence plan

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,26 @@
+# PR Context Dossier
+Refs: robotsix-cai/robotsix-cai#659
+
+## Files touched
+- `cai_lib/actions/plan.py`:394-404 — replaced `log_run(result="ok"); return 0` with `return handle_plan_gate(issue)` at the tail of `handle_plan`
+
+## Files read (not touched) that matter
+- `cai_lib/actions/plan.py` — source of both `handle_plan` and `handle_plan_gate`; verified `_cai_plan_confidence` stash at line 380 is set before the gate call
+
+## Key symbols
+- `handle_plan` (`cai_lib/actions/plan.py`:~200) — planning handler; now calls gate inline
+- `handle_plan_gate` (`cai_lib/actions/plan.py`:411) — unchanged; diverts MEDIUM/LOW to `:human-needed`
+- `issue["_cai_plan_confidence"]` (`cai_lib/actions/plan.py`:380) — stashed before the inline call so the gate can read it without reparsing
+
+## Design decisions
+- Removed intermediate `log_run(result="ok")` — `handle_plan_gate`'s own `log_run(result="gate_ok")` is the authoritative terminal log
+- Kept dispatcher registry `PLANNED → handle_plan_gate` unchanged — it acts as recovery safety net for issues already stuck at `:planned`
+- `return handle_plan_gate(issue)` is inside the `try` block so the `finally` cleanup still fires
+
+## Out of scope / known gaps
+- Operational fix for issue #648 (manually move label to `:human-needed`) — cannot be done via code change; requires `gh` CLI access
+- No changes to `handle_plan_gate`, dispatcher registry, FSM, or any other handler
+
+## Invariants this change relies on
+- `issue["_cai_plan_confidence"]` is always set at line 380 before the success-path tail is reached
+- All error paths in `handle_plan` return before line 394, so the gate call only fires on success

--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ action so two concurrent `implement` runs can't pick the same issue.
                        │        ▼       solved
                        │     planned
                        │        │
-                       │   (gate: HIGH/
-                       │   low confidence)
+                       │   (confidence gate:
+                       │    HIGH skips;
+                       │    else → diverts)
                        │        ▼
                        └─→ human-needed
                             │ unblock

--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -394,14 +394,14 @@ def handle_plan(issue: dict) -> int:
         dur = f"{int(time.monotonic() - t0)}s"
         conf_name = plan_confidence.name if plan_confidence else "MISSING"
         print(
-            f"[cai plan] #{issue_number} planned and advanced :planning → :planned "
-            f"in {dur} (confidence={conf_name})",
+            f"[cai plan] #{issue_number} planned :planning → :planned in {dur} "
+            f"(confidence={conf_name}); running confidence gate inline",
             flush=True,
         )
-        log_run("plan", repo=REPO, issue=issue_number,
-                duration=dur, result="ok",
-                confidence=conf_name, exit=0)
-        return 0
+        # Run the confidence gate inline so it is atomic with planning.
+        # (The dispatcher also has PLANNED → handle_plan_gate as a safety net
+        # for issues already stuck at :planned.)
+        return handle_plan_gate(issue)
 
     finally:
         if work_dir.exists():


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#659

**Issue:** #659 — Issue #648 stuck at `:planned` with MEDIUM-confidence plan

## PR Summary

### What this fixes
Issue #648 got stuck at `:planned` with a MEDIUM-confidence plan because `handle_plan_gate` (which diverts non-HIGH confidence to `:human-needed`) is only called by the dispatcher as a *separate dispatch cycle* after `handle_plan` completes. If the process is killed or the drain loop doesn't pick up the issue quickly, the issue has no forward path.

### What was changed
- **`cai_lib/actions/plan.py`**: At the end of `handle_plan()`, replaced the `log_run(result="ok"); return 0` block with `return handle_plan_gate(issue)`, calling the confidence gate inline and atomically within the same process. The intermediate log line is removed; `handle_plan_gate`'s own log becomes the authoritative terminal record. The dispatcher's `PLANNED → handle_plan_gate` entry is kept unchanged as a recovery safety net for issues already stuck at `:planned`.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
