### PR TITLE
fix: retroactive sweep relies on stateReason, posts marker separately

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -117,6 +117,7 @@
 | `tests/test_plan.py` | TODO: add description |
 | `tests/test_pr_bounce.py` | TODO: add description |
 | `tests/test_publish.py` | Tests for publish.py issue publishing |
+| `tests/test_retroactive_sweep.py` | TODO: add description |
 | `tests/test_revise_filter.py` | TODO: add description |
 | `tests/test_rollback.py` | Tests for rollback functionality |
 | `tests/test_subprocess_utils.py` | TODO: add description |

--- a/cai_lib/cmd_agents.py
+++ b/cai_lib/cmd_agents.py
@@ -56,7 +56,7 @@ def _fetch_closed_auto_improve_issues(limit: int = 50) -> list[dict]:
             "--label", "auto-improve",
             "--state", "closed",
             "--json",
-            "number,title,labels,closedAt,comments",
+            "number,title,labels,closedAt,stateReason,comments",
             "--limit", str(limit),
         ]) or []
     except subprocess.CalledProcessError:
@@ -78,17 +78,28 @@ def _fetch_closed_auto_improve_issues(limit: int = 50) -> list[dict]:
             rationale = body[:600]
             rationale_author = author
             break
-        # Detect whether this issue was already closed by any cai agent
-        # (either _retroactive_no_action_sweep or _migrate_no_action_labels).
-        has_retroactive_close = any(
-            "closing as **not planned**" in (c.get("body") or "").lower()
-            for c in comments
+        # Detect whether this issue already has the NOT_PLANNED terminal
+        # state. We rely on GitHub's native stateReason rather than a
+        # marker-comment substring because `gh issue close --comment ...`
+        # silently drops the comment when the issue is already closed —
+        # so the sweep's own marker is not guaranteed to be persisted on
+        # the issue. The comment-marker check is kept as a backup for
+        # issues closed by historical paths that used `gh issue comment`
+        # separately.
+        state_reason = (issue.get("stateReason") or "").upper()
+        has_retroactive_close = (
+            state_reason == "NOT_PLANNED"
+            or any(
+                "closing as **not planned**" in (c.get("body") or "").lower()
+                for c in comments
+            )
         )
         result.append({
             "number": issue["number"],
             "title": issue["title"],
             "labels": [lbl["name"] for lbl in issue.get("labels", [])],
             "closedAt": issue.get("closedAt", ""),
+            "stateReason": state_reason,
             "rationale": rationale,
             "rationale_author": rationale_author,
             "has_retroactive_close": has_retroactive_close,

--- a/cai_lib/github.py
+++ b/cai_lib/github.py
@@ -246,14 +246,32 @@ def close_issue_not_planned(
 ) -> bool:
     """Close a GitHub issue as 'not planned' with a marker comment.
 
-    Returns True on success, False on failure (logs the error).
-    This replaces the retired auto-improve:no-action label.
+    Posts the marker via `gh issue comment` first, then closes with
+    `--reason "not planned"`. The two calls are split because
+    `gh issue close --comment X` silently drops the comment when the
+    issue is already closed — splitting guarantees the audit-trail
+    marker is persisted regardless of the issue's initial state.
+
+    Returns True when the close call succeeds (posting the comment
+    is best-effort and only logs a warning on failure).
     """
+    comment_result = subprocess.run(
+        ["gh", "issue", "comment", str(issue_number),
+         "--repo", REPO,
+         "--body", comment],
+        capture_output=True,
+        text=True,
+    )
+    if comment_result.returncode != 0:
+        print(
+            f"[{log_prefix}] WARNING: gh issue comment failed for "
+            f"#{issue_number}: {comment_result.stderr.strip()}",
+            file=sys.stderr, flush=True,
+        )
     result = subprocess.run(
         ["gh", "issue", "close", str(issue_number),
          "--repo", REPO,
-         "--reason", "not planned",
-         "--comment", comment],
+         "--reason", "not planned"],
         capture_output=True,
         text=True,
     )

--- a/tests/test_retroactive_sweep.py
+++ b/tests/test_retroactive_sweep.py
@@ -1,0 +1,108 @@
+"""Tests for _retroactive_no_action_sweep's state-reason guard.
+
+Covers the root cause fixed for #862: `gh issue close --comment ...`
+silently drops the comment when the issue is already closed, so the
+sweep's own marker is not guaranteed to be present. The guard must
+therefore rely on GitHub's native `stateReason == NOT_PLANNED` field
+rather than a comment-substring match.
+"""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib import cmd_agents  # noqa: E402
+
+
+def _issue(number, state_reason, comments=None, labels=None):
+    return {
+        "number": number,
+        "title": f"Issue {number}",
+        "labels": [{"name": lbl} for lbl in (labels or [])],
+        "closedAt": "2026-04-18T12:00:00Z",
+        "stateReason": state_reason,
+        "comments": comments or [],
+    }
+
+
+class TestRetroactiveSweepStateReason(unittest.TestCase):
+
+    def test_already_not_planned_is_skipped_even_without_marker(self):
+        """Issues already NOT_PLANNED must be skipped even when the
+        marker comment is absent (reproduces the #862 regression)."""
+        issues = [_issue(855, "NOT_PLANNED", comments=[])]
+        closed_numbers: list[int] = []
+
+        def fake_close(num, comment, log_prefix="cai"):
+            closed_numbers.append(num)
+            return True
+
+        with patch.object(cmd_agents, "_gh_json", return_value=issues), \
+                patch.object(cmd_agents, "close_issue_not_planned",
+                             side_effect=fake_close), \
+                patch.object(cmd_agents, "log_run"):
+            swept = cmd_agents._retroactive_no_action_sweep()
+
+        self.assertEqual(swept, [])
+        self.assertEqual(closed_numbers, [])
+
+    def test_completed_without_terminal_label_is_swept(self):
+        """A COMPLETED issue without merged/solved labels must be
+        swept (the real target of the retroactive sweep)."""
+        issues = [_issue(900, "COMPLETED", comments=[], labels=[])]
+        closed_numbers: list[int] = []
+
+        def fake_close(num, comment, log_prefix="cai"):
+            closed_numbers.append(num)
+            return True
+
+        with patch.object(cmd_agents, "_gh_json", return_value=issues), \
+                patch.object(cmd_agents, "close_issue_not_planned",
+                             side_effect=fake_close), \
+                patch.object(cmd_agents, "log_run"):
+            swept = cmd_agents._retroactive_no_action_sweep()
+
+        self.assertEqual(len(swept), 1)
+        self.assertEqual(swept[0]["number"], 900)
+        self.assertEqual(closed_numbers, [900])
+
+    def test_merged_label_still_wins(self):
+        """Issues with a terminal lifecycle label (merged/solved)
+        must be skipped regardless of stateReason."""
+        issues = [
+            _issue(910, "COMPLETED", comments=[],
+                   labels=[cmd_agents.LABEL_MERGED]),
+            _issue(911, "COMPLETED", comments=[],
+                   labels=[cmd_agents.LABEL_SOLVED]),
+        ]
+
+        with patch.object(cmd_agents, "_gh_json", return_value=issues), \
+                patch.object(cmd_agents, "close_issue_not_planned") as closer, \
+                patch.object(cmd_agents, "log_run"):
+            swept = cmd_agents._retroactive_no_action_sweep()
+
+        self.assertEqual(swept, [])
+        closer.assert_not_called()
+
+    def test_comment_marker_still_honored_as_backup(self):
+        """Even when stateReason is COMPLETED, a prior marker comment
+        must still short-circuit (kept as a defense in depth)."""
+        marker = ("Retroactively closing as **not planned** — issue "
+                  "was closed without a terminal lifecycle label.")
+        issues = [_issue(920, "COMPLETED",
+                         comments=[{"body": marker,
+                                    "author": {"login": "cai-bot"}}])]
+
+        with patch.object(cmd_agents, "_gh_json", return_value=issues), \
+                patch.object(cmd_agents, "close_issue_not_planned") as closer, \
+                patch.object(cmd_agents, "log_run"):
+            swept = cmd_agents._retroactive_no_action_sweep()
+
+        self.assertEqual(swept, [])
+        closer.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Root cause of #862: `gh issue close --comment X` silently drops the comment when the issue is already closed, so the sweep's own marker was never persisted. PR #861's case-insensitive match still couldn't find a comment that had never been posted.
- `_fetch_closed_auto_improve_issues` now checks `stateReason == NOT_PLANNED` (ground truth). Comment-substring check retained as backup.
- `close_issue_not_planned` now posts the marker via `gh issue comment` first, then closes — guaranteeing the audit-trail comment is persisted regardless of initial state.

## Test plan
- [x] `python -m unittest tests.test_retroactive_sweep -v` — 4 new tests pass
- [x] `python -m unittest discover -s tests -v` — full suite 211 tests pass

Refs #862
Refs #863

🤖 Generated with [Claude Code](https://claude.com/claude-code)