### PR TITLE
auto-improve: [#763 Step 3/5] Migrate `cai-agent-audit` to file-based JSON output

### DIFF
--- a/.claude/agents/cai-agent-audit.md
+++ b/.claude/agents/cai-agent-audit.md
@@ -1,7 +1,7 @@
 ---
 name: cai-agent-audit
-description: Weekly Opus audit of `.claude/agents/*.md` for Claude Code best-practice violations, unused agents, and near-duplicate purposes. Read-only; emits `### Finding:` blocks plus a memory update.
-tools: Read, Grep, Glob
+description: Weekly Opus audit of `.claude/agents/*.md` for Claude Code best-practice violations, unused agents, and near-duplicate purposes. Read-only; writes findings to findings.json plus a memory update.
+tools: Read, Grep, Glob, Write
 model: opus
 memory: project
 ---
@@ -18,7 +18,7 @@ verifiable findings in three categories:
 | Agent exists under `.claude/agents/` but is never invoked via `claude -p --agent <name>` in `cai.py` or under `cai_lib/**/*.py`, and is not referenced as `subagent_type: <name>` from another agent that IS invoked | `unused_agent` |
 | Two or more agents have so-similar `description` / purpose that they should be merged to reduce maintenance surface | `redundant_agents` |
 
-You have Read, Grep, and Glob — no write tools.
+You have Read, Grep, Glob, and Write. Use Write only to emit findings.json; do not modify any other files.
 
 ## What you receive
 
@@ -48,24 +48,28 @@ for patterns the supervisor has accepted.
 5. Pairwise compare `description` fields. Flag pairs whose
    purposes overlap substantially with `redundant_agents`.
 
-## Output format
+## Output
 
-For each finding:
+Write all findings to `<work_dir>/findings.json` using this schema:
 
+```json
+{
+  "findings": [
+    {
+      "title": "<short imperative string>",
+      "category": "best_practice_violation|unused_agent|redundant_agents",
+      "key": "<stable-slug-for-deduplication>",
+      "confidence": "low|medium|high",
+      "evidence": "<markdown string>",
+      "remediation": "<markdown string>"
+    }
+  ]
+}
 ```
-### Finding: <short imperative title>
 
-- **Category:** `best_practice_violation` | `unused_agent` | `redundant_agents`
-- **Key:** <stable-slug-for-deduplication>
-- **Confidence:** low | medium | high
-- **Evidence:**
-  - <file:line — what you observed>
-- **Remediation:** <what should be done>
-```
+If there are no findings, write `{"findings": []}`. Use stdout freely for narrative analysis and the Memory Update block below.
 
-If no problems: output exactly `No findings.`
-
-After findings, always output:
+After findings, always output on stdout:
 
 ```
 ## Memory Update
@@ -85,4 +89,4 @@ After findings, always output:
 - Do not propose deletion of an agent whose absence from cai.py grep
   you have not actually verified — false positives are very costly here.
 - Do not raise style/formatting issues (indentation, heading case).
-- Do not modify any files.
+- Do not modify any files other than writing findings.json.

--- a/cai.py
+++ b/cai.py
@@ -2215,11 +2215,13 @@ def cmd_agent_audit(args) -> int:
 
     user_message = _work_directory_block(work_dir) + "\n" + memory_section
 
+    findings_file = work_dir / "findings.json"
+
     print(f"[cai agent-audit] running agent for {work_dir}", flush=True)
     agent = _run_claude_p(
         ["claude", "-p", "--agent", "cai-agent-audit",
          "--permission-mode", "acceptEdits",
-         "--allowedTools", "Read,Grep,Glob",
+         "--allowedTools", "Read,Grep,Glob,Write",
          "--add-dir", str(work_dir)],
         category="agent-audit",
         agent="cai-agent-audit",
@@ -2242,10 +2244,22 @@ def cmd_agent_audit(args) -> int:
 
     _save_agent_audit_memory(agent.stdout)
 
+    if not findings_file.exists():
+        print(
+            f"[cai agent-audit] agent did not write {findings_file} — "
+            f"expected findings.json output",
+            file=sys.stderr, flush=True,
+        )
+        shutil.rmtree(work_dir, ignore_errors=True)
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run("agent-audit", repo=REPO, result="no_findings_file",
+                duration=dur, exit=1)
+        return 1
+
     print("[cai agent-audit] publishing findings", flush=True)
     published = _run(
-        ["python", str(PUBLISH_SCRIPT), "--namespace", "agent-audit"],
-        input=agent.stdout,
+        ["python", str(PUBLISH_SCRIPT), "--namespace", "agent-audit",
+         "--findings-file", str(findings_file)],
     )
 
     shutil.rmtree(work_dir, ignore_errors=True)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -50,7 +50,7 @@ State transitions between these rows are rendered in [the lifecycle FSM diagram]
 | Agent | Description | Tools | Model | Lifecycle trigger | Mode |
 |---|---|---|---|---|---|
 | `cai-analyze` | Analyze parsed transcript signals and raise auto-improve findings | Read, Grep, Glob, Skill | sonnet | Scheduled (cron) | Read-only |
-| `cai-agent-audit` | Weekly audit of `.claude/agents/*.md` for Claude Code best-practice violations, unused agents, and near-duplicate purposes | Read, Grep, Glob | opus | Scheduled (weekly, cron) | Read-only |
+| `cai-agent-audit` | Weekly audit of `.claude/agents/*.md` for Claude Code best-practice violations, unused agents, and near-duplicate purposes; writes findings to findings.json | Read, Grep, Glob, Write | opus | Scheduled (weekly, cron) | Read-only |
 | `cai-audit` | Audit issue queue and PRs for lifecycle state-machine inconsistencies | Read, Grep, Glob | sonnet | Scheduled (cron) | Read-only |
 | `cai-check-workflows` | Analyze recent GitHub Actions workflow failures and emit structured findings for new, unreported failures | Read, Grep, Glob | haiku | Scheduled (cron) | Read-only |
 | `cai-comment-filter` | Classify PR comments as resolved or unresolved, replacing the commit-timestamp watermark in the revise handler | None | haiku | Inline, invoked by handle_revise (REVISION_PENDING) | Inline-only |


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#773

**Issue:** #773 — [#763 Step 3/5] Migrate `cai-agent-audit` to file-based JSON output

## PR Summary

### What this fixes
`cai-agent-audit` was emitting findings via `### Finding:` markdown blocks on stdout, which caused `publish.py` to silently drop them when the output didn't match the expected contract. This migrates the agent to write a structured `findings.json` file instead.

### What was changed
- **`.claude/agents/cai-agent-audit.md`** (via staging): updated `tools:` frontmatter to add `Write`, updated `description:` to reflect file-based output, replaced the `## Output format` section (with `### Finding:` template) with a new `## Output` section specifying the `findings.json` JSON schema, updated the body paragraph to mention `Write`, and updated the last guardrail bullet to permit writing `findings.json`.
- **`cai.py` `cmd_agent_audit`**: added `findings_file = work_dir / "findings.json"` before the agent call; changed `--allowedTools` from `"Read,Grep,Glob"` to `"Read,Grep,Glob,Write"`; added a guard block after the agent run that exits 1 if `findings_file` does not exist; replaced the `_run(PUBLISH_SCRIPT, input=agent.stdout)` call with `_run(PUBLISH_SCRIPT, "--findings-file", str(findings_file))` (no `input=` pipe).

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
