### PR TITLE
auto-improve: Centralize FSM orphan-resource sweeps in cmd_audit

### DIFF
--- a/cai_lib/actions/revise.py
+++ b/cai_lib/actions/revise.py
@@ -28,7 +28,7 @@ from cai_lib.fsm import (
     apply_pr_transition,
     get_pr_state,
 )
-from cai_lib.github import _gh_json, _set_labels, _close_orphaned_prs
+from cai_lib.github import _gh_json, _set_labels
 from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.logging_utils import log_run, log_run as _log_run_alias  # noqa: F401
 from cai_lib.cmd_helpers import (
@@ -391,15 +391,9 @@ def handle_revise(pr: dict) -> int:
     """
     print("[cai revise] checking for PRs with unaddressed comments", flush=True)
 
-    # Close PRs whose linked issue was closed — otherwise they sit
-    # open forever (revise skips them, merge can't land conflicts).
-    orphaned = len(_close_orphaned_prs(log_prefix="cai revise"))
-    if orphaned:
-        print(
-            f"[cai revise] closed {orphaned} orphaned PR(s) "
-            "(linked issue was closed)",
-            flush=True,
-        )
+    # Orphaned-PR sweep is now owned by `cmd_audit` (Step 1g) so
+    # PRs parked at any non-revision state (e.g. :pr-human-needed)
+    # are also covered. See issue #869.
 
     # Recover any PRs the rebase resolver has given up on, so they
     # don't sit stuck forever. Refs #144.

--- a/cai_lib/cmd_agents.py
+++ b/cai_lib/cmd_agents.py
@@ -693,6 +693,10 @@ def cmd_audit(args) -> int:
 
     # Step 1g: Close open PRs whose linked issue is already closed —
     # must run after 1f so newly-no-actioned issues are visible as CLOSED.
+    # Note: scenario 6 from issue #869 (PRs with a terminal label like
+    # auto-improve:approved but still OPEN) needs no separate sweep —
+    # if cmd_merge fails after labelling, the dispatcher picks the PR
+    # up on the next cycle and retries handle_merge.
     closed_orphans = _close_orphaned_prs(log_prefix="cai audit")
     if closed_orphans:
         print(


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#869

**Issue:** #869 — Centralize FSM orphan-resource sweeps in cmd_audit

## PR Summary

### What this fixes
PR #866 migrated `_close_orphaned_prs` to `cai_lib/github.py` and wired it into `cmd_audit`, but the duplicate call still remained in `handle_revise` (revise.py). This PR removes that duplicate so the orphan sweep is owned exclusively by `cmd_audit`, and documents the scenario 6 design decision.

### What was changed
- **`cai_lib/actions/revise.py`**: Removed `_close_orphaned_prs` from the import line (now unused) and removed the orphaned-PR sweep call + surrounding print block from `handle_revise`, replacing it with a comment pointing readers to the new owner (`cmd_audit` Step 1g, issue #869).
- **`cai_lib/cmd_agents.py`**: Added a 4-line comment near the Step 1g `_close_orphaned_prs` call documenting that scenario 6 (PRs with terminal label but still OPEN) needs no separate sweep — the dispatcher retries `handle_merge` on the next cycle.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
