### PR TITLE
auto-improve: [#827 Step 2/3] Update staging helpers to support subdirectory structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,16 +69,16 @@ wrapper pre-creates is the workaround for both cases:
 **For agent definition files** (`.claude/agents/*.md`):
 
   1. **Read** the current agent file at its clone-side path to
-     see the existing content: `Read("<work_dir>/.claude/agents/<basename>.md")`.
+     see the existing content: `Read("<work_dir>/.claude/agents/<relative-path>.md")`.
      (Read is allowed; only Edit/Write on that path is blocked.)
   2. **Write** the FULL new file content (YAML frontmatter +
      body, exactly what you want the final file to look like)
-     to `<work_dir>/.cai-staging/agents/<same-basename>.md`
-     using the Write tool.
-  3. The wrapper copies `.cai-staging/agents/*.md` over
-     `.claude/agents/*.md` (matching by basename) after you exit
-     successfully, then deletes the staging directory so it
-     doesn't land in the PR.
+     to `<work_dir>/.cai-staging/agents/<same-relative-path>.md`
+     using the Write tool. Preserve any subdirectory structure.
+  3. The wrapper recursively walks `.cai-staging/agents/`, preserves
+     subdirectory paths, and copies each file to the matching path in
+     `.claude/agents/` after you exit successfully, then deletes the
+     staging directory so it doesn't land in the PR.
 
 **For plugin files** (`.claude/plugins/<plugin-path>`):
 
@@ -121,8 +121,10 @@ Rules (apply to agents, plugins, and CLAUDE.md files):
 
 Example of updating an agent file:
 
-  - GOOD: `Read("<work_dir>/.claude/agents/cai-implement.md")` then
+  - GOOD (flat): `Read("<work_dir>/.claude/agents/cai-implement.md")` then
     `Write("<work_dir>/.cai-staging/agents/cai-implement.md", "<full new content>")`
+  - GOOD (nested): `Read("<work_dir>/.claude/agents/lifecycle/cai-triage.md")` then
+    `Write("<work_dir>/.cai-staging/agents/lifecycle/cai-triage.md", "<full new content>")`
   - BAD:  `Edit("<work_dir>/.claude/agents/cai-implement.md", old, new)`  (blocked)
 
 Example of creating a plugin skill:

--- a/cai_lib/actions/fix_ci.py
+++ b/cai_lib/actions/fix_ci.py
@@ -418,12 +418,12 @@ def handle_fix_ci(pr: dict) -> int:
         if agent.stdout:
             print(agent.stdout, flush=True)
 
-        # 10b. Apply any staged .claude/agents/*.md updates.
+        # 10b. Apply any staged .claude/agents/**/*.md updates.
         applied = _apply_agent_edit_staging(work_dir)
         if applied:
             print(
                 f"[cai fix-ci] applied {applied} staged "
-                f".claude/agents/*.md update(s)",
+                f".claude/agents/**/*.md update(s)",
                 flush=True,
             )
 

--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -558,12 +558,12 @@ def handle_implement(issue: dict) -> int:
             n = _create_suggested_issues(suggested, issue_number)
             print(f"[cai implement] created {n}/{len(suggested)} suggested issue(s)", flush=True)
 
-        # 5c. Apply any `.claude/agents/*.md` updates the agent staged.
+        # 5c. Apply any `.claude/agents/**/*.md` updates the agent staged.
         applied = _apply_agent_edit_staging(work_dir)
         if applied:
             print(
                 f"[cai implement] applied {applied} staged "
-                f".claude/agents/*.md update(s)",
+                f".claude/agents/**/*.md update(s)",
                 flush=True,
             )
 

--- a/cai_lib/actions/review_docs.py
+++ b/cai_lib/actions/review_docs.py
@@ -213,7 +213,7 @@ def handle_review_docs(pr: dict) -> int:
         if applied:
             print(
                 f"[cai review-docs] applied {applied} staged "
-                f".claude/agents/*.md update(s)",
+                f".claude/agents/**/*.md update(s)",
                 flush=True,
             )
 

--- a/cai_lib/actions/revise.py
+++ b/cai_lib/actions/revise.py
@@ -876,7 +876,7 @@ def handle_revise(pr: dict) -> int:
             if agent.stdout:
                 print(agent.stdout, flush=True)
 
-            # 6b. Apply any `.claude/agents/*.md` updates the agent
+            # 6b. Apply any `.claude/agents/**/*.md` updates the agent
             #     staged at `<work_dir>/.cai-staging/agents/`. We
             #     apply UNCONDITIONALLY (even on agent non-zero
             #     exit) because cai-revise's return code is
@@ -890,7 +890,7 @@ def handle_revise(pr: dict) -> int:
             if applied:
                 print(
                     f"[cai revise] applied {applied} staged "
-                    f".claude/agents/*.md update(s)",
+                    f".claude/agents/**/*.md update(s)",
                     flush=True,
                 )
 

--- a/cai_lib/cmd_helpers_git.py
+++ b/cai_lib/cmd_helpers_git.py
@@ -128,27 +128,28 @@ def _work_directory_block(work_dir: Path) -> str:
         f"    {staging_abs}\n\n"
         "To update an `.claude/agents/<name>.md` file, use the "
         "Write tool to write the COMPLETE new file content "
-        "(frontmatter + body) to "
-        f"`{staging_abs}/<name>.md`. After your session exits "
-        "successfully the wrapper copies every file it finds in "
-        f"`{staging_rel}/` back over the corresponding "
-        "`.claude/agents/<same-name>.md` in the clone, then deletes "
-        "the staging directory so it never lands in the PR.\n\n"
+        "(frontmatter + body) to the corresponding path under "
+        f"`{staging_abs}/`. After your session exits "
+        "successfully the wrapper recursively walks every file it finds "
+        f"in `{staging_rel}/`, preserving subdirectory paths, and copies "
+        "each one to the matching `.claude/agents/<relative-path>.md` in "
+        "the clone, then deletes the staging directory so it never lands "
+        "in the PR.\n\n"
         "Rules:\n"
         "  - Staged files are copied unconditionally — new agent "
         "definitions are created if no target exists yet.\n"
         "  - Write the FULL file, not a diff or patch. The wrapper "
         "does an unconditional full-file overwrite.\n"
-        "  - Use the same basename as the target "
-        f"(e.g. `{staging_abs}/cai-implement.md` → "
-        f"`{work_dir}/.claude/agents/cai-implement.md`).\n"
+        "  - Preserve the relative path from the staging root "
+        f"(e.g. `{staging_abs}/lifecycle/cai-triage.md` → "
+        f"`{work_dir}/.claude/agents/lifecycle/cai-triage.md`).\n"
         "  - Do NOT attempt `Edit` or `Write` on the protected "
         f"`{work_dir}/.claude/agents/...` path — it will always "
         "fail. Go through the staging dir.\n\n"
         "Example:\n"
-        f"  - GOOD: `Write(\"{staging_abs}/cai-implement.md\", "
+        f"  - GOOD: `Write(\"{staging_abs}/lifecycle/cai-triage.md\", "
         "\"<full new file content>\")`\n"
-        f"  - BAD:  `Edit(\"{work_dir}/.claude/agents/cai-implement.md\", "
+        f"  - BAD:  `Edit(\"{work_dir}/.claude/agents/lifecycle/cai-triage.md\", "
         "...)`  (blocked by claude-code)\n"
         "\n"
         "## Updating `CLAUDE.md` files (self-modification)\n\n"
@@ -208,13 +209,15 @@ def _apply_agent_edit_staging(work_dir: Path) -> int:
     Security boundaries:
 
       1. Each staged agent file is copied to `<work_dir>/.claude/agents/`
-         using the same basename. If no target exists a new file is
-         created; if one exists it is overwritten.
+         preserving its subdirectory path relative to the staging root.
+         If no target exists a new file is created; if one exists it is
+         overwritten. Parent directories are created as needed.
       2. Staged plugin trees are merged into `<work_dir>/.claude/plugins/`
          using shutil.copytree with dirs_exist_ok=True.
       3. The staging dir lives entirely inside `work_dir` so escapes
-         via `..` are not possible (the wrapper iterates one
-         directory level via `iterdir()` and copies whole files).
+         via `..` are not possible (the wrapper recursively walks the
+         staging directory via `rglob("*.md")` and copies whole files
+         preserving subdirectory paths).
       4. The staging dir is removed before commit if all staging
          operations succeeded. If plugin staging fails, the staging
          dir is preserved for inspection and the function returns


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#831

**Issue:** #831 — [#827 Step 2/3] Update staging helpers to support subdirectory structure

## PR Summary

### What this fixes
The `_apply_agent_edit_staging` function's docstring incorrectly described flat `iterdir()` iteration, and the `_work_directory_block` prose told agents to use the same basename (flat path) when staging agent file edits, making it unclear how to stage files in subdirectories.

### What was changed
- **`cai_lib/cmd_helpers_git.py`**: Updated `_apply_agent_edit_staging` docstring to remove stale `iterdir()` reference and describe the recursive `rglob`-based walk that preserves subdirectory paths. Updated `_work_directory_block` staging prose — changed the "same basename" rule to "preserve the relative path from the staging root" with a `lifecycle/cai-triage.md` subdirectory example in GOOD/BAD.
- **`cai_lib/actions/implement.py`**, **`fix_ci.py`**, **`revise.py`**, **`review_docs.py`**: Cosmetic update of log strings and comments from `.claude/agents/*.md` to `.claude/agents/**/*.md` to accurately reflect the recursive staging apply.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
