### PR TITLE
install.sh: default local transcript path under $INSTALL_DIR

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -179,11 +179,11 @@ case "$ENABLE_SYNC" in
       2)
         echo
         echo "Enter the absolute path on this host where transcripts live."
-        echo "Must be an existing directory. It will be bind-mounted"
-        echo "into the container at the same path."
-        echo "Example: /srv/cai-transcripts"
+        echo "Created if missing. Bind-mounted into the container at the"
+        echo "same path. The default lives under the install directory so"
+        echo "no root / chown is needed."
         echo
-        prompt SYNC_PATH "Local path"
+        prompt SYNC_PATH "Local path" "${INSTALL_DIR}/transcripts"
         if [[ -z "$SYNC_PATH" ]]; then
           echo "ERROR: local path cannot be empty."
           exit 1


### PR DESCRIPTION
## Summary
- Previous UX presented an empty prompt with example path `/srv/cai-transcripts` requiring root permissions
- Now defaults to `${INSTALL_DIR}/transcripts`, which the user already owns and can use without permission errors
- Improves UX by allowing users to simply press Enter to accept the sensible default

## Test plan
- Run install.sh and proceed to the local-mode transcript sync configuration step
- Verify the prompt shows `[${INSTALL_DIR}/transcripts]` as the default
- Press Enter without typing a path and confirm it accepts the default
- Verify the directory is created under $INSTALL_DIR and is accessible by the installer user


🤖 Generated with Claude Code