### PR TITLE
fix(install): stop running containers before wiping volumes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -512,9 +512,17 @@ fi
 # cai_transcripts) that no longer match the current
 # (cai_home + cai_agent_memory) layout. Stale volumes can also have
 # wrong-ownership files left over from when the container ran as
-# root. Easier to wipe and start fresh than to migrate.
+# root or as a different HOST_UID. Easier to wipe and start fresh
+# than to migrate.
+#
+# `docker compose down --volumes --remove-orphans` first to stop any
+# running cai / watchtower containers from a prior install — without
+# this, the `docker volume rm` below silently fails with "volume in
+# use" and the subsequent `docker compose run --user cai` commands
+# hit a stale, already-chowned /home/cai they can't write to.
 echo
-echo "Wiping any existing cai volumes for a clean install..."
+echo "Stopping any running cai containers and wiping volumes for a clean install..."
+docker compose down --volumes --remove-orphans 2>/dev/null || true
 for vol in cai_home cai_agent_memory cai_logs cai_claude cai_gh_config cai_transcripts; do
   if docker volume inspect "$vol" >/dev/null 2>&1; then
     if docker volume rm "$vol" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Adds `docker compose down --volumes --remove-orphans` before the explicit `docker volume rm` loop in `install.sh`.
- Fixes re-install permission-denied errors like `open /home/cai/.config/gh/config.yml: permission denied` from `gh auth login`.

## Why
When install.sh is re-run on a host where `docker compose up -d` had previously been executed, the running `cai` container keeps named volumes "in use". `docker volume rm` silently fails, the volumes keep their previous chown state (HOST_UID-owned, mode 600), and the subsequent `docker compose run --user cai` commands (fresh containers, cai=UID 1000) can't read /home/cai.

Bringing the compose stack down first ensures the volumes are unlocked before the wipe.

## Test plan
- [ ] After `docker compose up -d` has populated volumes, re-run `install.sh`; confirm `gh auth login` completes cleanly.
- [ ] Fresh install on a host with no prior cai containers still works (the `down` command is a no-op there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)