### PR TITLE
chore: promote cai-plan to opus

### DIFF
--- a/.claude/agents/cai-plan.md
+++ b/.claude/agents/cai-plan.md
@@ -2,7 +2,7 @@
 name: cai-plan
 description: Generate a detailed fix plan for an auto-improve issue. Read-only — examines the codebase and produces a structured plan that the fix agent will implement. First of two serial planners — the second receives this plan and proposes an alternative. Output is evaluated by cai-select.
 tools: Read, Grep, Glob, Agent
-model: sonnet
+model: opus
 ---
 
 # Plan Generator


### PR DESCRIPTION
## Summary
- Upgrade `cai-plan` agent from sonnet to opus for better drafting quality
- Aligns with selector agent (already on opus)
- Both serial drafter passes benefit since the same agent file is invoked twice sequentially

## Test plan
- N/A — config-only change, no code or test surface touched

🤖 Generated with Claude Code