### PR TITLE
auto-improve: Rescue prevention: **Retry planner agents on exit-1 failure before diverting.**

### DIFF
--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -38,6 +38,7 @@ from cai_lib.logging_utils import log_run
 from cai_lib.cmd_helpers import (
     _work_directory_block,
     _strip_stored_plan_block,
+    _extract_stored_plan,
     _fetch_previous_fix_attempts,
     _build_attempt_history_block,
 )
@@ -363,29 +364,31 @@ def _run_plan_select_pipeline(
     # cai-select two failure placeholders (which forces a :human-needed
     # divert even when the refined plan is high-quality — see issue #879).
     if not plan1_ok and not plan2_ok:
-        refined_plan = _extract_refined_plan(issue.get("body", "") or "")
-        if refined_plan:
-            from cai_lib.fsm import Confidence
-            reason = (
-                "Both cai-plan invocations failed on all retry attempts; "
-                "falling back to the cai-refine-embedded plan. "
-                "The fix agent should treat the plan as best-effort."
-            )
+        from cai_lib.fsm import Confidence
+        # For resume scenarios, prefer any stored plan already in the body.
+        embedded = _extract_stored_plan(issue.get("body", "") or "")
+        if not embedded:
+            # Fresh run: fall back to the ## Refined Issue section.
+            embedded = _extract_refined_plan(issue.get("body", "") or "")
+        if not embedded:
             print(
-                f"[cai plan] both planners failed for #{issue_number} — "
-                f"using refinement-embedded plan ({len(refined_plan)} chars) "
-                "with LOW confidence",
-                flush=True,
+                f"[cai plan] both planners failed and no embedded plan "
+                f"found in body for #{issue_number}; pipeline cannot proceed",
+                file=sys.stderr, flush=True,
             )
-            return refined_plan + "\n", Confidence.LOW, reason
-        # No refined block found (shouldn't happen for :refined issues, but
-        # defensively fall through to the existing select path so we retain
-        # the old failure behaviour rather than returning None-with-plan).
+            return None
+        reason = (
+            "Both cai-plan invocations failed on all retry attempts; "
+            "falling back to the refinement-embedded plan with "
+            "LOW confidence so an admin can review."
+        )
         print(
-            f"[cai plan] both planners failed and no ## Refined Issue "
-            f"block found in body for #{issue_number}; proceeding to select",
+            f"[cai plan] both planners failed for #{issue_number} — "
+            f"using refinement-embedded plan ({len(embedded)} chars) "
+            "with LOW confidence",
             flush=True,
         )
+        return embedded + "\n", Confidence.LOW, reason
 
     plans = [plan1_text, plan2_text]
 

--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -108,8 +108,11 @@ def _select_plan_target(issue_number: int | None = None):
     return min(candidates, key=lambda c: c.get("createdAt", ""))
 
 
-def _run_plan_agent(issue: dict, plan_index: int, work_dir: Path, attempt_history_block: str = "", first_plan: str = "") -> str:
-    """Run a single cai-plan agent and return its stdout.
+def _run_plan_agent(
+    issue: dict, plan_index: int, work_dir: Path,
+    attempt_history_block: str = "", first_plan: str = "",
+) -> tuple[str, bool]:
+    """Run a single cai-plan agent and return ``(stdout, success)``.
 
     Called serially (2×) by _run_plan_select_pipeline — the second call
     receives the first plan to produce an alternative approach.
@@ -117,6 +120,10 @@ def _run_plan_agent(issue: dict, plan_index: int, work_dir: Path, attempt_histor
     Runs with `cwd=/app` and `--add-dir <work_dir>` so the agent
     reads its definition from the canonical location while
     operating on the clone via absolute paths (#342).
+
+    Retries once on non-zero exit before giving up.  Returns a
+    ``(text, True)`` tuple on success or ``(placeholder, False)``
+    after all attempts are exhausted.
     """
     user_message = (
         _work_directory_block(work_dir)
@@ -133,26 +140,62 @@ def _run_plan_agent(issue: dict, plan_index: int, work_dir: Path, attempt_histor
             "propose a meaningfully different solution.\n\n"
             f"{first_plan}\n"
         )
-    result = _run_claude_p(
-        ["claude", "-p", "--agent", "cai-plan",
-         "--dangerously-skip-permissions",
-         "--add-dir", str(work_dir)],
-        category="plan.plan",
-        agent="cai-plan",
-        input=user_message,
-        cwd="/app",
-    )
-    if result.returncode != 0:
-        stderr_preview = (result.stderr or "")[:400].rstrip()
+    MAX_ATTEMPTS = 2  # 1 initial + 1 retry on non-zero exit
+    last_returncode = 0
+    last_stderr = ""
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        result = _run_claude_p(
+            ["claude", "-p", "--agent", "cai-plan",
+             "--dangerously-skip-permissions",
+             "--add-dir", str(work_dir)],
+            category="plan.plan",
+            agent="cai-plan",
+            input=user_message,
+            cwd="/app",
+        )
+        if result.returncode == 0:
+            return (result.stdout or "", True)
+        last_returncode = result.returncode
+        last_stderr = result.stderr or ""
+        stderr_preview = last_stderr[:400].rstrip()
         print(
-            f"[cai plan] plan agent {plan_index} failed for "
-            f"#{issue['number']} (exit {result.returncode})"
+            f"[cai plan] plan agent {plan_index} attempt {attempt}/"
+            f"{MAX_ATTEMPTS} failed for #{issue['number']} "
+            f"(exit {result.returncode})"
             + (f":\n{stderr_preview}" if stderr_preview else ""),
             file=sys.stderr,
             flush=True,
         )
-        return f"(Plan {plan_index} failed: exit {result.returncode})"
-    return result.stdout or ""
+    # All attempts exhausted — return a placeholder plus failure flag so
+    # the pipeline can detect both-failed-twice and fall back.
+    return (
+        f"(Plan {plan_index} failed: exit {last_returncode} "
+        f"after {MAX_ATTEMPTS} attempts)",
+        False,
+    )
+
+
+def _extract_refined_plan(issue_body: str) -> str | None:
+    """Return the ``## Refined Issue`` block from *issue_body* or None.
+
+    Used as a fallback source of a plan when both cai-plan invocations
+    fail repeatedly. Strips any pre-existing stored plan block first so
+    a stale cai-plan block does not mask the refine block.
+    """
+    body = _strip_stored_plan_block(issue_body or "")
+    marker = "## Refined Issue"
+    start = body.find(marker)
+    if start == -1:
+        return None
+    # The refine handler appends a `---` separator before the quoted
+    # original issue text (cai_lib/actions/refine.py:270-275). Trim
+    # there if present so we don't include the quoted original body.
+    remainder = body[start:]
+    sep_idx = remainder.find("\n---\n")
+    if sep_idx != -1:
+        remainder = remainder[:sep_idx]
+    remainder = remainder.strip()
+    return remainder or None
 
 
 _SELECT_JSON_SCHEMA = {
@@ -294,17 +337,57 @@ def _run_plan_select_pipeline(
     """
     issue_number = issue["number"]
 
-    # Step 1: Run Plan 1.
+    # Step 1: Run Plan 1 (with a single retry on non-zero exit).
     print(f"[cai plan] running plan agent 1/2 for #{issue_number}", flush=True)
-    plan1 = _run_plan_agent(issue, 1, work_dir, attempt_history_block)
-    print(f"[cai plan] plan 1: {len(plan1)} chars", flush=True)
+    plan1_text, plan1_ok = _run_plan_agent(issue, 1, work_dir, attempt_history_block)
+    print(
+        f"[cai plan] plan 1: {len(plan1_text)} chars "
+        f"(ok={plan1_ok})",
+        flush=True,
+    )
 
-    # Step 2: Run Plan 2 with knowledge of Plan 1, asking for an alternative.
+    # Step 2: Run Plan 2 with knowledge of Plan 1 when available.
     print(f"[cai plan] running plan agent 2/2 for #{issue_number}", flush=True)
-    plan2 = _run_plan_agent(issue, 2, work_dir, attempt_history_block, first_plan=plan1)
-    print(f"[cai plan] plan 2: {len(plan2)} chars", flush=True)
+    plan2_first = plan1_text if plan1_ok else ""
+    plan2_text, plan2_ok = _run_plan_agent(
+        issue, 2, work_dir, attempt_history_block, first_plan=plan2_first,
+    )
+    print(
+        f"[cai plan] plan 2: {len(plan2_text)} chars "
+        f"(ok={plan2_ok})",
+        flush=True,
+    )
 
-    plans = [plan1, plan2]
+    # Step 2b: If both planners failed all attempts, fall back to the
+    # refinement-embedded plan with LOW confidence instead of handing
+    # cai-select two failure placeholders (which forces a :human-needed
+    # divert even when the refined plan is high-quality — see issue #879).
+    if not plan1_ok and not plan2_ok:
+        refined_plan = _extract_refined_plan(issue.get("body", "") or "")
+        if refined_plan:
+            from cai_lib.fsm import Confidence
+            reason = (
+                "Both cai-plan invocations failed on all retry attempts; "
+                "falling back to the cai-refine-embedded plan. "
+                "The fix agent should treat the plan as best-effort."
+            )
+            print(
+                f"[cai plan] both planners failed for #{issue_number} — "
+                f"using refinement-embedded plan ({len(refined_plan)} chars) "
+                "with LOW confidence",
+                flush=True,
+            )
+            return refined_plan + "\n", Confidence.LOW, reason
+        # No refined block found (shouldn't happen for :refined issues, but
+        # defensively fall through to the existing select path so we retain
+        # the old failure behaviour rather than returning None-with-plan).
+        print(
+            f"[cai plan] both planners failed and no ## Refined Issue "
+            f"block found in body for #{issue_number}; proceeding to select",
+            flush=True,
+        )
+
+    plans = [plan1_text, plan2_text]
 
     # Step 3: Run the select agent to pick the best plan.
     print(f"[cai plan] running select agent for #{issue_number}", flush=True)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -112,27 +112,147 @@ class TestRunSelectAgent(unittest.TestCase):
 
 
 class TestRunPlanAgent(unittest.TestCase):
-    """_run_plan_agent() surfaces stderr on subprocess failure."""
+    """_run_plan_agent() retries once on non-zero exit and surfaces stderr."""
 
     @patch("cai_lib.actions.plan._build_issue_block", return_value="")
     @patch("cai_lib.actions.plan._work_directory_block", return_value="")
     @patch("cai_lib.actions.plan._run_claude_p")
-    def test_logs_stderr_on_nonzero_exit(self, mock_run, _mwb, _mib):
+    def test_retries_once_on_nonzero_then_fails(self, mock_run, _mwb, _mib):
         from cai_lib.actions import plan
-        mock_run.return_value = subprocess.CompletedProcess(
+        failed = subprocess.CompletedProcess(
             args=["claude"], returncode=2,
             stdout="", stderr="cai-plan: rate limited",
         )
+        mock_run.side_effect = [failed, failed]
 
         with patch("builtins.print") as mock_print:
-            out = plan._run_plan_agent(
+            text, ok = plan._run_plan_agent(
                 {"number": 42, "title": "t", "body": "b"},
                 1, Path("/tmp/x"),
             )
 
-        self.assertIn("Plan 1 failed: exit 2", out)
+        self.assertFalse(ok)
+        self.assertIn("Plan 1 failed: exit 2", text)
+        self.assertEqual(mock_run.call_count, 2)
         printed = " ".join(str(c) for c in mock_print.call_args_list)
         self.assertIn("cai-plan: rate limited", printed)
+        self.assertIn("attempt 1/2", printed)
+        self.assertIn("attempt 2/2", printed)
+
+    @patch("cai_lib.actions.plan._build_issue_block", return_value="")
+    @patch("cai_lib.actions.plan._work_directory_block", return_value="")
+    @patch("cai_lib.actions.plan._run_claude_p")
+    def test_retry_recovers_on_second_attempt(self, mock_run, _mwb, _mib):
+        from cai_lib.actions import plan
+        failed = subprocess.CompletedProcess(
+            args=["claude"], returncode=1, stdout="", stderr="transient",
+        )
+        ok_proc = subprocess.CompletedProcess(
+            args=["claude"], returncode=0,
+            stdout="## Plan\n\nSummary: do X", stderr="",
+        )
+        mock_run.side_effect = [failed, ok_proc]
+
+        text, ok = plan._run_plan_agent(
+            {"number": 42, "title": "t", "body": "b"},
+            2, Path("/tmp/x"),
+        )
+
+        self.assertTrue(ok)
+        self.assertIn("do X", text)
+        self.assertEqual(mock_run.call_count, 2)
+
+
+class TestExtractRefinedPlan(unittest.TestCase):
+    """_extract_refined_plan() extracts the ## Refined Issue block."""
+
+    def test_returns_block_stripped_at_separator(self):
+        from cai_lib.actions.plan import _extract_refined_plan
+        body = (
+            "## Refined Issue\n\n"
+            "### Description\nfix the thing\n\n"
+            "### Plan\n1. do it\n\n"
+            "---\n\n"
+            "> **Original issue text:**\n> please fix\n"
+        )
+        result = _extract_refined_plan(body)
+        self.assertIsNotNone(result)
+        self.assertIn("## Refined Issue", result)
+        self.assertIn("fix the thing", result)
+        self.assertNotIn("Original issue text", result)
+
+    def test_returns_none_when_marker_missing(self):
+        from cai_lib.actions.plan import _extract_refined_plan
+        body = "## Some other section\n\nstuff\n"
+        self.assertIsNone(_extract_refined_plan(body))
+
+    def test_strips_preexisting_stored_plan_block(self):
+        from cai_lib.actions.plan import _extract_refined_plan
+        body = (
+            "<!-- cai-plan-start -->\n"
+            "## Selected Implementation Plan\n\nold plan\n"
+            "<!-- cai-plan-end -->\n\n"
+            "## Refined Issue\n\nthe real plan\n"
+        )
+        result = _extract_refined_plan(body)
+        self.assertIsNotNone(result)
+        self.assertIn("## Refined Issue", result)
+        self.assertIn("the real plan", result)
+        self.assertNotIn("old plan", result)
+
+
+class TestPlanSelectPipelineFallback(unittest.TestCase):
+    """When both planners fail all retries, fall back to refined plan."""
+
+    @patch("cai_lib.actions.plan._run_select_agent")
+    @patch("cai_lib.actions.plan._run_plan_agent")
+    def test_both_failed_uses_refined_plan_with_low_confidence(
+        self, mock_plan, mock_select,
+    ):
+        from cai_lib.actions import plan
+        mock_plan.side_effect = [
+            ("(Plan 1 failed: exit 1 after 2 attempts)", False),
+            ("(Plan 2 failed: exit 1 after 2 attempts)", False),
+        ]
+        issue = {
+            "number": 99, "title": "t",
+            "body": (
+                "## Refined Issue\n\n"
+                "### Description\nfix the thing\n\n"
+                "### Plan\n1. do it\n\n"
+                "---\n\n"
+                "> **Original issue text:**\n> please fix\n"
+            ),
+        }
+
+        result = plan._run_plan_select_pipeline(issue, Path("/tmp/x"))
+
+        self.assertIsNotNone(result)
+        plan_text, conf, reason = result
+        self.assertIn("## Refined Issue", plan_text)
+        self.assertNotIn("Original issue text", plan_text)  # trimmed at ---
+        self.assertEqual(conf, Confidence.LOW)
+        self.assertIn("Both cai-plan invocations failed", reason)
+        mock_select.assert_not_called()
+
+    @patch("cai_lib.actions.plan._run_select_agent")
+    @patch("cai_lib.actions.plan._run_plan_agent")
+    def test_partial_success_still_runs_select(self, mock_plan, mock_select):
+        from cai_lib.actions import plan
+        mock_plan.side_effect = [
+            ("(Plan 1 failed: exit 1 after 2 attempts)", False),
+            ("## Plan\nSummary: do X", True),
+        ]
+        mock_select.return_value = (
+            "selected", Confidence.MEDIUM, "ok",
+        )
+        issue = {"number": 99, "title": "t",
+                 "body": "## Refined Issue\n\nstuff\n"}
+
+        result = plan._run_plan_select_pipeline(issue, Path("/tmp/x"))
+
+        self.assertIsNotNone(result)
+        mock_select.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -232,7 +232,22 @@ class TestPlanSelectPipelineFallback(unittest.TestCase):
         self.assertIn("## Refined Issue", plan_text)
         self.assertNotIn("Original issue text", plan_text)  # trimmed at ---
         self.assertEqual(conf, Confidence.LOW)
-        self.assertIn("Both cai-plan invocations failed", reason)
+        self.assertIn("refinement-embedded plan", reason)
+        mock_select.assert_not_called()
+
+    @patch("cai_lib.actions.plan._run_select_agent")
+    @patch("cai_lib.actions.plan._run_plan_agent")
+    def test_double_failure_no_embedded_returns_none(self, mock_plan, mock_select):
+        from cai_lib.actions.plan import _run_plan_select_pipeline
+        mock_plan.side_effect = [
+            ("(Plan 1 failed: exit 1 after 2 attempts)", False),
+            ("(Plan 2 failed: exit 1 after 2 attempts)", False),
+        ]
+        issue = {"number": 999, "title": "t", "body": "", "labels": []}
+
+        result = _run_plan_select_pipeline(issue, Path("/tmp/x"))
+
+        self.assertIsNone(result)
         mock_select.assert_not_called()
 
     @patch("cai_lib.actions.plan._run_select_agent")


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#879

**Issue:** #879 — Rescue prevention: **Retry planner agents on exit-1 failure before diverting.**

## PR Summary

### What this fixes
When both `cai-plan` invocations fail with a non-zero exit (as in issue #868), the orchestrator was immediately sending failure-placeholder strings to `cai-select`, which forced a `:human-needed` divert even when the refined issue plan was high-quality. This PR adds a retry (1 initial + 1 retry = 2 total attempts) per planner invocation, and when both planners still fail after all retries, falls back to the refinement-embedded `## Refined Issue` block with `Confidence.LOW` rather than handing placeholders to `cai-select`.

### What was changed
- **`cai_lib/actions/plan.py`**:
  - `_run_plan_agent`: changed return type from `str` to `tuple[str, bool]`; added `MAX_ATTEMPTS=2` retry loop with per-attempt stderr logging; returns `(placeholder, False)` after all attempts exhausted
  - `_extract_refined_plan`: new helper that extracts the `## Refined Issue` block from an issue body (stripping any pre-existing stored plan block and trimming at `\n---\n`)
  - `_run_plan_select_pipeline`: updated to unpack `(text, ok)` tuples from `_run_plan_agent`; passes empty `first_plan` to plan2 when plan1 failed; adds both-failed fallback that returns the refined plan with `Confidence.LOW`
- **`tests/test_plan.py`**:
  - Replaced `test_logs_stderr_on_nonzero_exit` with `test_retries_once_on_nonzero_then_fails` (verifies 2 subprocess calls and tuple return) and `test_retry_recovers_on_second_attempt`
  - Added `TestExtractRefinedPlan` class covering the separator-trim, missing-marker, and stored-plan-strip cases
  - Added `TestPlanSelectPipelineFallback` class covering the both-failed → refined-plan path and the partial-success → select path

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
