### PR TITLE
auto-improve: Remove HTML comment before YAML frontmatter in cai-triage.md

### DIFF
--- a/.claude/agents/cai-triage.md
+++ b/.claude/agents/cai-triage.md
@@ -1,4 +1,3 @@
-<!-- Forced tool-use: submit_triage_verdict. See #686 Step 2. -->
 ---
 name: cai-triage
 description: Triage `auto-improve:raised` issues one at a time — classify as REFINE, PLAN_APPROVE, APPLY, or HUMAN. Inline-only — full issue body is provided in the user message. Minimal tool use.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#796

**Issue:** #796 — Remove HTML comment before YAML frontmatter in cai-triage.md

## PR Summary

### What this fixes
`cai-triage.md` had an HTML comment (`<!-- Forced tool-use: submit_triage_verdict. See #686 Step 2. -->`) on line 1, before the YAML frontmatter delimiter. Claude Code's subagent discovery requires frontmatter to begin on line 1, so the comment prevented the agent from loading correctly.

### What was changed
- `.claude/agents/cai-triage.md` — removed the HTML comment on line 1 so that the `---` YAML frontmatter delimiter is now line 1. No other content was modified.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
