### PR TITLE
fix(subprocess): read structured_output from --json-schema envelope

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -100,4 +100,5 @@
 | `tests/test_publish.py` | Tests for publish.py issue publishing |
 | `tests/test_revise_filter.py` | TODO: add description |
 | `tests/test_rollback.py` | Tests for rollback functionality |
+| `tests/test_subprocess_utils.py` | TODO: add description |
 | `tests/test_unblock.py` | Tests for cai_lib.cmd_unblock — admin-comment filtering and agent input formatting |

--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -165,13 +165,37 @@ def _run_claude_p(
             row["subagents"] = subagent_rows
         log_cost(row)
 
-        # Rewrite stdout to the result text so existing callers stay
-        # backwards compatible. If `result` is missing (e.g. the run
-        # ended with subtype=error_max_budget_usd, which omits the
-        # result field), fall back to the text of the last assistant
-        # stream event so callers still see the agent's final output
-        # instead of the raw JSON envelope.
-        if "result" in envelope and isinstance(envelope["result"], str):
+        # Rewrite stdout so callers see a sensible final value. Priority:
+        #
+        #   1. `structured_output` — present when the caller passed
+        #      `--json-schema` and the Agent SDK's constrained-decoding
+        #      path succeeded. This is the *validated* payload; the
+        #      free-form `result` text in the same envelope contains
+        #      the model's reasoning and will not parse as JSON (bug
+        #      behind #729 / #695 — gate-critical agents read the wrong
+        #      field). Serialize it back so existing `json.loads(stdout)`
+        #      callers keep working unchanged.
+        #   2. `error_max_structured_output_retries` subtype — the
+        #      constrained-decoding retry loop gave up. Log it explicitly
+        #      so the caller's empty-output branch gets a clear reason,
+        #      and leave stdout empty.
+        #   3. `result` string — the normal free-form path for callers
+        #      without `--json-schema`.
+        #   4. Last assistant text — fallback when `result` is absent
+        #      (e.g. subtype=error_max_budget_usd drops that field).
+        subtype = envelope.get("subtype")
+        structured = envelope.get("structured_output")
+        if structured is not None:
+            proc.stdout = json.dumps(structured)
+        elif subtype == "error_max_structured_output_retries":
+            print(
+                f"[cai cost] structured output retries exhausted "
+                f"({category}/{agent}); schema was not satisfied",
+                file=sys.stderr,
+                flush=True,
+            )
+            proc.stdout = ""
+        elif "result" in envelope and isinstance(envelope["result"], str):
             proc.stdout = envelope["result"]
         elif isinstance(parsed, list):
             salvaged = _last_assistant_text(parsed)

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -1,0 +1,147 @@
+"""Tests for cai_lib.subprocess_utils — envelope parsing in _run_claude_p.
+
+Focus: the stdout rewrite priority order when a claude -p invocation
+returns a JSON envelope. The rules a gate-critical agent depends on:
+
+  1. `structured_output` (from --json-schema constrained decoding) wins
+     over the free-form `result` text, because the free-form text
+     contains the model's reasoning and won't json.loads — this was the
+     root cause of the #729 (cai-select) and #695 (cai-triage) failures.
+  2. `error_max_structured_output_retries` subtype surfaces as an empty
+     stdout + a dedicated log line so callers' emptiness check fires.
+  3. Without a schema, the `result` text still wins (unchanged).
+"""
+import json
+import os
+import subprocess
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _envelope_list(**result_fields) -> str:
+    """Build a claude-p --output-format json --verbose response body.
+
+    The real CLI emits a JSON array of stream events; the final
+    element has type=result and carries cost/structured-output data.
+    """
+    return json.dumps([
+        {"type": "system"},
+        {"type": "result", **result_fields},
+    ])
+
+
+class TestRunClaudePEnvelope(unittest.TestCase):
+    """_run_claude_p rewrites proc.stdout based on envelope priority."""
+
+    def _mock_run(self, stdout: str, returncode: int = 0, stderr: str = ""):
+        return subprocess.CompletedProcess(
+            args=["claude", "-p"], returncode=returncode,
+            stdout=stdout, stderr=stderr,
+        )
+
+    @patch("cai_lib.subprocess_utils.log_cost")
+    @patch("cai_lib.subprocess_utils._run")
+    def test_structured_output_wins_over_result(self, mock_run, _mock_log):
+        """When --json-schema succeeded, structured_output must override result text.
+
+        This is the #729 / #695 regression: the model's reasoning lives
+        in `result`, and the validated payload lives in `structured_output`.
+        Callers use json.loads(stdout), so stdout must be the validated
+        payload — not the prose the model produced.
+        """
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        validated = {"plan": "do X", "confidence": "HIGH",
+                     "confidence_reason": "sound"}
+        reasoning = "Routed **APPLY** (HIGH). Plan looks correct."
+        mock_run.return_value = self._mock_run(_envelope_list(
+            subtype="success",
+            structured_output=validated,
+            result=reasoning,
+            total_cost_usd=0.1,
+            usage={"input_tokens": 10, "output_tokens": 5},
+        ))
+
+        proc = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-select",
+             "--json-schema", "{}"],
+            category="plan.select", agent="cai-select",
+        )
+
+        # stdout must be the validated JSON payload, not the reasoning.
+        self.assertEqual(json.loads(proc.stdout), validated)
+        self.assertNotIn("Routed", proc.stdout)
+
+    @patch("cai_lib.subprocess_utils.log_cost")
+    @patch("cai_lib.subprocess_utils._run")
+    def test_retries_exhausted_leaves_stdout_empty(self, mock_run, _mock_log):
+        """error_max_structured_output_retries → empty stdout + diagnostic log."""
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        mock_run.return_value = self._mock_run(_envelope_list(
+            subtype="error_max_structured_output_retries",
+            result="I couldn't match the schema sorry",
+            total_cost_usd=0.2,
+            usage={"input_tokens": 10, "output_tokens": 5},
+        ))
+
+        with patch("builtins.print") as mock_print:
+            proc = _run_claude_p(
+                ["claude", "-p", "--agent", "cai-triage",
+                 "--json-schema", "{}"],
+                category="triage", agent="cai-triage",
+            )
+
+        # stdout empty so the caller's "no output" guard triggers.
+        self.assertEqual(proc.stdout, "")
+        # A dedicated log line names the failure mode.
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("structured output retries exhausted", printed)
+
+    @patch("cai_lib.subprocess_utils.log_cost")
+    @patch("cai_lib.subprocess_utils._run")
+    def test_result_text_used_when_no_schema(self, mock_run, _mock_log):
+        """Without --json-schema the envelope has no structured_output; use result."""
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        mock_run.return_value = self._mock_run(_envelope_list(
+            subtype="success",
+            result="plain agent output",
+            total_cost_usd=0.05,
+            usage={"input_tokens": 10, "output_tokens": 5},
+        ))
+
+        proc = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-plan"],
+            category="plan.plan", agent="cai-plan",
+        )
+
+        self.assertEqual(proc.stdout, "plain agent output")
+
+    @patch("cai_lib.subprocess_utils.log_cost")
+    @patch("cai_lib.subprocess_utils._run")
+    def test_structured_output_none_falls_through_to_result(self, mock_run, _mock_log):
+        """structured_output: null must not be treated as present."""
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        mock_run.return_value = self._mock_run(_envelope_list(
+            subtype="success",
+            structured_output=None,
+            result="fallback text",
+            total_cost_usd=0.05,
+            usage={"input_tokens": 10, "output_tokens": 5},
+        ))
+
+        proc = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-plan"],
+            category="plan.plan", agent="cai-plan",
+        )
+
+        self.assertEqual(proc.stdout, "fallback text")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Root-cause fix for #729 (4 cai-select failures) and the live cai-triage failure observed on issue #695. The Agent SDK's `--json-schema` flag **does** guarantee schema conformance via constrained decoding — but it puts the validated payload on `envelope["structured_output"]`, not `envelope["result"]`. Our `_run_claude_p` wrapper was reading the wrong field, so gate-critical agents (cai-select, cai-triage, cai-merge, cai-comment-filter, revise filter) were receiving the model's free-form reasoning text and calling `json.loads` on it.

Concrete example from the live container log:

```
[cai triage] failed to parse JSON verdict: Expecting value: line 1 column 1 (char 0);
  stdout starts with: 'Routed **REFINE** (HIGH). Plan references a non-existent …'
```

That prose is the `result` field. The actual schema-validated JSON was sitting in `structured_output`, unread.

From [Agent SDK docs](https://code.claude.com/docs/en/agent-sdk/structured-outputs):
> "Define a JSON Schema for the structure you need, and the SDK guarantees the output matches it."
> "When the agent finishes, the result message includes a `structured_output` field with validated data matching your schema."

## Changes

In `cai_lib/subprocess_utils.py:_run_claude_p`, replace the single-field `result` rewrite with a priority order:

1. **`structured_output`** present → `json.dumps()` it → `proc.stdout`. Existing `json.loads(result.stdout)` callers now see the *validated* payload unchanged.
2. **`subtype == "error_max_structured_output_retries"`** → empty stdout + dedicated log line. The caller's "no output" guard fires with a clear reason instead of getting the raw reasoning.
3. **`result` string** → used as before (non-schema callers unaffected).
4. **Last assistant text** → fallback when `result` is missing (e.g. `error_max_budget_usd` subtype).

## Benefits

- cai-select, cai-triage, cai-merge, cai-comment-filter, and revise-filter all start receiving validated JSON automatically — no per-caller changes needed.
- The markdown-fence stripping added in #734 becomes belt-and-braces (harmless; can be removed in a future cleanup).
- `error_max_structured_output_retries` is now a first-class failure path instead of a silent fallthrough to the model's prose.

## Test plan

- [x] `python -m unittest tests.test_subprocess_utils` — 4 new tests pass (structured-wins, retries-exhausted, no-schema passthrough, null-structured fallthrough).
- [x] `python -m unittest discover -s tests` — 195 tests, unchanged pass count vs. main (same pre-existing lint test failure, no new regressions).
- [x] `ruff check cai_lib/subprocess_utils.py tests/test_subprocess_utils.py` — zero violations. Repo-wide count unchanged at 36 (pre-existing).

## Follow-ups (not in this PR)

- The markdown-fence stripping from #734 in `cai_lib/actions/plan.py` is now redundant and can be removed in a small cleanup PR.
- Four stuck issues from #729 (#689, #701, #715, #721) still need the manual `human:solved` called out in the audit issue's remediation.

Refs #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)