### PR TITLE
auto-improve: [#799 Step 6/6] Extract `cmd_cycle` and `cmd_dispatch` from `cai.py` → `cai_lib/cmd_cycle.py`; reduce `cai.py` to pure dispatcher

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -65,7 +65,7 @@
 | `cai_lib/actions/revise.py` | Handler for PRState.REVISION_PENDING — runs cai-revise |
 | `cai_lib/actions/triage.py` | Handler for IssueState.RAISED / TRIAGING — runs cai-triage |
 | `cai_lib/cmd_agents.py` | CLI subcommands extracted from cai.py: analyze, audit, propose, code-audit, agent-audit, update-check, cost-optimize, external-scout |
-| `cai_lib/cmd_cycle.py` | TODO: add description |
+| `cai_lib/cmd_cycle.py` | Cycle and dispatch entry-points — `cmd_cycle` (one cycle tick with flock serialization), `cmd_dispatch` (direct FSM dispatch for specific issues/PRs) |
 | `cai_lib/cmd_helpers.py` | Cross-command helpers shared between cai.py and cai_lib/actions/* |
 | `cai_lib/cmd_helpers_git.py` | Git and worktree helpers for cai action wrappers |
 | `cai_lib/cmd_helpers_github.py` | GitHub API helpers for cai action wrappers |

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -65,6 +65,7 @@
 | `cai_lib/actions/revise.py` | Handler for PRState.REVISION_PENDING — runs cai-revise |
 | `cai_lib/actions/triage.py` | Handler for IssueState.RAISED / TRIAGING — runs cai-triage |
 | `cai_lib/cmd_agents.py` | CLI subcommands extracted from cai.py: analyze, audit, propose, code-audit, agent-audit, update-check, cost-optimize, external-scout |
+| `cai_lib/cmd_cycle.py` | TODO: add description |
 | `cai_lib/cmd_helpers.py` | Cross-command helpers shared between cai.py and cai_lib/actions/* |
 | `cai_lib/cmd_helpers_git.py` | Git and worktree helpers for cai action wrappers |
 | `cai_lib/cmd_helpers_github.py` | GitHub API helpers for cai action wrappers |

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -65,7 +65,7 @@
 | `cai_lib/actions/revise.py` | Handler for PRState.REVISION_PENDING — runs cai-revise |
 | `cai_lib/actions/triage.py` | Handler for IssueState.RAISED / TRIAGING — runs cai-triage |
 | `cai_lib/cmd_agents.py` | CLI subcommands extracted from cai.py: analyze, audit, propose, code-audit, agent-audit, update-check, cost-optimize, external-scout |
-| `cai_lib/cmd_cycle.py` | Cycle and dispatch entry-points — `cmd_cycle` (one cycle tick with flock serialization), `cmd_dispatch` (direct FSM dispatch for specific issues/PRs) |
+| `cai_lib/cmd_cycle.py` | TODO: add description |
 | `cai_lib/cmd_helpers.py` | Cross-command helpers shared between cai.py and cai_lib/actions/* |
 | `cai_lib/cmd_helpers_git.py` | Git and worktree helpers for cai action wrappers |
 | `cai_lib/cmd_helpers_github.py` | GitHub API helpers for cai action wrappers |

--- a/cai.py
+++ b/cai.py
@@ -216,14 +216,12 @@ the cai_home volume.
 No third-party Python dependencies — only stdlib.
 """
 import argparse
-import fcntl
 import json
 import os
 import re
 import shutil
 import subprocess
 import sys
-import time
 import uuid
 
 from datetime import datetime, timedelta, timezone
@@ -242,7 +240,7 @@ from cai_lib.config import (  # noqa: E402
 )
 
 from cai_lib.logging_utils import (  # noqa: E402
-    log_run, log_cost,  # noqa: F401
+    log_cost,  # noqa: F401
     _get_issue_category, _log_outcome, _load_outcome_counts,
     _load_outcome_stats, _load_cost_log, _row_ts, _build_cost_summary,
 )
@@ -256,15 +254,13 @@ from cai_lib.subprocess_utils import _run, _run_claude_p  # noqa: E402
 
 
 from cai_lib.github import (  # noqa: E402
-    _gh_json, check_gh_auth, check_claude_auth,
-    _set_labels, _set_pr_labels, _issue_has_label, _build_issue_block,
+    check_gh_auth, check_claude_auth,
+    _set_pr_labels, _issue_has_label, _build_issue_block,
     _build_implement_user_message, _fetch_linked_issue_block,
     close_issue_not_planned, _recover_stale_pr_open,
 )
-from cai_lib.watchdog import _rollback_stale_in_progress  # noqa: E402
 from cai_lib.cmd_helpers import _work_directory_block  # noqa: E402
 from cai_lib.cmd_unblock import cmd_unblock  # noqa: E402
-from cai_lib.dispatcher import dispatch_drain  # noqa: E402
 from cai_lib.cmd_misc import (  # noqa: E402
     cmd_init, cmd_verify, cmd_test,
     cmd_cost_report, cmd_health_report, cmd_check_workflows,
@@ -273,141 +269,7 @@ from cai_lib.cmd_agents import (  # noqa: E402
     cmd_analyze, cmd_audit, cmd_propose, cmd_code_audit,
     cmd_agent_audit, cmd_update_check, cmd_cost_optimize, cmd_external_scout,
 )
-
-
-# ---------------------------------------------------------------------------
-# Cycle (full pipeline without analyze)
-# ---------------------------------------------------------------------------
-
-def _run_step(name: str, handler, args) -> int:
-    """Run a single cycle step, catching exceptions."""
-    print(f"\n[cai cycle] === {name} ===", flush=True)
-    try:
-        return handler(args)
-    except Exception as exc:
-        print(f"[cai cycle] {name} raised {exc!r}", file=sys.stderr, flush=True)
-        return 1
-
-
-_CYCLE_LOCK_PATH = f"/tmp/cai-cycle-{REPO.replace('/', '-')}.lock"
-
-
-def cmd_cycle(args) -> int:
-    """One cycle tick under a non-blocking flock.
-
-    Delegates to :func:`_cmd_cycle_inner`, which reconciles labels,
-    runs audit, and dispatches a single actionable issue/PR via the
-    FSM dispatcher. The flock on ``_CYCLE_LOCK_PATH`` (per-repo) ensures
-    overlapping supercronic fires don't step on each other.
-    """
-    lock_fd = os.open(_CYCLE_LOCK_PATH, os.O_CREAT | os.O_RDWR, 0o644)
-    try:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except BlockingIOError:
-        os.close(lock_fd)
-        print("[cai cycle] another cycle is already running; skipping this tick",
-              flush=True)
-        return 0
-
-    try:
-        return _cmd_cycle_inner(args)
-    finally:
-        try:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-        finally:
-            os.close(lock_fd)
-
-
-def _cmd_cycle_inner(args) -> int:
-    """One cycle tick: restart-recovery + dispatch one actionable issue/PR.
-
-    Verify and audit run on their own cron cadences (CAI_VERIFY_SCHEDULE,
-    CAI_AUDIT_SCHEDULE) — the cycle is purely restart-recovery + dispatch.
-    """
-    print("[cai cycle] starting cycle tick", flush=True)
-    t0 = time.monotonic()
-    all_results: dict[str, int] = {}
-    had_failure = False
-
-    # Phase 0: self-heal parent label. Dispatcher lists open issues via
-    # `--label auto-improve`, so any issue carrying an FSM state label
-    # (e.g. auto-improve:raised) but missing the parent `auto-improve`
-    # label is invisible to the cycle. Add the parent where missing.
-    _fsm_state_labels = (
-        LABEL_RAISED, LABEL_REFINING, LABEL_REFINED,
-        LABEL_PLANNING, LABEL_PLANNED, LABEL_PLAN_APPROVED,
-        LABEL_APPLYING, LABEL_APPLIED, LABEL_IN_PROGRESS,
-        LABEL_PR_OPEN, LABEL_REVISING, LABEL_MERGED,
-        LABEL_HUMAN_NEEDED, LABEL_TRIAGING,
-    )
-    _healed: set[int] = set()
-    for _lbl in _fsm_state_labels:
-        try:
-            _issues = _gh_json([
-                "issue", "list",
-                "--repo", REPO,
-                "--label", _lbl,
-                "--state", "open",
-                "--json", "number,labels",
-                "--limit", "100",
-            ]) or []
-        except Exception:
-            continue
-        for _iss in _issues:
-            _num = _iss["number"]
-            if _num in _healed:
-                continue
-            _names = [lb["name"] for lb in _iss.get("labels", [])]
-            if "auto-improve" not in _names:
-                if _set_labels(_num, add=["auto-improve"], log_prefix="cai cycle"):
-                    print(
-                        f"[cai cycle] self-heal: added parent "
-                        f"`auto-improve` to #{_num}",
-                        flush=True,
-                    )
-                _healed.add(_num)
-
-    # Phase 1: restart recovery — force-rollback any stuck locks left
-    # behind by a previous run that crashed mid-handler.
-    rolled_back = _rollback_stale_in_progress(immediate=True)
-    if rolled_back:
-        nums = ", ".join(f"#{i['number']}" for i in rolled_back)
-        print(f"[cai cycle] recovered {len(rolled_back)} stale lock(s): {nums}",
-              flush=True)
-
-    # Phase 2: dispatch a single actionable issue/PR via the FSM dispatcher.
-    # Note: :applied → :solved bookkeeping is handled by handle_applied in
-    # the dispatcher (IssueState.APPLIED), so no separate Phase 1.5 is needed.
-    rc = _run_step("dispatch", lambda _a: dispatch_drain(), args)
-    all_results["dispatch"] = rc
-    if rc != 0:
-        had_failure = True
-
-    dur = f"{time.monotonic() - t0:.1f}s"
-    summary = " ".join(f"{k}={v}" for k, v in all_results.items())
-    print(f"\n[cai cycle] done in {dur} — {summary}", flush=True)
-    log_run("cycle", repo=REPO, results=summary,
-            duration=dur, exit=1 if had_failure else 0)
-    return 1 if had_failure else 0
-
-
-def cmd_dispatch(args) -> int:
-    """Dispatch one or more FSM actions.
-
-    With no args, drains the actionable queue: repeatedly picks the
-    oldest actionable issue/PR and dispatches it until the queue is
-    empty (or a loop-guard / max-iter cap fires). With --issue N,
-    fetches issue N, derives its FSM state, and runs the matching
-    handler exactly once. With --pr N, same for a PR.
-    """
-    from cai_lib.dispatcher import (
-        dispatch_issue, dispatch_pr, dispatch_drain,
-    )
-    if getattr(args, "issue", None) is not None:
-        return dispatch_issue(args.issue)
-    if getattr(args, "pr", None) is not None:
-        return dispatch_pr(args.pr)
-    return dispatch_drain()
+from cai_lib.cmd_cycle import cmd_cycle, cmd_dispatch  # noqa: E402
 
 
 

--- a/cai_lib/cmd_cycle.py
+++ b/cai_lib/cmd_cycle.py
@@ -1,0 +1,142 @@
+"""Cycle and dispatch entry-points for the cai pipeline."""
+import fcntl
+import os
+import sys
+import time
+
+from cai_lib.config import *  # noqa: E402,F403
+from cai_lib.github import _gh_json, _set_labels
+from cai_lib.watchdog import _rollback_stale_in_progress
+from cai_lib.dispatcher import dispatch_drain
+from cai_lib.logging_utils import log_run
+
+
+def _run_step(name: str, handler, args) -> int:
+    """Run a single cycle step, catching exceptions."""
+    print(f"\n[cai cycle] === {name} ===", flush=True)
+    try:
+        return handler(args)
+    except Exception as exc:
+        print(f"[cai cycle] {name} raised {exc!r}", file=sys.stderr, flush=True)
+        return 1
+
+
+_CYCLE_LOCK_PATH = f"/tmp/cai-cycle-{REPO.replace('/', '-')}.lock"
+
+
+def cmd_cycle(args) -> int:
+    """One cycle tick under a non-blocking flock.
+
+    Delegates to :func:`_cmd_cycle_inner`, which reconciles labels,
+    runs audit, and dispatches a single actionable issue/PR via the
+    FSM dispatcher. The flock on ``_CYCLE_LOCK_PATH`` (per-repo) ensures
+    overlapping supercronic fires don't step on each other.
+    """
+    lock_fd = os.open(_CYCLE_LOCK_PATH, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        os.close(lock_fd)
+        print("[cai cycle] another cycle is already running; skipping this tick",
+              flush=True)
+        return 0
+
+    try:
+        return _cmd_cycle_inner(args)
+    finally:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        finally:
+            os.close(lock_fd)
+
+
+def _cmd_cycle_inner(args) -> int:
+    """One cycle tick: restart-recovery + dispatch one actionable issue/PR.
+
+    Verify and audit run on their own cron cadences (CAI_VERIFY_SCHEDULE,
+    CAI_AUDIT_SCHEDULE) — the cycle is purely restart-recovery + dispatch.
+    """
+    print("[cai cycle] starting cycle tick", flush=True)
+    t0 = time.monotonic()
+    all_results: dict[str, int] = {}
+    had_failure = False
+
+    # Phase 0: self-heal parent label. Dispatcher lists open issues via
+    # `--label auto-improve`, so any issue carrying an FSM state label
+    # (e.g. auto-improve:raised) but missing the parent `auto-improve`
+    # label is invisible to the cycle. Add the parent where missing.
+    _fsm_state_labels = (
+        LABEL_RAISED, LABEL_REFINING, LABEL_REFINED,
+        LABEL_PLANNING, LABEL_PLANNED, LABEL_PLAN_APPROVED,
+        LABEL_APPLYING, LABEL_APPLIED, LABEL_IN_PROGRESS,
+        LABEL_PR_OPEN, LABEL_REVISING, LABEL_MERGED,
+        LABEL_HUMAN_NEEDED, LABEL_TRIAGING,
+    )
+    _healed: set[int] = set()
+    for _lbl in _fsm_state_labels:
+        try:
+            _issues = _gh_json([
+                "issue", "list",
+                "--repo", REPO,
+                "--label", _lbl,
+                "--state", "open",
+                "--json", "number,labels",
+                "--limit", "100",
+            ]) or []
+        except Exception:
+            continue
+        for _iss in _issues:
+            _num = _iss["number"]
+            if _num in _healed:
+                continue
+            _names = [lb["name"] for lb in _iss.get("labels", [])]
+            if "auto-improve" not in _names:
+                if _set_labels(_num, add=["auto-improve"], log_prefix="cai cycle"):
+                    print(
+                        f"[cai cycle] self-heal: added parent "
+                        f"`auto-improve` to #{_num}",
+                        flush=True,
+                    )
+                _healed.add(_num)
+
+    # Phase 1: restart recovery — force-rollback any stuck locks left
+    # behind by a previous run that crashed mid-handler.
+    rolled_back = _rollback_stale_in_progress(immediate=True)
+    if rolled_back:
+        nums = ", ".join(f"#{i['number']}" for i in rolled_back)
+        print(f"[cai cycle] recovered {len(rolled_back)} stale lock(s): {nums}",
+              flush=True)
+
+    # Phase 2: dispatch a single actionable issue/PR via the FSM dispatcher.
+    # Note: :applied → :solved bookkeeping is handled by handle_applied in
+    # the dispatcher (IssueState.APPLIED), so no separate Phase 1.5 is needed.
+    rc = _run_step("dispatch", lambda _a: dispatch_drain(), args)
+    all_results["dispatch"] = rc
+    if rc != 0:
+        had_failure = True
+
+    dur = f"{time.monotonic() - t0:.1f}s"
+    summary = " ".join(f"{k}={v}" for k, v in all_results.items())
+    print(f"\n[cai cycle] done in {dur} — {summary}", flush=True)
+    log_run("cycle", repo=REPO, results=summary,
+            duration=dur, exit=1 if had_failure else 0)
+    return 1 if had_failure else 0
+
+
+def cmd_dispatch(args) -> int:
+    """Dispatch one or more FSM actions.
+
+    With no args, drains the actionable queue: repeatedly picks the
+    oldest actionable issue/PR and dispatches it until the queue is
+    empty (or a loop-guard / max-iter cap fires). With --issue N,
+    fetches issue N, derives its FSM state, and runs the matching
+    handler exactly once. With --pr N, same for a PR.
+    """
+    from cai_lib.dispatcher import (
+        dispatch_issue, dispatch_pr, dispatch_drain,
+    )
+    if getattr(args, "issue", None) is not None:
+        return dispatch_issue(args.issue)
+    if getattr(args, "pr", None) is not None:
+        return dispatch_pr(args.pr)
+    return dispatch_drain()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#823

**Issue:** #823 — [#799 Step 6/6] Extract `cmd_cycle` and `cmd_dispatch` from `cai.py` → `cai_lib/cmd_cycle.py`; reduce `cai.py` to pure dispatcher

## PR Summary

### What this fixes
`cai.py` contained `cmd_cycle`, `cmd_dispatch`, and their private helpers (`_run_step`, `_CYCLE_LOCK_PATH`, `_cmd_cycle_inner`) inline, making the file unnecessarily large. This is Step 6/6 of #799 — the final extraction to reduce `cai.py` to a pure argparse dispatcher.

### What was changed
- **`cai_lib/cmd_cycle.py`** (new file): Contains verbatim copies of `_run_step`, `_CYCLE_LOCK_PATH`, `cmd_cycle`, `_cmd_cycle_inner`, and `cmd_dispatch` from `cai.py`, with their own stdlib and library imports.
- **`cai.py`**: Removed `import fcntl`, `import time`, `log_run` from logging import, `_gh_json`/`_set_labels` from github import, `from cai_lib.watchdog import _rollback_stale_in_progress`, `from cai_lib.dispatcher import dispatch_drain`; deleted the extracted function bodies (~135 lines); added `from cai_lib.cmd_cycle import cmd_cycle, cmd_dispatch`.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
