### PR TITLE
fix: hoist _work_directory_block import to module level

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -283,6 +283,7 @@ from cai_lib.github import (  # noqa: E402
     close_issue_not_planned, close_issue_completed,
 )
 from cai_lib.watchdog import _rollback_stale_in_progress  # noqa: E402
+from cai_lib.cmd_helpers import _work_directory_block  # noqa: E402
 from cai_lib.cmd_unblock import cmd_unblock  # noqa: E402
 from cai_lib.actions.confirm import (  # noqa: E402
     _parse_verdicts,
@@ -2485,7 +2486,6 @@ def cmd_maintain(args) -> int:
 
     APPLYING itself is the lock (no separate in-progress label).
     """
-    from cai_lib.cmd_helpers import _work_directory_block
     from cai_lib.fsm import (
         apply_transition_with_confidence,
         parse_confidence,


### PR DESCRIPTION
## Summary
- `cai.py` calls `_work_directory_block` at module scope in 7 places (cmd_propose, cmd_agent_audit, cmd_update_check, cmd_external_scout, the cai-git dispatch, and a couple of review sub-messages), but the import was only inside `cmd_maintain`.
- Every other caller raised `NameError: name '_work_directory_block' is not defined` at runtime — reproduced with `docker compose exec cai python /app/cai.py agent-audit`.
- Hoist the import up next to the other `cai_lib.*` imports in `cai.py` and drop the now-redundant local import inside `cmd_maintain`.

## Test plan
- [x] `python -c "import cai"` succeeds (confirms no NameError at import / binding time).
- [ ] Rebuild the image and run `docker compose exec cai python /app/cai.py agent-audit` end-to-end.
- [ ] Spot-check other affected paths (`propose`, `update-check`, `external-scout`) in a dev container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)