### PR TITLE
feat: cross-host transcript sync via rsync + central SSH server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,14 @@
 # documented in docker-compose.yml.
 
 ANTHROPIC_API_KEY=
+
+# --- Optional: cross-host transcript sync ---------------------------------
+#
+# Populate these only if you run cai for the same repo on multiple
+# machines and want `cai analyze` / `cai confirm` to see the union of
+# every host's transcripts. See docs/configuration.md for the full
+# setup including the public-key step and server-side cleanup script.
+#
+# CAI_TRANSCRIPT_SYNC_URL=cai@vps.example.com:/srv/cai-transcripts
+# CAI_TRANSCRIPT_SYNC_SCHEDULE=*/15 * * * *
+# CAI_MACHINE_ID=laptop

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -86,6 +86,7 @@
 | `cai_lib/parse.py` | Deterministic signal extractor from Claude Code JSONL transcripts |
 | `cai_lib/publish.py` | GitHub issue publisher with fingerprint dedup |
 | `cai_lib/subprocess_utils.py` | Subprocess helpers extracted from cai.py |
+| `cai_lib/transcript_sync.py` | Cross-host transcript sync — push/pull session jsonls to a central SSH server |
 | `cai_lib/watchdog.py` | Stale-lock watchdog that rolls back orphaned :in-progress / :revising labels |
 | `docker-compose.yml` | Multi-service orchestration with named volumes |
 | `docs/_config.yml` | Jekyll configuration for GitHub Pages docs |
@@ -102,6 +103,7 @@
 | `pyproject.toml` | Python project configuration (ruff lint settings) |
 | `scripts/generate-fsm-docs.py` | Generator script for docs/fsm.md (renders cai_lib.fsm transitions as Mermaid) |
 | `scripts/generate-index.sh` | Generator script for CODEBASE_INDEX.md |
+| `scripts/server-cleanup.sh` | Server-side age/size cleanup for the transcript-sync store (runs on the OVH box, not in the container) |
 | `tests/__init__.py` | Test package init |
 | `tests/test_dispatcher.py` | Tests for the FSM dispatcher and state→handler registries |
 | `tests/test_dup_check.py` | TODO: add description |
@@ -118,5 +120,6 @@
 | `tests/test_revise_filter.py` | TODO: add description |
 | `tests/test_rollback.py` | Tests for rollback functionality |
 | `tests/test_subprocess_utils.py` | TODO: add description |
+| `tests/test_transcript_sync.py` | Tests for cai_lib.transcript_sync — no-op path, parse_source fallback, repo slug |
 | `tests/test_unblock.py` | Tests for cai_lib.cmd_unblock — admin-comment filtering and agent input formatting |
 | `workspaces.json.example` | Template for multi-workspace configuration with per-repo cycle schedules |

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN apt-get update \
         wget \
         gnupg \
         git \
+        rsync \
+        openssh-client \
     && mkdir -p -m 755 /etc/apt/keyrings \
     && wget -nv -O /etc/apt/keyrings/githubcli-archive-keyring.gpg \
         https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -105,7 +107,8 @@ RUN wget -nv -O /usr/local/bin/supercronic \
 # created on first run inside the volume.
 RUN groupadd --system --gid 1000 cai \
     && useradd --system --gid cai --uid 1000 --create-home --shell /bin/bash cai \
-    && mkdir -p /var/log/cai /home/cai/.config/gh /home/cai/.claude/projects \
+    && mkdir -p /var/log/cai /home/cai/.config/gh /home/cai/.claude/projects /home/cai/.ssh \
+    && chmod 700 /home/cai/.ssh \
     && chown -R cai:cai /var/log/cai /home/cai
 
 # `/app` is populated by cloning the repo at build time instead of

--- a/cai.py
+++ b/cai.py
@@ -270,6 +270,7 @@ from cai_lib.cmd_agents import (  # noqa: E402
     cmd_agent_audit, cmd_update_check, cmd_cost_optimize, cmd_external_scout,
 )
 from cai_lib.cmd_cycle import cmd_cycle, cmd_dispatch  # noqa: E402
+from cai_lib.transcript_sync import cmd_transcript_sync  # noqa: E402
 
 
 
@@ -303,6 +304,10 @@ def main() -> int:
     sub.add_parser("cost-optimize", help="Weekly cost-reduction proposal or evaluation")
     sub.add_parser("check-workflows", help="Check GitHub Actions for recent workflow failures and raise findings")
     sub.add_parser("cycle", help="One cycle tick: verify, audit, dispatch one actionable issue/PR")
+    sub.add_parser(
+        "transcript-sync",
+        help="Push local transcripts to the central server and pull the aggregate mirror back (no-op when CAI_TRANSCRIPT_SYNC_URL unset)",
+    )
     sub.add_parser("test", help="Run the project test suite")
 
     cost_parser = sub.add_parser(
@@ -333,15 +338,20 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    auth_rc = check_gh_auth()
-    if auth_rc != 0:
-        return auth_rc
+    # transcript-sync only shells out to rsync/ssh; it never touches GitHub
+    # or Claude. Skipping the auth checks lets sync run independently of
+    # pipeline-credential state (e.g. when gh auth hasn't been configured
+    # yet on a fresh install that wants to start shipping transcripts).
+    if args.command != "transcript-sync":
+        auth_rc = check_gh_auth()
+        if auth_rc != 0:
+            return auth_rc
 
-    auth_rc = check_claude_auth()
-    if auth_rc != 0:
-        return auth_rc
+        auth_rc = check_claude_auth()
+        if auth_rc != 0:
+            return auth_rc
 
-    ensure_all_labels()
+        ensure_all_labels()
 
     handlers = {
         "init": cmd_init,
@@ -360,6 +370,7 @@ def main() -> int:
         "health-report": cmd_health_report,
         "cost-optimize": cmd_cost_optimize,
         "check-workflows": cmd_check_workflows,
+        "transcript-sync": cmd_transcript_sync,
         "test": cmd_test,
     }
     return handlers[args.command](args)

--- a/cai_lib/actions/confirm.py
+++ b/cai_lib/actions/confirm.py
@@ -26,8 +26,8 @@ from cai_lib.config import (
     LABEL_SOLVED,
     PARSE_SCRIPT,
     REPO,
-    TRANSCRIPT_DIR,
 )
+from cai_lib import transcript_sync
 from cai_lib.cmd_helpers import _fetch_previous_fix_attempts
 from cai_lib.fsm import apply_transition
 from cai_lib.github import _gh_json, _set_labels, close_issue_completed
@@ -81,8 +81,13 @@ def handle_confirm(issue: dict) -> int:
     print(f"[cai confirm] found {len(merged_issues)} merged issue(s)", flush=True)
 
     # 2. Run parse.py against the transcript dir (global window settings).
+    # When cross-host sync is enabled, refresh the aggregate mirror first
+    # so the confirm check considers signals from every machine, not just
+    # this one. No-op when sync is disabled.
+    transcript_sync.pull()
+    parse_dir = transcript_sync.parse_source()
     parsed = _run(
-        ["python", str(PARSE_SCRIPT), str(TRANSCRIPT_DIR)],
+        ["python", str(PARSE_SCRIPT), str(parse_dir)],
         capture_output=True,
     )
     if parsed.returncode != 0:

--- a/cai_lib/cmd_agents.py
+++ b/cai_lib/cmd_agents.py
@@ -33,6 +33,7 @@ from cai_lib.github import (
 )
 from cai_lib.watchdog import _rollback_stale_in_progress
 from cai_lib.cmd_helpers import _work_directory_block
+from cai_lib import transcript_sync
 
 
 # ---------------------------------------------------------------------------
@@ -234,9 +235,17 @@ def cmd_analyze(args) -> int:
     print("[cai analyze] running self-analyzer", flush=True)
     t0 = time.monotonic()
 
-    if not TRANSCRIPT_DIR.exists():
+    # When cross-host transcript sync is enabled, pull every machine's
+    # bucket into the local aggregate mirror before parsing — this way
+    # the analyzer sees tool-call activity from all machines that share
+    # this repo, not only the host this container runs on. No-op when
+    # sync is disabled.
+    transcript_sync.pull()
+    parse_dir = transcript_sync.parse_source()
+
+    if not parse_dir.exists():
         print(
-            f"[cai analyze] no transcript dir at {TRANSCRIPT_DIR}; nothing to analyze",
+            f"[cai analyze] no transcript dir at {parse_dir}; nothing to analyze",
             flush=True,
         )
         log_run("analyze", repo=REPO, sessions=0, tool_calls=0,
@@ -244,7 +253,7 @@ def cmd_analyze(args) -> int:
         return 0
 
     parsed = _run(
-        ["python", str(PARSE_SCRIPT), str(TRANSCRIPT_DIR)],
+        ["python", str(PARSE_SCRIPT), str(parse_dir)],
         capture_output=True,
     )
     if parsed.returncode != 0:

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -7,6 +7,14 @@ from pathlib import Path
 REPO: str = os.environ.get("CAI_REPO", "damien-robotsix/robotsix-cai")
 SMOKE_PROMPT = "Say hello in one short sentence."
 
+
+def _repo_slug(repo: str) -> str:
+    """Turn ``owner/repo`` into a filesystem-safe slug for server paths."""
+    return repo.replace("/", "_")
+
+
+REPO_SLUG: str = _repo_slug(REPO)
+
 # Root of claude-code's per-cwd transcript dirs. claude-code writes
 # `~/.claude/projects/<sanitized-cwd>/<session-id>.jsonl` for every
 # session, so this directory contains one subdir per cwd:
@@ -19,6 +27,62 @@ SMOKE_PROMPT = "Say hello in one short sentence."
 # Path is /home/cai/... because the container runs as the non-root
 # `cai` user (uid 1000) — see Dockerfile.
 TRANSCRIPT_DIR = Path("/home/cai/.claude/projects")
+
+# When cross-host transcript sync is enabled (CAI_TRANSCRIPT_SYNC_URL set),
+# the analyzer/confirm handlers read from this aggregate mirror — populated
+# by `cai transcript-sync` via rsync — instead of the local-only
+# TRANSCRIPT_DIR. The mirror holds one subdir per machine-id:
+#
+#   /home/cai/.claude/projects-aggregate/<machine-id>/<encoded-cwd>/<session>.jsonl
+#
+# `parse.py` walks .jsonl files recursively, so the extra level of
+# nesting is transparent to it.
+TRANSCRIPT_AGGREGATE_DIR = Path("/home/cai/.claude/projects-aggregate")
+
+# Cross-host transcript-sync configuration. The feature is a no-op when
+# ``CAI_TRANSCRIPT_SYNC_URL`` is unset, so existing single-host
+# deployments behave exactly as before. See cai_lib.transcript_sync and
+# docs/configuration.md for the full design.
+TRANSCRIPT_SYNC_URL: str = os.environ.get("CAI_TRANSCRIPT_SYNC_URL", "").strip()
+TRANSCRIPT_SYNC_SSH_KEY = Path(
+    os.environ.get("CAI_TRANSCRIPT_SYNC_SSH_KEY", "/home/cai/.ssh/cai_transcript_key")
+)
+# Bind-mounted from the host's /etc/machine-id — see docker-compose.yml.
+# Container's own /etc/machine-id is the container ID and rotates on every
+# `docker compose up`, so it's unusable as a stable bucket key.
+_HOST_MACHINE_ID_PATH = Path("/etc/host-machine-id")
+
+
+def _resolve_machine_id() -> str:
+    """Resolve the stable per-host identifier used for server bucket paths.
+
+    Resolution order:
+      1. ``CAI_MACHINE_ID`` env var (human-readable override — e.g. ``laptop``).
+      2. First 12 chars of the host's ``/etc/machine-id`` (bind-mounted at
+         ``/etc/host-machine-id`` by docker-compose.yml).
+      3. Empty string — callers must treat this as "sync disabled for this
+         container" and surface a clear error. We do NOT fall back to the
+         container's own hostname: it's usually a random container ID that
+         rotates on every restart and would silently create a new server
+         bucket on every reboot.
+    """
+    explicit = os.environ.get("CAI_MACHINE_ID", "").strip()
+    if explicit:
+        return explicit
+    try:
+        host_mid = _HOST_MACHINE_ID_PATH.read_text().strip()
+    except (FileNotFoundError, PermissionError):
+        return ""
+    return host_mid[:12] if host_mid else ""
+
+
+MACHINE_ID: str = _resolve_machine_id()
+
+
+def transcript_sync_enabled() -> bool:
+    """True when transcript-sync is configured. Missing MACHINE_ID disables it."""
+    return bool(TRANSCRIPT_SYNC_URL) and bool(MACHINE_ID)
+
 
 # Files baked into the image alongside cai.py.
 PARSE_SCRIPT = Path("/app/parse.py")

--- a/cai_lib/transcript_sync.py
+++ b/cai_lib/transcript_sync.py
@@ -33,15 +33,12 @@ import subprocess
 import sys
 from pathlib import Path
 
-from cai_lib.config import (
-    MACHINE_ID,
-    REPO_SLUG,
-    TRANSCRIPT_AGGREGATE_DIR,
-    TRANSCRIPT_DIR,
-    TRANSCRIPT_SYNC_SSH_KEY,
-    TRANSCRIPT_SYNC_URL,
-    transcript_sync_enabled,
-)
+# Access config attributes lazily (``config.TRANSCRIPT_SYNC_URL`` etc.)
+# rather than importing them by value. Tests can then patch individual
+# attributes on the config module without having to reload this module,
+# and runtime behaviour picks up changes to the environment exposed via
+# config without any reload dance at all.
+from cai_lib import config
 
 
 _SSH_OPTIONS = [
@@ -55,20 +52,45 @@ _SSH_OPTIONS = [
 ]
 
 
+def _is_local_url(url: str) -> bool:
+    """True when the sync URL is a plain filesystem path, not SSH.
+
+    Local mode is used when the cai container runs on the same host as
+    the transcript store (e.g. a VPS that both hosts cai and acts as the
+    central store for other laptops that push over SSH). The path is
+    expected to be bind-mounted into the container; rsync then runs
+    directly against the filesystem with no SSH transport at all.
+
+    Heuristic: an SSH URL always contains ``:`` (``user@host:/path``),
+    a local path never does.
+    """
+    return ":" not in url
+
+
 def _ssh_command() -> str:
     """Build the ``-e`` argument for rsync — ``ssh -i <key> <opts>``."""
-    parts = ["ssh", "-i", str(TRANSCRIPT_SYNC_SSH_KEY), *_SSH_OPTIONS]
+    parts = ["ssh", "-i", str(config.TRANSCRIPT_SYNC_SSH_KEY), *_SSH_OPTIONS]
     return " ".join(parts)
 
 
 def _server_bucket() -> str:
     """Return ``<url>/<repo-slug>/<machine-id>`` — this host's push target."""
-    return f"{TRANSCRIPT_SYNC_URL.rstrip('/')}/{REPO_SLUG}/{MACHINE_ID}"
+    return (
+        f"{config.TRANSCRIPT_SYNC_URL.rstrip('/')}/"
+        f"{config.REPO_SLUG}/{config.MACHINE_ID}"
+    )
 
 
 def _server_slug() -> str:
     """Return ``<url>/<repo-slug>`` — the pull source (every machine's bucket)."""
-    return f"{TRANSCRIPT_SYNC_URL.rstrip('/')}/{REPO_SLUG}"
+    return f"{config.TRANSCRIPT_SYNC_URL.rstrip('/')}/{config.REPO_SLUG}"
+
+
+def _transport_args() -> list[str]:
+    """rsync transport flags. Empty for local mode; ``-e ssh …`` for SSH."""
+    if _is_local_url(config.TRANSCRIPT_SYNC_URL):
+        return []
+    return ["-e", _ssh_command()]
 
 
 def _ensure_rsync() -> bool:
@@ -81,6 +103,20 @@ def _ensure_rsync() -> bool:
         )
         return False
     return True
+
+
+def _local_has_transcripts() -> bool:
+    """True when there is at least one .jsonl under ``TRANSCRIPT_DIR``.
+
+    Guards ``push()`` against wiping the server bucket on a fresh install:
+    the container's TRANSCRIPT_DIR exists (pre-created in the image) but
+    is empty until the first claude session runs. An `rsync --delete`
+    of an empty source would drop every file from this machine's bucket
+    on the server.
+    """
+    if not config.TRANSCRIPT_DIR.exists():
+        return False
+    return any(config.TRANSCRIPT_DIR.rglob("*.jsonl"))
 
 
 def _run_rsync(args: list[str], *, label: str) -> int:
@@ -107,28 +143,41 @@ def _run_rsync(args: list[str], *, label: str) -> int:
     return result.returncode
 
 
+def _ensure_local_bucket() -> None:
+    """In local mode, create this host's bucket directory if missing.
+
+    SSH mode relies on sshd+rsync auto-creating remote paths; local mode
+    hits the filesystem directly, so we make sure the target exists.
+    """
+    if not _is_local_url(config.TRANSCRIPT_SYNC_URL):
+        return
+    Path(_server_bucket()).mkdir(parents=True, exist_ok=True)
+
+
 def push() -> int:
     """Push the local transcript tree into this host's server bucket.
 
-    No-op (returns 0) when the feature is disabled or the local dir is
-    missing. Uses ``--delete`` so the server bucket mirrors the local
-    window — per-machine history beyond the local window is NOT preserved
-    (server-side cleanup enforces age/size instead).
+    No-op (returns 0) when the feature is disabled or the local dir has
+    no .jsonl files yet — pushing an empty tree with ``--delete`` would
+    wipe this machine's server bucket on a fresh install. Uses
+    ``--delete`` once there's content so the bucket mirrors the local
+    window; server-side cleanup enforces age/size across machines.
     """
-    if not transcript_sync_enabled():
+    if not config.transcript_sync_enabled():
         return 0
-    if not TRANSCRIPT_DIR.exists():
+    if not _local_has_transcripts():
         return 0
     if not _ensure_rsync():
         return 0
+    _ensure_local_bucket()
     return _run_rsync(
         [
             "-az",
             "--delete",
-            "-e", _ssh_command(),
+            *_transport_args(),
             # Trailing slashes: rsync copies the *contents* of TRANSCRIPT_DIR
             # into the server bucket, not the directory itself.
-            f"{TRANSCRIPT_DIR}/",
+            f"{config.TRANSCRIPT_DIR}/",
             f"{_server_bucket()}/",
         ],
         label="push",
@@ -142,17 +191,23 @@ def pull() -> int:
     missing. Does NOT use ``--delete`` so a transient server outage can't
     empty the local mirror mid-run.
     """
-    if not transcript_sync_enabled():
+    if not config.transcript_sync_enabled():
         return 0
     if not _ensure_rsync():
         return 0
-    TRANSCRIPT_AGGREGATE_DIR.mkdir(parents=True, exist_ok=True)
+    config.TRANSCRIPT_AGGREGATE_DIR.mkdir(parents=True, exist_ok=True)
+    if _is_local_url(config.TRANSCRIPT_SYNC_URL):
+        # In local mode the source may not exist yet (no machine has
+        # pushed). rsync would emit "No such file or directory" and
+        # return non-zero — harmless but noisy. Skip gracefully.
+        if not Path(_server_slug()).exists():
+            return 0
     return _run_rsync(
         [
             "-az",
-            "-e", _ssh_command(),
+            *_transport_args(),
             f"{_server_slug()}/",
-            f"{TRANSCRIPT_AGGREGATE_DIR}/",
+            f"{config.TRANSCRIPT_AGGREGATE_DIR}/",
         ],
         label="pull",
     )
@@ -160,7 +215,7 @@ def pull() -> int:
 
 def sync() -> int:
     """Push then pull. Returns 0 iff both succeed; otherwise the first failure."""
-    if not transcript_sync_enabled():
+    if not config.transcript_sync_enabled():
         print(
             "[transcript-sync] disabled (CAI_TRANSCRIPT_SYNC_URL or "
             "CAI_MACHINE_ID unset) — nothing to do",
@@ -173,6 +228,11 @@ def sync() -> int:
     return pull()
 
 
+def transcript_sync_enabled() -> bool:
+    """Backwards-compat shim — prefer ``config.transcript_sync_enabled()``."""
+    return config.transcript_sync_enabled()
+
+
 def parse_source() -> Path:
     """Return the directory parse.py should walk.
 
@@ -180,9 +240,11 @@ def parse_source() -> Path:
     Otherwise fall back to the local-only directory so deployments without
     sync configured keep behaving as before.
     """
-    if transcript_sync_enabled() and any(TRANSCRIPT_AGGREGATE_DIR.rglob("*.jsonl")):
-        return TRANSCRIPT_AGGREGATE_DIR
-    return TRANSCRIPT_DIR
+    if config.transcript_sync_enabled() and any(
+        config.TRANSCRIPT_AGGREGATE_DIR.rglob("*.jsonl")
+    ):
+        return config.TRANSCRIPT_AGGREGATE_DIR
+    return config.TRANSCRIPT_DIR
 
 
 def cmd_transcript_sync(args) -> int:  # noqa: ARG001 - args required by dispatcher

--- a/cai_lib/transcript_sync.py
+++ b/cai_lib/transcript_sync.py
@@ -1,0 +1,193 @@
+"""Cross-host transcript synchronisation.
+
+When ``CAI_TRANSCRIPT_SYNC_URL`` is set (see :mod:`cai_lib.config`), this
+module pushes the local container's Claude Code session transcripts to a
+central server over SSH/rsync and pulls the union of every machine's
+transcripts back into a local aggregate directory. The analyzer and
+confirm handlers then parse that aggregate instead of the local-only
+``TRANSCRIPT_DIR`` so the self-improvement signal sees what *all*
+machines have done, not just this one.
+
+Feature is opt-in: if ``CAI_TRANSCRIPT_SYNC_URL`` is unset the module's
+public functions are no-ops and the caller falls back to the existing
+single-host behaviour.
+
+Server layout::
+
+    <TRANSCRIPT_SYNC_URL>/
+      <repo-slug>/               # e.g. damien-robotsix_robotsix-cai
+        <machine-id>/            # stable per-host identifier
+          <encoded-cwd>/
+            <session-id>.jsonl
+          ...
+
+Age and size enforcement happen server-side via ``scripts/server-cleanup.sh``
+(run from a cron on the remote host). This module intentionally only deals
+with transport.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from cai_lib.config import (
+    MACHINE_ID,
+    REPO_SLUG,
+    TRANSCRIPT_AGGREGATE_DIR,
+    TRANSCRIPT_DIR,
+    TRANSCRIPT_SYNC_SSH_KEY,
+    TRANSCRIPT_SYNC_URL,
+    transcript_sync_enabled,
+)
+
+
+_SSH_OPTIONS = [
+    # Accept new host keys automatically (first connection) but still fail
+    # on mismatch. The known_hosts file lives under /home/cai/.ssh which
+    # is persisted in the cai_home volume, so after the first run the host
+    # key is pinned and subsequent runs use strict checking.
+    "-o", "StrictHostKeyChecking=accept-new",
+    # Short timeout so a broken network doesn't wedge a cron run.
+    "-o", "ConnectTimeout=15",
+]
+
+
+def _ssh_command() -> str:
+    """Build the ``-e`` argument for rsync — ``ssh -i <key> <opts>``."""
+    parts = ["ssh", "-i", str(TRANSCRIPT_SYNC_SSH_KEY), *_SSH_OPTIONS]
+    return " ".join(parts)
+
+
+def _server_bucket() -> str:
+    """Return ``<url>/<repo-slug>/<machine-id>`` — this host's push target."""
+    return f"{TRANSCRIPT_SYNC_URL.rstrip('/')}/{REPO_SLUG}/{MACHINE_ID}"
+
+
+def _server_slug() -> str:
+    """Return ``<url>/<repo-slug>`` — the pull source (every machine's bucket)."""
+    return f"{TRANSCRIPT_SYNC_URL.rstrip('/')}/{REPO_SLUG}"
+
+
+def _ensure_rsync() -> bool:
+    """True iff rsync is on PATH. Logs a single clear message when not."""
+    if shutil.which("rsync") is None:
+        print(
+            "[transcript-sync] rsync not installed — skipping (install rsync "
+            "in the image to enable cross-host transcript sync)",
+            flush=True,
+        )
+        return False
+    return True
+
+
+def _run_rsync(args: list[str], *, label: str) -> int:
+    """Run rsync with a consistent log prefix. Returns the exit code."""
+    cmd = ["rsync", *args]
+    try:
+        result = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print(f"[transcript-sync] {label}: rsync not found", flush=True)
+        return 127
+    if result.returncode != 0:
+        # Truncate to keep the log usable when a server is misconfigured.
+        err = (result.stderr or "").strip().splitlines()[-5:]
+        print(
+            f"[transcript-sync] {label} failed (exit {result.returncode}): "
+            f"{' | '.join(err) or '(no stderr)'}",
+            flush=True,
+        )
+    return result.returncode
+
+
+def push() -> int:
+    """Push the local transcript tree into this host's server bucket.
+
+    No-op (returns 0) when the feature is disabled or the local dir is
+    missing. Uses ``--delete`` so the server bucket mirrors the local
+    window — per-machine history beyond the local window is NOT preserved
+    (server-side cleanup enforces age/size instead).
+    """
+    if not transcript_sync_enabled():
+        return 0
+    if not TRANSCRIPT_DIR.exists():
+        return 0
+    if not _ensure_rsync():
+        return 0
+    return _run_rsync(
+        [
+            "-az",
+            "--delete",
+            "-e", _ssh_command(),
+            # Trailing slashes: rsync copies the *contents* of TRANSCRIPT_DIR
+            # into the server bucket, not the directory itself.
+            f"{TRANSCRIPT_DIR}/",
+            f"{_server_bucket()}/",
+        ],
+        label="push",
+    )
+
+
+def pull() -> int:
+    """Pull every machine's bucket into the local aggregate mirror.
+
+    No-op (returns 0) when disabled. Creates the aggregate directory if
+    missing. Does NOT use ``--delete`` so a transient server outage can't
+    empty the local mirror mid-run.
+    """
+    if not transcript_sync_enabled():
+        return 0
+    if not _ensure_rsync():
+        return 0
+    TRANSCRIPT_AGGREGATE_DIR.mkdir(parents=True, exist_ok=True)
+    return _run_rsync(
+        [
+            "-az",
+            "-e", _ssh_command(),
+            f"{_server_slug()}/",
+            f"{TRANSCRIPT_AGGREGATE_DIR}/",
+        ],
+        label="pull",
+    )
+
+
+def sync() -> int:
+    """Push then pull. Returns 0 iff both succeed; otherwise the first failure."""
+    if not transcript_sync_enabled():
+        print(
+            "[transcript-sync] disabled (CAI_TRANSCRIPT_SYNC_URL or "
+            "CAI_MACHINE_ID unset) — nothing to do",
+            flush=True,
+        )
+        return 0
+    rc = push()
+    if rc != 0:
+        return rc
+    return pull()
+
+
+def parse_source() -> Path:
+    """Return the directory parse.py should walk.
+
+    When sync is enabled AND the aggregate exists with content, use it.
+    Otherwise fall back to the local-only directory so deployments without
+    sync configured keep behaving as before.
+    """
+    if transcript_sync_enabled() and any(TRANSCRIPT_AGGREGATE_DIR.rglob("*.jsonl")):
+        return TRANSCRIPT_AGGREGATE_DIR
+    return TRANSCRIPT_DIR
+
+
+def cmd_transcript_sync(args) -> int:  # noqa: ARG001 - args required by dispatcher
+    """CLI entrypoint: `cai transcript-sync`. Runs push + pull."""
+    rc = sync()
+    if rc != 0:
+        print(f"[transcript-sync] exited with rc={rc}", file=sys.stderr)
+    return rc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,17 @@ services:
       CAI_MERGE_MAX_DIFF_LEN: "200000"      # max chars of PR diff passed to merge agent
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "50"        # read at most N recent transcript files (0 = no limit)
+      # Cross-host transcript sync. Leave CAI_TRANSCRIPT_SYNC_URL empty to
+      # disable (default). When set, the analyzer and confirm step pull a
+      # merged view of every machine's transcripts before running, so the
+      # self-improvement signal reflects activity across the fleet, not
+      # just this container. See docs/configuration.md for server setup.
+      CAI_TRANSCRIPT_SYNC_URL: ""          # e.g. cai@ovh.example.com:/srv/cai-transcripts
+      CAI_TRANSCRIPT_SYNC_SCHEDULE: "*/15 * * * *"  # every 15 min — push + pull
+      # CAI_MACHINE_ID overrides the auto-detected host id. Leave unset
+      # to read /etc/machine-id (bind-mounted below). Useful for
+      # human-readable bucket names: CAI_MACHINE_ID: "laptop".
+      # CAI_MACHINE_ID: ""
     volumes:
       # Persistent state for the cai user — Claude OAuth credentials,
       # session transcripts, gh config, claude-code's runtime
@@ -78,6 +89,14 @@ services:
       # For API-key auth, set ANTHROPIC_API_KEY in .env instead — the
       # volume can stay empty and claude-code will use the env var.
       - cai_home:/home/cai
+      # Stable per-host identifier for cross-host transcript sync.
+      # `/etc/machine-id` is a 32-char systemd-generated ID unique to
+      # each Linux host; bind-mounting it lets the container derive a
+      # stable bucket key without a per-host env var. Read-only.
+      # (The container's own /etc/machine-id is the container ID and
+      # rotates on every `docker compose up`, which would create a new
+      # server bucket on every restart — so we use the host's instead.)
+      - /etc/machine-id:/etc/host-machine-id:ro
       # Persistent per-agent memory (`.claude/agent-memory/<name>/`).
       # Each declarative subagent has `memory: project` in its
       # frontmatter, which Claude Code stores under

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,78 @@ Schedule values use standard cron format: `minute hour day month weekday`. To di
 | `CAI_TRANSCRIPT_WINDOW_DAYS` | `7` | Only parse session transcripts from the last N days |
 | `CAI_TRANSCRIPT_MAX_FILES` | `50` | Read at most N recent transcript files (0 = no limit) |
 
+## Cross-host Transcript Sync
+
+When you run cai for the same repository on multiple machines, each
+container only sees the sessions that happened on its own host.
+`cai analyze` and `cai confirm` then only reason about a local slice of
+activity, missing signals from the rest of the fleet.
+
+The transcript-sync feature addresses this by pushing each host's
+transcripts to a central SSH server you own (any cheap VPS works — OVH,
+Hetzner, a home lab box) and pulling the union back before
+analyze/confirm run.
+
+### Enabling
+
+The easiest path is to re-run `install.sh` and answer **yes** to the
+"Enable transcript sync?" prompt. The installer:
+
+1. Prompts for the SSH destination (e.g. `cai@vps.example.com:/srv/cai-transcripts`).
+2. Generates a dedicated `cai_transcript_key` (ed25519) in the install directory.
+3. Prints the public key for you to add to the remote user's
+   `~/.ssh/authorized_keys`.
+4. Wires the key + `/etc/machine-id` bind mounts + sync env vars into
+   the generated `docker-compose.yml`.
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `CAI_TRANSCRIPT_SYNC_URL` | _(unset → disabled)_ | SSH destination: `<user>@<host>:<absolute-path>`. Feature is a no-op when unset. |
+| `CAI_TRANSCRIPT_SYNC_SSH_KEY` | `/home/cai/.ssh/cai_transcript_key` | Path inside the container to the private key used for rsync. Expected to be bind-mounted read-only from the host. |
+| `CAI_TRANSCRIPT_SYNC_SCHEDULE` | `*/15 * * * *` | Cron expression for the push+pull job. Only appended to the crontab when `CAI_TRANSCRIPT_SYNC_URL` is set. |
+| `CAI_MACHINE_ID` | _(from `/etc/machine-id`)_ | Stable per-host identifier used as the server bucket name. Defaults to the first 12 chars of the host's `/etc/machine-id` (bind-mounted into the container at `/etc/host-machine-id`). Set explicitly for human-readable bucket names (e.g. `laptop`, `ovh-box`). |
+
+### Server layout
+
+```
+<CAI_TRANSCRIPT_SYNC_URL>/
+  <repo-slug>/                 # e.g. damien-robotsix_robotsix-cai
+    <machine-id>/              # from CAI_MACHINE_ID or /etc/machine-id
+      <encoded-cwd>/
+        <session-id>.jsonl
+```
+
+Each host pushes into its own `<machine-id>` bucket with
+`rsync --delete`, so a machine's bucket always mirrors its current
+7-day window. Analyzers pull the full `<repo-slug>` subtree — i.e. the
+union of every machine's window — into
+`/home/cai/.claude/projects-aggregate/` before parsing.
+
+### Server-side cleanup
+
+Age and size caps are enforced by `scripts/server-cleanup.sh` — copy it
+to the server and add a cron entry:
+
+```
+30 3 * * * CAI_SERVER_MAX_AGE_DAYS=30 CAI_SERVER_MAX_SIZE_MB=2000 \
+  /srv/cai-transcripts-cleanup.sh >> /var/log/cai-cleanup.log 2>&1
+```
+
+The script is self-contained, has a `--dry-run` mode via
+`CAI_SERVER_DRY_RUN=1`, and documents all env vars at the top.
+
+### Manual one-off sync
+
+```
+docker compose exec cai python /app/cai.py transcript-sync
+```
+
+Runs push + pull immediately, then exits. Useful right after you enable
+the feature to populate the aggregate mirror without waiting for the
+first cron tick.
+
 ## Multi-workspace Configuration
 
 By default, `robotsix-cai` maintains only the primary repository (Lane 1). To extend the container to manage additional repositories, create a `workspaces.json` file listing the repos to maintain:
@@ -97,6 +169,9 @@ Agent-level overrides live in `.claude/agents/<name>.md` YAML frontmatter (`tool
 | Path | Purpose |
 |---|---|
 | `/home/cai/.claude/projects` | Transcript directory — Claude Code writes `.jsonl` session files here |
+| `/home/cai/.claude/projects-aggregate` | Cross-host aggregate mirror (populated by `cai transcript-sync`; only present when `CAI_TRANSCRIPT_SYNC_URL` is set) |
+| `/home/cai/.ssh/cai_transcript_key` | Private key used for transcript-sync SSH (bind-mounted read-only) |
+| `/etc/host-machine-id` | Host's `/etc/machine-id` bind-mounted read-only to give transcript-sync a stable per-host bucket key |
 | `/app/.claude/agent-memory` | Per-agent persistent memory files (checked into git) |
 | `/var/log/cai/cai.log` | Structured run log (JSON lines, one entry per `cai` invocation) |
 | `/var/log/cai/cai-cost.jsonl` | Per-invocation cost log (input/output tokens + USD) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,12 +69,34 @@ The easiest path is to re-run `install.sh` and answer **yes** to the
 4. Wires the key + `/etc/machine-id` bind mounts + sync env vars into
    the generated `docker-compose.yml`.
 
+### Two transports: SSH vs local path
+
+`CAI_TRANSCRIPT_SYNC_URL` supports two URL shapes and picks the transport
+from the shape:
+
+- **SSH** — `<user>@<host>:<absolute-path>` (contains `:`). The
+  container rsyncs over SSH with the key at
+  `CAI_TRANSCRIPT_SYNC_SSH_KEY`. Use this from any machine that is NOT
+  hosting the transcript store itself.
+
+- **Local path** — an absolute filesystem path with no `:` (e.g.
+  `/srv/cai-transcripts`). The container rsyncs directly against a
+  bind-mount of that path. Use this on the host that is ALSO the
+  central store, so its own pushes/pulls don't SSH-loopback
+  unnecessarily. The path must be bind-mounted into the container
+  (the installer does this automatically when you pick local mode)
+  and writable by UID 1000.
+
+Both modes share the same server layout and same machine-id logic —
+the only difference is whether the container takes the SSH path or the
+loopback path.
+
 ### Environment variables
 
 | Variable | Default | Description |
 |---|---|---|
-| `CAI_TRANSCRIPT_SYNC_URL` | _(unset → disabled)_ | SSH destination: `<user>@<host>:<absolute-path>`. Feature is a no-op when unset. |
-| `CAI_TRANSCRIPT_SYNC_SSH_KEY` | `/home/cai/.ssh/cai_transcript_key` | Path inside the container to the private key used for rsync. Expected to be bind-mounted read-only from the host. |
+| `CAI_TRANSCRIPT_SYNC_URL` | _(unset → disabled)_ | Transport + destination. SSH form: `<user>@<host>:<absolute-path>`. Local form: plain absolute path with no colon. Feature is a no-op when unset. |
+| `CAI_TRANSCRIPT_SYNC_SSH_KEY` | `/home/cai/.ssh/cai_transcript_key` | Path inside the container to the private key used for rsync-over-SSH. Ignored in local-path mode. |
 | `CAI_TRANSCRIPT_SYNC_SCHEDULE` | `*/15 * * * *` | Cron expression for the push+pull job. Only appended to the crontab when `CAI_TRANSCRIPT_SYNC_URL` is set. |
 | `CAI_MACHINE_ID` | _(from `/etc/machine-id`)_ | Stable per-host identifier used as the server bucket name. Defaults to the first 12 chars of the host's `/etc/machine-id` (bind-mounted into the container at `/etc/host-machine-id`). Set explicitly for human-readable bucket names (e.g. `laptop`, `ovh-box`). |
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,6 +56,8 @@ CAI_COST_OPTIMIZE_SCHEDULE="${CAI_COST_OPTIMIZE_SCHEDULE:-0 5 * * 0}"
 CAI_CHECK_WORKFLOWS_SCHEDULE="${CAI_CHECK_WORKFLOWS_SCHEDULE:-0 */6 * * *}"
 CAI_AGENT_AUDIT_SCHEDULE="${CAI_AGENT_AUDIT_SCHEDULE:-0 6 * * 0}"
 CAI_EXTERNAL_SCOUT_SCHEDULE="${CAI_EXTERNAL_SCOUT_SCHEDULE:-0 6 * * 1}"
+CAI_TRANSCRIPT_SYNC_SCHEDULE="${CAI_TRANSCRIPT_SYNC_SCHEDULE:-*/15 * * * *}"
+CAI_TRANSCRIPT_SYNC_URL="${CAI_TRANSCRIPT_SYNC_URL:-}"
 CAI_WORKSPACES_CONFIG="${CAI_WORKSPACES_CONFIG:-/app/workspaces.json}"
 
 CRONTAB_PATH=/tmp/crontab
@@ -77,6 +79,13 @@ $CAI_CHECK_WORKFLOWS_SCHEDULE python /app/cai.py check-workflows
 $CAI_AGENT_AUDIT_SCHEDULE python /app/cai.py agent-audit
 $CAI_EXTERNAL_SCOUT_SCHEDULE python /app/cai.py external-scout
 CRONTAB
+
+# Append the transcript-sync cron line only when sync is actually
+# configured. The cmd_transcript_sync handler no-ops when disabled, but
+# running it every 15 min for no reason would clutter docker logs.
+if [ -n "$CAI_TRANSCRIPT_SYNC_URL" ]; then
+  echo "$CAI_TRANSCRIPT_SYNC_SCHEDULE python /app/cai.py transcript-sync" >> "$CRONTAB_PATH"
+fi
 
 # Append per-workspace cycle lines from the workspaces config file.
 if [ -s "$CAI_WORKSPACES_CONFIG" ]; then

--- a/install.sh
+++ b/install.sh
@@ -162,73 +162,147 @@ TRANSCRIPT_SYNC_VOLUMES=""
 case "$ENABLE_SYNC" in
   y|Y|yes|Yes|YES)
     echo
-    echo "Enter the SSH destination for the shared transcript store."
-    echo "Format: <user>@<host>:<absolute-path>"
-    echo "Example: cai@ovh.example.com:/srv/cai-transcripts"
+    echo "Pick the transport for the transcript store:"
     echo
-    prompt SYNC_URL "Sync URL"
-    if [[ -z "$SYNC_URL" ]]; then
-      echo "ERROR: sync URL cannot be empty when sync is enabled."
-      exit 1
-    fi
+    echo "  1) SSH — transcripts live on a remote server you own."
+    echo "     This host rsyncs to it via SSH. Use this for laptops"
+    echo "     and any host that isn't the one holding the store."
+    echo
+    echo "  2) Local — transcripts live on this host's filesystem,"
+    echo "     bind-mounted into the container. Use this on the"
+    echo "     host that IS the central store (e.g. the VPS itself),"
+    echo "     so its own pushes/pulls avoid a pointless SSH loopback."
+    echo
+    prompt SYNC_MODE "Transport [1/2]" "1"
 
-    # Generate a dedicated ed25519 keypair just for transcript sync.
-    # Kept separate from any user's personal keys so it can be rotated
-    # or revoked without collateral damage.
-    SYNC_KEY_PATH="${INSTALL_DIR}/cai_transcript_key"
-    if [[ -f "$SYNC_KEY_PATH" ]]; then
-      echo
-      echo "[i] Reusing existing key at $SYNC_KEY_PATH"
-    else
-      echo
-      echo "Generating a dedicated ed25519 keypair at $SYNC_KEY_PATH ..."
-      ssh-keygen -t ed25519 -N '' -f "$SYNC_KEY_PATH" \
-        -C "cai-transcript-sync@$(hostname)" >/dev/null
-      echo "[OK] Key generated."
-    fi
+    case "$SYNC_MODE" in
+      2)
+        echo
+        echo "Enter the absolute path on this host where transcripts live."
+        echo "Must be an existing directory. It will be bind-mounted"
+        echo "into the container at the same path."
+        echo "Example: /srv/cai-transcripts"
+        echo
+        prompt SYNC_PATH "Local path"
+        if [[ -z "$SYNC_PATH" ]]; then
+          echo "ERROR: local path cannot be empty."
+          exit 1
+        fi
+        if [[ "$SYNC_PATH" != /* ]]; then
+          echo "ERROR: local path must be absolute (starts with /)."
+          exit 1
+        fi
+        if [[ ! -d "$SYNC_PATH" ]]; then
+          echo "[i] $SYNC_PATH does not exist yet; creating it."
+          mkdir -p "$SYNC_PATH"
+        fi
+        # For the cai container (UID 1000) to write here, the dir must
+        # be writable by that UID. If the host user isn't UID 1000,
+        # document the chown the user needs to run.
+        if [[ "$(stat -c %u "$SYNC_PATH")" != "1000" ]]; then
+          echo
+          echo "[!] $SYNC_PATH is not owned by UID 1000 (the cai user in the container)."
+          echo "    The container will likely hit 'permission denied' on push."
+          echo "    Fix with: sudo chown -R 1000:1000 $SYNC_PATH"
+          echo
+          prompt _OWN_CONTINUE "Press Enter when ready (or Ctrl-C to abort)" ""
+        fi
 
-    # Mount permissions matter: the cai user inside the container runs
-    # as UID 1000. If the host user isn't UID 1000, the bind-mount will
-    # show up owned by a different UID and ssh will refuse to use it.
-    # We chmod the file 600 (ssh's required perms) and rely on the
-    # common case (host's first user = UID 1000 = matches cai).
-    chmod 600 "$SYNC_KEY_PATH"
-    chmod 644 "${SYNC_KEY_PATH}.pub"
-
-    echo
-    echo "==========================================================="
-    echo "ACTION REQUIRED — install the public key on the sync server"
-    echo "==========================================================="
-    echo
-    echo "Copy the following public key into the remote user's"
-    echo "~/.ssh/authorized_keys on the sync server:"
-    echo
-    cat "${SYNC_KEY_PATH}.pub"
-    echo
-    echo "One-liner from this host (if you have password SSH access):"
-    SYNC_USER_HOST="${SYNC_URL%:*}"
-    echo "    ssh-copy-id -i ${SYNC_KEY_PATH}.pub ${SYNC_USER_HOST}"
-    echo
-    echo "Also create the transcript root on the server, e.g.:"
-    SYNC_REMOTE_PATH="${SYNC_URL#*:}"
-    echo "    ssh ${SYNC_USER_HOST} 'mkdir -p ${SYNC_REMOTE_PATH} && chmod 700 ${SYNC_REMOTE_PATH}'"
-    echo
-    echo "For automatic age/size cleanup, copy scripts/server-cleanup.sh"
-    echo "to the server and wire it into its cron (see the script header"
-    echo "for env vars and an example cron line)."
-    echo
-    prompt _SYNC_CONTINUE "Press Enter once the public key is installed" ""
-
-    TRANSCRIPT_SYNC_ENV=$(cat <<EOF
+        SYNC_URL="$SYNC_PATH"
+        TRANSCRIPT_SYNC_ENV=$(cat <<EOF
       CAI_TRANSCRIPT_SYNC_URL: "${SYNC_URL}"
       CAI_TRANSCRIPT_SYNC_SCHEDULE: "*/15 * * * *"
 EOF
 )
-    TRANSCRIPT_SYNC_VOLUMES=$(cat <<'EOF'
+        # In local mode we bind-mount the host path at the same path
+        # inside the container so the user sees consistent paths in
+        # logs and docker exec sessions.
+        TRANSCRIPT_SYNC_VOLUMES=$(cat <<EOF
+      - ${SYNC_PATH}:${SYNC_PATH}
+      - /etc/machine-id:/etc/host-machine-id:ro
+EOF
+)
+        echo
+        echo "[OK] Local-path transport configured (${SYNC_PATH})."
+        echo "    No SSH key needed. Remote hosts should still SSH-push to"
+        echo "    this server's $SYNC_PATH — see docs/configuration.md."
+        echo
+        ;;
+      *)
+        echo
+        echo "Enter the SSH destination for the shared transcript store."
+        echo "Format: <user>@<host>:<absolute-path>"
+        echo "Example: cai@ovh.example.com:/srv/cai-transcripts"
+        echo
+        prompt SYNC_URL "Sync URL"
+        if [[ -z "$SYNC_URL" ]]; then
+          echo "ERROR: sync URL cannot be empty when sync is enabled."
+          exit 1
+        fi
+        if [[ "$SYNC_URL" != *:* ]]; then
+          echo "ERROR: SSH URL must contain ':' (user@host:/path). Did you mean local mode?"
+          exit 1
+        fi
+
+        # Generate a dedicated ed25519 keypair just for transcript sync.
+        # Kept separate from any user's personal keys so it can be rotated
+        # or revoked without collateral damage.
+        SYNC_KEY_PATH="${INSTALL_DIR}/cai_transcript_key"
+        if [[ -f "$SYNC_KEY_PATH" ]]; then
+          echo
+          echo "[i] Reusing existing key at $SYNC_KEY_PATH"
+        else
+          echo
+          echo "Generating a dedicated ed25519 keypair at $SYNC_KEY_PATH ..."
+          ssh-keygen -t ed25519 -N '' -f "$SYNC_KEY_PATH" \
+            -C "cai-transcript-sync@$(hostname)" >/dev/null
+          echo "[OK] Key generated."
+        fi
+
+        # Mount permissions matter: the cai user inside the container runs
+        # as UID 1000. If the host user isn't UID 1000, the bind-mount will
+        # show up owned by a different UID and ssh will refuse to use it.
+        # We chmod the file 600 (ssh's required perms) and rely on the
+        # common case (host's first user = UID 1000 = matches cai).
+        chmod 600 "$SYNC_KEY_PATH"
+        chmod 644 "${SYNC_KEY_PATH}.pub"
+
+        echo
+        echo "==========================================================="
+        echo "ACTION REQUIRED — install the public key on the sync server"
+        echo "==========================================================="
+        echo
+        echo "Copy the following public key into the remote user's"
+        echo "~/.ssh/authorized_keys on the sync server:"
+        echo
+        cat "${SYNC_KEY_PATH}.pub"
+        echo
+        echo "One-liner from this host (if you have password SSH access):"
+        SYNC_USER_HOST="${SYNC_URL%:*}"
+        echo "    ssh-copy-id -i ${SYNC_KEY_PATH}.pub ${SYNC_USER_HOST}"
+        echo
+        echo "Also create the transcript root on the server, e.g.:"
+        SYNC_REMOTE_PATH="${SYNC_URL#*:}"
+        echo "    ssh ${SYNC_USER_HOST} 'mkdir -p ${SYNC_REMOTE_PATH} && chmod 700 ${SYNC_REMOTE_PATH}'"
+        echo
+        echo "For automatic age/size cleanup, copy scripts/server-cleanup.sh"
+        echo "to the server and wire it into its cron (see the script header"
+        echo "for env vars and an example cron line)."
+        echo
+        prompt _SYNC_CONTINUE "Press Enter once the public key is installed" ""
+
+        TRANSCRIPT_SYNC_ENV=$(cat <<EOF
+      CAI_TRANSCRIPT_SYNC_URL: "${SYNC_URL}"
+      CAI_TRANSCRIPT_SYNC_SCHEDULE: "*/15 * * * *"
+EOF
+)
+        TRANSCRIPT_SYNC_VOLUMES=$(cat <<'EOF'
       - ./cai_transcript_key:/home/cai/.ssh/cai_transcript_key:ro
       - /etc/machine-id:/etc/host-machine-id:ro
 EOF
 )
+        ;;
+    esac
     ;;
   *)
     ;;

--- a/install.sh
+++ b/install.sh
@@ -139,6 +139,101 @@ else
   CAI_ADMIN_ENV_LINE=""
 fi
 
+# Cross-host transcript sync — optional. When enabled, every machine
+# running this container pushes its Claude Code session transcripts to
+# a central SSH server, then pulls the union back before analyze/confirm.
+# Single-host installs should skip this; only turn it on if you run
+# cai against the same repo from multiple hosts and want the analyzer
+# to see the full picture.
+echo
+echo "Enable cross-host transcript sync?"
+echo
+echo "Only relevant if you run cai for this repo on multiple machines"
+echo "and want the self-improvement signal to reflect activity across"
+echo "all of them. Requires an SSH-accessible server you own (e.g. a"
+echo "VPS) to act as the shared transcript store."
+echo
+echo "Leave this disabled for single-host installs."
+echo
+prompt ENABLE_SYNC "Enable transcript sync? [y/N]" "n"
+
+TRANSCRIPT_SYNC_ENV=""
+TRANSCRIPT_SYNC_VOLUMES=""
+case "$ENABLE_SYNC" in
+  y|Y|yes|Yes|YES)
+    echo
+    echo "Enter the SSH destination for the shared transcript store."
+    echo "Format: <user>@<host>:<absolute-path>"
+    echo "Example: cai@ovh.example.com:/srv/cai-transcripts"
+    echo
+    prompt SYNC_URL "Sync URL"
+    if [[ -z "$SYNC_URL" ]]; then
+      echo "ERROR: sync URL cannot be empty when sync is enabled."
+      exit 1
+    fi
+
+    # Generate a dedicated ed25519 keypair just for transcript sync.
+    # Kept separate from any user's personal keys so it can be rotated
+    # or revoked without collateral damage.
+    SYNC_KEY_PATH="${INSTALL_DIR}/cai_transcript_key"
+    if [[ -f "$SYNC_KEY_PATH" ]]; then
+      echo
+      echo "[i] Reusing existing key at $SYNC_KEY_PATH"
+    else
+      echo
+      echo "Generating a dedicated ed25519 keypair at $SYNC_KEY_PATH ..."
+      ssh-keygen -t ed25519 -N '' -f "$SYNC_KEY_PATH" \
+        -C "cai-transcript-sync@$(hostname)" >/dev/null
+      echo "[OK] Key generated."
+    fi
+
+    # Mount permissions matter: the cai user inside the container runs
+    # as UID 1000. If the host user isn't UID 1000, the bind-mount will
+    # show up owned by a different UID and ssh will refuse to use it.
+    # We chmod the file 600 (ssh's required perms) and rely on the
+    # common case (host's first user = UID 1000 = matches cai).
+    chmod 600 "$SYNC_KEY_PATH"
+    chmod 644 "${SYNC_KEY_PATH}.pub"
+
+    echo
+    echo "==========================================================="
+    echo "ACTION REQUIRED — install the public key on the sync server"
+    echo "==========================================================="
+    echo
+    echo "Copy the following public key into the remote user's"
+    echo "~/.ssh/authorized_keys on the sync server:"
+    echo
+    cat "${SYNC_KEY_PATH}.pub"
+    echo
+    echo "One-liner from this host (if you have password SSH access):"
+    SYNC_USER_HOST="${SYNC_URL%:*}"
+    echo "    ssh-copy-id -i ${SYNC_KEY_PATH}.pub ${SYNC_USER_HOST}"
+    echo
+    echo "Also create the transcript root on the server, e.g.:"
+    SYNC_REMOTE_PATH="${SYNC_URL#*:}"
+    echo "    ssh ${SYNC_USER_HOST} 'mkdir -p ${SYNC_REMOTE_PATH} && chmod 700 ${SYNC_REMOTE_PATH}'"
+    echo
+    echo "For automatic age/size cleanup, copy scripts/server-cleanup.sh"
+    echo "to the server and wire it into its cron (see the script header"
+    echo "for env vars and an example cron line)."
+    echo
+    prompt _SYNC_CONTINUE "Press Enter once the public key is installed" ""
+
+    TRANSCRIPT_SYNC_ENV=$(cat <<EOF
+      CAI_TRANSCRIPT_SYNC_URL: "${SYNC_URL}"
+      CAI_TRANSCRIPT_SYNC_SCHEDULE: "*/15 * * * *"
+EOF
+)
+    TRANSCRIPT_SYNC_VOLUMES=$(cat <<'EOF'
+      - ./cai_transcript_key:/home/cai/.ssh/cai_transcript_key:ro
+      - /etc/machine-id:/etc/host-machine-id:ro
+EOF
+)
+    ;;
+  *)
+    ;;
+esac
+
 case "$AUTH_CHOICE" in
   1)
     cat > docker-compose.yml <<YAML
@@ -175,6 +270,7 @@ services:
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "50"        # read at most N recent transcript files (0 = no limit)
 ${CAI_ADMIN_ENV_LINE}
+${TRANSCRIPT_SYNC_ENV}
     volumes:
       # Persistent state for the cai user (Claude OAuth credentials,
       # session transcripts, gh config, claude-code's runtime
@@ -194,6 +290,7 @@ ${CAI_ADMIN_ENV_LINE}
       # survive container restarts.
       - cai_agent_memory:/app/.claude/agent-memory
       - cai_logs:/var/log/cai
+${TRANSCRIPT_SYNC_VOLUMES}
 ${CAI_LABEL_BLOCK}${WATCHTOWER_SERVICE}
 
 volumes:
@@ -249,6 +346,7 @@ services:
       CAI_TRANSCRIPT_WINDOW_DAYS: "7"       # only parse sessions from last N days
       CAI_TRANSCRIPT_MAX_FILES: "50"        # read at most N recent transcript files (0 = no limit)
 ${CAI_ADMIN_ENV_LINE}
+${TRANSCRIPT_SYNC_ENV}
     volumes:
       # Persistent state for the cai user (Claude transcripts, gh
       # config, claude-code's runtime \`.claude.json\`, etc.).
@@ -261,6 +359,7 @@ ${CAI_ADMIN_ENV_LINE}
       # survive container restarts.
       - cai_agent_memory:/app/.claude/agent-memory
       - cai_logs:/var/log/cai
+${TRANSCRIPT_SYNC_VOLUMES}
 ${CAI_LABEL_BLOCK}${WATCHTOWER_SERVICE}
 
 volumes:

--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -98,6 +98,8 @@ declare -A DESCRIPTIONS=(
   ["cai_lib/parse.py"]="Deterministic signal extractor from Claude Code JSONL transcripts"
   ["cai_lib/publish.py"]="GitHub issue publisher with fingerprint dedup"
   ["cai_lib/subprocess_utils.py"]="Subprocess helpers extracted from cai.py"
+  ["cai_lib/transcript_sync.py"]="Cross-host transcript sync — push/pull session jsonls to a central SSH server"
+  ["scripts/server-cleanup.sh"]="Server-side age/size cleanup for the transcript-sync store (runs on the OVH box, not in the container)"
   ["docs/_config.yml"]="Jekyll configuration for GitHub Pages docs"
   ["docs/agents.md"]="Documentation: agent definitions and pipeline phase mapping"
   ["docs/architecture.md"]="Documentation: pipeline overview and system architecture"
@@ -117,6 +119,7 @@ declare -A DESCRIPTIONS=(
   ["tests/test_parse.py"]="Tests for parse.py signal extraction"
   ["tests/test_publish.py"]="Tests for publish.py issue publishing"
   ["tests/test_rollback.py"]="Tests for rollback functionality"
+  ["tests/test_transcript_sync.py"]="Tests for cai_lib.transcript_sync — no-op path, parse_source fallback, repo slug"
 )
 
 # ---------------------------------------------------------------------------
@@ -133,7 +136,11 @@ declare -A DESCRIPTIONS=(
 |------|---------|
 HEADER
 
-  git -C "$REPO_ROOT" ls-files | grep -v '^\.cai/' | sort | while IFS= read -r f; do
+  # Force C locale so ordering is deterministic across machines — GNU
+  # sort's default is locale-aware (e.g. underscores collate differently
+  # under fr_FR than under C), which otherwise causes churn when contributors
+  # regenerate the index on their own machines.
+  git -C "$REPO_ROOT" ls-files | grep -v '^\.cai/' | LC_ALL=C sort | while IFS= read -r f; do
     desc="${DESCRIPTIONS[$f]:-TODO: add description}"
     printf '| `%s` | %s |\n' "$f" "$desc"
   done

--- a/scripts/server-cleanup.sh
+++ b/scripts/server-cleanup.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# robotsix-cai — server-side transcript cleanup.
+#
+# Runs on the host that receives transcript uploads from one or more
+# cai containers (see cai_lib/transcript_sync.py). This script is NOT
+# run inside the container: `scp` or `rsync` it onto your OVH box and
+# wire it into a cron on the server.
+#
+# It enforces two caps on the transcript root:
+#
+#   * Age  — deletes *.jsonl older than CAI_SERVER_MAX_AGE_DAYS
+#     (default 30) and removes empty directories it leaves behind.
+#   * Size — if the remaining tree is still larger than
+#     CAI_SERVER_MAX_SIZE_MB (default 2000 MB), deletes the oldest
+#     files one at a time until the total is under the cap.
+#
+# Environment variables (all optional):
+#
+#   CAI_SERVER_TRANSCRIPT_ROOT  Directory to clean up. Default:
+#                               /srv/cai-transcripts.
+#   CAI_SERVER_MAX_AGE_DAYS     Files older than this are deleted.
+#                               Default: 30.
+#   CAI_SERVER_MAX_SIZE_MB      Total size cap (in megabytes).
+#                               Default: 2000.
+#   CAI_SERVER_DRY_RUN          If set to any non-empty value, prints
+#                               what would be deleted without actually
+#                               deleting anything.
+#
+# Example cron entry on the server (daily at 03:30):
+#
+#   30 3 * * * /srv/cai-transcripts-cleanup.sh >> /var/log/cai-cleanup.log 2>&1
+
+set -euo pipefail
+
+ROOT="${CAI_SERVER_TRANSCRIPT_ROOT:-/srv/cai-transcripts}"
+MAX_AGE_DAYS="${CAI_SERVER_MAX_AGE_DAYS:-30}"
+MAX_SIZE_MB="${CAI_SERVER_MAX_SIZE_MB:-2000}"
+DRY_RUN="${CAI_SERVER_DRY_RUN:-}"
+
+if [ ! -d "$ROOT" ]; then
+  echo "[cai-cleanup] $ROOT does not exist; nothing to do"
+  exit 0
+fi
+
+log() { echo "[cai-cleanup] $*"; }
+
+log "root=$ROOT max_age=${MAX_AGE_DAYS}d max_size=${MAX_SIZE_MB}MB dry_run=${DRY_RUN:-no}"
+
+# --- Age cap -----------------------------------------------------------------
+# `find -mtime +N` matches files whose mtime is > N*24h ago.
+if [ -n "$DRY_RUN" ]; then
+  aged=$(find "$ROOT" -type f -name '*.jsonl' -mtime "+$MAX_AGE_DAYS" -print | wc -l)
+  log "would delete $aged file(s) older than ${MAX_AGE_DAYS}d"
+else
+  deleted=$(find "$ROOT" -type f -name '*.jsonl' -mtime "+$MAX_AGE_DAYS" -print -delete | wc -l)
+  log "age pass: deleted $deleted file(s) older than ${MAX_AGE_DAYS}d"
+  # Clean up empty directories left behind (ignoring errors on non-empty).
+  find "$ROOT" -mindepth 1 -type d -empty -delete 2>/dev/null || true
+fi
+
+# --- Size cap ----------------------------------------------------------------
+# Convert the cap to bytes for exact comparison.
+cap_bytes=$((MAX_SIZE_MB * 1024 * 1024))
+
+current_bytes() {
+  # `du -sb` gives bytes; strip the trailing path column.
+  du -sb "$ROOT" 2>/dev/null | awk '{print $1}'
+}
+
+total=$(current_bytes)
+log "size pass start: total=${total}B cap=${cap_bytes}B"
+
+if [ "$total" -le "$cap_bytes" ]; then
+  log "under cap, done"
+  exit 0
+fi
+
+# Stream oldest-first (sorted by mtime ascending) and delete until under cap.
+# find -printf prints the mtime (seconds since epoch, %T@) + size (%s) + path (%p)
+# tab-separated. sort -n on the first field gives oldest first.
+removed=0
+freed=0
+while IFS=$'\t' read -r _mtime size path; do
+  [ -z "$path" ] && continue
+  if [ -n "$DRY_RUN" ]; then
+    log "would delete: $path ($size B)"
+  else
+    rm -f -- "$path"
+  fi
+  freed=$((freed + size))
+  removed=$((removed + 1))
+  if [ $((total - freed)) -le "$cap_bytes" ]; then
+    break
+  fi
+done < <(find "$ROOT" -type f -name '*.jsonl' -printf '%T@\t%s\t%p\n' | sort -n)
+
+log "size pass: removed=$removed freed=${freed}B"
+
+if [ -z "$DRY_RUN" ]; then
+  find "$ROOT" -mindepth 1 -type d -empty -delete 2>/dev/null || true
+fi
+
+log "done: total=$(current_bytes)B"

--- a/tests/test_transcript_sync.py
+++ b/tests/test_transcript_sync.py
@@ -1,0 +1,103 @@
+"""Tests for cai_lib.transcript_sync — the no-op path and helper composition.
+
+The actual rsync transport is deliberately NOT tested here (it would
+require an SSH target). We cover the boundary: when sync is disabled
+the public entry points return 0 and don't touch anything; when the
+aggregate dir is empty, parse_source falls back to the local dir.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+# Make the repo root importable regardless of cwd.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _reload_with_env(env: dict[str, str]):
+    """Reload config + transcript_sync under a fresh os.environ snapshot."""
+    with mock.patch.dict(os.environ, env, clear=False):
+        import cai_lib.config as config_mod
+        import cai_lib.transcript_sync as sync_mod
+        importlib.reload(config_mod)
+        importlib.reload(sync_mod)
+        return config_mod, sync_mod
+
+
+class TestDisabled(unittest.TestCase):
+    def test_sync_url_unset_disables_feature(self):
+        config_mod, sync_mod = _reload_with_env({
+            "CAI_TRANSCRIPT_SYNC_URL": "",
+            "CAI_MACHINE_ID": "whatever",
+        })
+        self.assertFalse(sync_mod.transcript_sync_enabled())
+        self.assertEqual(sync_mod.push(), 0)
+        self.assertEqual(sync_mod.pull(), 0)
+        self.assertEqual(sync_mod.sync(), 0)
+
+    def test_missing_machine_id_disables_even_with_url(self):
+        # MACHINE_ID must resolve to non-empty for the feature to engage.
+        with mock.patch.dict(os.environ, {
+            "CAI_TRANSCRIPT_SYNC_URL": "user@host:/tmp",
+            "CAI_MACHINE_ID": "",
+        }, clear=False), mock.patch(
+            "cai_lib.config._HOST_MACHINE_ID_PATH",
+            Path("/nonexistent/machine-id"),
+        ):
+            import cai_lib.config as config_mod
+            import cai_lib.transcript_sync as sync_mod
+            importlib.reload(config_mod)
+            importlib.reload(sync_mod)
+            self.assertEqual(config_mod.MACHINE_ID, "")
+            self.assertFalse(sync_mod.transcript_sync_enabled())
+
+
+class TestParseSource(unittest.TestCase):
+    def test_falls_back_to_local_when_aggregate_empty(self):
+        config_mod, sync_mod = _reload_with_env({
+            "CAI_TRANSCRIPT_SYNC_URL": "",
+        })
+        # Aggregate dir doesn't exist — source must be the local dir.
+        self.assertEqual(sync_mod.parse_source(), config_mod.TRANSCRIPT_DIR)
+
+    def test_uses_aggregate_when_enabled_and_populated(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            agg = tmp_path / "aggregate"
+            agg.mkdir()
+            (agg / "machine-a").mkdir()
+            (agg / "machine-a" / "session-1.jsonl").write_text(
+                '{"type":"user"}\n'
+            )
+
+            with mock.patch.dict(os.environ, {
+                "CAI_TRANSCRIPT_SYNC_URL": "user@host:/tmp",
+                "CAI_MACHINE_ID": "machine-a",
+            }, clear=False):
+                import cai_lib.config as config_mod
+                import cai_lib.transcript_sync as sync_mod
+                importlib.reload(config_mod)
+                importlib.reload(sync_mod)
+                # Point the module at our temp aggregate.
+                with mock.patch.object(sync_mod, "TRANSCRIPT_AGGREGATE_DIR", agg):
+                    self.assertTrue(sync_mod.transcript_sync_enabled())
+                    self.assertEqual(sync_mod.parse_source(), agg)
+
+
+class TestRepoSlug(unittest.TestCase):
+    def test_slash_becomes_underscore(self):
+        config_mod, _ = _reload_with_env({
+            "CAI_REPO": "owner/repo-name",
+        })
+        self.assertEqual(config_mod.REPO_SLUG, "owner_repo-name")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transcript_sync.py
+++ b/tests/test_transcript_sync.py
@@ -1,15 +1,15 @@
-"""Tests for cai_lib.transcript_sync — the no-op path and helper composition.
+"""Tests for cai_lib.transcript_sync.
 
-The actual rsync transport is deliberately NOT tested here (it would
-require an SSH target). We cover the boundary: when sync is disabled
-the public entry points return 0 and don't touch anything; when the
-aggregate dir is empty, parse_source falls back to the local dir.
+Tests patch attributes on ``cai_lib.config`` (the module ``transcript_sync``
+reads from at call time) rather than reloading modules — reloading leaks
+state into other test files via by-value imports (e.g. ``ADMIN_LOGINS``
+in ``cai_lib.cmd_unblock``).
 """
 
 from __future__ import annotations
 
-import importlib
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -17,55 +17,39 @@ from pathlib import Path
 from unittest import mock
 
 
-# Make the repo root importable regardless of cwd.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
-def _reload_with_env(env: dict[str, str]):
-    """Reload config + transcript_sync under a fresh os.environ snapshot."""
-    with mock.patch.dict(os.environ, env, clear=False):
-        import cai_lib.config as config_mod
-        import cai_lib.transcript_sync as sync_mod
-        importlib.reload(config_mod)
-        importlib.reload(sync_mod)
-        return config_mod, sync_mod
+from cai_lib import config, transcript_sync  # noqa: E402
+
+
+def _rsync_available() -> bool:
+    try:
+        subprocess.run(["rsync", "--version"], check=True, capture_output=True)
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
 
 
 class TestDisabled(unittest.TestCase):
     def test_sync_url_unset_disables_feature(self):
-        config_mod, sync_mod = _reload_with_env({
-            "CAI_TRANSCRIPT_SYNC_URL": "",
-            "CAI_MACHINE_ID": "whatever",
-        })
-        self.assertFalse(sync_mod.transcript_sync_enabled())
-        self.assertEqual(sync_mod.push(), 0)
-        self.assertEqual(sync_mod.pull(), 0)
-        self.assertEqual(sync_mod.sync(), 0)
+        with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", ""), \
+             mock.patch.object(config, "MACHINE_ID", "anything"):
+            self.assertFalse(config.transcript_sync_enabled())
+            self.assertEqual(transcript_sync.push(), 0)
+            self.assertEqual(transcript_sync.pull(), 0)
+            self.assertEqual(transcript_sync.sync(), 0)
 
     def test_missing_machine_id_disables_even_with_url(self):
-        # MACHINE_ID must resolve to non-empty for the feature to engage.
-        with mock.patch.dict(os.environ, {
-            "CAI_TRANSCRIPT_SYNC_URL": "user@host:/tmp",
-            "CAI_MACHINE_ID": "",
-        }, clear=False), mock.patch(
-            "cai_lib.config._HOST_MACHINE_ID_PATH",
-            Path("/nonexistent/machine-id"),
-        ):
-            import cai_lib.config as config_mod
-            import cai_lib.transcript_sync as sync_mod
-            importlib.reload(config_mod)
-            importlib.reload(sync_mod)
-            self.assertEqual(config_mod.MACHINE_ID, "")
-            self.assertFalse(sync_mod.transcript_sync_enabled())
+        with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", "user@host:/tmp"), \
+             mock.patch.object(config, "MACHINE_ID", ""):
+            self.assertFalse(config.transcript_sync_enabled())
 
 
 class TestParseSource(unittest.TestCase):
-    def test_falls_back_to_local_when_aggregate_empty(self):
-        config_mod, sync_mod = _reload_with_env({
-            "CAI_TRANSCRIPT_SYNC_URL": "",
-        })
-        # Aggregate dir doesn't exist — source must be the local dir.
-        self.assertEqual(sync_mod.parse_source(), config_mod.TRANSCRIPT_DIR)
+    def test_falls_back_to_local_when_aggregate_missing(self):
+        with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", ""):
+            self.assertEqual(transcript_sync.parse_source(), config.TRANSCRIPT_DIR)
 
     def test_uses_aggregate_when_enabled_and_populated(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -73,30 +57,90 @@ class TestParseSource(unittest.TestCase):
             agg = tmp_path / "aggregate"
             agg.mkdir()
             (agg / "machine-a").mkdir()
-            (agg / "machine-a" / "session-1.jsonl").write_text(
-                '{"type":"user"}\n'
-            )
+            (agg / "machine-a" / "session-1.jsonl").write_text('{"t":"u"}\n')
 
-            with mock.patch.dict(os.environ, {
-                "CAI_TRANSCRIPT_SYNC_URL": "user@host:/tmp",
-                "CAI_MACHINE_ID": "machine-a",
-            }, clear=False):
-                import cai_lib.config as config_mod
-                import cai_lib.transcript_sync as sync_mod
-                importlib.reload(config_mod)
-                importlib.reload(sync_mod)
-                # Point the module at our temp aggregate.
-                with mock.patch.object(sync_mod, "TRANSCRIPT_AGGREGATE_DIR", agg):
-                    self.assertTrue(sync_mod.transcript_sync_enabled())
-                    self.assertEqual(sync_mod.parse_source(), agg)
+            with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", "user@host:/tmp"), \
+                 mock.patch.object(config, "MACHINE_ID", "machine-a"), \
+                 mock.patch.object(config, "TRANSCRIPT_AGGREGATE_DIR", agg):
+                self.assertTrue(config.transcript_sync_enabled())
+                self.assertEqual(transcript_sync.parse_source(), agg)
 
 
 class TestRepoSlug(unittest.TestCase):
     def test_slash_becomes_underscore(self):
-        config_mod, _ = _reload_with_env({
-            "CAI_REPO": "owner/repo-name",
-        })
-        self.assertEqual(config_mod.REPO_SLUG, "owner_repo-name")
+        self.assertEqual(config._repo_slug("owner/repo-name"), "owner_repo-name")
+        self.assertEqual(config._repo_slug("a/b/c"), "a_b_c")
+
+
+class TestTransportSelection(unittest.TestCase):
+    def test_colon_url_is_ssh(self):
+        self.assertFalse(transcript_sync._is_local_url("cai@host:/srv/cai-transcripts"))
+        with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", "cai@h:/srv/x"), \
+             mock.patch.object(config, "TRANSCRIPT_SYNC_SSH_KEY", Path("/tmp/k")):
+            args = transcript_sync._transport_args()
+            self.assertEqual(args[0], "-e")
+            self.assertIn("ssh", args[1])
+            self.assertIn("/tmp/k", args[1])
+
+    def test_plain_path_is_local(self):
+        self.assertTrue(transcript_sync._is_local_url("/srv/cai-transcripts"))
+        with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", "/srv/cai-transcripts"):
+            self.assertEqual(transcript_sync._transport_args(), [])
+
+
+@unittest.skipUnless(_rsync_available(), "rsync not installed on this host")
+class TestLocalPushPull(unittest.TestCase):
+    """End-to-end-ish: real rsync against a temp dir, no SSH."""
+
+    def test_push_and_pull_roundtrip_local(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            local_src = tmp_path / "src"
+            local_src.mkdir()
+            (local_src / "-app").mkdir()
+            (local_src / "-app" / "session1.jsonl").write_text('{"t":"u"}\n')
+
+            store = tmp_path / "store"
+            store.mkdir()
+            aggregate = tmp_path / "agg"
+
+            with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", str(store)), \
+                 mock.patch.object(config, "MACHINE_ID", "test-host"), \
+                 mock.patch.object(config, "REPO_SLUG", "owner_repo"), \
+                 mock.patch.object(config, "TRANSCRIPT_DIR", local_src), \
+                 mock.patch.object(config, "TRANSCRIPT_AGGREGATE_DIR", aggregate):
+                self.assertEqual(transcript_sync.push(), 0)
+                bucket = store / "owner_repo" / "test-host"
+                self.assertTrue(
+                    (bucket / "-app" / "session1.jsonl").exists(),
+                    "expected pushed file in server bucket",
+                )
+
+                self.assertEqual(transcript_sync.pull(), 0)
+                pulled = aggregate / "test-host" / "-app" / "session1.jsonl"
+                self.assertTrue(pulled.exists(), "expected file in aggregate mirror")
+                self.assertEqual(pulled.read_text(), '{"t":"u"}\n')
+
+    def test_empty_source_does_not_push(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            empty_src = tmp_path / "src"
+            empty_src.mkdir()  # exists but no .jsonl
+            store = tmp_path / "store"
+            store.mkdir()
+            bucket = store / "owner_repo" / "test-host"
+            bucket.mkdir(parents=True)
+            (bucket / "old-session.jsonl").write_text('{"t":"u"}\n')
+
+            with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", str(store)), \
+                 mock.patch.object(config, "MACHINE_ID", "test-host"), \
+                 mock.patch.object(config, "REPO_SLUG", "owner_repo"), \
+                 mock.patch.object(config, "TRANSCRIPT_DIR", empty_src):
+                self.assertEqual(transcript_sync.push(), 0)
+                self.assertTrue(
+                    (bucket / "old-session.jsonl").exists(),
+                    "empty-source push must not --delete the bucket",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
When cai runs for the same repo from multiple machines, each container only sees its local sessions — the analyzer and confirm step miss signals from the rest of the fleet. This PR adds an opt-in, rsync-over-ssh transcript store so `cai analyze` and `cai confirm` see the union across hosts.

### How it works (no-op when `CAI_TRANSCRIPT_SYNC_URL` is unset)
- New `cai transcript-sync` subcommand rsyncs local transcripts into `<server>/<repo-slug>/<machine-id>/` and pulls every machine's bucket back into `/home/cai/.claude/projects-aggregate/`. Scheduled via `CAI_TRANSCRIPT_SYNC_SCHEDULE` (default `*/15 * * * *`); cron line is only emitted when sync is configured.
- `cmd_analyze` and `handle_confirm` call `transcript_sync.pull()` inline before parsing and read the aggregate mirror instead of `TRANSCRIPT_DIR`. `parse.py`'s `rglob("*.jsonl")` handles the extra nesting transparently.
- Machine identity comes from the host's `/etc/machine-id` (bind-mounted read-only at `/etc/host-machine-id`). `CAI_MACHINE_ID` overrides for human-readable bucket names.
- `install.sh` prompts for the sync URL, generates a dedicated ed25519 keypair, prints the pubkey, and wires key/env/mounts into the generated `docker-compose.yml`.
- `scripts/server-cleanup.sh` is a self-contained age + size enforcer for the remote server (documented, not run in-container).

### Also
- `Dockerfile`: adds `rsync` + `openssh-client`, pre-creates `/home/cai/.ssh` with 700.
- `scripts/generate-index.sh`: pins sort to `LC_ALL=C` so `CODEBASE_INDEX.md` regenerates identically on any contributor's machine (pre-existing churn source).
- 5 new unit tests covering the no-op path, missing machine-id, and `parse_source` fallback.

## Test plan
- [x] `pytest tests/` passes (197 passed; only pre-existing `test_lint.py` failure from unused imports left over in `cai.py` after the #844 refactor)
- [ ] Fresh install via `install.sh` with sync enabled: key generated, compose YAML includes sync env + mounts, `docker compose up` succeeds
- [ ] With `CAI_TRANSCRIPT_SYNC_URL` set: `docker compose exec cai python /app/cai.py transcript-sync` succeeds, the OVH bucket fills, `projects-aggregate/` mirrors back
- [ ] With sync disabled: existing `cai analyze` / `cai confirm` behavior unchanged (falls back to local `TRANSCRIPT_DIR`)
- [ ] `scripts/server-cleanup.sh --dry-run` on the server emits expected deletes without actually deleting

🤖 Generated with [Claude Code](https://claude.com/claude-code)