### PR TITLE
.claude/settings.json: fix $schema URL so Claude Code stops prompting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,3 @@
 {
-  "$schema": "https://code.claude.com/schemas/settings.json"
+  "$schema": "https://json.schemastore.org/claude-code-settings.json"
 }


### PR DESCRIPTION
## Summary
- The old `$schema` URL triggers an "Invalid value" warning and a skip/continue prompt on every `claude` startup
- Claude Code only accepts `https://json.schemastore.org/claude-code-settings.json` as the valid schema URL
- This commit updates `.claude/settings.json` to use the correct schema URL

## Test plan
- [ ] Launch `claude` and confirm no schema-validation prompt appears at startup
- [ ] Verify the settings file is properly recognized by Claude Code

🤖 Generated with Claude Code