### PR TITLE
auto-improve: Ensure every agent's schedule specifies rate/frequency

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -132,7 +132,7 @@ Subcommands:
                             `auto-improve:raised` so they flow through
                             the refine → fix pipeline.
 
-    python cai.py update-check  Periodic Claude Code release check.
+    python cai.py update-check  Weekly Claude Code release check.
                             Clones the repo, fetches the latest Claude
                             Code releases from GitHub, and runs a Sonnet
                             agent that compares the current pinned
@@ -168,7 +168,7 @@ Subcommands:
                             Haiku agent to identify persistent failures.
                             Findings are published via publish.py with the
                             `check-workflows` namespace. Runs every 6 hours
-                            by default (CAI_CHECK_WORKFLOWS_SCHEDULE).
+                            by default (configurable via CAI_CHECK_WORKFLOWS_SCHEDULE).
 
     python cai.py unblock   Scan open issues/PRs parked at
                             `auto-improve:human-needed` (or
@@ -181,6 +181,23 @@ Subcommands:
                             issue/PR to the FSM. Requires CAI_ADMIN_LOGINS
                             to be set; without it, `human:solved` is silently
                             ignored.
+
+Default schedules (all configurable via environment variables):
+
+    Subcommand        Default cron       Frequency               Env var
+    ─────────────     ──────────────     ─────────────────────   ──────────────────────────
+    cycle             0 * * * *          Hourly at :00           CAI_CYCLE_SCHEDULE
+    verify            15 * * * *         Hourly at :15           CAI_VERIFY_SCHEDULE
+    analyze           0 0 * * *          Daily at midnight       CAI_ANALYZER_SCHEDULE
+    audit             0 */6 * * *        Every 6 hours           CAI_AUDIT_SCHEDULE
+    check-workflows   0 */6 * * *        Every 6 hours           CAI_CHECK_WORKFLOWS_SCHEDULE
+    code-audit        0 3 * * 0          Weekly, Sundays 03:00   CAI_CODE_AUDIT_SCHEDULE
+    propose           0 4 * * 0          Weekly, Sundays 04:00   CAI_PROPOSE_SCHEDULE
+    cost-optimize     0 5 * * 0          Weekly, Sundays 05:00   CAI_COST_OPTIMIZE_SCHEDULE
+    agent-audit       0 6 * * 0          Weekly, Sundays 06:00   CAI_AGENT_AUDIT_SCHEDULE
+    update-check      0 4 * * 1          Weekly, Mondays 04:00   CAI_UPDATE_CHECK_SCHEDULE
+    external-scout    0 6 * * 1          Weekly, Mondays 06:00   CAI_EXTERNAL_SCOUT_SCHEDULE
+    health-report     0 7 * * 1          Weekly, Mondays 07:00   CAI_HEALTH_REPORT_SCHEDULE
 
 The container runs `entrypoint.sh`, which executes `cai.py cycle` once
 synchronously at startup (driving the full issue-solving pipeline:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,17 +13,17 @@
 #
 #    Orthogonal (independent) tasks — not part of the fix pipeline,
 #    so they keep their own schedules:
-#      - verify:         label-state reconciliation with GitHub
-#      - analyze:        parse own transcripts, raise findings as issues
-#      - audit:          periodic queue/PR consistency checks (includes human-needed)
-#      - code-audit:     periodic source code consistency checks
-#      - propose:        weekly creative improvement proposals
-#      - update-check:   periodic Claude Code release checks
-#      - health-report:  automated pipeline health report
-#      - cost-optimize:  weekly cost-reduction proposal or evaluation
-#      - check-workflows: monitor GitHub Actions for failures
-#      - agent-audit:    weekly audit of .claude/agents/ for consistency and usage
-#      - external-scout: weekly scout for open-source libraries that could replace in-house plumbing
+#      - verify:         label-state reconciliation with GitHub (hourly at :15)
+#      - analyze:        parse own transcripts, raise findings as issues (daily at midnight)
+#      - audit:          periodic queue/PR consistency checks (every 6 hours)
+#      - code-audit:     periodic source code consistency checks (weekly, Sundays 03:00)
+#      - propose:        weekly creative improvement proposals (Sundays 04:00)
+#      - update-check:   periodic Claude Code release checks (weekly, Mondays 04:00)
+#      - health-report:  automated pipeline health report (weekly, Mondays 07:00)
+#      - cost-optimize:  weekly cost-reduction proposal or evaluation (Sundays 05:00)
+#      - check-workflows: monitor GitHub Actions for failures (every 6 hours)
+#      - agent-audit:    weekly audit of .claude/agents/ for consistency and usage (Sundays 06:00)
+#      - external-scout: weekly scout for open-source libraries that could replace in-house plumbing (Mondays 06:00)
 #
 # Environment variables:
 #   CAI_WORKSPACES_CONFIG  Path to a JSON file listing additional repos to maintain


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#785

**Issue:** #785 — Ensure every agent's schedule specifies rate/frequency

## PR Summary

### What this fixes
Several orthogonal subcommand descriptions in `cai.py` used vague language ("Periodic") or omitted schedule information entirely, and the `entrypoint.sh` preamble listed tasks without their default rates — making it hard for maintainers to understand when each agent runs.

### What was changed
- **`cai.py` (module docstring)**: Changed "Periodic" to "Weekly" for the `update-check` entry; added "configurable via" to the `check-workflows` schedule note; inserted a centralized 12-row "Default schedules" reference table (with cron expression, plain-English frequency, and env var) immediately before the closing prose paragraph.
- **`entrypoint.sh` (preamble comments)**: Appended the default rate in parentheses to each of the 11 orthogonal task bullets (lines 16–26).

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
