### PR TITLE
fix(triage): post reasoning comment before diverting to human-needed

### DIFF
--- a/cai_lib/actions/triage.py
+++ b/cai_lib/actions/triage.py
@@ -26,7 +26,7 @@ from cai_lib.fsm import (
     apply_transition,
     get_issue_state,
 )
-from cai_lib.github import _set_labels
+from cai_lib.github import _post_issue_comment, _set_labels
 from cai_lib.logging_utils import log_run
 from cai_lib.subprocess_utils import _run, _run_claude_p
 
@@ -212,6 +212,13 @@ def handle_triage(issue: dict) -> int:
 
     # 6. Execute verdict.
     if decision == "HUMAN":
+        _post_issue_comment(
+            issue_number,
+            f"cai-triage routed this issue to `:human-needed` "
+            f"(confidence={confidence or 'MISSING'}).\n\n"
+            f"**Reasoning:** {reasoning}",
+            log_prefix="cai triage",
+        )
         apply_transition(
             issue_number, "triaging_to_human",
             current_labels=[LABEL_TRIAGING],


### PR DESCRIPTION
## Summary

- When `cai-triage` returns `decision=HUMAN`, the handler silently flipped the issue to `:human-needed`. The agent's `reasoning` field (already required by the JSON schema) was logged but never posted — admins saw the parked issue with no explanation.
- Post the reasoning (plus confidence) as a comment on the issue *before* the `triaging_to_human` transition, so the explanation is visible on GitHub.
- Matches the behavior of `apply_transition_with_confidence` in `fsm.py`, which posts a divert-reason comment for plan/merge gates.

## Why not `refining_to_human`?

`refining_to_human` is defined in `fsm.py:237` but never actually called from `refine.py` — it's a dead transition. The stale comment at `fsm.py:228-232` describing a confidence gate on `refining_to_refined` doesn't match the code (`refine.py` uses plain `apply_transition`, not the confidence-gated variant). Not touched here — separate cleanup.

## Test plan

- [ ] Ruff passes on the changed file (`ruff check cai_lib/actions/triage.py` — all checks pass locally)
- [ ] Existing triage tests still pass (no regressions; this path wasn't covered before)
- [ ] Next time cai-triage routes an issue to HUMAN, verify the comment appears on the issue with the agent's reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)