### PR TITLE
fix(install): chown local transcript dir to HOST_UID:HOST_GID

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -217,12 +217,13 @@ case "$ENABLE_SYNC" in
           echo "       Pick a path under a directory you can write to."
           exit 1
         fi
-        echo "[i] Ensuring $SYNC_PATH exists and is owned by UID 1000 (via docker)..."
+        echo "[i] Ensuring $SYNC_PATH exists and is owned by UID ${HOST_UID}:${HOST_GID} (via docker)..."
         if ! docker run --rm --user 0 \
              -v "${SYNC_PARENT}:/mnt" \
              -e TARGET="/mnt/${SYNC_BASE}" \
+             -e OWNER="${HOST_UID}:${HOST_GID}" \
              alpine:3 \
-             sh -c 'mkdir -p "$TARGET" && chown 1000:1000 "$TARGET"'; then
+             sh -c 'mkdir -p "$TARGET" && chown "$OWNER" "$TARGET"'; then
           echo "ERROR: failed to create/chown $SYNC_PATH via docker."
           exit 1
         fi


### PR DESCRIPTION
## Summary
- install.sh captures `HOST_UID`/`HOST_GID` from the installer and passes them to the container, where entrypoint.sh remaps the `cai` user to those IDs at startup.
- The local-mode transcript-path chown hardcoded `1000:1000`, so on hosts where the installer user wasn't UID 1000 the bind-mount ended up owned by the wrong user.
- Symptom observed on server.robotsix.net (installer = `robotsix`, UID 1001): `/home/robotsix/robotsix-cai/{transcripts,logs}` got chowned to UID 1000 = `debian`, and subsequent SSH-push rsyncs from remote hosts (coming in as `robotsix`) failed with `mkdir ... Permission denied (13)`.

Fix: chown to `${HOST_UID}:${HOST_GID}` instead of the hardcoded `1000:1000`.

## Test plan
- [ ] Re-run `install.sh` on server.robotsix.net, pick Local transport at the same path, verify ownership matches the host `robotsix` user.
- [ ] From a remote host, `python3 /app/cai.py transcript-sync` and confirm the rsync push succeeds (no permission-denied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)