### PR TITLE
auto-improve: cai-maintain agent must emit machine-parseable 'Confidence reason:' line

### DIFF
--- a/.claude/agents/cai-maintain.md
+++ b/.claude/agents/cai-maintain.md
@@ -32,6 +32,7 @@ You are the `cai-maintain` agent. You receive a `kind:maintenance` issue body in
 - Use `gh issue close --reason not-planned` for bulk-close operations.
 - For workflow edits, use the `Read` tool to read the YAML file, then `Bash` with `sed` or a Python one-liner to edit it in the work directory.
 - After all operations, write a brief summary of what succeeded and what failed.
+- When `Confidence` is `MEDIUM` or `LOW`, you MUST emit a `Confidence reason:` line on its own line immediately after the `Confidence:` line. One sentence is enough; no markdown headings, block quotes, or multi-line prose — the line must match `^Confidence reason: <text>$` so `parse_confidence_reason` can extract it.
 
 ## Output format
 
@@ -46,6 +47,7 @@ You are the `cai-maintain` agent. You receive a `kind:maintenance` issue body in
 <1-3 sentences describing the overall outcome>
 
 Confidence: HIGH|MEDIUM|LOW
+Confidence reason: <one-line explanation, required when Confidence is MEDIUM or LOW>
 ```
 
-If the `Ops:` block is missing or empty, emit `Confidence: LOW` with explanation: "No Ops block found in issue body."
+If the `Ops:` block is missing or empty, emit `Confidence: LOW` followed by `Confidence reason: No Ops block found in issue body.`

--- a/tests/test_maintain.py
+++ b/tests/test_maintain.py
@@ -40,10 +40,14 @@ def _make_clone_result(rc=0):
     return r
 
 
-def _make_agent_result(confidence="HIGH", rc=0):
+def _make_agent_result(confidence="HIGH", rc=0, reason=None):
     r = MagicMock()
+    reason_line = ""
+    if confidence in ("MEDIUM", "LOW"):
+        default_reason = "Some operations could not be verified." if reason is None else reason
+        reason_line = f"Confidence reason: {default_reason}\n"
     r.returncode = rc
-    r.stdout = f"## Maintenance Summary\n\nConfidence: {confidence}\n"
+    r.stdout = f"## Maintenance Summary\n\nConfidence: {confidence}\n{reason_line}"
     r.stderr = ""
     return r
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#769

**Issue:** #769 — cai-maintain agent must emit machine-parseable 'Confidence reason:' line

## PR Summary

### What this fixes
The `cai-maintain` agent was not emitting a machine-parseable `Confidence reason:` line, so `parse_confidence_reason` (which expects `^Confidence reason:\s*(.+)$`) could never extract a reason — even when the agent improvised a `> **Reason:**` block quote as seen in #765.

### What was changed
- `.claude/agents/cai-maintain.md` (via `.cai-staging/agents/`):
  - Added `Confidence reason: <one-line explanation, required when Confidence is MEDIUM or LOW>` as a second line in the output format template immediately after `Confidence: HIGH|MEDIUM|LOW`
  - Added a new "Rules" bullet mandating the `Confidence reason:` line for MEDIUM/LOW confidence, explicitly banning markdown headings, block quotes, and multi-line prose
  - Updated the trailing "missing Ops block" sentence to use the line form (`emit 'Confidence: LOW' followed by 'Confidence reason: No Ops block found in issue body.'`) instead of prose

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
