### PR TITLE
refactor(unblock): migrate cai-unblock to forced tool-use

### DIFF
--- a/.claude/agents/cai-unblock.md
+++ b/.claude/agents/cai-unblock.md
@@ -42,7 +42,7 @@ After the header, three sections follow:
 
 ## Issue resume targets (Kind: issue)
 
-Return exactly one of these state names in a `ResumeTo:` line. Each
+Return exactly one of these state names in the `resume_to` field. Each
 maps to a `human_to_<state>` transition defined in
 `cai_lib/fsm.py`.
 
@@ -60,7 +60,7 @@ admin wants to accept an existing plan, pick `PLAN_APPROVED`.)
 
 ## PR resume targets (Kind: pr)
 
-Return exactly one of these state names in a `ResumeTo:` line. Each
+Return exactly one of these state names in the `resume_to` field. Each
 maps to a `pr_human_to_<state>` transition defined in
 `cai_lib/fsm.py`.
 
@@ -79,32 +79,38 @@ the admin greenlights the merge.)
 ## Fallback
 
 If the admin's comment is unrelated to the pending decision or you
-cannot decide with confidence:
+cannot decide with confidence, emit `confidence: LOW` with the safest
+restart target:
 
-- For `Kind: issue`, emit `ResumeTo: RAISED` with `Confidence: LOW`.
-- For `Kind: pr`, emit `ResumeTo: REVIEWING_CODE` with `Confidence: LOW`.
+- For `Kind: issue`, use `resume_to: RAISED`.
+- For `Kind: pr`, use `resume_to: REVIEWING_CODE`.
 
 Either restarts the relevant submachine without pretending certainty.
+The wrapper leaves the target parked whenever `confidence` is not
+`HIGH`, so `LOW` is the correct signal for an ambiguous comment.
 
 ## Output format
 
-Your last non-empty reply must end with these two lines, each on its
-own line, in this exact casing:
+You must respond by invoking the tool the runtime provides with a
+JSON object conforming to this schema:
 
 ```
-ResumeTo: <STATE_NAME>
-Confidence: HIGH | MEDIUM | LOW
+{
+  "resume_to": "<STATE_NAME>",       // one of the table entries above
+  "confidence": "HIGH|MEDIUM|LOW",
+  "reasoning": "≤3 sentences explaining your interpretation"
+}
 ```
 
-Before those two lines, include one short paragraph (≤3 sentences)
-explaining how you interpreted the admin's comment. No other
-sections.
+`--json-schema` forced tool-use guarantees the structure; do not emit
+free-form prose in addition. The `reasoning` field is where your
+short interpretation goes.
 
 ## Hard rules
 
 - Never invent states that are not in the table for the given kind.
-- Never emit `ResumeTo: HUMAN_NEEDED` or `ResumeTo: PR_HUMAN_NEEDED`
+- Never emit `resume_to: HUMAN_NEEDED` or `resume_to: PR_HUMAN_NEEDED`
   — the target is already parked there.
-- If you set `Confidence: LOW`, the wrapper will leave the target
-  parked rather than firing the resume transition — that is the
-  correct outcome when the admin comment is ambiguous.
+- If you set `confidence: LOW` (or `MEDIUM`), the wrapper will leave
+  the target parked rather than firing the resume transition — that
+  is the correct outcome when the admin comment is ambiguous.

--- a/cai_lib/cmd_unblock.py
+++ b/cai_lib/cmd_unblock.py
@@ -18,6 +18,7 @@ removes the ``human:solved`` label so the signal is one-shot.
 """
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 import time
@@ -35,14 +36,42 @@ from cai_lib.fsm import (
     Confidence,
     apply_transition,
     apply_pr_transition,
-    parse_confidence,
-    parse_resume_target,
     resume_transition_for,
     resume_pr_transition_for,
 )
 from cai_lib.github import _gh_json, _set_pr_labels
 from cai_lib.logging_utils import log_run
 from cai_lib.subprocess_utils import _run_claude_p
+
+
+# JSON schema for structured unblock verdict (forced tool-use via --json-schema).
+# Combined enum covers both the issue-side and PR-side resume targets — the
+# cai-unblock agent chooses from the subset appropriate for the ``Kind:`` header
+# in the user message.
+_UNBLOCK_JSON_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "resume_to": {
+            "type": "string",
+            "enum": [
+                # Issue-side (Kind: issue)
+                "RAISED", "REFINING", "NEEDS_EXPLORATION",
+                "PLAN_APPROVED", "SOLVED",
+                # PR-side (Kind: pr)
+                "REVIEWING_CODE", "REVIEWING_DOCS",
+                "REVISION_PENDING", "APPROVED",
+            ],
+        },
+        "confidence": {
+            "type": "string",
+            "enum": ["LOW", "MEDIUM", "HIGH"],
+        },
+        "reasoning": {
+            "type": "string",
+        },
+    },
+    "required": ["resume_to", "confidence", "reasoning"],
+}
 
 
 def _list_human_needed_issues() -> list[dict]:
@@ -142,7 +171,8 @@ def _try_unblock_issue(issue: dict) -> Optional[str]:
     user_message = _build_unblock_message(kind="issue", issue=issue)
     result = _run_claude_p(
         ["claude", "-p", "--agent", "cai-unblock",
-         "--dangerously-skip-permissions"],
+         "--dangerously-skip-permissions",
+         "--json-schema", json.dumps(_UNBLOCK_JSON_SCHEMA)],
         category="unblock",
         agent="cai-unblock",
         input=user_message,
@@ -155,11 +185,27 @@ def _try_unblock_issue(issue: dict) -> Optional[str]:
         )
         return "agent_failed"
 
-    stdout = result.stdout
-    print(stdout, flush=True)
+    try:
+        payload = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(
+            f"[cai unblock] #{issue_number} failed to parse JSON: {exc}; "
+            f"stdout starts with: {(result.stdout or '')[:120]!r}",
+            file=sys.stderr,
+            flush=True,
+        )
+        payload = {}
 
-    target = parse_resume_target(stdout)
-    confidence = parse_confidence(stdout)
+    target = (payload.get("resume_to") or "").upper() or None
+    conf_str = (payload.get("confidence") or "").upper()
+    confidence = Confidence[conf_str] if conf_str in Confidence.__members__ else None
+    reasoning = payload.get("reasoning", "(no reasoning provided)")
+    print(
+        f"[cai unblock] #{issue_number} verdict: resume_to={target or 'MISSING'} "
+        f"confidence={conf_str or 'MISSING'} reasoning={reasoning}",
+        flush=True,
+    )
+
     if confidence != Confidence.HIGH:
         print(
             f"[cai unblock] #{issue_number} confidence="
@@ -269,7 +315,8 @@ def _try_unblock_pr(pr: dict) -> Optional[str]:
     user_message = _build_unblock_message(kind="pr", issue=pr)
     result = _run_claude_p(
         ["claude", "-p", "--agent", "cai-unblock",
-         "--dangerously-skip-permissions"],
+         "--dangerously-skip-permissions",
+         "--json-schema", json.dumps(_UNBLOCK_JSON_SCHEMA)],
         category="unblock",
         agent="cai-unblock",
         input=user_message,
@@ -282,11 +329,27 @@ def _try_unblock_pr(pr: dict) -> Optional[str]:
         )
         return "agent_failed"
 
-    stdout = result.stdout
-    print(stdout, flush=True)
+    try:
+        payload = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(
+            f"[cai unblock] PR #{pr_number} failed to parse JSON: {exc}; "
+            f"stdout starts with: {(result.stdout or '')[:120]!r}",
+            file=sys.stderr,
+            flush=True,
+        )
+        payload = {}
 
-    target = parse_resume_target(stdout)
-    confidence = parse_confidence(stdout)
+    target = (payload.get("resume_to") or "").upper() or None
+    conf_str = (payload.get("confidence") or "").upper()
+    confidence = Confidence[conf_str] if conf_str in Confidence.__members__ else None
+    reasoning = payload.get("reasoning", "(no reasoning provided)")
+    print(
+        f"[cai unblock] PR #{pr_number} verdict: resume_to={target or 'MISSING'} "
+        f"confidence={conf_str or 'MISSING'} reasoning={reasoning}",
+        flush=True,
+    )
+
     if confidence != Confidence.HIGH:
         print(
             f"[cai unblock] PR #{pr_number} confidence="

--- a/tests/test_unblock.py
+++ b/tests/test_unblock.py
@@ -5,6 +5,7 @@ agent via `claude -p` and is tested end-to-end in a live container.
 These tests cover the deterministic pieces that don't need claude:
 admin-comment filtering and agent-input formatting.
 """
+import json
 import os
 import sys
 import unittest
@@ -157,7 +158,11 @@ class TestResumeStripsHumanSolvedLabel(unittest.TestCase):
             ],
         }
 
-        agent_stdout = "ResumeTo: REFINING\nConfidence: HIGH\n"
+        agent_stdout = json.dumps({
+            "resume_to": "REFINING",
+            "confidence": "HIGH",
+            "reasoning": "admin asked to re-run refine",
+        })
         fake_agent = mock.MagicMock()
         fake_agent.returncode = 0
         fake_agent.stdout = agent_stdout
@@ -265,7 +270,11 @@ class TestTryUnblockPrSkips(unittest.TestCase):
                  "body": "looks good, merge it"},
             ],
         }
-        agent_stdout = "ResumeTo: APPROVED\nConfidence: HIGH\n"
+        agent_stdout = json.dumps({
+            "resume_to": "APPROVED",
+            "confidence": "HIGH",
+            "reasoning": "admin greenlighted merge",
+        })
         fake_agent = mock.MagicMock()
         fake_agent.returncode = 0
         fake_agent.stdout = agent_stdout


### PR DESCRIPTION
## Summary
- Completes step 4/4 of #686 (issue #695) — migrates `cai-unblock` from regex-scraped `ResumeTo:` / `Confidence:` text output to a JSON schema enforced by `claude -p --json-schema`, matching the pattern already used by `cai-merge`, `cai-triage`, and `cai-select`.
- Updates `cmd_unblock.py` (both `_try_unblock_issue` and `_try_unblock_pr`): adds `_UNBLOCK_JSON_SCHEMA` with `resume_to` / `confidence` / `reasoning`, passes `--json-schema json.dumps(...)` to the Claude invocation, parses via `json.loads` with a graceful empty-dict fallback on `JSONDecodeError`.
- Rewrites `.claude/agents/cai-unblock.md` Output format & Fallback sections to describe the JSON schema instead of the old two-line text format.
- Fixes two `tests/test_unblock.py` tests (`test_apply_transition_receives_human_solved_in_extra_remove`, `test_resumed_clears_human_solved`) whose mocked subprocess stdouts still used the old text format — this is what the auto-improve implementer run for #695 missed and what blocked the PR.

## Test plan
- [x] `python -m unittest tests.test_unblock` — all 16 tests pass
- [x] `python -m unittest discover tests` — 190 tests, only `test_lint_passes` fails (pre-existing, unrelated, skipped in-container)

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)