### PR TITLE
fix(merge): raise diff cap to 200KB and drop test-first prioritization

### DIFF
--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -61,7 +61,7 @@ _BOT_BRANCH_RE = re.compile(r"^auto-improve/(\d+)-")
 # Truncate very large diffs before feeding the merge agent to bound
 # token cost per PR.  Configurable via env var so the ceiling can be
 # raised without a code change.
-_MERGE_MAX_DIFF_LEN = int(os.environ.get("CAI_MERGE_MAX_DIFF_LEN", "40000"))
+_MERGE_MAX_DIFF_LEN = int(os.environ.get("CAI_MERGE_MAX_DIFF_LEN", "200000"))
 
 # JSON schema for structured merge verdict (forced tool-use via --json-schema).
 _MERGE_JSON_SCHEMA = {
@@ -84,45 +84,27 @@ _MERGE_JSON_SCHEMA = {
 
 
 def _assemble_diff(raw_diff: str, max_len: int) -> str:
-    """Assemble a diff string within *max_len* characters, prioritising test files.
+    """Assemble a diff string within *max_len* characters.
 
     Splits *raw_diff* into per-file chunks (each starts with a
-    ``diff --git `` header line), sorts test-file chunks first, then
-    concatenates within the character budget.  Any omitted files are
-    listed in a trailing note so the agent knows the diff is incomplete.
+    ``diff --git `` header line) and concatenates them in their natural
+    order until the budget is exhausted. Omitted files are listed in a
+    trailing note so the agent knows the diff is incomplete.
     """
     if len(raw_diff) <= max_len:
         return raw_diff
 
-    # Split into per-file chunks.  Each chunk starts with "diff --git ".
-    # We keep the delimiter as the first line of each chunk.
     _DIFF_HEADER = re.compile(r"^diff --git ", re.MULTILINE)
     parts = _DIFF_HEADER.split(raw_diff)
-    # parts[0] is any preamble before the first "diff --git" line (often empty).
     preamble = parts[0]
-    chunks: list[str] = []
-    for part in parts[1:]:
-        chunks.append("diff --git " + part)
-
-    def _is_test_chunk(chunk: str) -> bool:
-        # Inspect the first line (the diff --git header) for the file path.
-        first_line = chunk.split("\n", 1)[0]
-        return bool(
-            re.search(r"tests/", first_line)
-            or re.search(r"test_\w+\.py", first_line)
-        )
-
-    test_chunks = [c for c in chunks if _is_test_chunk(c)]
-    other_chunks = [c for c in chunks if not _is_test_chunk(c)]
-    sorted_chunks = test_chunks + other_chunks
+    chunks = ["diff --git " + part for part in parts[1:]]
 
     assembled = preamble
     omitted: list[str] = []
-    for chunk in sorted_chunks:
+    for chunk in chunks:
         if len(assembled) + len(chunk) <= max_len:
             assembled += chunk
         else:
-            # Extract a short filename for the omission note.
             first_line = chunk.split("\n", 1)[0]
             m = re.search(r"b/(\S+)$", first_line)
             omitted.append(m.group(1) if m else first_line[:60])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       CAI_CHECK_WORKFLOWS_SCHEDULE: "0 */6 * * *" # every 6h (check for CI workflow failures)
       CAI_AGENT_AUDIT_SCHEDULE: "0 6 * * 0"  # weekly Sunday 06:00 UTC (agent definition audit)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
-      CAI_MERGE_MAX_DIFF_LEN: "40000"       # max chars of PR diff passed to merge agent
+      CAI_MERGE_MAX_DIFF_LEN: "200000"      # max chars of PR diff passed to merge agent
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "50"        # read at most N recent transcript files (0 = no limit)
     volumes:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@
 | `ANTHROPIC_API_KEY` | API authentication for headless `claude` invocations inside the container | Required |
 | `CAI_ADMIN_LOGINS` | Comma-separated list of GitHub logins authorized to use the `human:solved` label to unblock stuck issues and PRs. Without this, the `human:solved` workflow is silently ignored and parked tasks remain unblocked. See `cai unblock` in the CLI reference for details. | _(optional; unblock workflow disabled if not set)_ |
 | `CAI_MERGE_CONFIDENCE_THRESHOLD` | Minimum confidence level for `cai merge` auto-merge (`high`, `medium`, `disabled`) | `high` |
-| `CAI_MERGE_MAX_DIFF_LEN` | Maximum character length for PR diffs passed to the merge agent; test files are prioritised within the budget so they remain visible even for large PRs | `40000` |
+| `CAI_MERGE_MAX_DIFF_LEN` | Maximum character length for PR diffs passed to the merge agent. Diffs over this cap are packed in natural (alphabetical) file order and any files that don't fit are listed as omitted. | `200000` |
 
 `CAI_MERGE_CONFIDENCE_THRESHOLD` controls how aggressively the merge agent promotes PRs:
 - `high` — only auto-merge when `cai-merge` emits a `high` confidence verdict

--- a/install.sh
+++ b/install.sh
@@ -171,7 +171,7 @@ services:
       CAI_COST_OPTIMIZE_SCHEDULE: "0 5 * * 0" # weekly Sunday 05:00 UTC (cost-reduction analysis)
       CAI_CHECK_WORKFLOWS_SCHEDULE: "0 */6 * * *" # every 6h (check for CI workflow failures)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
-      CAI_MERGE_MAX_DIFF_LEN: "40000"       # max chars of PR diff passed to merge agent
+      CAI_MERGE_MAX_DIFF_LEN: "200000"      # max chars of PR diff passed to merge agent
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "50"        # read at most N recent transcript files (0 = no limit)
 ${CAI_ADMIN_ENV_LINE}
@@ -245,7 +245,7 @@ services:
       CAI_COST_OPTIMIZE_SCHEDULE: "0 5 * * 0" # weekly Sunday 05:00 UTC (cost-reduction analysis)
       CAI_CHECK_WORKFLOWS_SCHEDULE: "0 */6 * * *" # every 6h (check for CI workflow failures)
       CAI_MERGE_CONFIDENCE_THRESHOLD: "high" # high | medium | disabled
-      CAI_MERGE_MAX_DIFF_LEN: "40000"       # max chars of PR diff passed to merge agent
+      CAI_MERGE_MAX_DIFF_LEN: "200000"      # max chars of PR diff passed to merge agent
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "50"        # read at most N recent transcript files (0 = no limit)
 ${CAI_ADMIN_ENV_LINE}

--- a/tests/test_merge_diff.py
+++ b/tests/test_merge_diff.py
@@ -16,8 +16,6 @@ def _make_file_chunk(path: str, size: int) -> str:
     """
     header = f"diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n"
     body_size = max(0, size - len(header))
-    # Fill with '+' lines of 80 chars each so the diff looks plausible.
-    # Do NOT truncate mid-line — keep whole lines so the chunk ends with \n.
     lines = []
     while sum(len(l) for l in lines) < body_size:
         lines.append("+" + "x" * 79 + "\n")
@@ -33,60 +31,64 @@ class TestAssembleDiff(unittest.TestCase):
         result = _assemble_diff(raw, 40_000)
         self.assertEqual(result, raw)
 
-    def test_test_files_prioritised_over_source_files(self):
-        """When total diff exceeds budget, test-file chunks appear before source chunks."""
-        # Create a large source chunk that nearly fills the budget, and a
-        # smaller test chunk appended after it.  Without prioritisation the
-        # test chunk would be cut off; with prioritisation it should appear
-        # first and be retained.
+    def test_natural_order_preserved(self):
+        """Files are packed in their original diff order, not reshuffled."""
+        budget = 10_000
+        a = _make_file_chunk("cai_lib/a_first.py", 2_000)
+        b = _make_file_chunk("cai_lib/b_second.py", 2_000)
+        c = _make_file_chunk("tests/test_c.py", 2_000)
+        raw = a + b + c
+        self.assertLess(len(raw), budget)
+
+        result = _assemble_diff(raw, budget)
+
+        self.assertEqual(result, raw)
+        pos_a = result.find("cai_lib/a_first.py")
+        pos_b = result.find("cai_lib/b_second.py")
+        pos_c = result.find("tests/test_c.py")
+        self.assertLess(pos_a, pos_b)
+        self.assertLess(pos_b, pos_c)
+
+    def test_tail_files_omitted_when_budget_exhausted(self):
+        """When total exceeds budget, trailing chunks are dropped and noted."""
         budget = 5_000
-        # Use sizes that are multiples of 81 (line length) + header size so
-        # the chunk lengths are predictable and total reliably exceeds budget.
-        source_chunk = _make_file_chunk("src/big_source.py", budget - 200)
-        test_chunk = _make_file_chunk("tests/test_feature.py", 400)
-        raw = source_chunk + test_chunk  # test chunk at end, total > budget
+        head = _make_file_chunk("cai_lib/head.py", budget - 200)
+        tail = _make_file_chunk("cai_lib/tail.py", 1_000)
+        raw = head + tail
         self.assertGreater(len(raw), budget)
 
         result = _assemble_diff(raw, budget)
 
-        # The test chunk should be present (it was prioritised).
-        self.assertIn("tests/test_feature.py", result)
-        # An omission note should appear because source was dropped.
+        self.assertIn("cai_lib/head.py", result)
         self.assertIn("file(s) omitted", result)
-        # Test chunk should appear before source chunk (if source was included at all).
-        test_pos = result.find("tests/test_feature.py")
-        source_pos = result.find("src/big_source.py")
-        if source_pos != -1:
-            self.assertLess(test_pos, source_pos)
+        self.assertIn("cai_lib/tail.py", result.split("file(s) omitted")[1])
 
-    def test_source_file_omitted_when_test_fills_budget(self):
-        """Source files are omitted when test files consume the budget."""
-        budget = 3_000
-        test_chunk = _make_file_chunk("tests/test_x.py", budget - 200)
-        source_chunk = _make_file_chunk("src/impl.py", 600)
-        raw = source_chunk + test_chunk
+    def test_test_files_not_privileged(self):
+        """A test-file chunk at the end is dropped if it does not fit."""
+        budget = 5_000
+        source = _make_file_chunk("cai_lib/impl.py", budget - 200)
+        test = _make_file_chunk("tests/test_feature.py", 1_000)
+        raw = source + test
         self.assertGreater(len(raw), budget)
 
         result = _assemble_diff(raw, budget)
 
-        self.assertIn("tests/test_x.py", result)
+        self.assertIn("cai_lib/impl.py", result)
         self.assertIn("file(s) omitted", result)
-        self.assertIn("src/impl.py", result.split("file(s) omitted")[1])
+        self.assertIn("tests/test_feature.py",
+                      result.split("file(s) omitted")[1])
 
-    def test_test_file_alone_exceeds_budget(self):
-        """When even the test file alone exceeds budget, include what fits and note omission."""
+    def test_single_oversized_file_omitted(self):
+        """A single file larger than the whole budget is listed as omitted."""
         budget = 1_000
-        # A test chunk larger than the whole budget.
-        test_chunk = _make_file_chunk("tests/test_huge.py", budget + 500)
-        raw = test_chunk
+        chunk = _make_file_chunk("cai_lib/huge.py", budget + 500)
+        raw = chunk
         self.assertGreater(len(raw), budget)
 
         result = _assemble_diff(raw, budget)
 
-        # The result should be truncated (preamble empty, no chunk fits).
-        # The omission note should list the test file as omitted.
         self.assertIn("file(s) omitted", result)
-        self.assertIn("tests/test_huge.py", result)
+        self.assertIn("cai_lib/huge.py", result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Raises `CAI_MERGE_MAX_DIFF_LEN` default from 40,000 to 200,000 chars so large refactor PRs (e.g. file splits) fit inside the merge agent's context budget.
- Drops test-file prioritization in `_assemble_diff` — chunks are now packed in natural git-diff order (alphabetical by file path). Tests are no longer privileged; trailing files that don't fit are still listed in the omission note.
- Updates `docker-compose.yml` and `install.sh` env defaults to `200000`.
- Updates `docs/configuration.md` to reflect the new default and order.
- Rewrites `tests/test_merge_diff.py` to cover the new behavior.

## Motivation
On PR #824 (the `cai_lib/fsm.py` split into `fsm_states`/`fsm_transitions`/`fsm_confidence`), the merge agent returned a `medium hold` with reasoning `"cannot verify correctness — two core implementation files truncated"`. Root cause: the combined diff exceeded the 40KB cap, and the test-first packing order meant tests (if any) or smaller files consumed the budget first, pushing the key implementation files off the list. This fix eliminates that pathology.

## Test plan
- [x] `python3 -m pytest tests/test_merge_diff.py -v` — 5/5 pass
- [x] Full suite (minus pre-existing lint failure on `main`): 197/197 pass