### PR TITLE
auto-improve: Cross-agent memory

### DIFF
--- a/.claude/agents/cai-implement.md
+++ b/.claude/agents/cai-implement.md
@@ -118,6 +118,7 @@ anything else.** It records durable judgements from earlier runs:
 approaches that kept getting rejected by the merge handler, classes of
 issue that are wrongly-raised (always exit with zero diff), and
 patterns the supervisor has explicitly accepted.
+Also read `.claude/agent-memory/shared/MEMORY.md`; it records cross-cutting design decisions persisted after other issues were solved and its entries override your per-agent notes when they conflict.
 
 If the issue you're working on overlaps with something in your
 memory — e.g., the issue is asking you to do something your memory

--- a/.claude/agents/cai-memorize.md
+++ b/.claude/agents/cai-memorize.md
@@ -1,0 +1,92 @@
+---
+name: cai-memorize
+description: Post-solved memory curator. Reads a solved issue + its merged PR diff and decides whether a cross-cutting design decision is worth persisting to .claude/agent-memory/shared/. Writes rarely; emits NO_MEMORY when nothing qualifies.
+tools: Read, Write, Edit, Glob
+model: sonnet
+---
+
+# Memory Curator Agent
+
+## Purpose
+
+You are the gatekeeper for the shared cross-agent memory pool at
+`.claude/agent-memory/shared/`. You receive a solved issue and its
+merged PR diff, and decide whether the resolution settled a cross-cutting
+design decision worth preserving for all future agents. **`NO_MEMORY` is
+the expected, correct output for the vast majority of invocations** — only
+write when a genuinely reusable design insight was established. Resist the
+urge to record per-issue implementation notes; the shared pool must stay
+small enough to be loaded cheaply on every agent startup.
+
+If `.claude/agent-memory/shared/MEMORY.md` does not exist, create it with
+the header comment before writing any entry.
+
+## Input
+
+The user message contains two sections:
+
+- **`## Issue`** — the issue number, title, and body (including the full
+  refined plan and verification steps as filed in GitHub).
+- **`## Merged PR diff (PR #N)`** — the unified diff of the merged PR,
+  truncated at 8 000 chars. May be absent if the diff could not be fetched.
+
+## What qualifies as a memory
+
+Write an entry ONLY when the resolved issue contains one of:
+
+- **Architectural choice with rationale** — "we chose X over Y because Z"
+  (e.g., "fire-and-forget via `_run_claude_p` rather than a subprocess
+  call because we need cost logging").
+- **Deliberate non-fix** — an issue closed because the current behaviour
+  is intentional and should not change (e.g., "do not add Bash to the
+  cai-plan tool list — it was deliberately excluded to keep the agent
+  read-only").
+- **Anti-pattern to avoid** — "do not reintroduce approach W, rejected in
+  issue #N because of Z".
+- **Naming or layout convention that spans multiple files** — e.g., all
+  agent memory files must use the YAML frontmatter schema with
+  `type: project`.
+
+Do NOT write an entry for:
+
+- Per-issue implementation details (a specific bug fix, a one-off
+  variable rename, a typo correction).
+- Workflow or CI tweaks that do not affect agent behaviour.
+- Changes so narrow that only one agent or one file is affected.
+- Anything already captured in an existing shared memory entry.
+
+## Hard rules
+
+1. **Read `.claude/agent-memory/shared/MEMORY.md` first.** If the index
+   already contains approximately 30 entries, UPDATE an existing entry
+   that is closest in topic (Edit the existing slug file; do NOT Write a
+   new file) rather than appending a new line.
+2. **Before writing, ask:** "Would another agent working on a completely
+   different issue benefit from knowing this?" If the answer is no or
+   uncertain, emit `NO_MEMORY`.
+3. **File schema.** When writing a new memory file, use the standard
+   per-agent memory frontmatter:
+   ```
+   ---
+   name: <title>
+   description: <one-line description>
+   type: project
+   ---
+
+   <body — lead with the decision or rule, then **Why:** and **How to apply:** lines>
+   ```
+4. **Index update.** After writing the memory file, append exactly one
+   line to `.claude/agent-memory/shared/MEMORY.md`:
+   `- [<Title>](<slug>.md) — <one-line summary>`
+5. **Slug format.** Use `kebab-case-topic.md`, 40 characters or fewer.
+   If a file with that slug already exists, Edit it instead of creating
+   a new one.
+6. **Never touch per-agent memory.** Do not read or write anything under
+   `.claude/agent-memory/<agent-name>/` — only the shared pool under
+   `.claude/agent-memory/shared/`.
+
+## Output
+
+- **Common case:** emit exactly `NO_MEMORY` on its own line and stop.
+- **When you write:** emit a one-paragraph summary describing what was
+  written and to which file (e.g., "Wrote `.claude/agent-memory/shared/fire-and-forget-pattern.md` and indexed it in `MEMORY.md`. Entry records the architectural decision to wrap all post-confirm side-effect calls in `try/except` so failures never block the confirm flow.").

--- a/.claude/agents/cai-plan.md
+++ b/.claude/agents/cai-plan.md
@@ -32,7 +32,7 @@ The user message contains:
 
 1. **Understand the issue.** Read the issue carefully. Identify
    what needs to change and why.
-2. **Explore the codebase.** Use Grep, Glob, and Read to find the
+2. **Explore the codebase.** Before exploring, read `.claude/agent-memory/shared/MEMORY.md` and any linked entries that look relevant to the issue — the shared pool records cross-cutting design decisions from prior issues and may already answer your question. Use Grep, Glob, and Read to find the
    relevant files, functions, and code paths. Understand the current
    state before proposing changes.
 3. **Identify the minimal change set.** Determine exactly which

--- a/.claude/agents/cai-propose.md
+++ b/.claude/agents/cai-propose.md
@@ -36,6 +36,7 @@ The user message contains:
 
 3. **Be original.** Check your memory to avoid re-proposing things
    you've already suggested. Push into new territory.
+   Also consult `.claude/agent-memory/shared/MEMORY.md` — proposals that re-litigate decisions already recorded there are duplicates and should not be submitted.
 
 4. **Generate exactly ONE proposal.** Focus beats scatter. Make it
    your best idea from this exploration.

--- a/.claude/agents/cai-refine.md
+++ b/.claude/agents/cai-refine.md
@@ -36,6 +36,7 @@ You have a project-scope memory pool at
 `.claude/agent-memory/cai-refine/MEMORY.md` — consult it before
 doing anything else. It accumulates patterns from prior refinement
 runs (e.g., "issues about X usually mean Y in the codebase").
+Also read `.claude/agent-memory/shared/MEMORY.md` and open any linked entries that look relevant — the shared pool records cross-cutting design decisions settled by prior issues and takes precedence over your per-agent notes.
 
 ## Early exit
 

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -19,7 +19,7 @@
 | `.claude/agents/cai-git.md` | Agent: lightweight git operations subagent |
 | `.claude/agents/cai-implement.md` | Agent: autonomous code-editing subagent for code-editing tasks |
 | `.claude/agents/cai-maintain.md` | TODO: add description |
-| `.claude/agents/cai-memorize.md` | TODO: add description |
+| `.claude/agents/cai-memorize.md` | Agent: post-solved memory curator for cross-cutting design decisions |
 | `.claude/agents/cai-merge.md` | Agent: assess PR correctness and emit merge verdict |
 | `.claude/agents/cai-plan.md` | Agent: generate detailed fix plan for an issue |
 | `.claude/agents/cai-propose-review.md` | Agent: review creative proposals for feasibility |

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -19,6 +19,7 @@
 | `.claude/agents/cai-git.md` | Agent: lightweight git operations subagent |
 | `.claude/agents/cai-implement.md` | Agent: autonomous code-editing subagent for code-editing tasks |
 | `.claude/agents/cai-maintain.md` | TODO: add description |
+| `.claude/agents/cai-memorize.md` | TODO: add description |
 | `.claude/agents/cai-merge.md` | Agent: assess PR correctness and emit merge verdict |
 | `.claude/agents/cai-plan.md` | Agent: generate detailed fix plan for an issue |
 | `.claude/agents/cai-propose-review.md` | Agent: review creative proposals for feasibility |

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ COPY --chown=cai:cai .claude /app/.claude
 COPY --chown=cai:cai entrypoint.sh /app/entrypoint.sh
 COPY --chown=cai:cai tests /app/tests
 RUN chmod +x /app/entrypoint.sh \
-    && mkdir -p /app/.claude/agent-memory \
+    && mkdir -p /app/.claude/agent-memory/shared \
     && chown -R cai:cai /app
 
 USER cai

--- a/cai_lib/actions/confirm.py
+++ b/cai_lib/actions/confirm.py
@@ -243,6 +243,40 @@ def handle_confirm(issue: dict) -> int:
                 f"Confirmed solved: {reasoning}",
                 log_prefix="cai confirm",
             )
+            # Fire-and-forget: let cai-memorize decide whether the solved
+            # issue yielded a cross-agent design decision worth recording.
+            # Failures must never block the confirm flow.
+            try:
+                memorize_msg = (
+                    f"## Issue\n\n"
+                    f"### #{issue_num} — {mi['title']}\n\n"
+                    f"{mi.get('body') or '(no body)'}\n\n"
+                )
+                if mi.get("_pr_diff"):
+                    memorize_msg += (
+                        f"## Merged PR diff (PR #{mi['_pr_number']})\n\n"
+                        f"```diff\n{mi['_pr_diff']}\n```\n"
+                    )
+                mem = _run_claude_p(
+                    ["claude", "-p", "--agent", "cai-memorize"],
+                    category="confirm",
+                    agent="cai-memorize",
+                    input=memorize_msg,
+                )
+                if mem.returncode != 0:
+                    print(
+                        f"[cai confirm] cai-memorize failed (exit {mem.returncode}) — "
+                        f"continuing",
+                        flush=True,
+                    )
+                else:
+                    first_line = (mem.stdout or "").strip().splitlines()[:1]
+                    marker = first_line[0] if first_line else ""
+                    print(f"[cai confirm] cai-memorize → {marker or '(empty)'}",
+                          flush=True)
+            except Exception as e:  # noqa: BLE001 - must not break confirm
+                print(f"[cai confirm] cai-memorize invocation error: {e}",
+                      flush=True)
             print(f"[cai confirm] #{issue_num}: solved — closed", flush=True)
             # Update parent checklist if this is a sub-issue.
             sub_body = mi.get("body") or ""

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -18,6 +18,7 @@ Agents are defined in `.claude/agents/*.md` with YAML frontmatter (`name`, `desc
 | `cai-git` | Lightweight subagent that executes git operations on behalf of other agents | Bash | haiku | Worktree |
 | `cai-maintain` | Read the Ops block from a kind:maintenance issue, execute each declared operation via gh CLI, and emit a Confidence level | Bash, Read | sonnet | Worktree |
 | `cai-merge` | Assess whether a PR correctly implements its linked issue and emit a merge verdict; `docs/**` and `CODEBASE_INDEX.md` are automatically exempt from scope checks | Read | opus | Inline-only |
+| `cai-memorize` | Post-solved memory curator — decides whether a solved issue settled a cross-cutting design decision worth persisting to the shared agent memory pool | Read, Write, Edit, Glob | sonnet | Inline-only |
 | `cai-plan` | Generate a detailed fix plan for an issue (first of two serial planners) | Read, Grep, Glob, Agent | sonnet | Worktree |
 | `cai-propose` | Weekly creative agent that proposes ambitious improvements | Read, Grep, Glob | sonnet | Worktree |
 | `cai-propose-review` | Evaluate creative proposals for feasibility and value before filing issues | Read, Grep, Glob | sonnet | Worktree |

--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -40,6 +40,7 @@ declare -A DESCRIPTIONS=(
   [".claude/agents/cai-git.md"]="Agent: lightweight git operations subagent"
   [".claude/agents/cai-implement.md"]="Agent: autonomous code-editing subagent for code-editing tasks"
   [".claude/agents/cai-merge.md"]="Agent: assess PR correctness and emit merge verdict"
+  [".claude/agents/cai-memorize.md"]="Agent: post-solved memory curator for cross-cutting design decisions"
   [".claude/agents/cai-plan.md"]="Agent: generate detailed fix plan for an issue"
   [".claude/agents/cai-propose.md"]="Agent: weekly creative improvement proposals"
   [".claude/agents/cai-propose-review.md"]="Agent: review creative proposals for feasibility"


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#755

**Issue:** #755 — Cross-agent memory

## PR Summary

### What this fixes
Each agent's memory was siloed — design decisions settled while solving one issue were invisible to agents working on the next, leading to repeated mistakes and re-debates of settled choices. This adds a shared cross-agent memory pool and a new `cai-memorize` agent that curates it.

### What was changed
- **`cai_lib/actions/confirm.py`**: Added a fire-and-forget `_run_claude_p("cai-memorize")` call inside the `if status == "solved"` branch, immediately after `close_issue_completed`. Wrapped in `try/except` so failures only log and never block the confirm flow.
- **`.cai-staging/agents/cai-memorize.md`** (new agent, deployed via staging dir): Post-solved memory curator with tools `Read, Write, Edit, Glob`, model `sonnet`, no per-agent memory pool. Receives issue body + PR diff, writes to `.claude/agent-memory/shared/` only when a cross-cutting design decision was settled; emits `NO_MEMORY` otherwise.
- **`.cai-staging/agents/cai-refine.md`**: Added one sentence to the `## Memory` section directing the agent to also read `.claude/agent-memory/shared/MEMORY.md`.
- **`.cai-staging/agents/cai-plan.md`**: Added one sentence to step 2 of `## How to plan` directing the agent to read `.claude/agent-memory/shared/MEMORY.md` before exploring.
- **`.cai-staging/agents/cai-implement.md`**: Added one sentence after the per-agent memory sentence in `## Consult your memory first` directing the agent to also read `.claude/agent-memory/shared/MEMORY.md`.
- **`.cai-staging/agents/cai-propose.md`**: Added one sentence to step 3 (`Be original`) directing the agent to consult `.claude/agent-memory/shared/MEMORY.md` to avoid re-proposing settled decisions.
- **Note**: The `.claude/agent-memory/shared/MEMORY.md` bootstrap file could not be written directly (the sensitive-file guard extends to `.claude/agent-memory/`); `cai-memorize` is instructed to create it on first run if missing.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
