### PR TITLE
fix(transcript-sync): add --mkpath so first SSH push creates remote bucket

### DIFF
--- a/cai_lib/transcript_sync.py
+++ b/cai_lib/transcript_sync.py
@@ -146,8 +146,9 @@ def _run_rsync(args: list[str], *, label: str) -> int:
 def _ensure_local_bucket() -> None:
     """In local mode, create this host's bucket directory if missing.
 
-    SSH mode relies on sshd+rsync auto-creating remote paths; local mode
-    hits the filesystem directly, so we make sure the target exists.
+    SSH mode uses rsync's ``--mkpath`` to auto-create remote intermediate
+    directories; local mode hits the filesystem directly, so we make sure
+    the target exists.
     """
     if not _is_local_url(config.TRANSCRIPT_SYNC_URL):
         return
@@ -174,6 +175,10 @@ def push() -> int:
         [
             "-az",
             "--delete",
+            # --mkpath creates missing intermediate dirs on the receiver
+            # (e.g. the per-repo and per-host bucket). Without it the
+            # first push to a fresh server fails with ENOENT.
+            "--mkpath",
             *_transport_args(),
             # Trailing slashes: rsync copies the *contents* of TRANSCRIPT_DIR
             # into the server bucket, not the directory itself.


### PR DESCRIPTION
## Summary
- SSH-mode push assumed sshd+rsync would auto-create the per-repo/per-host bucket dirs on the receiver. Plain rsync doesn't — it fails with `No such file or directory` until intermediate dirs exist.
- Observed on first push to server.robotsix.net after fixing the chown issue in #874: rsync exit 11, `mkdir "<root>/damien-robotsix_robotsix-cai/<machine-id>" failed: No such file or directory`.
- Install.sh only instructs the operator to `mkdir` the transcript *root*, not the nested bucket path, so the first-push failure is the default experience.

Fix: add `--mkpath` (rsync 3.2.3+) to the push args so the receiver creates the missing components.

## Test plan
- [x] `python -m unittest tests.test_transcript_sync` — all 9 tests pass locally.
- [ ] On a host with `CAI_TRANSCRIPT_SYNC_URL` pointing at a server where only the transcript root exists, run `python /app/cai.py transcript-sync` and confirm push succeeds on the first call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)