### PR TITLE
fix(plan): surface stderr on cai-select/cai-plan failures

### DIFF
--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -149,6 +149,14 @@ def _run_plan_agent(issue: dict, plan_index: int, work_dir: Path, attempt_histor
         cwd="/app",
     )
     if result.returncode != 0:
+        stderr_preview = (result.stderr or "")[:400].rstrip()
+        print(
+            f"[cai plan] plan agent {plan_index} failed for "
+            f"#{issue['number']} (exit {result.returncode})"
+            + (f":\n{stderr_preview}" if stderr_preview else ""),
+            file=sys.stderr,
+            flush=True,
+        )
         return f"(Plan {plan_index} failed: exit {result.returncode})"
     return result.stdout or ""
 
@@ -220,16 +228,36 @@ def _run_select_agent(
         cwd="/app",
     )
     if result.returncode != 0 or not (result.stdout or "").strip():
-        print("[cai plan] cai-select produced no output", file=sys.stderr)
+        stderr_preview = (result.stderr or "")[:400].rstrip()
+        stdout_preview = (result.stdout or "")[:200].rstrip()
+        print(
+            f"[cai plan] cai-select produced no output for #{issue['number']} "
+            f"(exit {result.returncode})"
+            + (f"\n  stderr: {stderr_preview}" if stderr_preview else "")
+            + (f"\n  stdout: {stdout_preview!r}" if stdout_preview else ""),
+            file=sys.stderr,
+            flush=True,
+        )
         return None
 
+    # Defensive: strip a surrounding ```json ... ``` fence if the model
+    # wrapped its schema-validated output in markdown. --json-schema
+    # normally prevents this, but fall back gracefully rather than
+    # diverting an otherwise-valid plan to :human-needed.
+    stdout_raw = (result.stdout or "").strip()
+    if stdout_raw.startswith("```"):
+        lines = stdout_raw.splitlines()
+        if lines[0].startswith("```") and lines[-1].startswith("```"):
+            stdout_raw = "\n".join(lines[1:-1]).strip()
+
     try:
-        payload = json.loads(result.stdout)
+        payload = json.loads(stdout_raw)
     except (json.JSONDecodeError, ValueError) as exc:
         print(
             f"[cai plan] cai-select output was not valid JSON: {exc}; "
-            f"stdout starts with: {(result.stdout or '')[:120]!r}",
+            f"stdout starts with: {(result.stdout or '')[:200]!r}",
             file=sys.stderr,
+            flush=True,
         )
         return None
 

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,12 +1,14 @@
 """Tests for cai_lib.actions.plan — handle_plan() behaviour."""
 import os
+import subprocess
 import sys
 import unittest
-from unittest.mock import patch, MagicMock
+from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from cai_lib.fsm import IssueState
+from cai_lib.fsm import Confidence, IssueState
 
 
 class TestHandlePlanUnexpectedState(unittest.TestCase):
@@ -29,6 +31,108 @@ class TestHandlePlanUnexpectedState(unittest.TestCase):
         # Confirm the log_run was for unexpected_state
         call_kwargs = mock_log_run.call_args
         self.assertIn("unexpected_state", str(call_kwargs))
+
+
+class TestRunSelectAgent(unittest.TestCase):
+    """_run_select_agent() diagnostics and parse robustness."""
+
+    def _issue(self):
+        return {"number": 777, "title": "t", "body": "b", "labels": []}
+
+    def _completed(self, stdout: str = "", stderr: str = "", returncode: int = 0):
+        return subprocess.CompletedProcess(
+            args=["claude"], returncode=returncode, stdout=stdout, stderr=stderr,
+        )
+
+    @patch("cai_lib.actions.plan._run_claude_p")
+    def test_parses_valid_json(self, mock_run):
+        from cai_lib.actions.plan import _run_select_agent
+        mock_run.return_value = self._completed(stdout=(
+            '{"plan":"do X","confidence":"HIGH",'
+            '"confidence_reason":"both plans converge"}'
+        ))
+
+        out = _run_select_agent(self._issue(), ["p1", "p2"], Path("/tmp/x"))
+
+        self.assertIsNotNone(out)
+        plan, conf, reason = out
+        self.assertIn("do X", plan)
+        self.assertEqual(conf, Confidence.HIGH)
+        self.assertEqual(reason, "both plans converge")
+
+    @patch("cai_lib.actions.plan._run_claude_p")
+    def test_strips_markdown_code_fence(self, mock_run):
+        """Model sometimes wraps --json-schema output in ```json``` — we should cope."""
+        from cai_lib.actions.plan import _run_select_agent
+        mock_run.return_value = self._completed(stdout=(
+            '```json\n'
+            '{"plan":"go","confidence":"MEDIUM",'
+            '"confidence_reason":"scope unclear"}\n'
+            '```'
+        ))
+
+        out = _run_select_agent(self._issue(), ["p1", "p2"], Path("/tmp/x"))
+
+        self.assertIsNotNone(out)
+        _, conf, reason = out
+        self.assertEqual(conf, Confidence.MEDIUM)
+        self.assertEqual(reason, "scope unclear")
+
+    @patch("cai_lib.actions.plan._run_claude_p")
+    def test_logs_stderr_on_nonzero_exit(self, mock_run):
+        """When cai-select exits non-zero, stderr must surface in the log."""
+        from cai_lib.actions import plan
+        mock_run.return_value = self._completed(
+            stdout="",
+            stderr="boom: API overloaded",
+            returncode=1,
+        )
+
+        with patch("builtins.print") as mock_print:
+            out = plan._run_select_agent(self._issue(), ["p1", "p2"], Path("/tmp/x"))
+
+        self.assertIsNone(out)
+        # Stderr preview must appear in at least one print call.
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("boom: API overloaded", printed)
+        self.assertIn("exit 1", printed)
+
+    @patch("cai_lib.actions.plan._run_claude_p")
+    def test_invalid_json_stdout_preview_in_log(self, mock_run):
+        from cai_lib.actions import plan
+        mock_run.return_value = self._completed(stdout="not json at all <xml/>")
+
+        with patch("builtins.print") as mock_print:
+            out = plan._run_select_agent(self._issue(), ["p1", "p2"], Path("/tmp/x"))
+
+        self.assertIsNone(out)
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("not valid JSON", printed)
+        self.assertIn("not json at all", printed)
+
+
+class TestRunPlanAgent(unittest.TestCase):
+    """_run_plan_agent() surfaces stderr on subprocess failure."""
+
+    @patch("cai_lib.actions.plan._build_issue_block", return_value="")
+    @patch("cai_lib.actions.plan._work_directory_block", return_value="")
+    @patch("cai_lib.actions.plan._run_claude_p")
+    def test_logs_stderr_on_nonzero_exit(self, mock_run, _mwb, _mib):
+        from cai_lib.actions import plan
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["claude"], returncode=2,
+            stdout="", stderr="cai-plan: rate limited",
+        )
+
+        with patch("builtins.print") as mock_print:
+            out = plan._run_plan_agent(
+                {"number": 42, "title": "t", "body": "b"},
+                1, Path("/tmp/x"),
+            )
+
+        self.assertIn("Plan 1 failed: exit 2", out)
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("cai-plan: rate limited", printed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Issue #729 (4 consecutive plan-pipeline failures in a 32-min window) is undiagnosable from the run log: `_run_select_agent` only emitted `"cai-select produced no output"` with no stderr, no return code, and no stdout preview, and `_run_plan_agent` dropped its stderr on the floor too. This PR closes that gap so the next recurrence can be root-caused without guesswork.
- Defensively strips a surrounding ` ```json ``` ` fence from cai-select's output before `json.loads` — `--json-schema` normally prevents it, but a markdown-wrapped payload shouldn't be enough to divert an otherwise-valid plan to `:human-needed`.
- Matches the diagnostic pattern cai-triage already follows in `cai_lib/actions/triage.py:177-186`.

## Rationale

- The audit issue asks "Inspect the plan pipeline code (dual-planner + cai-select) for a crash or API-path regression introduced around 23:30Z 2026-04-15." Recent changes there:
  - `b83bcd1` — refactor cai-select to use `--json-schema` instead of the Anthropic SDK
  - `fff5163` — add required `confidence_reason` to the select schema
- Without captured stderr, we can't tell which of those paths (or an unrelated transient API/model failure) caused the 4 drops. After this PR, the run log carries the claude-code return code, stderr preview, and stdout preview, so the next failure is self-diagnosing.
- The 4 stuck issues (#689, #701, #715, #721) still need manual `human:solved` to resume — that's orthogonal and called out in the issue's remediation note.

## Test plan

- [x] `python -m unittest tests.test_plan` — 6 tests pass (4 new).
- [x] `ruff check cai_lib/actions/plan.py tests/test_plan.py` — zero new violations (2 pre-existing F821 `Confidence` forward-ref warnings unchanged).
- [x] `python -m unittest discover -s tests` — unchanged result vs. main (same pre-existing lint failure, no new test failures).

Refs #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)