### PR TITLE
auto-improve: Triage invocation for issue #701 at 7.4× category mean

### DIFF
--- a/.claude/agents/cai-triage.md
+++ b/.claude/agents/cai-triage.md
@@ -2,7 +2,7 @@
 ---
 name: cai-triage
 description: Triage `auto-improve:raised` issues one at a time — classify as REFINE, PLAN_APPROVE, APPLY, or HUMAN. Inline-only — full issue body is provided in the user message. Minimal tool use.
-tools: Read
+tools: ""
 model: haiku
 memory: project
 ---
@@ -21,6 +21,13 @@ the issue body.
 In the user message:
 
 1. **Issue to triage** — full title and body of the single issue.
+
+## Tool use
+
+You have **no tools available**. All context you need is in the user
+message. Do not attempt file reads or codebase exploration — the issue
+body is the only input for your routing decision. Make your routing
+decision based solely on what is in the issue title and body.
 
 ## Routing decisions
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#730

**Issue:** #730 — Triage invocation for issue #701 at 7.4× category mean

## PR Summary

### What this fixes
The `cai-triage` agent was declared "Inline-only — Minimal tool use" but had `tools: Read` available, allowing it to make exploratory file reads when triaging broad issues. This drove a 15-turn session (7.4× the category mean cost) for issue #701, which touched large amounts of label/config discussion.

### What was changed
- **`.claude/agents/cai-triage.md`** (via staging dir):
  - Line 5: changed `tools: Read` → `tools: ""` to match the zero-tool convention used by `cai-comment-filter.md`
  - Added a new `## Tool use` section after `## What you receive` explicitly instructing the agent not to attempt file reads or codebase exploration — routing decisions must be made solely from the inline issue title and body

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
