### PR TITLE
auto-improve: Support recursive sub-issue decomposition for complex multi-step issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,10 @@ approach and this guidance does not apply.
 
 If the refine subagent detects that work requires multiple independent steps, it produces a `## Multi-Step Decomposition` output. The wrapper then:
 1. Labels the parent issue `auto-improve:parent`
-2. Creates one sub-issue per step, with titles formatted as `[#{parent} Step X/Y] <title>` (e.g. `[#123 Step 1/3] Add schema migration`) so you can identify the parent from a list view. Each sub-issue body includes a back-reference to the parent.
+2. Creates one sub-issue per step, with titles formatted as `[#{parent} Step X/Y] <title>` (e.g. `[#123 Step 1/3] Add schema migration`) so you can identify the parent from a list view. Each sub-issue is labeled with `depth:N` (where N is the decomposition depth, starting at 1 for top-level decompositions). Each sub-issue body includes a back-reference to the parent.
 3. Adds a checklist to the parent issue to track sub-issue completion
+
+Decomposition supports recursion: sub-issues can themselves be decomposed into further sub-issues up to a maximum depth (controlled by `CAI_MAX_DECOMPOSITION_DEPTH`, default: 2). Issues at maximum depth will not be decomposed further and will be refined as single units of work.
 
 You can watch the parent issue's checklist to monitor progress. Note: if an issue already has a structured `### Plan` section when filed, the refine subagent will skip refinement, and no sub-issues will be created — the implement subagent will execute the steps directly from the issue body.
 
@@ -615,6 +617,11 @@ the same global window settings.
   auto-merge. One of `high` (default), `medium`, or `disabled`. See
   the [Confidence-gated auto-merge](#confidence-gated-auto-merge)
   section for details.
+- **`CAI_MAX_DECOMPOSITION_DEPTH`** — maximum recursion depth for
+  multi-step decomposition. Default: `2`. Sub-issues at this depth will
+  be refined as single units of work without further decomposition. Increase
+  to support deeper hierarchies of sub-issues, or decrease to limit
+  decomposition to shallower hierarchies.
 
 **Troubleshooting: `cannot run ssh` errors.** If `cai.py dispatch` fails
 with `error: cannot run ssh: No such file or directory`, your

--- a/cai.py
+++ b/cai.py
@@ -948,20 +948,35 @@ def cmd_verify(args) -> int:
     except subprocess.CalledProcessError:
         parent_issues = []
 
-    for parent in parent_issues:
-        if all_sub_issues_closed(parent["number"]) is True:
-            _run(
-                ["gh", "issue", "close", str(parent["number"]),
-                 "--repo", REPO,
-                 "--comment",
-                 "All sub-issues completed. Closing parent."],
-                capture_output=True,
-            )
-            print(
-                f"[cai verify] parent #{parent['number']}: "
-                f"all sub-issues done — closed",
-                flush=True,
-            )
+    for _pass in range(2):
+        for parent in parent_issues:
+            if all_sub_issues_closed(parent["number"]) is True:
+                _run(
+                    ["gh", "issue", "close", str(parent["number"]),
+                     "--repo", REPO,
+                     "--comment",
+                     "All sub-issues completed. Closing parent."],
+                    capture_output=True,
+                )
+                print(
+                    f"[cai verify] parent #{parent['number']}: "
+                    f"all sub-issues done — closed",
+                    flush=True,
+                )
+        # Re-fetch before second pass: parents closed in pass 1
+        # should not be re-attempted.
+        if _pass == 0:
+            try:
+                parent_issues = _gh_json([
+                    "issue", "list",
+                    "--repo", REPO,
+                    "--label", LABEL_PARENT,
+                    "--state", "open",
+                    "--json", "number",
+                    "--limit", "50",
+                ]) or []
+            except subprocess.CalledProcessError:
+                parent_issues = []
 
     print(f"[cai verify] done ({transitioned} transitioned)", flush=True)
     log_run("verify", repo=REPO, checked=len(issues), transitioned=transitioned, exit=0)

--- a/cai_lib/actions/refine.py
+++ b/cai_lib/actions/refine.py
@@ -17,6 +17,8 @@ from cai_lib.config import (
     LABEL_RAISED,
     LABEL_REFINING,
     LABEL_PARENT,
+    LABEL_DEPTH_PREFIX,
+    MAX_DECOMPOSITION_DEPTH,
 )
 from cai_lib.fsm import apply_transition
 from cai_lib.github import _gh_json, _set_labels, _build_issue_block
@@ -48,6 +50,21 @@ def _parse_refine_next_step(text: str) -> "str | None":
     return m.group(1).upper()
 
 
+def _issue_depth(issue: dict) -> int:
+    """Return the decomposition depth of *issue* from its ``depth:N`` label.
+
+    Returns 0 if no ``depth:`` label is present (top-level issue).
+    """
+    for label in issue.get("labels", []):
+        name = label if isinstance(label, str) else label.get("name", "")
+        if name.startswith(LABEL_DEPTH_PREFIX):
+            try:
+                return int(name[len(LABEL_DEPTH_PREFIX):])
+            except ValueError:
+                pass
+    return 0
+
+
 def _find_sub_issue(parent_number: int, step: int) -> "int | None":
     """Return the issue number of an existing sub-issue for *parent_number*
     / *step* (open or closed), or None if none exists.
@@ -66,6 +83,7 @@ def _find_sub_issue(parent_number: int, step: int) -> "int | None":
 
 def _create_sub_issues(
     steps: list[dict], parent_number: int, parent_title: str,
+    depth: int = 0,
 ) -> list[int]:
     """Create GitHub sub-issues for a multi-step decomposition.
 
@@ -102,7 +120,7 @@ def _create_sub_issues(
             f"Step {s['step']} of {total}._\n"
         )
         title = f"[#{parent_number} Step {s['step']}/{total}] {s['title']}"
-        labels = ["auto-improve", LABEL_RAISED]
+        labels = ["auto-improve", LABEL_RAISED, f"{LABEL_DEPTH_PREFIX}{depth}"]
         # Use create_issue() (REST API) instead of gh issue create so we
         # get back the internal `id` needed for link_sub_issue().
         meta = create_issue(title, body, labels)
@@ -149,6 +167,14 @@ def handle_refine(issue: dict) -> int:
     # the agent may rewrite the body to incorporate exploration findings
     # and re-decide NextStep.
     user_message = _build_issue_block(issue)
+    current_depth = _issue_depth(issue)
+    if current_depth >= MAX_DECOMPOSITION_DEPTH:
+        user_message += (
+            f"\n\nIMPORTANT: This issue is at decomposition depth {current_depth} "
+            f"(max {MAX_DECOMPOSITION_DEPTH}). Do NOT produce a "
+            f"`## Multi-Step Decomposition` section. Refine this issue as a single "
+            f"unit of work."
+        )
     result = _run_claude_p(
         ["claude", "-p", "--agent", "cai-refine",
          "--dangerously-skip-permissions"],
@@ -199,7 +225,7 @@ def handle_refine(issue: dict) -> int:
                 f"{len(steps)} steps",
                 flush=True,
             )
-            sub_nums = _create_sub_issues(steps, issue_number, title)
+            sub_nums = _create_sub_issues(steps, issue_number, title, depth=current_depth + 1)
             _set_labels(
                 issue_number,
                 add=[LABEL_PARENT],

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -82,6 +82,8 @@ LABEL_HUMAN_SOLVED = "human:solved"
 LABEL_TRIAGING         = "auto-improve:triaging"
 LABEL_KIND_CODE        = "kind:code"
 LABEL_KIND_MAINTENANCE = "kind:maintenance"
+LABEL_DEPTH_PREFIX = "depth:"
+MAX_DECOMPOSITION_DEPTH: int = int(os.environ.get("CAI_MAX_DECOMPOSITION_DEPTH", "2"))
 
 # PR pipeline-state labels — one per PRState. Set by FSM transitions
 # (apply_pr_transition) and read by dispatch.

--- a/tests/test_multistep.py
+++ b/tests/test_multistep.py
@@ -124,5 +124,70 @@ class TestParseDecomposition(unittest.TestCase):
         self.assertEqual(steps[1]["title"], "Another title")
 
 
+from unittest.mock import patch, MagicMock
+from cai_lib.actions.refine import _issue_depth, _create_sub_issues, handle_refine
+
+
+class TestIssueDepth(unittest.TestCase):
+    def test_no_depth_label_returns_zero(self):
+        issue = {"labels": [{"name": "auto-improve"}, {"name": "auto-improve:raised"}]}
+        self.assertEqual(_issue_depth(issue), 0)
+
+    def test_depth_label_returns_n(self):
+        issue = {"labels": [{"name": "auto-improve"}, {"name": "depth:1"}]}
+        self.assertEqual(_issue_depth(issue), 1)
+
+    def test_depth_two(self):
+        issue = {"labels": [{"name": "depth:2"}, {"name": "auto-improve:raised"}]}
+        self.assertEqual(_issue_depth(issue), 2)
+
+    def test_empty_labels(self):
+        issue = {"labels": []}
+        self.assertEqual(_issue_depth(issue), 0)
+
+    def test_no_labels_key(self):
+        issue = {}
+        self.assertEqual(_issue_depth(issue), 0)
+
+    def test_malformed_depth_label_ignored(self):
+        issue = {"labels": [{"name": "depth:abc"}]}
+        self.assertEqual(_issue_depth(issue), 0)
+
+
+class TestCreateSubIssuesDepth(unittest.TestCase):
+    @patch("cai_lib.actions.refine.link_sub_issue")
+    @patch("cai_lib.actions.refine.create_issue")
+    @patch("cai_lib.actions.refine._find_sub_issue", return_value=None)
+    def test_depth_label_applied(self, mock_find, mock_create, mock_link):
+        mock_create.return_value = {"number": 42, "id": 999, "html_url": "http://x"}
+        steps = [{"step": 1, "title": "T", "body": "B"}]
+        _create_sub_issues(steps, 10, "Parent", depth=1)
+        labels = mock_create.call_args[0][2]
+        self.assertIn("depth:1", labels)
+
+
+class TestDepthGate(unittest.TestCase):
+    @patch("cai_lib.actions.refine._run_claude_p")
+    @patch("cai_lib.actions.refine.apply_transition")
+    @patch("cai_lib.actions.refine._build_issue_block", return_value="issue text")
+    def test_max_depth_injects_no_decompose(self, mock_build, mock_transition, mock_claude):
+        """At max depth, user_message should instruct agent not to decompose."""
+        mock_claude.return_value = MagicMock(
+            returncode=0, stdout="## Refined Issue\nContent", stderr=""
+        )
+        with patch("cai_lib.actions.refine._run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            with patch("cai_lib.actions.refine.MAX_DECOMPOSITION_DEPTH", 2):
+                issue = {
+                    "number": 5, "title": "Test",
+                    "labels": [{"name": "depth:2"}],
+                    "body": "test body",
+                }
+                handle_refine(issue)
+        call_kwargs = mock_claude.call_args
+        input_msg = call_kwargs.kwargs.get("input") or call_kwargs[1].get("input", "")
+        self.assertIn("Do NOT produce", input_msg)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#806

**Issue:** #806 — Support recursive sub-issue decomposition for complex multi-step issues

## PR Summary

### What this fixes
The system lacked depth tracking for recursive sub-issue decomposition, allowing unbounded hierarchy, and the verify sweep's parent-close loop was single-pass so grandparent issues required an extra cycle to close after their last child-parent closed.

### What was changed
- **`cai_lib/config.py`**: Added `LABEL_DEPTH_PREFIX = "depth:"` and `MAX_DECOMPOSITION_DEPTH` (default 2, env-overridable via `CAI_MAX_DECOMPOSITION_DEPTH`)
- **`cai_lib/actions/refine.py`**: Imported new constants; added `_issue_depth()` helper to read depth from `depth:N` labels; added `depth` parameter to `_create_sub_issues` which now applies the `depth:N` label to created sub-issues; `handle_refine` computes `current_depth` before the agent call and injects a no-decompose instruction into `user_message` when at max depth; passes `depth=current_depth + 1` to `_create_sub_issues`
- **`cai.py`**: Replaced single-pass parent-close loop with a two-pass loop that re-fetches open parent issues between passes, so grandparent issues close in the same verify sweep as their last child-parent
- **`tests/test_multistep.py`**: Added `TestIssueDepth` (6 unit tests for `_issue_depth`), `TestCreateSubIssuesDepth` (mocked test verifying `depth:1` label is applied), and `TestDepthGate` (integration test verifying the no-decompose instruction is injected at max depth)

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
