### PR TITLE
feat(audit): promote _close_orphaned_prs to shared github helper

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -113,6 +113,7 @@
 | `tests/test_maintain.py` | Tests for cai_lib.actions.maintain — handle_maintain confidence routing and FSM transitions |
 | `tests/test_merge_diff.py` | TODO: add description |
 | `tests/test_multistep.py` | Tests for multi-step plan support |
+| `tests/test_orphaned_prs.py` | TODO: add description |
 | `tests/test_parse.py` | Tests for parse.py signal extraction |
 | `tests/test_plan.py` | TODO: add description |
 | `tests/test_pr_bounce.py` | TODO: add description |

--- a/cai_lib/actions/revise.py
+++ b/cai_lib/actions/revise.py
@@ -28,7 +28,7 @@ from cai_lib.fsm import (
     apply_pr_transition,
     get_pr_state,
 )
-from cai_lib.github import _gh_json, _set_labels
+from cai_lib.github import _gh_json, _set_labels, _close_orphaned_prs
 from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.logging_utils import log_run, log_run as _log_run_alias  # noqa: F401
 from cai_lib.cmd_helpers import (
@@ -376,90 +376,6 @@ def _recover_stuck_rebase_prs() -> int:
     return recovered
 
 
-def _close_orphaned_prs() -> int:
-    """Close open auto-improve PRs whose linked issue has been closed.
-
-    If the linked issue is CLOSED, `_select_revise_targets` silently
-    skips the PR (it requires issue.state == OPEN), and `cmd_merge`
-    cannot merge it if it has conflicts, so the PR sits open forever
-    accumulating conflict with main. This recovery step closes such
-    orphaned PRs and strips the stale `:pr-open` label from the
-    closed issue so the state machine converges.
-
-    Returns the number of PRs closed.
-    """
-    try:
-        prs = _gh_json([
-            "pr", "list",
-            "--repo", REPO,
-            "--state", "open",
-            "--limit", "100",
-            "--json", "number,headRefName",
-        ])
-    except subprocess.CalledProcessError:
-        return 0
-
-    closed = 0
-    for pr in prs:
-        branch = pr.get("headRefName", "")
-        m = re.match(r"auto-improve/(\d+)-", branch)
-        if not m:
-            continue
-        issue_number = int(m.group(1))
-        pr_number = pr["number"]
-
-        try:
-            issue = _gh_json([
-                "issue", "view", str(issue_number),
-                "--repo", REPO,
-                "--json", "state",
-            ])
-        except subprocess.CalledProcessError:
-            continue
-        if not issue or issue.get("state", "").upper() != "CLOSED":
-            continue
-
-        print(
-            f"[cai revise] PR #{pr_number}: linked issue #{issue_number} "
-            f"is CLOSED; closing orphaned PR",
-            flush=True,
-        )
-
-        comment = (
-            "## Revise subagent: closing orphaned PR\n\n"
-            f"Linked issue #{issue_number} is closed, so this PR has "
-            "no tracking issue to drive it forward. Closing "
-            "automatically to prevent it from blocking the auto-improve "
-            "loop (revise skips PRs whose issue is closed; merge cannot "
-            "land it if it conflicts with `main`).\n\n"
-            "---\n"
-            "_Closed automatically by `cai revise` orphan recovery. "
-            "Reopen the issue if you want the implement subagent to retry._"
-        )
-        close_res = _run(
-            ["gh", "pr", "close", str(pr_number),
-             "--repo", REPO, "--delete-branch", "--comment", comment],
-            capture_output=True,
-        )
-        if close_res.returncode != 0:
-            print(
-                f"[cai revise] PR #{pr_number}: gh pr close failed:\n"
-                f"{close_res.stderr}",
-                file=sys.stderr,
-            )
-            continue
-
-        # Strip the stale :pr-open label from the closed issue.
-        _set_labels(
-            issue_number,
-            remove=[LABEL_PR_OPEN, LABEL_REVISING],
-            log_prefix="cai revise",
-        )
-        log_run("revise", repo=REPO, pr=pr_number, issue=issue_number,
-                result="closed_orphaned_pr", exit=0)
-        closed += 1
-
-    return closed
 
 
 def handle_revise(pr: dict) -> int:
@@ -477,7 +393,7 @@ def handle_revise(pr: dict) -> int:
 
     # Close PRs whose linked issue was closed — otherwise they sit
     # open forever (revise skips them, merge can't land conflicts).
-    orphaned = _close_orphaned_prs()
+    orphaned = len(_close_orphaned_prs(log_prefix="cai revise"))
     if orphaned:
         print(
             f"[cai revise] closed {orphaned} orphaned PR(s) "

--- a/cai_lib/cmd_agents.py
+++ b/cai_lib/cmd_agents.py
@@ -30,6 +30,7 @@ from cai_lib.subprocess_utils import _run, _run_claude_p
 
 from cai_lib.github import (
     _gh_json, _set_labels, close_issue_not_planned, _recover_stale_pr_open,
+    _close_orphaned_prs,
 )
 from cai_lib.watchdog import _rollback_stale_in_progress
 from cai_lib.cmd_helpers import _work_directory_block
@@ -679,6 +680,16 @@ def cmd_audit(args) -> int:
     # Step 1f: Retroactively close auto-improve issues closed without terminal labels.
     retroactive_no_action = _retroactive_no_action_sweep()
 
+    # Step 1g: Close open PRs whose linked issue is already closed —
+    # must run after 1f so newly-no-actioned issues are visible as CLOSED.
+    closed_orphans = _close_orphaned_prs(log_prefix="cai audit")
+    if closed_orphans:
+        print(
+            f"[cai audit] closed {len(closed_orphans)} orphaned PR(s) "
+            "(linked issue was closed)",
+            flush=True,
+        )
+
     # Step 2: Gather GitHub state for the claude-driven semantic checks.
 
     # 2a. Open auto-improve issues (full detail).
@@ -812,6 +823,11 @@ def cmd_audit(args) -> int:
         for ra in retroactive_no_action:
             deterministic_section += f"- #{ra['number']}: {ra['title']}\n"
         deterministic_section += "\n"
+    if closed_orphans:
+        deterministic_section += "## Orphaned PRs closed (linked issue closed) this run\n\n"
+        for co in closed_orphans:
+            deterministic_section += f"- PR #{co['pr']} (issue #{co['issue']})\n"
+        deterministic_section += "\n"
     # Cost summary so the audit agent can flag cost outliers — same
     # window as the run-log tail (last 7 days, top 10 invocations).
     cost_section = _build_cost_summary(days=7, top_n=10)
@@ -875,6 +891,7 @@ def cmd_audit(args) -> int:
                 branches_cleaned=len(deleted_orphaned),
                 merged_flagged=len(flagged_merged),
                 retroactive_no_action=len(retroactive_no_action),
+                orphaned_prs_closed=len(closed_orphans),
                 exit=audit.returncode)
         return audit.returncode
 
@@ -892,6 +909,7 @@ def cmd_audit(args) -> int:
                 branches_cleaned=len(deleted_orphaned),
                 merged_flagged=len(flagged_merged),
                 retroactive_no_action=len(retroactive_no_action),
+                orphaned_prs_closed=len(closed_orphans),
                 result="no_findings_file", duration=dur, exit=1)
         return 1
 
@@ -907,6 +925,7 @@ def cmd_audit(args) -> int:
             branches_cleaned=len(deleted_orphaned),
             merged_flagged=len(flagged_merged),
             retroactive_no_action=len(retroactive_no_action),
+            orphaned_prs_closed=len(closed_orphans),
             duration=dur, exit=published.returncode)
     return published.returncode
 

--- a/cai_lib/github.py
+++ b/cai_lib/github.py
@@ -353,6 +353,94 @@ def _recover_stale_pr_open(issues: list[dict], *, log_prefix: str = "cai") -> li
     return recovered
 
 
+def _close_orphaned_prs(*, log_prefix: str = "cai") -> list[dict]:
+    """Close open auto-improve PRs whose linked issue has been closed.
+
+    If the linked issue is CLOSED, the revise handler silently skips
+    the PR, and the merge handler cannot land it if it has conflicts,
+    so the PR sits open forever accumulating conflict with main. This
+    recovery step closes such orphaned PRs and strips the stale
+    ``:pr-open`` / ``:revising`` labels from the closed issue so the
+    state machine converges.
+
+    Shared by ``cai audit`` (periodic sweep) and ``cai revise``
+    (per-PR sweep). Returns the list of closed entries as
+    ``[{"pr": int, "issue": int}, …]`` so callers can surface counts.
+    """
+    subcmd = log_prefix.split()[-1]
+    try:
+        prs = _gh_json([
+            "pr", "list",
+            "--repo", REPO,
+            "--state", "open",
+            "--limit", "100",
+            "--json", "number,headRefName",
+        ])
+    except subprocess.CalledProcessError:
+        return []
+
+    closed_rows: list[dict] = []
+    for pr in prs or []:
+        branch = pr.get("headRefName", "")
+        m = re.match(r"auto-improve/(\d+)-", branch)
+        if not m:
+            continue
+        issue_number = int(m.group(1))
+        pr_number = pr["number"]
+
+        try:
+            issue = _gh_json([
+                "issue", "view", str(issue_number),
+                "--repo", REPO,
+                "--json", "state",
+            ])
+        except subprocess.CalledProcessError:
+            continue
+        if not issue or issue.get("state", "").upper() != "CLOSED":
+            continue
+
+        print(
+            f"[{log_prefix}] PR #{pr_number}: linked issue #{issue_number} "
+            f"is CLOSED; closing orphaned PR",
+            flush=True,
+        )
+
+        comment = (
+            "## Orphaned PR: closing automatically\n\n"
+            f"Linked issue #{issue_number} is closed, so this PR has "
+            "no tracking issue to drive it forward. Closing "
+            "automatically to prevent it from blocking the auto-improve "
+            "loop (revise skips PRs whose issue is closed; merge cannot "
+            "land it if it conflicts with `main`).\n\n"
+            "---\n"
+            f"_Closed automatically by `{log_prefix}` orphan recovery. "
+            "Reopen the issue if you want the implement subagent to retry._"
+        )
+        close_res = _run(
+            ["gh", "pr", "close", str(pr_number),
+             "--repo", REPO, "--delete-branch", "--comment", comment],
+            capture_output=True,
+        )
+        if close_res.returncode != 0:
+            print(
+                f"[{log_prefix}] PR #{pr_number}: gh pr close failed:\n"
+                f"{close_res.stderr}",
+                file=sys.stderr,
+            )
+            continue
+
+        _set_labels(
+            issue_number,
+            remove=[LABEL_PR_OPEN, LABEL_REVISING],
+            log_prefix=log_prefix,
+        )
+        log_run(subcmd, repo=REPO, pr=pr_number, issue=issue_number,
+                result="closed_orphaned_pr", exit=0)
+        closed_rows.append({"pr": pr_number, "issue": issue_number})
+
+    return closed_rows
+
+
 def close_issue_completed(
     issue_number: int,
     comment: str,

--- a/tests/test_orphaned_prs.py
+++ b/tests/test_orphaned_prs.py
@@ -1,0 +1,90 @@
+"""Tests for the shared `_close_orphaned_prs` helper in cai_lib.github.
+
+Covers the branch-regex contract (issue number parsed from the first
+`\\d+` group of the `auto-improve/<n>-…` prefix, so sub-step branches
+like `auto-improve/832-827-step-3-3-…` resolve to 832) and the guard
+that only closes PRs whose linked issue is actually CLOSED.
+"""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib import github as gh  # noqa: E402
+
+
+class TestCloseOrphanedPrs(unittest.TestCase):
+
+    def _fake_gh(self, prs, issue_states):
+        """Build a side-effect callable dispatching on `gh` sub-args."""
+
+        def _side_effect(args):
+            if args[:2] == ["pr", "list"]:
+                return prs
+            if args[:2] == ["issue", "view"]:
+                num = int(args[2])
+                return {"state": issue_states.get(num, "OPEN")}
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        return _side_effect
+
+    def test_closes_pr_when_linked_issue_closed(self):
+        prs = [{"number": 857,
+                "headRefName":
+                    "auto-improve/832-827-step-3-3-remove-original-flat-agent-files"}]
+        states = {832: "CLOSED"}
+        closed_cmds: list[list[str]] = []
+
+        def fake_run(args, **kwargs):
+            if args[:3] == ["gh", "pr", "close"]:
+                closed_cmds.append(args)
+
+                class R:
+                    returncode = 0
+                    stderr = ""
+                return R()
+            raise AssertionError(f"unexpected _run: {args}")
+
+        with patch.object(gh, "_gh_json",
+                          side_effect=self._fake_gh(prs, states)), \
+                patch.object(gh, "_set_labels", return_value=True), \
+                patch.object(gh, "_run", side_effect=fake_run), \
+                patch.object(gh, "log_run"):
+            result = gh._close_orphaned_prs(log_prefix="cai audit")
+
+        self.assertEqual(result, [{"pr": 857, "issue": 832}])
+        self.assertEqual(len(closed_cmds), 1)
+        self.assertIn("857", closed_cmds[0])
+        self.assertIn("--delete-branch", closed_cmds[0])
+
+    def test_skips_pr_when_linked_issue_still_open(self):
+        prs = [{"number": 900,
+                "headRefName": "auto-improve/500-some-fix"}]
+        states = {500: "OPEN"}
+
+        with patch.object(gh, "_gh_json",
+                          side_effect=self._fake_gh(prs, states)), \
+                patch.object(gh, "_set_labels", return_value=True), \
+                patch.object(gh, "_run") as run_mock, \
+                patch.object(gh, "log_run"):
+            result = gh._close_orphaned_prs(log_prefix="cai audit")
+
+        self.assertEqual(result, [])
+        run_mock.assert_not_called()
+
+    def test_skips_pr_with_non_auto_improve_branch(self):
+        prs = [{"number": 123, "headRefName": "feature/manual-branch"}]
+
+        with patch.object(gh, "_gh_json", return_value=prs), \
+                patch.object(gh, "_run") as run_mock, \
+                patch.object(gh, "log_run"):
+            result = gh._close_orphaned_prs(log_prefix="cai audit")
+
+        self.assertEqual(result, [])
+        run_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Closes the gap behind #860: PR #857 sat open for hours after its linked issue (#832) was closed as no-action because the existing orphan sweep only ran from `handle_revise`.
- Promotes `_close_orphaned_prs` from `cai_lib/actions/revise.py` into `cai_lib/github.py` with a configurable `log_prefix`. Now invoked unconditionally from `cmd_audit` (step 1g, after the retroactive sweep).
- Extends audit observability (new deterministic section + `orphaned_prs_closed` metric in all three `log_run("audit", …)` sites).
- Adds unit tests covering the CLOSED/OPEN/non-matching-branch paths.

## Test plan
- [x] `python -m unittest tests.test_orphaned_prs -v` — 3 new tests pass
- [x] `python -m unittest discover -s tests` — full suite 210 tests pass

Refs #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)