### PR TITLE
auto-improve: Retroactive no-action sweep guard misses its own marker comment (case-sensitivity bug)

### DIFF
--- a/cai_lib/cmd_agents.py
+++ b/cai_lib/cmd_agents.py
@@ -81,7 +81,7 @@ def _fetch_closed_auto_improve_issues(limit: int = 50) -> list[dict]:
         # Detect whether this issue was already closed by any cai agent
         # (either _retroactive_no_action_sweep or _migrate_no_action_labels).
         has_retroactive_close = any(
-            "Closing as **not planned**" in (c.get("body") or "")
+            "closing as **not planned**" in (c.get("body") or "").lower()
             for c in comments
         )
         result.append({


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#859

**Issue:** #859 — Retroactive no-action sweep guard misses its own marker comment (case-sensitivity bug)

## PR Summary

### What this fixes
The `has_retroactive_close` guard in `cai_lib/cmd_agents.py` used case-sensitive substring matching (`"Closing as **not planned**"`), which correctly matched `_migrate_no_action_labels`'s comment but missed the sweep's own comment (`"Retroactively closing as **not planned**"` — lowercase `c` after the adverb). This caused already-swept issues to be re-processed on every subsequent audit run.

### What was changed
- **`cai_lib/cmd_agents.py` line 84** — applied `.lower()` to the comment body before the substring check, so `"closing as **not planned**"` now matches both comment phrasings regardless of capitalization.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
