### PR TITLE
Remove $1.00 budget cap from cai-plan

### DIFF
--- a/.claude/agents/implementation/cai-plan.md
+++ b/.claude/agents/implementation/cai-plan.md
@@ -49,7 +49,6 @@ The user message contains:
 ## Hard rules
 
 1. **Read-only.** Do not modify any files — only read and plan.
-2. **$1.00 budget cap.** Each cai-plan invocation is limited to $1.00 via `--max-budget-usd` to prevent runaway exploration sessions. If the agent approaches or exhausts this budget, it will exit, and the fix pipeline will handle the failure gracefully.
 
 ## Agent-specific efficiency guidance
 

--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -117,9 +117,6 @@ def _run_plan_agent(issue: dict, plan_index: int, work_dir: Path, attempt_histor
     Runs with `cwd=/app` and `--add-dir <work_dir>` so the agent
     reads its definition from the canonical location while
     operating on the clone via absolute paths (#342).
-
-    Each invocation is capped at $1.00 via --max-budget-usd to
-    prevent runaway exploration sessions (typical run ~$0.60).
     """
     user_message = (
         _work_directory_block(work_dir)
@@ -139,7 +136,6 @@ def _run_plan_agent(issue: dict, plan_index: int, work_dir: Path, attempt_histor
     result = _run_claude_p(
         ["claude", "-p", "--agent", "cai-plan",
          "--dangerously-skip-permissions",
-         "--max-budget-usd", "1.00",
          "--add-dir", str(work_dir)],
         category="plan.plan",
         agent="cai-plan",


### PR DESCRIPTION
## Summary

Drops `--max-budget-usd 1.00` from `_run_plan_agent` in
`cai_lib/actions/plan.py` and the matching `## Hard rules` entry in
`.claude/agents/implementation/cai-plan.md`.

## Why

`cai-plan` was promoted from sonnet to opus in 44cf3c2 (2026-04-16),
but the \$1.00 per-invocation cap was left in place. On broader
exploration tasks both serial plan agents now blow that cap and exit
non-zero; `cai-select` sees `(Plan N failed: exit 1)` for both candidates
and ends up fabricating a plan from the refined-issue body at LOW
confidence — observed on #868, leading to an unnecessary
`auto-improve:human-needed` divert.

The agent's existing efficiency rules (CODEBASE_INDEX.md first,
Agent/Explore with haiku for broad search) already bound cost; the hard
opus-miscalibrated cap was doing more harm than good.

## Test plan

- [ ] Run a plan cycle on #868 after merge and confirm the pipeline
      produces real candidate plans instead of failure sentinels.
- [ ] Spot-check `cai-cost.jsonl` to confirm plan runs stay within a
      sensible range without the cap.