### PR TITLE
auto-improve: [#762 Step 1/2] Make `REPO` overridable via `CAI_REPO` environment variable

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -2547,7 +2547,7 @@ def _run_step(name: str, handler, args) -> int:
         return 1
 
 
-_CYCLE_LOCK_PATH = "/tmp/cai-cycle.lock"
+_CYCLE_LOCK_PATH = f"/tmp/cai-cycle-{REPO.replace('/', '-')}.lock"
 
 
 def cmd_cycle(args) -> int:
@@ -2555,7 +2555,7 @@ def cmd_cycle(args) -> int:
 
     Delegates to :func:`_cmd_cycle_inner`, which reconciles labels,
     runs audit, and dispatches a single actionable issue/PR via the
-    FSM dispatcher. The flock on ``_CYCLE_LOCK_PATH`` ensures
+    FSM dispatcher. The flock on ``_CYCLE_LOCK_PATH`` (per-repo) ensures
     overlapping supercronic fires don't step on each other.
     """
     lock_fd = os.open(_CYCLE_LOCK_PATH, os.O_CREAT | os.O_RDWR, 0o644)

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 
-REPO = "damien-robotsix/robotsix-cai"
+REPO: str = os.environ.get("CAI_REPO", "damien-robotsix/robotsix-cai")
 SMOKE_PROMPT = "Say hello in one short sentence."
 
 # Root of claude-code's per-cwd transcript dirs. claude-code writes

--- a/publish.py
+++ b/publish.py
@@ -38,6 +38,7 @@ Usage::
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -46,7 +47,7 @@ from dataclasses import dataclass
 
 # Lane 1 target — the backend improves itself. When Lane 2 lands, this
 # will be parameterized per workspace.
-REPO = "damien-robotsix/robotsix-cai"
+REPO = os.environ.get("CAI_REPO", "damien-robotsix/robotsix-cai")
 
 # The set of categories declared in .claude/agents/cai-analyze.md. Any
 # finding whose category is outside this set is rejected before we touch


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#765

**Issue:** #765 — [#762 Step 1/2] Make `REPO` overridable via `CAI_REPO` environment variable

## PR Summary

### What this fixes
`REPO` was hardcoded to `"damien-robotsix/robotsix-cai"` in `cai_lib/config.py`, preventing the cycle from targeting a different GitHub repo without code changes. The cycle lock path was also hardcoded, causing two `cai cycle` processes on different repos to block each other.

### What was changed
- **`cai_lib/config.py` line 7**: Changed `REPO` from a hardcoded string to `os.environ.get("CAI_REPO", "damien-robotsix/robotsix-cai")` — `os` was already imported
- **`cai.py` line 2550**: Changed `_CYCLE_LOCK_PATH` from `"/tmp/cai-cycle.lock"` to `f"/tmp/cai-cycle-{REPO.replace('/', '-')}.lock"` — a per-repo computed constant, requiring no call-site changes
- **`cai.py` line 2558**: Updated docstring to note the lock is "per-repo"

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
