### PR TITLE
auto-improve: Implement agent loops 8× on issue #695 without escalating to human-needed

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -90,7 +90,7 @@
 | `tests/test_dispatcher.py` | Tests for the FSM dispatcher and state→handler registries |
 | `tests/test_dup_check.py` | TODO: add description |
 | `tests/test_fsm.py` | Tests for cai_lib.fsm — states, transitions, Confidence, divert, marker, resume helpers |
-| `tests/test_implement_consecutive_failures.py` | TODO: add description |
+| `tests/test_implement_consecutive_failures.py` | Tests for consecutive test failure escalation logic — verifies the implement handler escalates to `:human-needed` after 3 consecutive regression test failures |
 | `tests/test_lint.py` | Lint check: ruff must report zero violations |
 | `tests/test_maintain.py` | TODO: add description |
 | `tests/test_merge_diff.py` | TODO: add description |

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -90,7 +90,7 @@
 | `tests/test_dispatcher.py` | Tests for the FSM dispatcher and state→handler registries |
 | `tests/test_dup_check.py` | TODO: add description |
 | `tests/test_fsm.py` | Tests for cai_lib.fsm — states, transitions, Confidence, divert, marker, resume helpers |
-| `tests/test_implement_consecutive_failures.py` | Tests for consecutive test failure escalation logic — verifies the implement handler escalates to `:human-needed` after 3 consecutive regression test failures |
+| `tests/test_implement_consecutive_failures.py` | TODO: add description |
 | `tests/test_lint.py` | Lint check: ruff must report zero violations |
 | `tests/test_maintain.py` | TODO: add description |
 | `tests/test_merge_diff.py` | TODO: add description |

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -90,6 +90,7 @@
 | `tests/test_dispatcher.py` | Tests for the FSM dispatcher and state→handler registries |
 | `tests/test_dup_check.py` | TODO: add description |
 | `tests/test_fsm.py` | Tests for cai_lib.fsm — states, transitions, Confidence, divert, marker, resume helpers |
+| `tests/test_implement_consecutive_failures.py` | TODO: add description |
 | `tests/test_lint.py` | Lint check: ruff must report zero violations |
 | `tests/test_maintain.py` | TODO: add description |
 | `tests/test_merge_diff.py` | TODO: add description |

--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ on the issue. If a human disagrees with the bot's assessment, they can
 re-open the issue (which transitions it to `:raised`) to restart the
 triage pipeline, allowing the triage agent to re-evaluate with new context.
 
+During implementation, the handler also runs regression tests (`tests/`) against
+the cloned working tree before pushing to avoid breaking changes. If regression
+tests fail, the issue is rolled back to `:plan-approved` and will be retried on
+the next cycle. However, if an issue fails regression tests **3 consecutive times**,
+it is escalated to `:human-needed` instead of being continuously retried. This
+prevents the implement loop from monopolizing cycles on unresolvable issues
+(e.g., when the plan contains a subtle bug that the agent cannot fix). A comment
+is posted to the issue explaining the escalation; you can relabel to
+`:plan-approved` to retry once the underlying problem is resolved.
+
 ### Filing issues with multi-step plans
 
 When filing an auto-improve issue, you can optionally include a

--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -33,6 +33,7 @@ from cai_lib.config import (
     LABEL_REFINED,
     LABEL_HUMAN_NEEDED,
     LABEL_RAISED,
+    LOG_PATH,
 )
 from cai_lib.github import (
     _gh_json,
@@ -64,6 +65,12 @@ from cai_lib.fsm import (
 # ---------------------------------------------------------------------------
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+# Max consecutive `tests_failed` entries for the same issue before we
+# escalate to :human-needed instead of rolling back. Prevents the
+# implement loop from monopolising cycles on an unresolvable issue
+# (see issues #748 / #695).
+_MAX_TESTS_FAILED_RETRIES = 3
 
 
 def _slugify(text: str, max_len: int = 50) -> str:
@@ -264,6 +271,35 @@ def _find_existing_branch(issue_number: int) -> str | None:
         if ref.startswith(prefix):
             return ref[len(prefix):]
     return None
+
+
+def _count_consecutive_tests_failed(issue_number: int) -> int:
+    """Count trailing consecutive ``result=tests_failed`` log entries
+    for *issue_number* in LOG_PATH.
+
+    Walks the [implement] entries for this issue in reverse and
+    counts how many trailing entries have ``result=tests_failed``.
+    Returns 0 on any I/O failure (the guard is best-effort — we
+    must never block the implement pipeline on log read errors).
+    """
+    try:
+        if not LOG_PATH.exists():
+            return 0
+        lines = LOG_PATH.read_text().splitlines()
+    except OSError:
+        return 0
+    issue_tag = f"issue={issue_number}"
+    relevant = [
+        ln for ln in lines
+        if "[implement]" in ln and issue_tag in ln and "result=" in ln
+    ]
+    count = 0
+    for ln in reversed(relevant):
+        if "result=tests_failed" in ln:
+            count += 1
+        else:
+            break
+    return count
 
 
 # ---------------------------------------------------------------------------
@@ -647,14 +683,83 @@ def handle_implement(issue: dict) -> int:
             capture_output=True,
         )
         if test_result.returncode != 0:
+            failure_output = (
+                f"{test_result.stdout or ''}\n"
+                f"{test_result.stderr or ''}"
+            ).strip()
             print(
                 f"[cai implement] regression tests failed — not opening PR\n"
-                f"{test_result.stdout}\n{test_result.stderr}",
+                f"{failure_output}",
                 file=sys.stderr,
             )
-            rollback()
+            # Log the failure first so it is visible to the consecutive-failure
+            # counter immediately below.
             log_run("implement", repo=REPO, issue=issue_number,
                     result="tests_failed", exit=1)
+
+            consecutive = _count_consecutive_tests_failed(issue_number)
+            if consecutive >= _MAX_TESTS_FAILED_RETRIES:
+                # Escalate to :human-needed instead of looping. Comment first
+                # (matches the spike branch ordering), then transition labels
+                # with the same double-retry guard so a transient GitHub
+                # failure does not leave the issue stuck without a lifecycle
+                # label.
+                truncated = failure_output[:3000]
+                if len(failure_output) > 3000:
+                    truncated += "\n\n... (truncated)"
+                comment_body = (
+                    "## Implement subagent: repeated test failures\n\n"
+                    f"Regression tests failed {consecutive} consecutive times "
+                    f"for this issue. Escalating to human review to avoid "
+                    f"monopolising the implement loop.\n\n"
+                    "### Last test output\n\n"
+                    f"```\n{truncated}\n```\n\n"
+                    "---\n"
+                    "_Set by `cai implement` after "
+                    f"{_MAX_TESTS_FAILED_RETRIES} consecutive `tests_failed` "
+                    "log entries. Re-label to "
+                    f"`{LABEL_PLAN_APPROVED}` to retry once the underlying "
+                    "problem is resolved._"
+                )
+                print(
+                    f"[cai implement] {consecutive} consecutive tests_failed "
+                    f"for #{issue_number}; marking auto-improve:human-needed",
+                    flush=True,
+                )
+                _run(
+                    ["gh", "issue", "comment", str(issue_number),
+                     "--repo", REPO,
+                     "--body", comment_body],
+                    capture_output=True,
+                )
+                terminal_remove = [LABEL_IN_PROGRESS]
+                if not _set_labels(
+                    issue_number,
+                    add=[LABEL_HUMAN_NEEDED],
+                    remove=terminal_remove,
+                ):
+                    if not _set_labels(
+                        issue_number,
+                        add=[LABEL_HUMAN_NEEDED],
+                        remove=terminal_remove,
+                    ):
+                        print(
+                            f"[cai implement] WARNING: label transition to "
+                            f"auto-improve:human-needed failed twice for "
+                            f"#{issue_number} — issue may be stuck without "
+                            "a lifecycle label",
+                            file=sys.stderr, flush=True,
+                        )
+                        rollback()
+                        log_run("implement", repo=REPO, issue=issue_number,
+                                result="label_transition_failed", exit=1)
+                        return 1
+                locked = False
+                log_run("implement", repo=REPO, issue=issue_number,
+                        result="tests_failed_escalated", exit=0)
+                return 0
+
+            rollback()
             return 1
 
         # 8. Push.

--- a/tests/test_implement_consecutive_failures.py
+++ b/tests/test_implement_consecutive_failures.py
@@ -1,0 +1,73 @@
+"""Tests for _count_consecutive_tests_failed."""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.actions.implement import _count_consecutive_tests_failed
+
+
+class TestCountConsecutiveTestsFailed(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".log", delete=False,
+        )
+        self.tmp.close()
+        self.log_path = Path(self.tmp.name)
+
+    def tearDown(self):
+        if self.log_path.exists():
+            self.log_path.unlink()
+
+    def _write(self, lines):
+        self.log_path.write_text("\n".join(lines) + "\n")
+
+    def test_empty_log_returns_zero(self):
+        missing = Path("/nonexistent/cai-test-log.log")
+        with patch("cai_lib.actions.implement.LOG_PATH", missing):
+            self.assertEqual(_count_consecutive_tests_failed(42), 0)
+
+    def test_all_tests_failed_returns_count(self):
+        self._write([
+            "2026-04-16T10:00:00Z [implement] repo=foo issue=42 result=tests_failed exit=1",
+            "2026-04-16T10:05:00Z [implement] repo=foo issue=42 result=tests_failed exit=1",
+            "2026-04-16T10:10:00Z [implement] repo=foo issue=42 result=tests_failed exit=1",
+        ])
+        with patch("cai_lib.actions.implement.LOG_PATH", self.log_path):
+            self.assertEqual(_count_consecutive_tests_failed(42), 3)
+
+    def test_stops_at_non_tests_failed(self):
+        self._write([
+            "2026-04-16T10:00:00Z [implement] repo=foo issue=42 result=subagent_failed exit=1",
+            "2026-04-16T10:05:00Z [implement] repo=foo issue=42 result=tests_failed exit=1",
+            "2026-04-16T10:10:00Z [implement] repo=foo issue=42 result=tests_failed exit=1",
+        ])
+        with patch("cai_lib.actions.implement.LOG_PATH", self.log_path):
+            self.assertEqual(_count_consecutive_tests_failed(42), 2)
+
+    def test_other_issue_not_counted(self):
+        self._write([
+            "2026-04-16T10:00:00Z [implement] repo=foo issue=42 result=tests_failed exit=1",
+            "2026-04-16T10:05:00Z [implement] repo=foo issue=99 result=tests_failed exit=1",
+            "2026-04-16T10:10:00Z [implement] repo=foo issue=42 result=tests_failed exit=1",
+        ])
+        with patch("cai_lib.actions.implement.LOG_PATH", self.log_path):
+            self.assertEqual(_count_consecutive_tests_failed(42), 2)
+
+    def test_non_consecutive_resets_count(self):
+        self._write([
+            "2026-04-16T10:00:00Z [implement] repo=foo issue=42 result=tests_failed exit=1",
+            "2026-04-16T10:05:00Z [implement] repo=foo issue=42 result=tests_passed exit=0",
+            "2026-04-16T10:10:00Z [implement] repo=foo issue=42 result=tests_failed exit=1",
+            "2026-04-16T10:15:00Z [implement] repo=foo issue=42 result=tests_failed exit=1",
+        ])
+        with patch("cai_lib.actions.implement.LOG_PATH", self.log_path):
+            self.assertEqual(_count_consecutive_tests_failed(42), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#748

**Issue:** #748 — Implement agent loops 8× on issue #695 without escalating to human-needed

## PR Summary

### What this fixes
The implement handler looped indefinitely when regression tests kept failing — 8 consecutive failures were observed for issue #695 over 13 hours with no automatic escalation. The fix adds a max-retry guard: after 3 consecutive `tests_failed` log entries for the same issue, the handler escalates to `:human-needed` instead of rolling back to `:plan-approved`.

### What was changed
- **`cai_lib/actions/implement.py`**: Added `LOG_PATH` to the `cai_lib.config` import; added `_MAX_TESTS_FAILED_RETRIES = 3` constant; added `_count_consecutive_tests_failed(issue_number)` helper that reads the log and counts trailing consecutive `tests_failed` entries for an issue; replaced the `tests_failed` branch (lines 649–658) with an escalation-aware variant that (a) logs the failure before querying the counter, (b) posts a comment and transitions to `:human-needed` with the double-retry `_set_labels` pattern when the threshold is reached, and (c) falls back to the original `rollback()`/return-1 behaviour otherwise.
- **`tests/test_implement_consecutive_failures.py`** (new): 5 unit tests for `_count_consecutive_tests_failed` covering: missing log file, all-tests-failed, stops at non-tests-failed entry, other-issue entries ignored, and non-consecutive entries reset the count.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
