### PR TITLE
auto-improve: Fix cai-review-docs prompt to handle sensitive agent files gracefully

### DIFF
--- a/.claude/agents/cai-review-docs.md
+++ b/.claude/agents/cai-review-docs.md
@@ -158,6 +158,13 @@ give the replacement>
 6. **Do not use Bash.** You have `Read`, `Grep`, `Glob`, `Edit`, and `Write` —
    use them exclusively. Bash is not available and all Bash calls will be
    rejected by the sandbox.
+7. **Use the staging directory for `.claude/agents/*.md` edits.** These files
+   are flagged as sensitive and direct Edit/Write calls against them will be
+   blocked. If you find stale documentation inside an agent definition file,
+   write the corrected FULL file to the staging directory described in the
+   "Updating `.claude/agents/*.md`" section of the work-directory block above.
+   The wrapper will copy it back automatically. Emit a `### Fixed: stale_docs`
+   block as usual after staging the fix.
 
 ## Agent-specific efficiency guidance
 

--- a/cai_lib/actions/review_docs.py
+++ b/cai_lib/actions/review_docs.py
@@ -21,7 +21,10 @@ from cai_lib.config import REPO
 from cai_lib.fsm import apply_pr_transition, get_pr_state, PRState
 from cai_lib.github import _gh_json, _fetch_linked_issue_block
 from cai_lib.subprocess_utils import _run, _run_claude_p
-from cai_lib.cmd_helpers import _git, _gh_user_identity, _work_directory_block
+from cai_lib.cmd_helpers import (
+    _git, _gh_user_identity, _work_directory_block,
+    _setup_agent_edit_staging, _apply_agent_edit_staging,
+)
 from cai_lib.logging_utils import log_run
 
 
@@ -131,6 +134,7 @@ def handle_review_docs(pr: dict) -> int:
         name, email = _gh_user_identity()
         _git(work_dir, "config", "user.name", name)
         _git(work_dir, "config", "user.email", email)
+        _setup_agent_edit_staging(work_dir)
 
         # --stat summary serves as the file-level map for the agent;
         # the full diff is intentionally omitted (token sink).
@@ -189,6 +193,7 @@ def handle_review_docs(pr: dict) -> int:
             return agent.returncode
 
         agent_output = (agent.stdout or "").strip()
+        _apply_agent_edit_staging(work_dir)
 
         # Did the agent make any doc changes?
         status_result = _git(work_dir, "status", "--porcelain", check=False)

--- a/cai_lib/actions/review_docs.py
+++ b/cai_lib/actions/review_docs.py
@@ -193,7 +193,13 @@ def handle_review_docs(pr: dict) -> int:
             return agent.returncode
 
         agent_output = (agent.stdout or "").strip()
-        _apply_agent_edit_staging(work_dir)
+        applied = _apply_agent_edit_staging(work_dir)
+        if applied:
+            print(
+                f"[cai review-docs] applied {applied} staged "
+                f".claude/agents/*.md update(s)",
+                flush=True,
+            )
 
         # Did the agent make any doc changes?
         status_result = _git(work_dir, "status", "--porcelain", check=False)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#790

**Issue:** #790 — Fix cai-review-docs prompt to handle sensitive agent files gracefully

## PR Summary

### What this fixes
The `cai-review-docs` agent could find stale documentation in `.claude/agents/*.md` files but was blocked from fixing them because those files are flagged as sensitive. The wrapper also lacked the staging mechanism wiring needed to apply any such fixes even if the agent used the staging directory correctly.

### What was changed
- **`cai_lib/actions/review_docs.py`**: Added `_setup_agent_edit_staging` and `_apply_agent_edit_staging` to the import; called `_setup_agent_edit_staging(work_dir)` after git identity configuration (so the staging directory exists when the agent runs), and `_apply_agent_edit_staging(work_dir)` after the agent exits successfully but before `git status --porcelain` checks for changes (so staged agent file edits are picked up by the commit step).
- **`.claude/agents/cai-review-docs.md`** (via staging): Added hard rule #7 instructing the agent to use the staging directory for `.claude/agents/*.md` edits instead of attempting direct Edit/Write calls that would be blocked.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
