### PR TITLE
Remap in-container cai user to host UID/GID at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # cai wrapper ephemeral directories (must never be committed)
 .cai-staging/
 .cai/
+.claude/agent-memory/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,6 +44,30 @@
 
 set -euo pipefail
 
+# Runtime UID/GID remap. When docker-compose.yml sets `user: "0:0"` and
+# passes HOST_UID/HOST_GID, we enter here as root, remap the in-container
+# cai user to match the host user so bind-mounts and named volumes have
+# matching ownership, then drop privileges and re-exec this script as
+# cai. Running directly as cai (no compose override) makes this branch
+# a no-op and the rest of the script runs unchanged.
+if [ "$(id -u)" -eq 0 ]; then
+  TARGET_UID="${HOST_UID:-1000}"
+  TARGET_GID="${HOST_GID:-1000}"
+  CURRENT_UID="$(id -u cai)"
+  CURRENT_GID="$(id -g cai)"
+  if [ "$CURRENT_UID" != "$TARGET_UID" ] || [ "$CURRENT_GID" != "$TARGET_GID" ]; then
+    echo "[entrypoint] remapping cai: ${CURRENT_UID}:${CURRENT_GID} -> ${TARGET_UID}:${TARGET_GID}"
+    groupmod -g "$TARGET_GID" -o cai
+    usermod  -u "$TARGET_UID" -o -g "$TARGET_GID" cai
+    # Chown only entries not already at the target UID/GID; full -R chown
+    # would rewalk the entire home volume on every container start.
+    find /home/cai /var/log/cai /app \
+      \( -not -uid "$TARGET_UID" -o -not -gid "$TARGET_GID" \) \
+      -exec chown -h "$TARGET_UID:$TARGET_GID" {} + 2>/dev/null || true
+  fi
+  exec runuser -u cai -- "$0" "$@"
+fi
+
 CAI_CYCLE_SCHEDULE="${CAI_CYCLE_SCHEDULE:-0 * * * *}"
 CAI_VERIFY_SCHEDULE="${CAI_VERIFY_SCHEDULE:-15 * * * *}"
 CAI_ANALYZER_SCHEDULE="${CAI_ANALYZER_SCHEDULE:-0 0 * * *}"

--- a/install.sh
+++ b/install.sh
@@ -67,6 +67,16 @@ if [[ -e docker-compose.yml ]]; then
   echo
 fi
 
+# Capture the host user's UID/GID. The generated compose passes these
+# to the container (HOST_UID/HOST_GID env + user: "0:0"), and entrypoint.sh
+# remaps the in-container 'cai' user to match before dropping privileges.
+# This keeps bind-mounts and named volumes owned by the host user without
+# needing a local image build or any host-side permission setup.
+HOST_UID="$(id -u)"
+HOST_GID="$(id -g)"
+echo "[i] Host UID/GID detected: ${HOST_UID}:${HOST_GID} (entrypoint will remap at startup)"
+echo
+
 echo "How should the container authenticate to Claude?"
 echo
 echo "  1) Open the claude REPL inside the container — it auto-prompts"
@@ -325,8 +335,17 @@ case "$AUTH_CHOICE" in
 services:
   cai:
     image: robotsix/cai:${IMAGE_TAG}
+    # Start as root so entrypoint.sh can remap the in-container cai user
+    # to match HOST_UID/HOST_GID, then drop privileges. Filled in by
+    # install.sh from \$(id -u)/\$(id -g).
+    user: "0:0"
     restart: unless-stopped
     environment:
+      # Host user UID/GID used by entrypoint.sh to remap the cai user
+      # at startup so bind-mounts and named volumes are owned by the
+      # host user. Captured by install.sh from the installer's shell.
+      HOST_UID: "${HOST_UID}"
+      HOST_GID: "${HOST_GID}"
       # Crontab expressions for the scheduled tasks (any valid
       # 5-field cron line — see https://crontab.guru/).
       #
@@ -399,10 +418,19 @@ YAML
 services:
   cai:
     image: robotsix/cai:${IMAGE_TAG}
+    # Start as root so entrypoint.sh can remap the in-container cai user
+    # to match HOST_UID/HOST_GID, then drop privileges. Filled in by
+    # install.sh from \$(id -u)/\$(id -g).
+    user: "0:0"
     restart: unless-stopped
     env_file:
       - .env
     environment:
+      # Host user UID/GID used by entrypoint.sh to remap the cai user
+      # at startup so bind-mounts and named volumes are owned by the
+      # host user. Captured by install.sh from the installer's shell.
+      HOST_UID: "${HOST_UID}"
+      HOST_GID: "${HOST_GID}"
       # Crontab expressions for the scheduled tasks (any valid
       # 5-field cron line — see https://crontab.guru/).
       #


### PR DESCRIPTION
## Summary
- `install.sh` captures `HOST_UID=$(id -u)` / `HOST_GID=$(id -g)` and bakes them into both generated compose templates along with `user: "0:0"`, so the container starts as root.
- `entrypoint.sh` adds a root-only branch that `usermod`/`groupmod -o` the in-container `cai` user to match the host, targeted-chowns `/home/cai`, `/var/log/cai`, `/app` (skipping entries already correct), then `exec runuser -u cai -- "$0" "$@"` drops privileges and re-enters as `cai`.
- No Dockerfile change; `runuser` is already part of util-linux in the base image.

## Why
Before this, the published image baked UID 1000 for the `cai` user. On hosts where the installer user isn't UID 1000 (multi-user boxes, some cloud VMs, servers with a dedicated service account), bind-mounts and volume-initial ownership ended up on mismatched UIDs and required a host-side chown/group dance to unbreak — in particular, cross-host transcript sync failed with `Permission denied` whenever the SSH push user on the server wasn't UID 1000.

## Test plan
- [ ] Run `install.sh` on a host where `id -u` == 1000 → remap is a no-op, volumes initialise at 1000.
- [ ] Run `install.sh` on a host where `id -u` != 1000 → logs show `[entrypoint] remapping cai: 1000:1000 -> <host-uid>:<host-gid>`, `docker compose exec cai id` reports the host UID.
- [ ] Existing deployments that don't pass `HOST_UID` keep running as `cai` unchanged (entrypoint's root branch is skipped).
- [ ] Cross-host transcript sync: a laptop `cai transcript-sync` push to a VPS (both remapped to their host user) lands under the correct bucket with no server-side chown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)