### PR TITLE
auto-improve: Issues #793, #800, #802 closed without terminal lifecycle labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ targeted invocation, `cai.py dispatch --issue N` and
 | `cai.py verify` | `15 * * * *` (hourly @15) | Label-state reconciliation — removes deprecated cai-managed labels from open issues, then keeps `:pr-open` / `:merged` / etc. consistent with actual GitHub state |
 | `cai.py dispatch [--issue N \| --pr N]` | _(manual/on-demand)_ | Direct entry into the FSM dispatcher for a specific issue or PR (or the oldest actionable item when no target is given) |
 | `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
-| `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` (6-hour TTL), `:revising` (1-hour TTL), and `:applying` (2-hour TTL) locks, flags stale `:merged` issues for human review, recovers `:pr-open` issues whose linked PR was closed (rolls back to `:refined`), deletes remote branches for merged/closed PRs, flags duplicates, stuck loops, label corruption, and human-needed issues (pipeline jams, abandoned issues, repeated diversions, missing divert reasons) as `auto-improve:raised` + `audit` findings (Opus) |
+| `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` (6-hour TTL), `:revising` (1-hour TTL), and `:applying` (2-hour TTL) locks, migrates open `:no-action` issues (deprecated label) to closed-as-not-planned, flags stale `:merged` issues for human review, recovers `:pr-open` issues whose linked PR was closed (rolls back to `:refined`), deletes remote branches for merged/closed PRs, retroactively closes closed issues lacking terminal labels (as 'not planned'), then flags duplicates, stuck loops, label corruption, and human-needed issues (pipeline jams, abandoned issues, repeated diversions, missing divert reasons) as `auto-improve:raised` + `audit` findings (Opus) |
 | `cai.py code-audit` | `0 3 * * 0` (weekly Sunday 03:00 UTC) | Source-code consistency audit — clones the repo read-only, runs an Opus agent to flag cross-file inconsistencies, dead code, missing references, duplicated logic, hardcoded drift, config mismatches, and registration mismatches; publishes findings as `code-audit` namespace issues |
 | `cai.py propose` | `0 4 * * 0` (weekly Sunday 04:00 UTC) | Creative improvement proposals — clones the repo read-only, runs a creative agent to propose an ambitious improvement, then a review agent to evaluate feasibility; approved proposals are filed as `auto-improve:raised` issues so they flow through the triage → (optionally skip to `:plan-approved` / `:applying`) → refine → plan → implement pipeline |
 | `cai.py update-check` | `0 4 * * 1` (weekly Monday 04:00 UTC) | Claude Code release check — clones the repo, fetches the latest Claude Code releases from GitHub, and runs a Sonnet agent that compares the current pinned version against the latest releases; findings (new versions, feature adoptions, deprecated flags, best practices) are published as `update-check` namespace issues |
@@ -221,8 +221,8 @@ Audit categories: `stale_lifecycle`, `lock_corruption`, `loop_stuck`,
 `cost_outlier`, `workflow_anomaly`, `fix_loop_efficiency`.
 
 There are five exceptions to "report-only": stale lock rollback, stale `:merged`
-flagging, orphaned-branch cleanup, `:pr-open` recovery, and silent dismissal
-detection. Three lock types are rolled back: `:in-progress` issues after
+flagging, orphaned-branch cleanup, `:pr-open` recovery, and retroactive terminal
+label enforcement. Three lock types are rolled back: `:in-progress` issues after
 6 hours with no recent fix activity, `:revising` issues after 1 hour with no
 recent revise activity, and `:applying` issues after 2 hours with no recent
 maintain activity — `:in-progress` and `:revising` are rolled back to
@@ -236,8 +236,8 @@ are rolled back to `:refined` to restart the refinement and planning cycle
 before a human can re-approve them for the implement subagent. Finally, closed
 `auto-improve` issues that lack a terminal label (`auto-improve:merged`,
 `auto-improve:solved`) and were not closed with `--reason "not planned"` are
-flagged for potential manual re-opening, since they may have been closed
-without proper dismissal processing.
+automatically re-closed with `--reason "not planned"` to satisfy the terminal
+state requirement.
 
 ### Comment-driven PR iteration
 

--- a/cai.py
+++ b/cai.py
@@ -1170,6 +1170,49 @@ def _migrate_no_action_labels() -> list[int]:
     return closed
 
 
+def _retroactive_no_action_sweep() -> list[dict]:
+    """Close recently-closed auto-improve issues that lack a terminal label.
+
+    Issues closed without auto-improve:merged or auto-improve:solved
+    (and not already closed as 'not planned') are re-closed with
+    --reason 'not planned' to satisfy the terminal-state requirement.
+    """
+    closed_issues = _fetch_closed_auto_improve_issues(limit=50)
+    terminal_labels = {LABEL_MERGED, LABEL_SOLVED}
+    swept = []
+    for ci in closed_issues:
+        labels = set(ci.get("labels", []))
+        if labels & terminal_labels:
+            continue  # already has a terminal label
+        # Check if already closed as "not planned".
+        try:
+            detail = _gh_json([
+                "issue", "view", str(ci["number"]),
+                "--repo", REPO,
+                "--json", "stateReason",
+            ])
+            if (detail or {}).get("stateReason") == "NOT_PLANNED":
+                continue
+        except subprocess.CalledProcessError:
+            pass  # proceed with re-close attempt
+        ok = close_issue_not_planned(
+            ci["number"],
+            "Retroactively closing as **not planned** — issue was closed "
+            "without a terminal lifecycle label.",
+            log_prefix="cai audit",
+        )
+        if ok:
+            swept.append({"number": ci["number"], "title": ci["title"]})
+            log_run("audit", action="no_action_applied_retroactively",
+                    issue=ci["number"])
+            print(
+                f"[audit] action=no_action_applied_retroactively "
+                f"issue=#{ci['number']}",
+                flush=True,
+            )
+    return swept
+
+
 def cmd_audit(args) -> int:
     """Run the periodic queue/PR consistency audit."""
     print("[cai audit] running audit", flush=True)
@@ -1206,6 +1249,9 @@ def cmd_audit(args) -> int:
     except subprocess.CalledProcessError:
         pr_open_issues = []
     recovered_pr_open = _recover_stale_pr_open(pr_open_issues, log_prefix="cai audit")
+
+    # Step 1f: Retroactively close auto-improve issues closed without terminal labels.
+    retroactive_no_action = _retroactive_no_action_sweep()
 
     # Step 2: Gather GitHub state for the claude-driven semantic checks.
 
@@ -1335,6 +1381,11 @@ def cmd_audit(args) -> int:
         for ri in recovered_pr_open:
             deterministic_section += f"- #{ri['number']}: {ri['title']}\n"
         deterministic_section += "\n"
+    if retroactive_no_action:
+        deterministic_section += "## Closed issues with :no-action applied retroactively this run\n\n"
+        for ra in retroactive_no_action:
+            deterministic_section += f"- #{ra['number']}: {ra['title']}\n"
+        deterministic_section += "\n"
     # Cost summary so the audit agent can flag cost outliers — same
     # window as the run-log tail (last 7 days, top 10 invocations).
     cost_section = _build_cost_summary(days=7, top_n=10)
@@ -1397,6 +1448,7 @@ def cmd_audit(args) -> int:
                 pr_open_recovered=len(recovered_pr_open),
                 branches_cleaned=len(deleted_orphaned),
                 merged_flagged=len(flagged_merged),
+                retroactive_no_action=len(retroactive_no_action),
                 exit=audit.returncode)
         return audit.returncode
 
@@ -1413,6 +1465,7 @@ def cmd_audit(args) -> int:
                 pr_open_recovered=len(recovered_pr_open),
                 branches_cleaned=len(deleted_orphaned),
                 merged_flagged=len(flagged_merged),
+                retroactive_no_action=len(retroactive_no_action),
                 result="no_findings_file", duration=dur, exit=1)
         return 1
 
@@ -1427,6 +1480,7 @@ def cmd_audit(args) -> int:
             pr_open_recovered=len(recovered_pr_open),
             branches_cleaned=len(deleted_orphaned),
             merged_flagged=len(flagged_merged),
+            retroactive_no_action=len(retroactive_no_action),
             duration=dur, exit=published.returncode)
     return published.returncode
 

--- a/cai.py
+++ b/cai.py
@@ -48,10 +48,10 @@ Subcommands:
                             and `:applying` (>2h) locks; unsticks stale
                             `:no-action` issues; flags stale `:merged`
                             issues; recovers `:pr-open` issues with closed
-                            PRs; cleans up orphaned branches; applies
-                            `:no-action` to closed issues lacking terminal
-                            labels; then runs an Opus-driven semantic
-                            check for duplicates, stuck loops, label
+                            PRs; cleans up orphaned branches; retroactively
+                            closes closed issues lacking terminal labels
+                            (as 'not planned'); then runs an Opus-driven
+                            semantic check for duplicates, stuck loops, label
                             corruption, and human-needed issues
                             (pipeline jams, abandoned tasks, repeated
                             diversions, missing reasons). Findings are


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#835

**Issue:** #835 — Issues #793, #800, #802 closed without terminal lifecycle labels

## PR Summary

### What this fixes
Issues were being closed by humans without going through terminal lifecycle labels (`auto-improve:merged` or `auto-improve:solved`), leaving them in an ambiguous state. The harness's `cmd_audit()` was documented to perform a retroactive sweep (in `cai-audit.md` lines 153–162) but the sweep was never implemented.

### What was changed
- **`cai.py`**: Added `_retroactive_no_action_sweep()` helper function (after `_migrate_no_action_labels`) that fetches recently closed auto-improve issues, skips those with terminal labels or already closed as "not planned", and re-closes the rest with `--reason "not planned"` plus a comment.
- **`cai.py`**: Called `_retroactive_no_action_sweep()` as Step 1f in `cmd_audit()`, after the existing Step 1e (`_recover_stale_pr_open`).
- **`cai.py`**: Added a `## Closed issues with :no-action applied retroactively this run` block to the deterministic section passed to the audit agent.
- **`cai.py`**: Added `retroactive_no_action=len(retroactive_no_action)` to all three `log_run("audit", ...)` calls for observability.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
