### PR TITLE
auto-improve: [#827 Step 1/3] Copy agents into categorical subfolders

### DIFF
--- a/cai_lib/cmd_helpers_git.py
+++ b/cai_lib/cmd_helpers_git.py
@@ -228,24 +228,23 @@ def _apply_agent_edit_staging(work_dir: Path) -> int:
 
     if staging.exists() and staging.is_dir():
         target_dir = work_dir / ".claude" / "agents"
-        for staged_file in sorted(staging.iterdir()):
-            if not staged_file.is_file():
-                continue
-
-            target = target_dir / staged_file.name
+        for staged_file in sorted(staging.rglob("*.md")):
+            rel = staged_file.relative_to(staging)
+            target = target_dir / rel
             if not target.exists():
                 print(
                     f"[cai] agent edit staging: creating new agent file "
-                    f".claude/agents/{staged_file.name}",
+                    f".claude/agents/{rel}",
                     flush=True,
                 )
 
             try:
+                target.parent.mkdir(parents=True, exist_ok=True)
                 content = staged_file.read_text()
                 target.write_text(content)
                 print(
                     f"[cai] applied staged agent file: "
-                    f".claude/agents/{staged_file.name} "
+                    f".claude/agents/{rel} "
                     f"({len(content)} bytes)",
                     flush=True,
                 )
@@ -253,7 +252,7 @@ def _apply_agent_edit_staging(work_dir: Path) -> int:
             except OSError as exc:
                 print(
                     f"[cai] agent edit staging: failed to apply "
-                    f"{staged_file.name}: {exc}",
+                    f"{rel}: {exc}",
                     file=sys.stderr,
                 )
                 continue


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#830

**Issue:** #830 — [#827 Step 1/3] Copy agents into categorical subfolders

## PR Summary

### What this fixes
`_apply_agent_edit_staging()` in `cai_lib/cmd_helpers_git.py` used `iterdir()` + `is_file()`, which silently skipped subdirectories in `.cai-staging/agents/`. This meant staging files at `.cai-staging/agents/<subdir>/<name>.md` were never copied to `.claude/agents/<subdir>/<name>.md`, blocking the agent categorization work in issue #830.

### What was changed
- **`cai_lib/cmd_helpers_git.py`** (lines 231–258): Replaced the `iterdir()` flat-file loop with `rglob("*.md")` + `relative_to()`, mirroring the proven CLAUDE.md staging pattern already in the same function. Added `target.parent.mkdir(parents=True, exist_ok=True)` before each write so subdirectories are created on the fly. Updated all log/error messages to use the full relative path (`rel`) instead of just the filename. This is backward-compatible — flat files in `.cai-staging/agents/` continue to work unchanged.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
