### PR TITLE
auto-improve: Don't add .cai/pr-context.md to CODEBASE_INDEX.md

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,26 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#675
+
+## Files touched
+- `scripts/generate-index.sh`:29 — removed `.cai/pr-context.md` entry from DESCRIPTIONS array
+- `scripts/generate-index.sh`:121 — added `grep -v '^\.cai/'` filter to the `git ls-files` pipeline
+- `CODEBASE_INDEX.md`:8 — removed stale `.cai/pr-context.md` row
+
+## Files read (not touched) that matter
+- `CODEBASE_INDEX.md` — confirmed stale entry existed at line 8
+
+## Key symbols
+- `DESCRIPTIONS` (`scripts/generate-index.sh`:14) — associative array mapping filenames to descriptions; `.cai/pr-context.md` entry removed
+- `git ls-files` pipeline (`scripts/generate-index.sh`:121) — now filters `.cai/` paths before generating index rows
+
+## Design decisions
+- Used `grep -v '^\.cai/'` in the pipeline rather than a gitignore-style list — the generator has no existing exclusion list, and a pipe filter is the minimal, targeted change
+- Removed only the `.cai/pr-context.md` DESCRIPTIONS entry; did not add a `.cai/` catch-all comment to the array (out of scope)
+
+## Out of scope / known gaps
+- Did not add `.cai/` to `.gitignore` — the issue only asks for generator-side filtering
+- Did not modify any agent prompts or workflow files
+
+## Invariants this change relies on
+- `.cai/` paths are never legitimate source files that should appear in CODEBASE_INDEX.md
+- The generator uses `git ls-files` (not `find`) so the `grep -v` filter covers all tracked files

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -5,7 +5,6 @@
 
 | File | Purpose |
 |------|---------|
-| `.cai/pr-context.md` | Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent |
 | `.claude/agents/cai-analyze.md` | Agent: parse transcript signals and raise auto-improve findings |
 | `.claude/agents/cai-audit-triage.md` | Agent: triage `auto-improve:raised` + `audit` findings with structured verdicts |
 | `.claude/agents/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |

--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -26,7 +26,6 @@ declare -A DESCRIPTIONS=(
   ["pyproject.toml"]="Python project configuration (ruff lint settings)"
   [".env.example"]="Template for required environment variables"
   [".gitignore"]="Git ignore rules"
-  [".cai/pr-context.md"]="Per-PR dossier with touched files, key symbols, and design decisions for the CI-fix subagent"
   [".claude/settings.json"]="Claude Code harness configuration"
   [".claude/agents/cai-analyze.md"]="Agent: parse transcript signals and raise auto-improve findings"
   [".claude/agents/cai-audit.md"]="Agent: audit issue queue and lifecycle state machine"
@@ -118,7 +117,7 @@ declare -A DESCRIPTIONS=(
 |------|---------|
 HEADER
 
-  git -C "$REPO_ROOT" ls-files | sort | while IFS= read -r f; do
+  git -C "$REPO_ROOT" ls-files | grep -v '^\.cai/' | sort | while IFS= read -r f; do
     desc="${DESCRIPTIONS[$f]:-TODO: add description}"
     printf '| `%s` | %s |\n' "$f" "$desc"
   done


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#675

**Issue:** #675 — Don't add .cai/pr-context.md to CODEBASE_INDEX.md

## PR Summary

### What this fixes
`scripts/generate-index.sh` was including `.cai/pr-context.md` (an ephemeral per-PR scratch file) in `CODEBASE_INDEX.md`, polluting the persistent source-file index with transient entries and causing unrelated index churn in every auto-improve PR diff.

### What was changed
- **`scripts/generate-index.sh`**: removed the `[".cai/pr-context.md"]` entry from the `DESCRIPTIONS` array, and added `grep -v '^\.cai/'` to the `git ls-files` pipeline so any future `.cai/` files tracked by git are silently excluded from the index.
- **`CODEBASE_INDEX.md`**: removed the stale `| \`.cai/pr-context.md\` |` row that was already committed.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
