### PR TITLE
auto-improve: Terminal SOLVED transitions don't close the issue (maintenance + human-resume)

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -46,7 +46,7 @@
 | `cai.py` | Main CLI dispatcher — 16+ subcommands for the self-improvement loop |
 | `cai_lib/__init__.py` | Package init for cai_lib library modules |
 | `cai_lib/actions/__init__.py` | Per-state action handlers for the FSM dispatcher |
-| `cai_lib/actions/confirm.py` | Handler for IssueState.MERGED — verifies remediation and transitions to :solved |
+| `cai_lib/actions/confirm.py` | Handler for IssueState.MERGED — verifies remediation, transitions to :solved, and closes the issue in GitHub as "completed" |
 | `cai_lib/actions/explore.py` | Handler for IssueState.NEEDS_EXPLORATION — runs cai-explore |
 | `cai_lib/actions/fix_ci.py` | Handler for PRState.CI_FAILING — runs cai-fix-ci |
 | `cai_lib/actions/implement.py` | Handler for IssueState.PLAN_APPROVED / IN_PROGRESS — runs cai-implement |

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -46,7 +46,7 @@
 | `cai.py` | Main CLI dispatcher — 16+ subcommands for the self-improvement loop |
 | `cai_lib/__init__.py` | Package init for cai_lib library modules |
 | `cai_lib/actions/__init__.py` | Per-state action handlers for the FSM dispatcher |
-| `cai_lib/actions/confirm.py` | Handler for IssueState.MERGED — verifies remediation, transitions to :solved, and closes the issue in GitHub as "completed" |
+| `cai_lib/actions/confirm.py` | Handler for IssueState.MERGED — verifies remediation and transitions to :solved |
 | `cai_lib/actions/explore.py` | Handler for IssueState.NEEDS_EXPLORATION — runs cai-explore |
 | `cai_lib/actions/fix_ci.py` | Handler for PRState.CI_FAILING — runs cai-fix-ci |
 | `cai_lib/actions/implement.py` | Handler for IssueState.PLAN_APPROVED / IN_PROGRESS — runs cai-implement |

--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ action so two concurrent `implement` runs can't pick the same issue.
                                                        (or re-queue)
 ```
 
+When an issue reaches the `solved` state (either via the confirm handler or
+human resume to SOLVED), it is automatically closed in GitHub with the
+reason "completed". This indicates that the fix was verified and the issue
+is resolved.
+
 When the implement subagent reviews an issue and determines no code change is
 needed, it closes the issue with `--reason "not planned"` (GitHub's native
 DISMISSED_RESOLVED state). The agent's reasoning is posted as a comment

--- a/cai.py
+++ b/cai.py
@@ -70,8 +70,9 @@ Subcommands:
 
     python cai.py confirm   Re-analyze the recent transcript window and
                             verify whether `:merged` issues are actually
-                            solved. Patterns that disappeared get closed
-                            with `:solved`; patterns that persist are
+                            solved. Patterns that disappeared trigger a
+                            SOLVED transition, which closes the issue as
+                            GitHub "completed"; patterns that persist are
                             re-queued to `:refined` (up to 3 attempts),
                             then escalated to `:needs-human-review`.
 

--- a/cai.py
+++ b/cai.py
@@ -260,7 +260,7 @@ from cai_lib.github import (  # noqa: E402
     _gh_json, check_gh_auth, check_claude_auth, _transcript_dir_is_empty,
     _set_labels, _set_pr_labels, _issue_has_label, _build_issue_block,
     _build_implement_user_message, _fetch_linked_issue_block,
-    close_issue_not_planned,
+    close_issue_not_planned, close_issue_completed,
 )
 from cai_lib.watchdog import _rollback_stale_in_progress  # noqa: E402
 from cai_lib.cmd_unblock import cmd_unblock  # noqa: E402
@@ -2521,6 +2521,12 @@ def _cmd_cycle_inner(args) -> int:
         )
         print(f"[cai cycle] advanced #{_ai['number']} :applied → :solved",
               flush=True)
+        close_issue_completed(
+            _ai["number"],
+            "Maintenance ops applied and verified "
+            "(auto-improve:applied → :solved). Closing as completed.",
+            log_prefix="cai cycle",
+        )
 
     # Phase 2: dispatch a single actionable issue/PR via the FSM dispatcher.
     rc = _run_step("dispatch", lambda _a: dispatch_drain(), args)

--- a/cai_lib/actions/confirm.py
+++ b/cai_lib/actions/confirm.py
@@ -28,7 +28,8 @@ from cai_lib.config import (
     TRANSCRIPT_DIR,
 )
 from cai_lib.cmd_helpers import _fetch_previous_fix_attempts
-from cai_lib.github import _gh_json, _set_labels
+from cai_lib.fsm import apply_transition
+from cai_lib.github import _gh_json, _set_labels, close_issue_completed
 from cai_lib.logging_utils import (
     _get_issue_category,
     _log_outcome,
@@ -231,13 +232,16 @@ def handle_confirm(issue: dict) -> int:
             cat = _get_issue_category(mi)
             prior_attempts = len(_fetch_previous_fix_attempts(issue_num))
             _log_outcome(issue_num, cat, "solved", prior_attempts)
-            _set_labels(issue_num, add=[LABEL_SOLVED], remove=[LABEL_MERGED], log_prefix="cai confirm")
-            _run(
-                ["gh", "issue", "close", str(issue_num),
-                 "--repo", REPO,
-                 "--comment",
-                 f"Confirmed solved: {reasoning}"],
-                capture_output=True,
+            current_labels = [lbl["name"] for lbl in mi.get("labels", [])]
+            apply_transition(
+                issue_num, "merged_to_solved",
+                current_labels=current_labels,
+                log_prefix="cai confirm",
+            )
+            close_issue_completed(
+                issue_num,
+                f"Confirmed solved: {reasoning}",
+                log_prefix="cai confirm",
             )
             print(f"[cai confirm] #{issue_num}: solved — closed", flush=True)
             # Update parent checklist if this is a sub-issue.

--- a/cai_lib/actions/confirm.py
+++ b/cai_lib/actions/confirm.py
@@ -1,10 +1,10 @@
 """MERGED -> SOLVED handler.
 
 Verifies that a merged PR actually remediated its linked issue. On a
-solved verdict we apply the ``merged_to_solved`` transition; on an
-unsolved verdict we re-queue up to three times before diverting to
-human review; inconclusive verdicts post reasoning without changing
-labels.
+solved verdict we apply the ``merged_to_solved`` transition and close
+the GitHub issue as "completed"; on an unsolved verdict we re-queue up
+to three times before diverting to human review; inconclusive verdicts
+post reasoning without changing labels.
 
 Derived from ``cmd_confirm`` in ``cai.py`` — the per-issue path is
 preserved byte-for-byte; only the outer "for each :merged issue" loop

--- a/cai_lib/cmd_unblock.py
+++ b/cai_lib/cmd_unblock.py
@@ -156,7 +156,9 @@ def _try_unblock_issue(issue: dict) -> Optional[str]:
         comment yet — the classifier has nothing to anchor on
       - ``"low_confidence"``   — agent's Confidence < HIGH, left parked
       - ``"no_target"``        — agent emitted no valid ResumeTo target
-      - ``"resumed"``          — transition fired, solved label cleared
+      - ``"resumed"``          — transition fired, solved label cleared;
+        if resumed to SOLVED, the issue is also closed in GitHub as
+        "completed"
       - ``"agent_failed"``     — claude invocation returned non-zero
     """
     issue_number = issue["number"]

--- a/cai_lib/cmd_unblock.py
+++ b/cai_lib/cmd_unblock.py
@@ -39,7 +39,7 @@ from cai_lib.fsm import (
     resume_transition_for,
     resume_pr_transition_for,
 )
-from cai_lib.github import _gh_json, _set_pr_labels
+from cai_lib.github import _gh_json, _set_pr_labels, close_issue_completed
 from cai_lib.logging_utils import log_run
 from cai_lib.subprocess_utils import _run_claude_p
 
@@ -245,6 +245,15 @@ def _try_unblock_issue(issue: dict) -> Optional[str]:
         f"→ {transition.to_state.name}",
         flush=True,
     )
+
+    if transition.name == "human_to_solved":
+        close_issue_completed(
+            issue_number,
+            f"Resumed to SOLVED per admin direction: {reasoning}. "
+            f"Closing as completed.",
+            log_prefix="cai unblock",
+        )
+
     return "resumed"
 
 

--- a/cai_lib/github.py
+++ b/cai_lib/github.py
@@ -260,3 +260,32 @@ def close_issue_not_planned(
         )
         return False
     return True
+
+
+def close_issue_completed(
+    issue_number: int,
+    comment: str,
+    log_prefix: str = "cai",
+) -> bool:
+    """Close a GitHub issue as 'completed' with an audit comment.
+
+    Use for terminal SOLVED transitions where the work was actually done
+    (maintenance drain, human-resume to SOLVED). For dismissals/no-action
+    closes, use ``close_issue_not_planned`` instead.
+    """
+    result = subprocess.run(
+        ["gh", "issue", "close", str(issue_number),
+         "--repo", REPO,
+         "--reason", "completed",
+         "--comment", comment],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"[{log_prefix}] WARNING: gh issue close failed for "
+            f"#{issue_number}: {result.stderr.strip()}",
+            file=sys.stderr, flush=True,
+        )
+        return False
+    return True

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -9,7 +9,7 @@ Agents are defined in `.claude/agents/*.md` with YAML frontmatter (`name`, `desc
 | `cai-check-workflows` | Analyze recent GitHub Actions workflow failures and emit structured findings for new, unreported failures | Read, Grep, Glob | haiku | Read-only |
 | `cai-comment-filter` | Classify PR comments as resolved or unresolved, replacing the commit-timestamp watermark in the revise handler | None | haiku | Inline-only |
 | `cai-code-audit` | Read-only source tree audit for inconsistencies, dead code, and missing cross-file references | Read, Grep, Glob | sonnet | Worktree |
-| `cai-confirm` | Verify each `auto-improve:merged` issue is actually resolved | Read, Grep, Glob | sonnet | Read-only |
+| `cai-confirm` | Verify each `auto-improve:merged` issue is actually resolved; close resolved issues in GitHub as "completed" | Read, Grep, Glob | sonnet | Read-only |
 | `cai-cost-optimize` | Weekly cost-reduction agent — analyzes spending trends, proposes one optimization | Read, Grep, Glob | sonnet | Read-only |
 | `cai-explore` | Autonomous exploration and benchmarking of `:needs-exploration` issues | Read, Grep, Glob, Bash, Agent, Write, Edit | opus | Clone |
 | `cai-fix-ci` | Diagnose and fix failing GitHub Actions checks on open PRs | Read, Edit, Write, Grep, Glob, Agent | sonnet | Worktree |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ Handler registry (issue states):
 | `REFINED` / `PLANNING` / `PLANNED` | `cai_lib/actions/plan.py` | Run plan + select, store the plan in the issue body, then apply the confidence gate: HIGH auto-promotes to `:plan-approved`; MEDIUM / LOW / missing diverts to `:human-needed` with a pending marker and a comment explaining the confidence reason (e.g., unverified assumptions, ambiguous scope). |
 | `PLAN_APPROVED` / `IN_PROGRESS` | `cai_lib/actions/implement.py` | Run `cai-implement` in a fresh worktree; commit, push, and open a PR. |
 | `PR` | `cai_lib/actions/pr_bounce.py` | Bounce to the linked PR's dispatcher. |
-| `MERGED` | `cai_lib/actions/confirm.py` | Verify the merged fix actually resolved the issue; transition to `:solved` or re-queue to `:refined`. |
+| `MERGED` | `cai_lib/actions/confirm.py` | Verify the merged fix actually resolved the issue; transition to `:solved` (and close the GitHub issue as "completed") or re-queue to `:refined`. |
 
 Handler registry (PR states):
 
@@ -47,7 +47,7 @@ Issues still enter the pipeline the same way: `cai analyze`, `cai propose`, `cai
 | `auto-improve:pr-open` | PR created, awaiting review and merge |
 | `auto-improve:revising` | Revise agent is running (lock; 1 h stale timeout) |
 | `auto-improve:merged` | PR merged, awaiting confirmation |
-| `auto-improve:solved` | Confirmed resolved |
+| `auto-improve:solved` | Confirmed resolved; GitHub issue is automatically closed as "completed" |
 | `auto-improve:needs-exploration` | Needs autonomous exploration (explore handler) |
 | `auto-improve:planned` | Plan generated and stored in issue body; confidence gate pending |
 | `auto-improve:planning` | Plan generation in progress (transient) |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,7 +64,7 @@ Three modes:
 | `cai dispatch --issue N` | Dispatch a specific issue by number. |
 | `cai dispatch --pr N` | Dispatch a specific PR by number. |
 
-Terminal or parked states (SOLVED, HUMAN_NEEDED, PR_HUMAN_NEEDED, PR MERGED) have no handler — the dispatcher returns without doing anything.
+Terminal or parked states (SOLVED, HUMAN_NEEDED, PR_HUMAN_NEEDED, PR MERGED) have no handler — the dispatcher returns without doing anything. Issues reaching the SOLVED state are automatically closed in GitHub as "completed".
 
 ## health-report
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#746

**Issue:** #746 — Terminal SOLVED transitions don't close the issue (maintenance + human-resume)

## PR Summary

### What this fixes
Two terminal SOLVED transitions in the auto-improve pipeline were performing label-only flips and leaving issues OPEN forever — the Phase 1.5 maintenance drain (`cai.py`) and the `human_to_solved` resume path (`cai_lib/cmd_unblock.py`) both called `apply_transition` but never followed up with `gh issue close`, producing issues like #732 stuck in OPEN+`:solved` state with no audit trail.

### What was changed
- **`cai_lib/github.py`**: Added `close_issue_completed` helper function (parallel to existing `close_issue_not_planned`) that calls `gh issue close --reason completed --comment <msg>`.
- **`cai.py`**: Added `close_issue_completed` to the top-of-file `cai_lib.github` import, and called it after the Phase 1.5 drain `_apply_transition` + print with the message "Maintenance ops applied and verified (auto-improve:applied → :solved). Closing as completed."
- **`cai_lib/cmd_unblock.py`**: Added `close_issue_completed` to the `cai_lib.github` import, and called it in `_try_unblock_issue` gated on `transition.name == "human_to_solved"`, using the existing `reasoning` local in the audit comment.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
