### PR TITLE
auto-improve: workflow amin-only-label

### DIFF
--- a/.github/workflows/admin-only-label.yml
+++ b/.github/workflows/admin-only-label.yml
@@ -12,14 +12,17 @@ name: Admin-only label guard
 on:
   issues:
     types: [labeled]
+  pull_request_target:
+    types: [labeled]
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   enforce:
     if: >-
-      contains(fromJSON('["auto-improve:plan-approved","auto-improve:raised","auto-improve:refined"]'), github.event.label.name)
+      contains(fromJSON('["auto-improve:raised","auto-improve:in-progress","auto-improve:pr-open","auto-improve:merged","auto-improve:solved","auto-improve:needs-exploration","auto-improve:refined","auto-improve:revising","auto-improve:parent","merge-blocked","auto-improve:planned","auto-improve:plan-approved","auto-improve:refining","auto-improve:planning","auto-improve:applying","auto-improve:applied","auto-improve:human-needed","auto-improve:pr-human-needed","human:solved","auto-improve:triaging","kind:code","kind:maintenance","pr:reviewing-code","pr:revision-pending","pr:reviewing-docs","pr:approved","pr:rebasing","pr:ci-failing","needs-human-review"]'), github.event.label.name)
     runs-on: ubuntu-latest
     steps:
       - name: Check sender's permission
@@ -37,10 +40,11 @@ jobs:
         if: steps.check.outputs.perm != 'admin'
         env:
           GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: |
           gh api -X DELETE \
-            "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/${{ github.event.label.name }}"
+            "repos/${{ github.repository }}/issues/${NUMBER}/labels/${{ github.event.label.name }}"
 
-          gh issue comment "${{ github.event.issue.number }}" \
+          gh issue comment "${NUMBER}" \
             --repo "${{ github.repository }}" \
             --body "@${{ github.event.sender.login }} only repo admins can apply the \`${{ github.event.label.name }}\` label — it triggers autonomous code execution by the cai implement subagent. The label has been removed."

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,19 +50,25 @@ Issues still enter the pipeline the same way: `cai analyze`, `cai propose`, `cai
 | `auto-improve:solved` | Confirmed resolved |
 | `auto-improve:needs-exploration` | Needs autonomous exploration (explore handler) |
 | `auto-improve:planned` | Plan generated and stored in issue body; confidence gate pending |
+| `auto-improve:planning` | Plan generation in progress (transient) |
 | `auto-improve:plan-approved` | Plan approved (HIGH confidence auto-approval or admin resume); ready for implement subagent |
+| `auto-improve:human-needed` | Awaiting admin review and decision; admin applies `human:solved` to resume |
 | `auto-improve:applying` | Maintenance ops are being applied (transient; Step 3 agent drains this state) |
 | `auto-improve:applied` | Maintenance ops applied; awaiting verification |
 | `auto-improve:parent` | Parent issue; child sub-issues carry the work |
 | `audit` | Source tag indicating an audit-originated finding (combined with `auto-improve:raised` in unified FSM) |
 | `merge-blocked` | PR has a blocking review finding; will not auto-merge |
 | `needs-human-review` | Issue or PR requires human attention |
+| `human:solved` | Admin-applied signal to resume FSM for parked issues/PRs (unblocking) |
+| `kind:code` | Issue is a code fix (vs. kind:maintenance) |
+| `kind:maintenance` | Issue is a maintenance operation (requires `Ops:` block in body) |
 | `pr:reviewing-code` | PR is in code review (review-pr handler); a new SHA lands here on any push |
 | `pr:revision-pending` | Review-pr handler posted findings; revise handler will address them |
 | `pr:reviewing-docs` | Code review clean; docs review is next |
 | `pr:approved` | Docs review clean; merge handler runs the final confidence-gated merge from here |
 | `pr:rebasing` | Mergeable=CONFLICTING with main; rebase handler runs cai-rebase, posts an outcome comment, and always bounces back to `pr:reviewing-code` so the rebased SHA is re-reviewed |
 | `pr:ci-failing` | Checks are red; fix-ci handler is the action — returns to `pr:reviewing-code` after a push |
+| `pr:human-needed` | PR awaiting human decision; human applies `human:solved` to resume |
 
 ## The Cycle Command
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#715

**Issue:** #715 — workflow amin-only-label

## PR Summary

### What this fixes
The `admin-only-label.yml` workflow only guarded 3 of the 29 FSM labels and had no `pull_request_target` trigger, leaving PR-scoped labels unprotected and most issue labels ungated against non-admin application.

### What was changed
- `.github/workflows/admin-only-label.yml`:
  - Added `pull_request_target: types: [labeled]` to the `on:` block to catch PR label events
  - Added `pull-requests: write` to `permissions:` so the workflow can remove labels from PRs
  - Expanded the `fromJSON` label list from 3 labels to all 29 FSM labels (`auto-improve:*`, `pr:*`, `merge-blocked`, `needs-human-review`, `human:solved`, `kind:code`, `kind:maintenance`)
  - Added `NUMBER` env var (`github.event.issue.number || github.event.pull_request.number`) to the "Remove label and notify" step and updated both the `gh api -X DELETE` call and `gh issue comment` to use `${NUMBER}` instead of the hardcoded issue-only expression

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
