### PR TITLE
auto-improve: Confidence divert comment lacks rationale — surface cai-select's 'why' in the human-needed notice

### DIFF
--- a/.cai/pr-context.md
+++ b/.cai/pr-context.md
@@ -1,0 +1,39 @@
+# PR Context Dossier
+Refs: robotsix/robotsix-cai#720
+
+## Files touched
+- `cai_lib/fsm.py`:65-98 — added `_CONFIDENCE_REASON_RE` regex and `parse_confidence_reason` helper
+- `cai_lib/actions/plan.py`:156-188 — extended `_SELECT_JSON_SCHEMA` with required `confidence_reason` field
+- `cai_lib/actions/plan.py`:186-254 — updated `_run_select_agent` to return 3-tuple `(plan_text, confidence, reason)`
+- `cai_lib/actions/plan.py`:256-303 — updated `_run_plan_select_pipeline` to return 3-tuple and unpack accordingly
+- `cai_lib/actions/plan.py`:400-412 — updated `handle_plan` to unpack 3-tuple, store reason in plan block, stash on issue dict
+- `cai_lib/actions/plan.py`:486-511 — updated `handle_plan_gate` to import/use `parse_confidence_reason` and pass `reason_extra=`
+- `tests/test_fsm.py`:14 — imported `parse_confidence_reason`
+- `tests/test_fsm.py`:122-157 — added 4 unit tests for `parse_confidence_reason`
+- `.cai-staging/agents/cai-select.md` — added `confidence_reason` as required field in JSON schema section
+
+## Files read (not touched) that matter
+- `cai_lib/fsm.py`:620-650 — `_render_human_divert_reason` already appends `reason_extra` to divert comment; no changes needed there
+- `cai_lib/fsm.py`:653-737 — `apply_transition_with_confidence` already accepts `reason_extra` param; only needed to wire it up
+
+## Key symbols
+- `parse_confidence_reason` (`cai_lib/fsm.py`:86) — extracts `Confidence reason: …` line from plan block; mirrors `parse_confidence`
+- `_CONFIDENCE_REASON_RE` (`cai_lib/fsm.py`:65) — regex anchored to line start, case-insensitive
+- `_SELECT_JSON_SCHEMA` (`cai_lib/actions/plan.py`:156) — now requires `confidence_reason`
+- `_run_select_agent` (`cai_lib/actions/plan.py`:186) — now returns 3-tuple including reason
+- `plan_confidence_reason` stored as `Confidence reason: <text>` line in plan block adjacent to `Confidence: <level>` line
+
+## Design decisions
+- `confidence_reason` made required in schema so model always provides it; for HIGH this becomes a brief confirmation
+- Stored as a plain text line `Confidence reason: …` in the plan block (not markdown) to match `Confidence:` convention and enable simple regex extraction
+- `handle_plan_gate` reads reason from both in-process stash and body parse for cross-process safety, mirroring how `plan_confidence` is handled
+- Rejected: storing as a separate metadata comment block — adds complexity and is harder to parse
+
+## Out of scope / known gaps
+- `cai-merge`, `cai-triage`, `cai-unblock` do not yet surface `confidence_reason`; the issue explicitly excludes them
+- No integration test added (manual trigger required per issue spec)
+
+## Invariants this change relies on
+- `apply_transition_with_confidence`'s `reason_extra` param already appends to the divert comment (`cai_lib/fsm.py`:643-644)
+- The plan block delimiter `<!-- cai-plan-start -->` / `<!-- cai-plan-end -->` is unchanged
+- `note` semantics (prepended blockquote for fix agent) are unchanged

--- a/.claude/agents/cai-select.md
+++ b/.claude/agents/cai-select.md
@@ -43,9 +43,10 @@ object — no prose, no code fences, no preamble. The schema is:
 
 ```json
 {
-  "plan":       "string  — full text of the chosen plan, pasted exactly as provided",
-  "confidence": "string  — one of HIGH, MEDIUM, LOW",
-  "note":       "string  — OPTIONAL; one-sentence flag for the fix agent"
+  "plan":               "string  — full text of the chosen plan, pasted exactly as provided",
+  "confidence":         "string  — one of HIGH, MEDIUM, LOW",
+  "confidence_reason":  "string  — 1-3 sentences explaining the confidence level (required)",
+  "note":               "string  — OPTIONAL; one-sentence flag for the fix agent"
 }
 ```
 
@@ -59,6 +60,13 @@ At **MEDIUM** or **LOW**, the wrapper parks the issue in
 before it is implemented — use these levels whenever either
 plan has ambiguity, unclear scope, non-trivial risk of
 regressions, or you are choosing a least-bad option.
+
+**`confidence_reason` is required for all confidence levels.** For
+MEDIUM or LOW, explain specifically what makes the plan fall short:
+unverified assumptions, ambiguous scope, missing edge cases,
+contradictions between plans, etc. For HIGH, briefly confirm why
+the plan is solid (e.g. "Both plans converge on the same minimal
+change with no ambiguity").
 
 If all plans are equally bad or none correctly addresses the issue,
 pick the least-bad option and emit `"confidence": "LOW"`. Use the

--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ is the program counter — the label on an issue/PR determines which
 handler fires; handlers are safely re-enterable so a crashed run
 resumes on the next tick. HIGH-confidence plans auto-promote to
 `:plan-approved`; lower-confidence plans divert to `:human-needed`
-for admin review, where an admin comment resumes them via
-`cai unblock`.
+for admin review with a comment explaining why the plan didn't reach
+HIGH confidence (e.g., unverified assumptions, ambiguous scope, missing
+edge cases). An admin comment resumes them via `cai unblock`.
 
 A flock in `cmd_cycle` serializes overlapping runs. For manual or
 targeted invocation, `cai.py dispatch --issue N` and

--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -165,29 +165,39 @@ _SELECT_JSON_SCHEMA = {
             "enum": ["HIGH", "MEDIUM", "LOW"],
             "description": "Confidence level for the selected plan.",
         },
+        "confidence_reason": {
+            "type": "string",
+            "description": (
+                "1-3 sentences explaining what makes the plan less than HIGH confidence: "
+                "unverified assumptions, ambiguous scope, missing edge cases, etc. "
+                "Required when confidence is MEDIUM or LOW; for HIGH confidence, "
+                "provide a brief statement confirming why the plan is solid."
+            ),
+        },
         "note": {
             "type": "string",
             "description": "Optional note flagging critical weaknesses for the fix agent.",
         },
     },
-    "required": ["plan", "confidence"],
+    "required": ["plan", "confidence", "confidence_reason"],
 }
 
 
 def _run_select_agent(
     issue: dict, plans: list[str], work_dir: Path,
-) -> "tuple[str, Confidence] | None":
-    """Run the cai-select agent and return ``(plan_text, confidence)``.
+) -> "tuple[str, Confidence, str] | None":
+    """Run the cai-select agent and return ``(plan_text, confidence, reason)``.
 
     Invokes the Claude Code subagent with ``--json-schema`` so the final
-    output is a structured JSON object ({plan, confidence, note?}) rather
-    than free-form text. Removes the regex-based confidence extraction that
-    previously diverted sound plans to ``:human-needed`` when the model
-    drifted from the ``Confidence: …`` trailer format.
+    output is a structured JSON object ({plan, confidence, confidence_reason,
+    note?}) rather than free-form text. Removes the regex-based confidence
+    extraction that previously diverted sound plans to ``:human-needed`` when
+    the model drifted from the ``Confidence: …`` trailer format.
 
     Returns ``None`` on subprocess or parse failure; otherwise returns
     the cleaned plan text (with optional ``> **Note:** …`` blockquote
-    prepended) and the :class:`~cai_lib.fsm.Confidence` enum member.
+    prepended), the :class:`~cai_lib.fsm.Confidence` enum member, and the
+    confidence reason string.
     """
     import json
 
@@ -225,6 +235,7 @@ def _run_select_agent(
 
     plan_text = payload.get("plan", "") or ""
     confidence_str = (payload.get("confidence") or "").upper()
+    confidence_reason = (payload.get("confidence_reason") or "").strip()
     note = payload.get("note", "") or ""
 
     if note:
@@ -239,12 +250,12 @@ def _run_select_agent(
         )
         return None
 
-    return plan_text.rstrip() + "\n", confidence
+    return plan_text.rstrip() + "\n", confidence, confidence_reason
 
 
 def _run_plan_select_pipeline(
     issue: dict, work_dir: Path, attempt_history_block: str = "",
-) -> "tuple[str, Confidence | None] | None":
+) -> "tuple[str, Confidence | None, str] | None":
     """Run the serial 2-plan → select pipeline.
 
     Plan 1 runs first; Plan 2 receives Plan 1's output and is asked
@@ -252,11 +263,11 @@ def _run_plan_select_pipeline(
     best and emits a trailing ``Confidence: HIGH|MEDIUM|LOW`` line
     indicating how sure it is that the chosen plan will succeed.
 
-    Returns ``(plan_text, confidence)`` — plan text and confidence arrive
-    as separate structured fields from the select agent's forced tool-use
-    call. ``confidence`` is a :class:`~cai_lib.fsm.Confidence` enum member,
-    or ``None`` when the select agent fails (treated as below-threshold by
-    the caller).
+    Returns ``(plan_text, confidence, confidence_reason)`` — plan text,
+    confidence, and reason arrive as separate structured fields from the
+    select agent's forced tool-use call. ``confidence`` is a
+    :class:`~cai_lib.fsm.Confidence` enum member, or ``None`` when the
+    select agent fails (treated as below-threshold by the caller).
     Returns ``None`` if the pipeline fails to produce any output.
     """
     issue_number = issue["number"]
@@ -280,14 +291,14 @@ def _run_plan_select_pipeline(
         print("[cai plan] select agent produced no output; skipping pipeline", flush=True)
         return None
 
-    plan_text, confidence = select_result
+    plan_text, confidence, confidence_reason = select_result
     conf_name = confidence.name if confidence else "MISSING"
     print(
         f"[cai plan] select agent produced {len(plan_text)} chars "
         f"(confidence={conf_name})",
         flush=True,
     )
-    return plan_text, confidence
+    return plan_text, confidence, confidence_reason
 
 
 # ---------------------------------------------------------------------------
@@ -388,7 +399,7 @@ def handle_plan(issue: dict) -> int:
             log_run("plan", repo=REPO, issue=issue_number,
                     duration=dur, result="pipeline_failed", exit=1)
             return 1
-        selected_plan, plan_confidence = pipeline_result
+        selected_plan, plan_confidence, plan_confidence_reason = pipeline_result
 
         # 5. Store plan in issue body (strip any old plan block first).
         current_body = _strip_stored_plan_block(issue.get("body", "") or "")
@@ -402,8 +413,10 @@ def handle_plan(issue: dict) -> int:
             "## Selected Implementation Plan\n\n"
             f"{selected_plan}\n"
             f"Confidence: {conf_name}\n"
-            "<!-- cai-plan-end -->"
         )
+        if plan_confidence_reason:
+            plan_block += f"Confidence reason: {plan_confidence_reason}\n"
+        plan_block += "<!-- cai-plan-end -->"
         new_body = f"{plan_block}\n\n{current_body}"
         update = _run(
             ["gh", "issue", "edit", str(issue_number),
@@ -423,11 +436,12 @@ def handle_plan(issue: dict) -> int:
                     duration=dur, result="edit_failed", exit=1)
             return 1
 
-        # Stash the confidence on the issue dict so the gate handler
-        # (run as a separate dispatcher step) can read it. This is
-        # belt-and-braces — the gate also reparses from the body if we
+        # Stash the confidence and reason on the issue dict so the gate
+        # handler (run as a separate dispatcher step) can read them. This
+        # is belt-and-braces — the gate also reparses from the body if we
         # ever split the two calls across processes.
         issue["_cai_plan_confidence"] = plan_confidence
+        issue["_cai_plan_confidence_reason"] = plan_confidence_reason
 
         # 6. Transition labels: :planning → :planned (waypoint).
         ok = apply_transition(
@@ -469,19 +483,23 @@ def handle_plan_gate(issue: dict) -> int:
     diverts to :human-needed (`planned_to_human`) with a pending marker
     so an admin can review.
     """
-    from cai_lib.fsm import parse_confidence
+    from cai_lib.fsm import parse_confidence, parse_confidence_reason
 
     t0 = time.monotonic()
     issue_number = issue["number"]
 
-    # Recover the confidence marker. Prefer the in-process stash from
-    # handle_plan; otherwise parse from the stored plan block in the
+    # Recover the confidence marker and reason. Prefer the in-process stash
+    # from handle_plan; otherwise parse from the stored plan block in the
     # issue body (for dispatchers that run the two handlers across
     # separate invocations).
     plan_confidence = issue.get("_cai_plan_confidence")
+    plan_confidence_reason = issue.get("_cai_plan_confidence_reason")
     if plan_confidence is None:
         body = issue.get("body", "") or ""
         plan_confidence = parse_confidence(body)
+    if plan_confidence_reason is None:
+        body = issue.get("body", "") or ""
+        plan_confidence_reason = parse_confidence_reason(body)
 
     # Apply the gate. HIGH → :plan-approved; below HIGH (or MISSING) →
     # :human-needed via the configured divert target.
@@ -489,6 +507,7 @@ def handle_plan_gate(issue: dict) -> int:
         issue_number, "planned_to_plan_approved", plan_confidence,
         current_labels=[LABEL_PLANNED],
         log_prefix="cai plan",
+        reason_extra=plan_confidence_reason or "",
     )
     if not ok:
         # Transition or divert refused (e.g. state drift, label-edit failure).

--- a/cai_lib/fsm.py
+++ b/cai_lib/fsm.py
@@ -62,6 +62,11 @@ _CONFIDENCE_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+_CONFIDENCE_REASON_RE = re.compile(
+    r"^Confidence reason:\s*(.+)$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
 
 def parse_confidence(text: str) -> Optional[Confidence]:
     """Extract ``Confidence: LOW|MEDIUM|HIGH`` from agent structured output.
@@ -76,6 +81,21 @@ def parse_confidence(text: str) -> Optional[Confidence]:
     if not m:
         return None
     return Confidence[m.group(1).upper()]
+
+
+def parse_confidence_reason(text: str) -> Optional[str]:
+    """Extract ``Confidence reason: <text>`` from a plan block body.
+
+    Returns the reason string, or ``None`` when the line is absent.
+    Backward-compatible: existing plan blocks without this line return
+    ``None`` and callers must treat that as "no reason available".
+    """
+    if not text:
+        return None
+    m = _CONFIDENCE_REASON_RE.search(text)
+    if not m:
+        return None
+    return m.group(1).strip()
 
 
 _RESUME_RE = re.compile(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ Handler registry (issue states):
 | `RAISED` / `TRIAGING` | `cai_lib/actions/triage.py` | Pre-check for duplicates/resolved issues via `cai-dup-check` (closes at HIGH confidence). Then classify the issue (REFINE / PLAN_APPROVE / APPLY / HUMAN). PLAN_APPROVE / APPLY at HIGH SkipConfidence skips ahead to `:plan-approved` or `:applying`. |
 | `REFINING` | `cai_lib/actions/refine.py` | Rewrite the issue into a structured plan with steps, verification, and scope guardrails. |
 | `NEEDS_EXPLORATION` | `cai_lib/actions/explore.py` | Run `cai-explore` to investigate an under-specified issue and route back to `:refining`. |
-| `REFINED` / `PLANNING` / `PLANNED` | `cai_lib/actions/plan.py` | Run plan + select, store the plan in the issue body, then apply the confidence gate: HIGH auto-promotes to `:plan-approved`; MEDIUM / LOW / missing diverts to `:human-needed` with a pending marker. |
+| `REFINED` / `PLANNING` / `PLANNED` | `cai_lib/actions/plan.py` | Run plan + select, store the plan in the issue body, then apply the confidence gate: HIGH auto-promotes to `:plan-approved`; MEDIUM / LOW / missing diverts to `:human-needed` with a pending marker and a comment explaining the confidence reason (e.g., unverified assumptions, ambiguous scope). |
 | `PLAN_APPROVED` / `IN_PROGRESS` | `cai_lib/actions/implement.py` | Run `cai-implement` in a fresh worktree; commit, push, and open a PR. |
 | `PR` | `cai_lib/actions/pr_bounce.py` | Bounce to the linked PR's dispatcher. |
 | `MERGED` | `cai_lib/actions/confirm.py` | Verify the merged fix actually resolved the issue; transition to `:solved` or re-queue to `:refined`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@
 
 Cron schedules are configurable via environment variables. Default values are set in `entrypoint.sh`; most are also explicitly configured in `docker-compose.yml`.
 
-`CAI_CYCLE_SCHEDULE` drives the unified dispatcher: each tick runs restart-recover → `dispatch_oldest_actionable()`, which picks the oldest open issue or PR whose lifecycle state has a handler and runs the matching handler in `cai_lib/actions/`. A flock serializes overlapping runs. The planner confidence gate is unchanged — HIGH auto-promotes to `:plan-approved`; MEDIUM / LOW / missing diverts to `:human-needed` with a pending marker, where an admin comment resumes it via `cai unblock`. `cai dispatch --issue N` / `cai dispatch --pr N` remains callable manually or from GitHub Actions for targeted retries. Verify and audit run on their own independent cron schedules (`CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`).
+`CAI_CYCLE_SCHEDULE` drives the unified dispatcher: each tick runs restart-recover → `dispatch_oldest_actionable()`, which picks the oldest open issue or PR whose lifecycle state has a handler and runs the matching handler in `cai_lib/actions/`. A flock serializes overlapping runs. The planner confidence gate is unchanged — HIGH auto-promotes to `:plan-approved`; MEDIUM / LOW / missing diverts to `:human-needed` with a pending marker and a comment explaining why the plan didn't reach HIGH confidence (e.g., unverified assumptions, ambiguous scope). An admin comment resumes it via `cai unblock`. `cai dispatch --issue N` / `cai dispatch --pr N` remains callable manually or from GitHub Actions for targeted retries. Verify and audit run on their own independent cron schedules (`CAI_VERIFY_SCHEDULE`, `CAI_AUDIT_SCHEDULE`).
 
 | Variable | Default | Description |
 |---|---|---|

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -11,7 +11,7 @@ from cai_lib.fsm import (
     ISSUE_TRANSITIONS, PR_TRANSITIONS,
     get_issue_state, render_fsm_mermaid,
     apply_transition, apply_transition_with_confidence, find_transition,
-    parse_confidence, parse_resume_target,
+    parse_confidence, parse_confidence_reason, parse_resume_target,
     resume_transition_for, resume_pr_transition_for,
     render_pending_marker, parse_pending_marker, strip_pending_marker,
 )
@@ -118,6 +118,37 @@ class TestConfidenceEnum(unittest.TestCase):
         # regex happens to land on and bypass the human gate.
         self.assertIsNone(
             parse_confidence("Confidence: HIGH | MEDIUM | LOW")
+        )
+
+    def test_parse_reason_valid(self):
+        body = "Confidence: MEDIUM\nConfidence reason: The plan has unverified assumptions."
+        self.assertEqual(
+            parse_confidence_reason(body),
+            "The plan has unverified assumptions.",
+        )
+
+    def test_parse_reason_multiword(self):
+        body = (
+            "Confidence: LOW\n"
+            "Confidence reason: Plan 1 and Plan 2 contradict each other on "
+            "which file to edit, leaving ambiguous scope for the fix agent.\n"
+        )
+        self.assertEqual(
+            parse_confidence_reason(body),
+            "Plan 1 and Plan 2 contradict each other on which file to edit, "
+            "leaving ambiguous scope for the fix agent.",
+        )
+
+    def test_parse_reason_missing_returns_none(self):
+        self.assertIsNone(parse_confidence_reason(""))
+        self.assertIsNone(parse_confidence_reason("Confidence: HIGH"))
+        self.assertIsNone(parse_confidence_reason("no reason line here"))
+
+    def test_parse_reason_case_insensitive(self):
+        body = "CONFIDENCE REASON: Missing edge cases for empty input."
+        self.assertEqual(
+            parse_confidence_reason(body),
+            "Missing edge cases for empty input.",
         )
 
     def test_transition_accepts(self):


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#720

**Issue:** #720 — Confidence divert comment lacks rationale — surface cai-select's 'why' in the human-needed notice

## PR Summary

### What this fixes
When the plan pipeline diverts an issue to `:human-needed` due to MEDIUM/LOW confidence, the posted comment only showed "Required: HIGH / Reported: MEDIUM" with no explanation of *why* the selector was uncertain, forcing admins to re-read the full plan to understand the weakness.

### What was changed
- **`cai_lib/fsm.py`**: Added `_CONFIDENCE_REASON_RE` regex and `parse_confidence_reason(text)` helper that extracts the `Confidence reason: …` line from a plan block body (returns `None` when absent for backward compatibility)
- **`cai_lib/actions/plan.py`**: Extended `_SELECT_JSON_SCHEMA` with a required `confidence_reason` field; updated `_run_select_agent` to return a 3-tuple `(plan_text, confidence, reason)`; updated `_run_plan_select_pipeline` to carry the reason through; updated `handle_plan` to store the reason as `Confidence reason: <text>` in the plan block and stash it on the issue dict; updated `handle_plan_gate` to import `parse_confidence_reason`, recover the reason from stash or body, and pass it as `reason_extra=` to `apply_transition_with_confidence`
- **`.cai-staging/agents/cai-select.md`**: Added `confidence_reason` as a required field to the JSON schema section with guidance that it's required for all confidence levels
- **`tests/test_fsm.py`**: Imported `parse_confidence_reason` and added 4 unit tests covering valid extraction, multi-sentence reasons, missing line returns `None`, and case-insensitivity

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
