### PR TITLE
auto-improve: [#762 Step 2/2] Workspace configuration file + entrypoint cron generation

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -107,4 +107,4 @@
 | `tests/test_rollback.py` | Tests for rollback functionality |
 | `tests/test_subprocess_utils.py` | TODO: add description |
 | `tests/test_unblock.py` | Tests for cai_lib.cmd_unblock — admin-comment filtering and agent input formatting |
-| `workspaces.json.example` | TODO: add description |
+| `workspaces.json.example` | Template for multi-workspace configuration with per-repo cycle schedules |

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -107,3 +107,4 @@
 | `tests/test_rollback.py` | Tests for rollback functionality |
 | `tests/test_subprocess_utils.py` | TODO: add description |
 | `tests/test_unblock.py` | Tests for cai_lib.cmd_unblock — admin-comment filtering and agent input formatting |
+| `workspaces.json.example` | TODO: add description |

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ check-workflows, code-audit, agent-audit) are **not** run at startup — they wa
 for their own cron ticks so container restarts don't re-trigger
 token-heavy analysis passes.
 
+**Multi-workspace support:** The container can optionally maintain additional
+repositories alongside the primary one. Create a `workspaces.json` file listing
+the additional repos and their cycle schedules, then set `CAI_WORKSPACES_CONFIG`
+to point to it. The entrypoint will generate independent cron lines for each
+workspace and run initial cycles on startup. See
+[docs/configuration.md](docs/configuration.md#multi-workspace-configuration) for
+details.
+
 ### Issue lifecycle
 
 The implement subagent transitions issues through a label-based state

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       CAI_HEALTH_REPORT_SCHEDULE: "0 7 * * 1" # weekly Monday 07:00 UTC (pipeline health report)
       CAI_COST_OPTIMIZE_SCHEDULE: "0 5 * * 0" # weekly Sunday 05:00 UTC (cost-reduction analysis)
       CAI_CHECK_WORKFLOWS_SCHEDULE: "0 */6 * * *" # every 6h (check for CI workflow failures)
+      CAI_AGENT_AUDIT_SCHEDULE: "0 6 * * 0"  # weekly Sunday 06:00 UTC (agent definition audit)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
       CAI_MERGE_MAX_DIFF_LEN: "40000"       # max chars of PR diff passed to merge agent
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,7 @@ Cron schedules are configurable via environment variables. Default values are se
 | `CAI_HEALTH_REPORT_SCHEDULE` | `0 7 * * 1` | Weekly (Monday 07:00 UTC) — pipeline health report |
 | `CAI_CHECK_WORKFLOWS_SCHEDULE` | `0 */6 * * *` | Every 6 hours — GitHub Actions workflow check |
 | `CAI_AGENT_AUDIT_SCHEDULE` | `0 6 * * 0` | Weekly (Sunday 06:00 UTC) — agent audit |
+| `CAI_WORKSPACES_CONFIG` | `/app/workspaces.json` | Path to a JSON file listing additional repositories to maintain (optional; see Multi-workspace section below) |
 
 Schedule values use standard cron format: `minute hour day month weekday`. To disable a scheduled agent, set its variable to an empty string or a comment value.
 
@@ -43,6 +44,41 @@ Schedule values use standard cron format: `minute hour day month weekday`. To di
 |---|---|---|
 | `CAI_TRANSCRIPT_WINDOW_DAYS` | `7` | Only parse session transcripts from the last N days |
 | `CAI_TRANSCRIPT_MAX_FILES` | `50` | Read at most N recent transcript files (0 = no limit) |
+
+## Multi-workspace Configuration
+
+By default, `robotsix-cai` maintains only the primary repository (Lane 1). To extend the container to manage additional repositories, create a `workspaces.json` file listing the repos to maintain:
+
+```json
+[
+  {
+    "repo": "owner/repo-name",
+    "cycle_schedule": "0 * * * *"
+  },
+  {
+    "repo": "owner/another-repo",
+    "cycle_schedule": "0 */6 * * *"
+  }
+]
+```
+
+**Field meanings:**
+
+- **`repo`** _(required)_ — GitHub repository identifier in `owner/repo` format
+- **`cycle_schedule`** _(optional)_ — cron schedule for this workspace's `cai.py cycle` runs (5-field format: `minute hour day month weekday`). If omitted, falls back to `CAI_CYCLE_SCHEDULE`. Each repo gets its own dispatcher cycle independent of the primary repository.
+
+**Configuration:**
+
+1. Create `workspaces.json` in your install directory (or elsewhere) with the repos you want to maintain
+2. Set `CAI_WORKSPACES_CONFIG` to the file's path in your `docker-compose.yml` (default: `/app/workspaces.json`)
+3. Restart the container: `docker compose up -d`
+
+The entrypoint will:
+- Parse the file and generate per-workspace cron lines appended to the generated crontab
+- Run an initial `cai.py cycle` for each workspace on startup (alongside the primary repo's startup cycle)
+- Schedule each workspace's cycle independently on its configured schedule
+
+See `workspaces.json.example` in the repository root for a complete example.
 
 ## Settings File
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,13 @@
 #      - agent-audit:    weekly audit of .claude/agents/ for consistency and usage
 #      - external-scout: weekly scout for open-source libraries that could replace in-house plumbing
 #
+# Environment variables:
+#   CAI_WORKSPACES_CONFIG  Path to a JSON file listing additional repos to maintain
+#                          (default: /app/workspaces.json). Each entry must have a
+#                          "repo" key (e.g. "owner/repo") and an optional
+#                          "cycle_schedule" (falls back to CAI_CYCLE_SCHEDULE).
+#                          If the file is absent the system behaves as today.
+#
 # 2. Do one synchronous `cai.py cycle` pass so `docker compose up -d`
 #    produces useful logs immediately rather than waiting for the first
 #    cron tick. Only the issue-solving cycle runs at startup; the
@@ -49,6 +56,7 @@ CAI_COST_OPTIMIZE_SCHEDULE="${CAI_COST_OPTIMIZE_SCHEDULE:-0 5 * * 0}"
 CAI_CHECK_WORKFLOWS_SCHEDULE="${CAI_CHECK_WORKFLOWS_SCHEDULE:-0 */6 * * *}"
 CAI_AGENT_AUDIT_SCHEDULE="${CAI_AGENT_AUDIT_SCHEDULE:-0 6 * * 0}"
 CAI_EXTERNAL_SCOUT_SCHEDULE="${CAI_EXTERNAL_SCOUT_SCHEDULE:-0 6 * * 1}"
+CAI_WORKSPACES_CONFIG="${CAI_WORKSPACES_CONFIG:-/app/workspaces.json}"
 
 CRONTAB_PATH=/tmp/crontab
 
@@ -70,6 +78,22 @@ $CAI_AGENT_AUDIT_SCHEDULE python /app/cai.py agent-audit
 $CAI_EXTERNAL_SCOUT_SCHEDULE python /app/cai.py external-scout
 CRONTAB
 
+# Append per-workspace cycle lines from the workspaces config file.
+if [ -s "$CAI_WORKSPACES_CONFIG" ]; then
+  python3 -c "
+import json, sys
+with open('$CAI_WORKSPACES_CONFIG') as f:
+    workspaces = json.load(f)
+default_schedule = '$CAI_CYCLE_SCHEDULE'
+for entry in workspaces:
+    repo = entry.get('repo', '').strip()
+    if not repo:
+        continue
+    schedule = entry.get('cycle_schedule', default_schedule)
+    print(schedule + ' CAI_REPO=' + repo + ' python /app/cai.py cycle')
+" >> "$CRONTAB_PATH" || echo "[entrypoint] warning: failed to parse $CAI_WORKSPACES_CONFIG"
+fi
+
 echo "[entrypoint] crontab:"
 sed 's/^/[entrypoint]   /' "$CRONTAB_PATH"
 echo
@@ -87,6 +111,22 @@ fi
 
 echo "[entrypoint] running initial cai.py cycle"
 python /app/cai.py cycle || echo "[entrypoint] cycle exited non-zero; continuing"
+
+# Run an eager startup cycle for each configured workspace.
+if [ -s "$CAI_WORKSPACES_CONFIG" ]; then
+  python3 -c "
+import json, sys
+with open('$CAI_WORKSPACES_CONFIG') as f:
+    workspaces = json.load(f)
+for entry in workspaces:
+    repo = entry.get('repo', '').strip()
+    if repo:
+        print(repo)
+" 2>/dev/null | while IFS= read -r repo; do
+    echo "[entrypoint] running initial cai.py cycle for workspace: $repo"
+    CAI_REPO="$repo" python /app/cai.py cycle || echo "[entrypoint] cycle for $repo exited non-zero; continuing"
+  done
+fi
 
 echo "[entrypoint] handing off to supercronic"
 exec supercronic "$CRONTAB_PATH"

--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -25,6 +25,7 @@ declare -A DESCRIPTIONS=(
   ["LICENSE"]="MIT license"
   ["pyproject.toml"]="Python project configuration (ruff lint settings)"
   [".env.example"]="Template for required environment variables"
+  ["workspaces.json.example"]="Template for multi-workspace configuration with per-repo cycle schedules"
   [".gitignore"]="Git ignore rules"
   [".claude/settings.json"]="Claude Code harness configuration"
   [".claude/agents/cai-agent-audit.md"]="Agent: weekly audit of .claude/agents/*.md for best-practice violations and unused agents"

--- a/workspaces.json.example
+++ b/workspaces.json.example
@@ -1,0 +1,6 @@
+[
+  {
+    "repo": "owner/other-repo",
+    "cycle_schedule": "0 * * * *"
+  }
+]


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#766

**Issue:** #766 — [#762 Step 2/2] Workspace configuration file + entrypoint cron generation

## PR Summary

### What this fixes
Issue #766 asks for a `CAI_WORKSPACES_CONFIG` JSON file that declares additional repos to maintain, wired into `entrypoint.sh` so each workspace gets a scheduled cron cycle line and an eager startup cycle — with zero behaviour change when the file is absent.

### What was changed
- **`workspaces.json.example`** (new) — documents the schema: an array of objects with `repo` (required) and optional `cycle_schedule`
- **`entrypoint.sh`** — four targeted additions:
  1. Added `CAI_WORKSPACES_CONFIG` documentation to the top comment block
  2. Declared `CAI_WORKSPACES_CONFIG="${CAI_WORKSPACES_CONFIG:-/app/workspaces.json}"` after the existing schedule vars
  3. After the base crontab heredoc: a `python3 -c` block that parses the JSON and appends `${schedule} CAI_REPO=${repo} python /app/cai.py cycle` lines for each workspace entry
  4. After the primary eager cycle: a loop that runs `CAI_REPO=<repo> python /app/cai.py cycle` for each configured workspace at startup

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
