### PR TITLE
feat: add agent-deletion tombstone staging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,25 @@ wrapper pre-creates is the workaround for both cases:
      `<work_dir>/` after you exit, then deletes the staging
      directory.
 
-Rules (apply to agents, plugins, and CLAUDE.md files):
+**For deleting agent files** (`.claude/agents/*.md` removals and
+migrations):
+
+  1. **Write** an empty (or any-content) `.md` tombstone file to
+     `<work_dir>/.cai-staging/agents-delete/<same-relative-path>.md`.
+     For example, to delete `.claude/agents/cai-triage.md`, write to
+     `.cai-staging/agents-delete/cai-triage.md`. To delete
+     `.claude/agents/lifecycle/cai-triage.md`, write to
+     `.cai-staging/agents-delete/lifecycle/cai-triage.md`.
+  2. The wrapper walks `.cai-staging/agents-delete/` with
+     `rglob("*.md")` after you exit and deletes each matching file
+     at `.claude/agents/<relative-path>.md`. Tombstone contents are
+     ignored — only the relative path matters. Missing targets are
+     silently skipped (stale tombstones are safe). Non-`.md` files
+     in the tombstone tree are ignored.
+  3. Do NOT try `Bash("rm ...")` on `.claude/agents/...` — it is
+     blocked by the same sensitive-file protection.
+
+Rules (apply to agents, plugins, CLAUDE.md files, and agent deletions):
 
   - Staged files are copied unconditionally — new definitions
     are created if no target exists yet.
@@ -136,3 +154,8 @@ Example of updating root CLAUDE.md:
 
   - GOOD: `Write("<work_dir>/.cai-staging/claudemd/CLAUDE.md", "<full content>")`
   - BAD:  `Write("<work_dir>/CLAUDE.md", ...)`  (blocked)
+
+Example of deleting an agent file:
+
+  - GOOD: `Write("<work_dir>/.cai-staging/agents-delete/cai-triage.md", "")`
+  - BAD:  `Bash("rm <work_dir>/.claude/agents/cai-triage.md")`  (blocked)

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -105,6 +105,7 @@
 | `scripts/generate-index.sh` | Generator script for CODEBASE_INDEX.md |
 | `scripts/server-cleanup.sh` | Server-side age/size cleanup for the transcript-sync store (runs on the OVH box, not in the container) |
 | `tests/__init__.py` | Test package init |
+| `tests/test_agent_staging.py` | TODO: add description |
 | `tests/test_dispatcher.py` | Tests for the FSM dispatcher and state→handler registries |
 | `tests/test_dup_check.py` | TODO: add description |
 | `tests/test_fsm.py` | Tests for cai_lib.fsm — states, transitions, Confidence, divert, marker, resume helpers |

--- a/cai_lib/cmd_helpers_git.py
+++ b/cai_lib/cmd_helpers_git.py
@@ -51,6 +51,7 @@ def _read_shared_memory() -> str:
 # Paths of the staging directories inside a cloned worktree, relative
 # to the clone root.
 AGENT_EDIT_STAGING_REL = Path(".cai-staging") / "agents"
+AGENT_DELETE_STAGING_REL = Path(".cai-staging") / "agents-delete"
 PLUGIN_STAGING_REL = Path(".cai-staging") / "plugins"
 CLAUDEMD_STAGING_REL = Path(".cai-staging") / "claudemd"
 
@@ -90,6 +91,7 @@ def _work_directory_block(work_dir: Path) -> str:
     """
     staging_rel = AGENT_EDIT_STAGING_REL.as_posix()
     staging_abs = (work_dir / AGENT_EDIT_STAGING_REL).as_posix()
+    delete_staging_abs = (work_dir / AGENT_DELETE_STAGING_REL).as_posix()
     claudemd_abs = (work_dir / CLAUDEMD_STAGING_REL).as_posix()
     return (
         "## Work directory\n\n"
@@ -152,6 +154,26 @@ def _work_directory_block(work_dir: Path) -> str:
         f"  - BAD:  `Edit(\"{work_dir}/.claude/agents/lifecycle/cai-triage.md\", "
         "...)`  (blocked by claude-code)\n"
         "\n"
+        "## Deleting `.claude/agents/*.md` files (self-modification)\n\n"
+        "The same `-p` protection blocks `Bash(\"rm ...\")` on any "
+        f"`{work_dir}/.claude/agents/...` path. To request deletion of "
+        "one or more agent files (e.g. when migrating a flat agent "
+        "into a subfolder layout), drop a **tombstone file** at:\n\n"
+        f"    {delete_staging_abs}/<same-relative-path>.md\n\n"
+        "The wrapper walks that directory with `rglob(\"*.md\")` after "
+        "your session exits, and for each tombstone found deletes the "
+        "matching file at `.claude/agents/<relative-path>.md`. The "
+        "tombstone's contents are ignored — only the relative path "
+        "matters; an empty string is fine. Missing targets are silently "
+        "skipped (stale tombstones are safe). Non-`.md` files in the "
+        "tombstone tree are ignored.\n\n"
+        "Example — delete a flat agent after migrating it to a subfolder:\n"
+        f"  1. `Write(\"{staging_abs}/lifecycle/cai-triage.md\", "
+        "\"<full new content>\")`  (write new subfolder copy)\n"
+        f"  2. `Write(\"{delete_staging_abs}/cai-triage.md\", \"\")`  "
+        "(tombstone the old flat copy)\n\n"
+        "Do NOT try `Bash(\"rm ...\")` on `.claude/agents/` — it is "
+        "blocked by the same sensitive-file protection.\n\n"
         "## Updating `CLAUDE.md` files (self-modification)\n\n"
         "Claude-code's headless `-p` mode also hardcodes a write block "
         "on `CLAUDE.md` files (project-level context files). Edit/Write "
@@ -193,6 +215,8 @@ def _setup_agent_edit_staging(work_dir: Path) -> Path:
     """
     staging = work_dir / AGENT_EDIT_STAGING_REL
     staging.mkdir(parents=True, exist_ok=True)
+    delete_staging = work_dir / AGENT_DELETE_STAGING_REL
+    delete_staging.mkdir(parents=True, exist_ok=True)
     plugin_staging = work_dir / PLUGIN_STAGING_REL
     plugin_staging.mkdir(parents=True, exist_ok=True)
     claudemd_staging = work_dir / CLAUDEMD_STAGING_REL
@@ -310,6 +334,42 @@ def _apply_agent_edit_staging(work_dir: Path) -> int:
                 # Preserve .cai-staging so staged files are not
                 # silently lost when the copy fails.
                 return applied
+
+    # Apply any agent-file deletions requested via tombstone markers at
+    # .cai-staging/agents-delete/<relative-path>.md. A file's presence in
+    # that tree signals "delete the matching path under .claude/agents/".
+    # Contents are ignored — only the relative path matters. Non-.md
+    # files are skipped. Path traversal is structurally impossible:
+    # rglob() only yields descendants of the staging root.
+    delete_staging = work_dir / AGENT_DELETE_STAGING_REL
+    if delete_staging.exists() and delete_staging.is_dir():
+        agents_dir = work_dir / ".claude" / "agents"
+        for tombstone in sorted(delete_staging.rglob("*.md")):
+            rel = tombstone.relative_to(delete_staging)
+            target = agents_dir / rel
+            try:
+                if target.is_file():
+                    target.unlink()
+                    print(
+                        f"[cai] applied staged agent deletion: "
+                        f".claude/agents/{rel}",
+                        flush=True,
+                    )
+                    applied += 1
+                else:
+                    print(
+                        f"[cai] agent edit staging: tombstone for "
+                        f".claude/agents/{rel} has no target file "
+                        f"(already absent; skipping)",
+                        flush=True,
+                    )
+            except OSError as exc:
+                print(
+                    f"[cai] agent edit staging: failed to delete "
+                    f".claude/agents/{rel}: {exc}",
+                    file=sys.stderr,
+                )
+                continue
 
     # Clean up the entire .cai-staging tree (one level above the
     # agents/ subdir) so nothing leaks into the PR.

--- a/tests/test_agent_staging.py
+++ b/tests/test_agent_staging.py
@@ -1,0 +1,114 @@
+"""Tests for the agent-deletion tombstone mechanism in
+cai_lib.cmd_helpers_git._apply_agent_edit_staging."""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.cmd_helpers_git import (  # noqa: E402
+    _apply_agent_edit_staging,
+    _setup_agent_edit_staging,
+)
+
+
+class TestAgentDeletionTombstones(unittest.TestCase):
+
+    def _make_tmp(self) -> Path:
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(tmp, ignore_errors=True))
+        return tmp
+
+    def _seed_agent(self, tmp: Path, rel: str) -> Path:
+        p = tmp / ".claude" / "agents" / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("stub")
+        return p
+
+    def _drop_tombstone(self, tmp: Path, rel: str) -> None:
+        t = tmp / ".cai-staging" / "agents-delete" / rel
+        t.parent.mkdir(parents=True, exist_ok=True)
+        t.write_text("")
+
+    def test_tombstone_deletes_flat_agent(self):
+        tmp = self._make_tmp()
+        _setup_agent_edit_staging(tmp)
+        self._seed_agent(tmp, "cai-triage.md")
+        self._drop_tombstone(tmp, "cai-triage.md")
+        applied = _apply_agent_edit_staging(tmp)
+        self.assertGreaterEqual(applied, 1)
+        self.assertFalse((tmp / ".claude/agents/cai-triage.md").exists())
+        self.assertFalse((tmp / ".cai-staging").exists(),
+                         "staging dir must be cleaned up")
+
+    def test_tombstone_deletes_subfolder_agent(self):
+        tmp = self._make_tmp()
+        _setup_agent_edit_staging(tmp)
+        self._seed_agent(tmp, "lifecycle/cai-refine.md")
+        self._drop_tombstone(tmp, "lifecycle/cai-refine.md")
+        applied = _apply_agent_edit_staging(tmp)
+        self.assertGreaterEqual(applied, 1)
+        self.assertFalse(
+            (tmp / ".claude/agents/lifecycle/cai-refine.md").exists())
+
+    def test_missing_target_is_silently_skipped(self):
+        tmp = self._make_tmp()
+        _setup_agent_edit_staging(tmp)
+        self._drop_tombstone(tmp, "does-not-exist.md")
+        # Must not raise; nothing should be created under agents/.
+        _apply_agent_edit_staging(tmp)
+        agents_dir = tmp / ".claude" / "agents"
+        if agents_dir.exists():
+            self.assertFalse(any(agents_dir.rglob("*")))
+
+    def test_unrelated_agents_untouched(self):
+        tmp = self._make_tmp()
+        _setup_agent_edit_staging(tmp)
+        self._seed_agent(tmp, "cai-triage.md")
+        self._seed_agent(tmp, "cai-keep.md")
+        self._drop_tombstone(tmp, "cai-triage.md")
+        _apply_agent_edit_staging(tmp)
+        self.assertFalse((tmp / ".claude/agents/cai-triage.md").exists())
+        self.assertTrue((tmp / ".claude/agents/cai-keep.md").exists())
+
+    def test_non_md_tombstones_ignored(self):
+        tmp = self._make_tmp()
+        _setup_agent_edit_staging(tmp)
+        self._seed_agent(tmp, "cai-triage.md")
+        stray = tmp / ".cai-staging" / "agents-delete" / "cai-triage.txt"
+        stray.parent.mkdir(parents=True, exist_ok=True)
+        stray.write_text("")
+        _apply_agent_edit_staging(tmp)
+        self.assertTrue((tmp / ".claude/agents/cai-triage.md").exists())
+
+    def test_write_plus_tombstone_atomic_migration(self):
+        """Canonical migration: write new subfolder copy + tombstone
+        the flat copy, both applied in one staging pass."""
+        tmp = self._make_tmp()
+        _setup_agent_edit_staging(tmp)
+        self._seed_agent(tmp, "cai-triage.md")
+        staged = tmp / ".cai-staging" / "agents" / "lifecycle" / "cai-triage.md"
+        staged.parent.mkdir(parents=True, exist_ok=True)
+        staged.write_text("NEW CONTENT")
+        self._drop_tombstone(tmp, "cai-triage.md")
+        applied = _apply_agent_edit_staging(tmp)
+        self.assertGreaterEqual(applied, 2)
+        self.assertFalse((tmp / ".claude/agents/cai-triage.md").exists())
+        self.assertEqual(
+            (tmp / ".claude/agents/lifecycle/cai-triage.md").read_text(),
+            "NEW CONTENT",
+        )
+
+    def test_empty_tombstone_dir_is_noop(self):
+        tmp = self._make_tmp()
+        _setup_agent_edit_staging(tmp)
+        self._seed_agent(tmp, "cai-triage.md")
+        _apply_agent_edit_staging(tmp)
+        self.assertTrue((tmp / ".claude/agents/cai-triage.md").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Claude Code's headless \`-p\` blocks both Edit/Write and \`Bash(\"rm\")\` on \`.claude/agents/*.md\` — so subagents had no way to delete flat agent files (the wall that closed #832 as no-action).
- Adds \`.cai-staging/agents-delete/\` tombstone directory: any \`.md\` under that tree signals \"delete the matching path under \`.claude/agents/\`\". Filesystem structure is the protocol — path traversal is structurally impossible (sandbox + rglob).
- Deletion loop runs after writes / plugins / CLAUDE.md loops so the canonical migration (write new subfolder copy + tombstone the flat copy) works atomically in one pass.
- Documents mechanism in \`_work_directory_block\` and root \`CLAUDE.md\`.

## Test plan
- [x] \`python -m unittest tests.test_agent_staging -v\` — 7 new tests pass (flat/subfolder, missing-target skip, stray-file isolation, non-.md filter, canonical migration)
- [x] \`python -m unittest discover -s tests\` — full suite 214 tests pass

Refs #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)