### PR TITLE
refactor(unblock): remove pending-marker mechanism, classify from full context

### DIFF
--- a/.claude/agents/cai-unblock.md
+++ b/.claude/agents/cai-unblock.md
@@ -28,12 +28,17 @@ world you are in:
 
 After the header, three sections follow:
 
-1. **Pending transition marker** — what the automation was trying
-   to do when it paused (e.g. `transition=refining_to_refined
-   from=REFINING intended=REFINED conf=MEDIUM`).
-2. **Body** — the issue or PR text the admin is commenting on.
-3. **Admin comments** — only comments from admin logins are shown,
-   newest last.
+1. **Labels** — the FSM labels currently on the target. Use them to
+   infer what stage the automation reached before parking (e.g.
+   `auto-improve:human-needed` + a plan block in the body means the
+   plan gate diverted).
+2. **Body** — the issue or PR text, including any stored plan block
+   (`<!-- cai-plan-start -->…<!-- cai-plan-end -->`).
+3. **Comments** — the full comment thread, chronological. Comments
+   from admin logins are tagged `[admin]`. The admin applied
+   `human:solved` after leaving at least one `[admin]` comment — that
+   comment is your primary signal for the resume target; non-admin
+   comments are context (automation notes, review history, etc.).
 
 ## Issue resume targets (Kind: issue)
 

--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -8,7 +8,7 @@ Two handlers:
   transitions to :class:`IssueState.PLANNED`.
 - :func:`handle_plan_gate` covers :class:`IssueState.PLANNED` and
   auto-advances the issue to ``PLAN_APPROVED`` via the confidence gate
-  (below-threshold diverts to ``:human-needed`` with a pending marker).
+  (below-threshold diverts to ``:human-needed`` for admin review).
 
 Derived from ``cmd_plan`` in ``cai.py`` — behaviour is preserved as
 closely as possible. The dispatcher is responsible for fetching the
@@ -44,8 +44,6 @@ from cai_lib.cmd_helpers import (
 from cai_lib.fsm import (
     apply_transition,
     apply_transition_with_confidence,
-    render_pending_marker,
-    strip_pending_marker,
     IssueState,
     get_issue_state,
 )
@@ -431,10 +429,6 @@ def handle_plan(issue: dict) -> int:
 
         # 5. Store plan in issue body (strip any old plan block first).
         current_body = _strip_stored_plan_block(issue.get("body", "") or "")
-        # Also strip any stale pending marker left from a prior run — the
-        # upcoming confidence gate (handle_plan_gate) will re-add one if
-        # it diverts.
-        current_body = strip_pending_marker(current_body)
         conf_name = plan_confidence.name if plan_confidence else "MISSING"
         plan_block = (
             "<!-- cai-plan-start -->\n"
@@ -508,8 +502,8 @@ def handle_plan_gate(issue: dict) -> int:
     ``_cai_plan_confidence`` by :func:`handle_plan` within the same
     process, or re-parsed from the issue body). HIGH-confidence plans
     auto-promote via ``planned_to_plan_approved``; anything below
-    diverts to :human-needed (`planned_to_human`) with a pending marker
-    so an admin can review.
+    diverts to :human-needed (`planned_to_human`) so an admin can
+    review.
     """
     from cai_lib.fsm import parse_confidence, parse_confidence_reason
 
@@ -554,31 +548,6 @@ def handle_plan_gate(issue: dict) -> int:
                 confidence=conf_name, diverted=int(diverted),
                 exit=1)
         return 1
-    if diverted:
-        # Append a pending marker so cai-unblock knows what we were
-        # trying to do when the admin comments. Re-read the body so the
-        # marker lands on the freshest content.
-        try:
-            fresh = _gh_json([
-                "issue", "view", str(issue_number),
-                "--repo", REPO,
-                "--json", "body",
-            ]) or {}
-            current_body = fresh.get("body", "") or ""
-        except Exception:  # pragma: no cover — defensive
-            current_body = issue.get("body", "") or ""
-        marker = render_pending_marker(
-            transition_name="planned_to_plan_approved",
-            from_state=IssueState.PLANNED,
-            intended_state=IssueState.PLAN_APPROVED,
-            confidence=plan_confidence,
-        )
-        marker_body = f"{current_body}\n\n{marker}\n"
-        _run(
-            ["gh", "issue", "edit", str(issue_number),
-             "--repo", REPO, "--body", marker_body],
-            capture_output=True,
-        )
 
     dur = f"{int(time.monotonic() - t0)}s"
     conf_name = plan_confidence.name if plan_confidence else "MISSING"

--- a/cai_lib/cmd_unblock.py
+++ b/cai_lib/cmd_unblock.py
@@ -36,15 +36,13 @@ from cai_lib.fsm import (
     apply_transition,
     apply_pr_transition,
     parse_confidence,
-    parse_pending_marker,
     parse_resume_target,
     resume_transition_for,
     resume_pr_transition_for,
-    strip_pending_marker,
 )
 from cai_lib.github import _gh_json, _set_pr_labels
 from cai_lib.logging_utils import log_run
-from cai_lib.subprocess_utils import _run, _run_claude_p
+from cai_lib.subprocess_utils import _run_claude_p
 
 
 def _list_human_needed_issues() -> list[dict]:
@@ -83,100 +81,65 @@ def _extract_admin_comments(issue: dict) -> list[dict]:
     return out
 
 
-def _build_unblock_message(
-    *,
-    kind: str,
-    issue: dict,
-    marker: Optional[dict],
-    admin_comments: list[dict],
-) -> str:
+def _build_unblock_message(*, kind: str, issue: dict) -> str:
     """Format the user message for the cai-unblock agent.
 
-    ``marker`` may be ``None`` — PRs are parked without a pending
-    marker written to their body (the ``approved_to_human`` path in
-    ``cai merge`` doesn't emit one), so the agent gets "(no marker)"
-    and relies solely on the admin comment plus PR body for context.
+    Includes the target's labels, body, and the full comment thread
+    (chronological, all authors) — the agent uses the admin's most recent
+    comment as the resume signal and the rest as context.
     """
-    if marker is None:
-        marker_line = "(no marker — target was parked without one)"
-    else:
-        marker_line = (
-            f"transition={marker.get('transition', '?')} "
-            f"from={marker.get('from', '?')} "
-            f"intended={marker.get('intended', '?')} "
-            f"conf={marker.get('conf', '?')}"
-        )
     body = issue.get("body") or "(no body)"
+    labels = [
+        (lb.get("name") if isinstance(lb, dict) else lb)
+        for lb in issue.get("labels", [])
+    ]
+    labels_line = ", ".join(labels) if labels else "(none)"
+
+    comments = issue.get("comments") or []
     comments_block = ""
-    for c in admin_comments:
+    for c in comments:
         author = (c.get("author") or {}).get("login") or "unknown"
         created = c.get("createdAt", "") or c.get("created_at", "")
+        marker = " [admin]" if is_admin_login(author) else ""
         text = c.get("body", "") or ""
-        comments_block += f"\n**{author}** ({created}):\n{text}\n"
+        comments_block += f"\n**{author}**{marker} ({created}):\n{text}\n"
+
     return (
         f"Kind: {kind}\n"
         f"\n"
-        f"## Pending transition marker\n"
-        f"{marker_line}\n"
+        f"## Labels\n"
+        f"{labels_line}\n"
         f"\n"
         f"## Body\n\n"
         f"### #{issue['number']} — {issue.get('title', '')}\n\n"
         f"{body}\n"
         f"\n"
-        f"## Admin comments\n"
-        f"{comments_block or '(no admin comments)'}\n"
+        f"## Comments\n"
+        f"{comments_block or '(no comments)'}\n"
     )
-
-
-def _clear_pending_marker_on_body(issue_number: int, current_body: str) -> bool:
-    """Strip the pending marker from *current_body* and push via gh."""
-    stripped = strip_pending_marker(current_body)
-    if stripped == current_body:
-        return True  # nothing to do
-    update = _run(
-        ["gh", "issue", "edit", str(issue_number),
-         "--repo", REPO, "--body", stripped],
-        capture_output=True,
-    )
-    if update.returncode != 0:
-        print(
-            f"[cai unblock] failed to strip marker on #{issue_number}:\n"
-            f"{update.stderr}",
-            file=sys.stderr,
-        )
-        return False
-    return True
 
 
 def _try_unblock_issue(issue: dict) -> Optional[str]:
     """Attempt to resume *issue* from :human-needed. Returns the result tag.
 
     Result tags (used for logging):
-      - ``"no_marker"``        — no pending marker in body, left parked
       - ``"no_admin_comment"`` — ``human:solved`` applied but no admin
-        comment yet — the classifier has nothing to read
+        comment yet — the classifier has nothing to anchor on
       - ``"low_confidence"``   — agent's Confidence < HIGH, left parked
       - ``"no_target"``        — agent emitted no valid ResumeTo target
-      - ``"resumed"``          — transition fired, marker + solved label cleared
+      - ``"resumed"``          — transition fired, solved label cleared
       - ``"agent_failed"``     — claude invocation returned non-zero
     """
     issue_number = issue["number"]
-    body = issue.get("body") or ""
-    marker = parse_pending_marker(body)
-    if not marker:
-        return "no_marker"
 
     admin_comments = _extract_admin_comments(issue)
     if not admin_comments:
         # Admin applied human:solved without leaving any comment. The
-        # classifier would have nothing to read, so leave the issue parked
-        # rather than guess. The label stays on so we retry once a comment
-        # lands.
+        # classifier would have nothing to anchor on, so leave the issue
+        # parked. The label stays on so we retry once a comment lands.
         return "no_admin_comment"
 
-    user_message = _build_unblock_message(
-        kind="issue", issue=issue, marker=marker, admin_comments=admin_comments,
-    )
+    user_message = _build_unblock_message(kind="issue", issue=issue)
     result = _run_claude_p(
         ["claude", "-p", "--agent", "cai-unblock",
          "--dangerously-skip-permissions"],
@@ -231,7 +194,6 @@ def _try_unblock_issue(issue: dict) -> Optional[str]:
     if not ok:
         return "agent_failed"
 
-    _clear_pending_marker_on_body(issue_number, body)
     print(
         f"[cai unblock] #{issue_number} resumed via {transition.name} "
         f"→ {transition.to_state.name}",
@@ -293,28 +255,18 @@ def _list_pr_human_needed_prs() -> list[dict]:
 def _try_unblock_pr(pr: dict) -> Optional[str]:
     """Attempt to resume *pr* from :pr-human-needed. Returns the result tag.
 
-    Mirrors :func:`_try_unblock_issue` with two differences:
-
-    - PR bodies are not expected to carry a pending marker (the
-      ``approved_to_human`` path in ``cai merge`` doesn't write one),
-      so the absence of a marker is not a skip condition.
-    - Resume target → ``pr_human_to_<state>`` transition via
-      :func:`resume_pr_transition_for`, applied with
-      :func:`apply_pr_transition`.
-
-    Result tags mirror the issue side; ``no_marker`` cannot occur here.
+    Mirrors :func:`_try_unblock_issue`. Resume target maps to a
+    ``pr_human_to_<state>`` transition via
+    :func:`resume_pr_transition_for`, applied with
+    :func:`apply_pr_transition`.
     """
     pr_number = pr["number"]
-    body = pr.get("body") or ""
-    marker = parse_pending_marker(body)  # may be None — informational only
 
     admin_comments = _extract_admin_comments(pr)
     if not admin_comments:
         return "no_admin_comment"
 
-    user_message = _build_unblock_message(
-        kind="pr", issue=pr, marker=marker, admin_comments=admin_comments,
-    )
+    user_message = _build_unblock_message(kind="pr", issue=pr)
     result = _run_claude_p(
         ["claude", "-p", "--agent", "cai-unblock",
          "--dangerously-skip-permissions"],

--- a/cai_lib/fsm.py
+++ b/cai_lib/fsm.py
@@ -524,73 +524,6 @@ def find_transition(name: str, transitions: Sequence[Transition] = _ALL_TRANSITI
     raise KeyError(f"unknown transition: {name!r}")
 
 
-# ---------------------------------------------------------------------------
-# Pending-marker helpers
-#
-# When a transition diverts to HUMAN_NEEDED because confidence was too low (or
-# missing), we append a hidden marker to the issue body so the resume loop
-# knows what the agent was trying to do. The marker survives edits because we
-# key on the delimiter pair and replace in place.
-# ---------------------------------------------------------------------------
-
-_PENDING_MARKER_START = "<!-- cai-fsm-pending"
-_PENDING_MARKER_END   = "-->"
-_PENDING_MARKER_RE = re.compile(
-    r"<!--\s*cai-fsm-pending\s+(.*?)\s*-->",
-    re.DOTALL,
-)
-
-
-def render_pending_marker(
-    *,
-    transition_name: str,
-    from_state: IssueState | PRState,
-    intended_state: IssueState | PRState,
-    confidence: Optional[Confidence],
-) -> str:
-    """Serialize a pending-transition marker for an issue body."""
-    conf = confidence.name if confidence is not None else "MISSING"
-    from_name = from_state.name if hasattr(from_state, "name") else str(from_state)
-    intended_name = (
-        intended_state.name if hasattr(intended_state, "name") else str(intended_state)
-    )
-    return (
-        f"{_PENDING_MARKER_START} "
-        f"transition={transition_name} from={from_name} "
-        f"intended={intended_name} conf={conf} {_PENDING_MARKER_END}"
-    )
-
-
-def parse_pending_marker(body: str) -> Optional[dict]:
-    """Extract the pending-transition marker from an issue *body*.
-
-    Returns a dict with keys ``transition``, ``from``, ``intended``, ``conf``
-    (all strings), or ``None`` if no marker is present.
-    """
-    if not body:
-        return None
-    m = _PENDING_MARKER_RE.search(body)
-    if not m:
-        return None
-    fields: dict = {}
-    for token in m.group(1).split():
-        if "=" in token:
-            k, v = token.split("=", 1)
-            fields[k] = v
-    if "transition" not in fields:
-        return None
-    return fields
-
-
-def strip_pending_marker(body: str) -> str:
-    """Remove any pending-transition marker from *body* (and trailing blank lines)."""
-    if not body:
-        return body
-    new = _PENDING_MARKER_RE.sub("", body)
-    # Collapse the blank lines the marker may have left behind.
-    return re.sub(r"\n{3,}", "\n\n", new).rstrip() + ("\n" if body.endswith("\n") else "")
-
-
 def apply_transition(
     issue_number: int,
     transition_name: str,
@@ -664,8 +597,8 @@ def _render_human_divert_reason(
         lines.extend(["", extra.rstrip()])
     lines.extend([
         "",
-        "See the pending marker in the body for how the automation intends "
-        "to resume once an admin responds.",
+        "Apply the `human:solved` label after leaving a comment to signal "
+        "the divert is resolved and have the FSM resume.",
     ])
     return "\n".join(lines)
 
@@ -689,9 +622,8 @@ def apply_transition_with_confidence(
     - When *confidence* is missing or below ``transition.min_confidence``,
       the intended state change is refused and the issue is instead moved
       to ``transition.human_label_if_below`` (defaults to
-      :data:`LABEL_HUMAN_NEEDED`). The caller is responsible for appending
-      a pending marker to the issue body so the resume loop can pick up
-      where the automation stopped — see :func:`render_pending_marker`.
+      :data:`LABEL_HUMAN_NEEDED`). An admin resumes the FSM by leaving a
+      comment and applying ``human:solved`` — see :mod:`cai_lib.cmd_unblock`.
     - When confidence meets the threshold, delegates to
       :func:`apply_transition` and returns ``(ok, False)``.
 

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -13,7 +13,6 @@ from cai_lib.fsm import (
     apply_transition, apply_transition_with_confidence, find_transition,
     parse_confidence, parse_confidence_reason, parse_resume_target,
     resume_transition_for, resume_pr_transition_for,
-    render_pending_marker, parse_pending_marker, strip_pending_marker,
 )
 from cai_lib.config import (
     LABEL_IN_PROGRESS, LABEL_RAISED, LABEL_REFINED, LABEL_REFINING,
@@ -314,49 +313,6 @@ class TestApplyTransitionWithConfidence(unittest.TestCase):
         self.assertEqual(calls, [])
         # State mismatch aborts before the divert → no comment either.
         self.assertEqual(comments, [])
-
-
-class TestPendingMarker(unittest.TestCase):
-
-    def test_roundtrip_with_confidence(self):
-        marker = render_pending_marker(
-            transition_name="raise_to_refining",
-            from_state=IssueState.RAISED,
-            intended_state=IssueState.REFINED,
-            confidence=Confidence.MEDIUM,
-        )
-        parsed = parse_pending_marker(f"body text\n{marker}\nmore text")
-        self.assertEqual(parsed["transition"], "raise_to_refining")
-        self.assertEqual(parsed["from"], "RAISED")
-        self.assertEqual(parsed["intended"], "REFINED")
-        self.assertEqual(parsed["conf"], "MEDIUM")
-
-    def test_roundtrip_with_missing_confidence(self):
-        marker = render_pending_marker(
-            transition_name="raise_to_refining",
-            from_state=IssueState.RAISED,
-            intended_state=IssueState.REFINED,
-            confidence=None,
-        )
-        parsed = parse_pending_marker(marker)
-        self.assertEqual(parsed["conf"], "MISSING")
-
-    def test_parse_returns_none_when_absent(self):
-        self.assertIsNone(parse_pending_marker("a plain issue body"))
-        self.assertIsNone(parse_pending_marker(""))
-
-    def test_strip_removes_marker(self):
-        marker = render_pending_marker(
-            transition_name="raise_to_refining",
-            from_state=IssueState.RAISED,
-            intended_state=IssueState.REFINED,
-            confidence=Confidence.LOW,
-        )
-        body = f"leading text\n\n{marker}\n\ntrailing text\n"
-        stripped = strip_pending_marker(body)
-        self.assertNotIn("cai-fsm-pending", stripped)
-        self.assertIn("leading text", stripped)
-        self.assertIn("trailing text", stripped)
 
 
 class TestResumeFromHuman(unittest.TestCase):

--- a/tests/test_unblock.py
+++ b/tests/test_unblock.py
@@ -51,70 +51,58 @@ class TestExtractAdminComments(unittest.TestCase):
 class TestBuildUnblockMessage(unittest.TestCase):
 
     def _fixture(self):
+        return {
+            "number": 42,
+            "title": "widget broke",
+            "body": "original body text",
+            "labels": [
+                {"name": "auto-improve:human-needed"},
+                {"name": "human:solved"},
+            ],
+            "comments": [
+                {"author": {"login": "automation-bot"},
+                 "createdAt": "2026-04-14T10:00:00Z",
+                 "body": "automation context note"},
+                {"author": {"login": "alice"},
+                 "createdAt": "2026-04-14T12:00:00Z",
+                 "body": "please re-try as plan-approved"},
+            ],
+        }
+
+    def test_contains_required_sections(self):
+        issue = self._fixture()
+        msg = U._build_unblock_message(kind="issue", issue=issue)
+        self.assertIn("Kind: issue", msg)
+        self.assertIn("## Labels", msg)
+        self.assertIn("auto-improve:human-needed", msg)
+        self.assertIn("human:solved", msg)
+        self.assertIn("widget broke", msg)
+        self.assertIn("original body text", msg)
+        self.assertIn("alice", msg)
+        self.assertIn("[admin]", msg)
+        self.assertIn("please re-try as plan-approved", msg)
+        # Non-admin comments are included unfiltered for context.
+        self.assertIn("automation-bot", msg)
+        self.assertIn("automation context note", msg)
+
+    def test_no_comments_placeholder(self):
         issue = {
             "number": 42,
             "title": "widget broke",
             "body": "original body text",
+            "labels": [],
             "comments": [],
         }
-        marker = {
-            "transition": "raise_to_refining",
-            "from": "RAISED",
-            "intended": "REFINING",
-            "conf": "MEDIUM",
-        }
-        admin_comments = [
-            {"author": {"login": "alice"},
-             "createdAt": "2026-04-14T12:00:00Z",
-             "body": "please re-try as plan-approved"},
-        ]
-        return issue, marker, admin_comments
-
-    def test_contains_required_sections(self):
-        issue, marker, comments = self._fixture()
-        msg = U._build_unblock_message(
-            kind="issue", issue=issue, marker=marker, admin_comments=comments,
-        )
-        self.assertIn("Kind: issue", msg)
-        self.assertIn("Pending transition marker", msg)
-        self.assertIn("transition=raise_to_refining", msg)
-        self.assertIn("from=RAISED", msg)
-        self.assertIn("intended=REFINING", msg)
-        self.assertIn("conf=MEDIUM", msg)
-        self.assertIn("widget broke", msg)
-        self.assertIn("original body text", msg)
-        self.assertIn("alice", msg)
-        self.assertIn("please re-try as plan-approved", msg)
-
-    def test_no_admin_comments_placeholder(self):
-        issue, marker, _ = self._fixture()
-        msg = U._build_unblock_message(
-            kind="issue", issue=issue, marker=marker, admin_comments=[],
-        )
-        self.assertIn("(no admin comments)", msg)
+        msg = U._build_unblock_message(kind="issue", issue=issue)
+        self.assertIn("(no comments)", msg)
 
 
 class TestTryUnblockIssueSkips(unittest.TestCase):
-    """The no-op branches do not invoke claude."""
-
-    def test_no_marker(self):
-        issue = {"number": 1, "title": "t", "body": "no marker here",
-                 "labels": [], "comments": [
-                     {"author": {"login": "alice"}, "body": "go ahead"},
-                 ]}
-        with mock.patch.object(U, "_run_claude_p") as fake:
-            result = U._try_unblock_issue(issue)
-        self.assertEqual(result, "no_marker")
-        fake.assert_not_called()
+    """The no-op branch does not invoke claude."""
 
     def test_no_admin_comment(self):
-        body = (
-            "issue text\n\n"
-            "<!-- cai-fsm-pending transition=raise_to_refining "
-            "from=RAISED intended=REFINING conf=MEDIUM -->\n"
-        )
-        issue = {"number": 2, "title": "t", "body": body, "labels": [],
-                 "comments": [
+        issue = {"number": 2, "title": "t", "body": "issue text",
+                 "labels": [], "comments": [
                      {"author": {"login": "stranger"}, "body": "hi"},
                  ]}
         with mock.patch.object(U, "_run_claude_p") as fake:
@@ -154,15 +142,10 @@ class TestResumeStripsHumanSolvedLabel(unittest.TestCase):
     """A successful resume must remove human:solved so the signal is one-shot."""
 
     def test_apply_transition_receives_human_solved_in_extra_remove(self):
-        body = (
-            "issue text\n\n"
-            "<!-- cai-fsm-pending transition=refining_to_refined "
-            "from=REFINING intended=REFINED conf=MEDIUM -->\n"
-        )
         issue = {
             "number": 77,
             "title": "t",
-            "body": body,
+            "body": "issue text",
             "labels": [
                 {"name": "auto-improve:human-needed"},
                 {"name": "human:solved"},
@@ -189,8 +172,7 @@ class TestResumeStripsHumanSolvedLabel(unittest.TestCase):
             return True
 
         with mock.patch.object(U, "_run_claude_p", return_value=fake_agent), \
-             mock.patch.object(U, "apply_transition", side_effect=fake_apply), \
-             mock.patch.object(U, "_clear_pending_marker_on_body", return_value=True):
+             mock.patch.object(U, "apply_transition", side_effect=fake_apply):
             result = U._try_unblock_issue(issue)
 
         self.assertEqual(result, "resumed")


### PR DESCRIPTION
## Summary
- Drop the cai-fsm-pending marker side-channel that got issues like #715 stuck in `:human-needed` when the marker-write silently failed.
- `cai-unblock` (haiku) now receives labels + body + full chronological comment thread (admin comments tagged `[admin]`) and decides the resume state from that context alone.
- Gate unchanged: `human:solved` label + at least one admin comment; `human:solved` still cleared one-shot on successful resume.
- Removes `render_pending_marker` / `parse_pending_marker` / `strip_pending_marker`, the plan-gate marker write, `_clear_pending_marker_on_body`, the `no_marker` skip branch, and the "Pending transition marker" section of the agent prompt.

## Test plan
- [x] `pytest tests/test_fsm.py tests/test_unblock.py tests/test_maintain.py tests/test_multistep.py` — 95 passed
- [ ] Next cycle: #715, #721, #731 (all parked at `:human-needed` + `human:solved`) should be classified and resumed