### PR TITLE
auto-improve: cmd_maintain divert comment drops the agent's Confidence reason

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -2489,6 +2489,7 @@ def cmd_maintain(args) -> int:
     from cai_lib.fsm import (
         apply_transition_with_confidence,
         parse_confidence,
+        parse_confidence_reason,
     )
 
     print("[cai maintain] starting maintenance apply step", flush=True)
@@ -2589,6 +2590,7 @@ def cmd_maintain(args) -> int:
 
     # 4. Parse confidence and apply FSM transition.
     confidence = parse_confidence(result.stdout)
+    confidence_reason = parse_confidence_reason(result.stdout)
     issue_labels = [lbl["name"] for lbl in issue.get("labels", [])]
     ok, diverted = apply_transition_with_confidence(
         issue_number,
@@ -2596,6 +2598,7 @@ def cmd_maintain(args) -> int:
         confidence,
         current_labels=issue_labels,
         log_prefix="cai maintain",
+        reason_extra=confidence_reason or "",
     )
 
     dur = f"{int(time.monotonic() - t0)}s"


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#768

**Issue:** #768 — cmd_maintain divert comment drops the agent's Confidence reason

## PR Summary

### What this fixes
`cmd_maintain` in `cai.py` was discarding the agent's `Confidence reason:` explanation when diverting issues to `auto-improve:human-needed`, leaving admins with no signal as to why maintain refused. This matched the bug observed on #765.

### What was changed
- **`cai.py`**: Added `parse_confidence_reason` to the local FSM import in `cmd_maintain` (line ~2492). After parsing confidence, also parse the reason with `confidence_reason = parse_confidence_reason(result.stdout)`. Passed `reason_extra=confidence_reason or ""` into the existing `apply_transition_with_confidence(...)` call, mirroring the pattern already used in `cai_lib/actions/plan.py`.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
