### PR TITLE
auto-improve: [#763 Step 1/5] Fail loud in `publish.py` when non-empty input produces zero findings

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -11,6 +11,10 @@ embedded in the issue body (`<!-- fingerprint: <key> -->`).
 Phase C.2 scope — this is the Lane 1 publish step. Lane 2 (workspace
 targets) is still deferred.
 
+Non-empty stdin that produces zero parsed ``### Finding:`` blocks exits 1
+with a stderr diagnostic (including the first ~500 chars of input); empty
+stdin still exits 0.
+
 No third-party Python dependencies — only stdlib plus the `gh` CLI.
 
 Usage::
@@ -522,8 +526,14 @@ def main() -> int:
 
     findings = parse_findings(text, valid_categories=valid_cats)
     if not findings:
-        print("[publish] no findings parsed; nothing to do")
-        return 0
+        snippet = text[:500].replace("\n", "↵")
+        print(
+            f"[publish] ERROR: non-empty input produced 0 findings — "
+            f"agent may have used prose instead of ### Finding: blocks.\n"
+            f"Input snippet: {snippet!r}",
+            file=sys.stderr,
+        )
+        return 1
 
     print(f"[publish] parsed {len(findings)} finding(s)")
     ensure_labels(namespace)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#771

**Issue:** #771 — [#763 Step 1/5] Fail loud in `publish.py` when non-empty input produces zero findings

## PR Summary

### What this fixes
`publish.py` was silently exiting 0 when stdin contained content but `parse_findings` returned no `### Finding:` blocks, making a broken agent run (that produced prose instead of structured findings) indistinguishable from a clean run.

### What was changed
- **`publish.py` lines 524–531**: Replaced the silent `print("[publish] no findings parsed; nothing to do") / return 0` with a loud failure path that prints an error to stderr (including the first ~500 chars of input with newlines replaced by `↵`) and returns exit code 1.
- **`publish.py` docstring (lines 14–16)**: Added a sentence documenting the new behaviour — non-empty stdin with zero parsed findings exits 1; empty stdin still exits 0.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
