### PR TITLE
refactor(dispatcher): use native sub-issues API for ordering gate

### DIFF
--- a/cai_lib/actions/confirm.py
+++ b/cai_lib/actions/confirm.py
@@ -18,7 +18,6 @@ import subprocess
 import sys
 import time
 
-from cai_lib.dispatcher import _parse_sub_issue_step
 from cai_lib.config import (
     LABEL_MERGED,
     LABEL_PR_NEEDS_HUMAN,
@@ -253,16 +252,6 @@ def handle_confirm(issue: dict) -> int:
                 print(f"[cai confirm] cai-memorize invocation error: {e}",
                       flush=True)
             print(f"[cai confirm] #{issue_num}: solved — closed", flush=True)
-            # Log parent if this is a sub-issue (native sub-issues API tracks
-            # completion automatically; no manual checklist update needed).
-            parsed_title = _parse_sub_issue_step(mi.get("title") or "")
-            if parsed_title is not None:
-                parent_number, _step = parsed_title
-                print(
-                    f"[cai confirm] #{issue_num} is sub-issue of "
-                    f"#{parent_number}; native sub-issues panel updated",
-                    flush=True,
-                )
             solved += 1
         elif status == "unsolved":
             cat = _get_issue_category(mi)

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -21,31 +21,59 @@ without creating an import cycle.
 """
 from __future__ import annotations
 
-import re
 import subprocess
 import sys
 from typing import Callable, Optional
 
-# Matches sub-issue titles produced by cai_lib.actions.refine:
-# ``[#123 Step 2/5] Do the thing``. Group 1 = parent number, group 2 = step.
-_SUB_ISSUE_TITLE_RE = re.compile(r"^\[#(\d+)\s+Step\s+(\d+)/\d+\]")
-
-
-def _parse_sub_issue_step(title: str) -> Optional[tuple[int, int]]:
-    """Return ``(parent_number, step)`` when *title* is a sub-issue title, else None."""
-    if not title:
-        return None
-    m = _SUB_ISSUE_TITLE_RE.match(title)
-    if not m:
-        return None
-    return int(m.group(1)), int(m.group(2))
-
-from cai_lib.config import LABEL_HUMAN_SOLVED, REPO
+from cai_lib.config import LABEL_HUMAN_SOLVED, LABEL_PARENT, REPO
 from cai_lib.fsm import (
     IssueState, PRState,
     get_issue_state, get_pr_state,
 )
 from cai_lib.github import _gh_json
+from cai_lib.issues import list_sub_issues
+
+
+def _build_ordering_gate() -> dict[int, tuple[int, int]]:
+    """Return a map ``child_number -> (parent_number, prior_open_sibling)``
+    for every sub-issue whose position in its parent's ordered sub-issues
+    list is preceded by a still-open sibling.
+
+    Sub-issues absent from the map are either step 1 under their parent,
+    have no still-open prior sibling, or have no parent at all — i.e. not
+    gated. The dispatcher uses this map to skip dispatching a sub-issue
+    until the immediately prior one closes, reproducing the previous
+    title-regex gate semantics without relying on title formatting.
+    """
+    try:
+        parents = _gh_json([
+            "issue", "list",
+            "--repo", REPO,
+            "--label", LABEL_PARENT,
+            "--state", "all",
+            "--json", "number",
+            "--limit", "200",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(f"[cai dispatch] gh issue list (parents) failed:\n{e.stderr}",
+              file=sys.stderr)
+        return {}
+
+    gate: dict[int, tuple[int, int]] = {}
+    for parent in parents:
+        parent_num = parent.get("number")
+        if parent_num is None:
+            continue
+        last_open_sibling: Optional[int] = None
+        for sub in list_sub_issues(parent_num):
+            child_num = sub.get("number")
+            if child_num is None:
+                continue
+            if last_open_sibling is not None:
+                gate[child_num] = (parent_num, last_open_sibling)
+            if sub.get("state") == "open":
+                last_open_sibling = child_num
+    return gate
 
 
 # ---------------------------------------------------------------------------
@@ -300,23 +328,20 @@ def _pick_oldest_actionable_target(
             "--repo", REPO,
             "--label", "auto-improve",
             "--state", "open",
-            "--json", "number,createdAt,labels,title",
+            "--json", "number,createdAt,labels",
             "--limit", "200",
         ]) or []
     except subprocess.CalledProcessError as e:
         print(f"[cai dispatch] gh issue list failed:\n{e.stderr}", file=sys.stderr)
         issues = []
 
-    # Build the set of (parent, step) pairs whose sub-issue is still open.
-    # A sub-issue at step N > 1 is gated on (parent, N-1) being absent from
-    # this set — i.e. the prior step has already been closed (its PR merged
-    # and confirm ran, or a human closed it). See the "ordering gate"
+    # Build the ordering gate from GitHub's native sub-issues API: for
+    # each parent issue (label ``auto-improve:parent``), fetch its
+    # ordered sub-issues and record, for every child, the immediately
+    # prior sibling that is still open. A child present in ``gate`` is
+    # blocked until that prior sibling closes. See the "ordering gate"
     # referenced in cai_lib/actions/refine.py::_create_sub_issues.
-    open_sub_steps: set[tuple[int, int]] = set()
-    for issue in issues:
-        parsed = _parse_sub_issue_step(issue.get("title", ""))
-        if parsed is not None:
-            open_sub_steps.add(parsed)
+    gate = _build_ordering_gate()
 
     try:
         prs = _gh_json([
@@ -339,17 +364,16 @@ def _pick_oldest_actionable_target(
         if state is not None and state in issue_states:
             if ("issue", issue["number"]) in skip:
                 continue
-            parsed = _parse_sub_issue_step(issue.get("title", ""))
-            if parsed is not None:
-                parent, step = parsed
-                if step > 1 and (parent, step - 1) in open_sub_steps:
-                    print(
-                        f"[cai dispatch] issue #{issue['number']} is "
-                        f"[#{parent} Step {step}/...]; prior step still open — "
-                        f"skipping until previous step is merged",
-                        flush=True,
-                    )
-                    continue
+            blocker = gate.get(issue["number"])
+            if blocker is not None:
+                parent, prior = blocker
+                print(
+                    f"[cai dispatch] issue #{issue['number']}: prior "
+                    f"sibling #{prior} under parent #{parent} still open — "
+                    f"skipping until previous sub-issue is closed",
+                    flush=True,
+                )
+                continue
             # HUMAN_NEEDED is actionable only when the admin has signalled
             # ready-to-resume via ``human:solved``. Other parked issues
             # stay out of the queue so we don't spin on them each tick.

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -596,60 +596,147 @@ class TestDispatchDrain(unittest.TestCase):
         self.assertEqual(di_calls, [10, 20])
 
 
-class TestSubIssueStepOrderingGate(unittest.TestCase):
-    """Sub-issues like ``[#P Step N/T]`` must wait until the step N-1
-    sub-issue has been closed (typically by its PR merging and confirm
-    closing it)."""
+class TestSubIssueOrderingGate(unittest.TestCase):
+    """Sub-issues linked under an ``auto-improve:parent`` issue must wait
+    until the immediately prior sibling (in the native sub-issues list
+    order) has been closed — typically by its PR merging and confirm
+    closing it."""
 
-    def _pick(self, issues):
+    def _pick(self, issues, sub_issues_by_parent):
         def fake_gh_json(cmd):
-            if "issue" in cmd and "list" in cmd:
+            # `_build_ordering_gate` lists parents first.
+            if "issue" in cmd and "list" in cmd and "--label" in cmd:
+                label_idx = cmd.index("--label") + 1
+                if cmd[label_idx] == "auto-improve:parent":
+                    return [{"number": p} for p in sub_issues_by_parent]
                 return issues
             if "pr" in cmd and "list" in cmd:
                 return []
             raise AssertionError(f"unexpected _gh_json call: {cmd}")
 
-        with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json):
+        def fake_list_sub_issues(parent_num):
+            return sub_issues_by_parent.get(parent_num, [])
+
+        with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json), \
+             patch.object(dispatcher, "list_sub_issues",
+                          side_effect=fake_list_sub_issues):
             return dispatcher._pick_oldest_actionable_target()
 
-    def test_later_step_skipped_while_prior_step_open(self):
+    def test_later_sibling_skipped_while_prior_sibling_open(self):
         issues = [
             {"number": 50, "createdAt": "2024-01-01T00:00:00Z",
-             "title": "[#621 Step 4/6] Previous step",
+             "title": "Previous step",
              "labels": [{"name": "auto-improve:in-progress"}]},
             {"number": 51, "createdAt": "2024-01-02T00:00:00Z",
-             "title": "[#621 Step 5/6] Migrate check-workflows",
+             "title": "Later step",
              "labels": [{"name": "auto-improve:refined"}]},
         ]
-        target = self._pick(issues)
+        sub_issues_by_parent = {
+            621: [
+                {"number": 50, "state": "open"},
+                {"number": 51, "state": "open"},
+            ],
+        }
+        target = self._pick(issues, sub_issues_by_parent)
         self.assertEqual(target, ("issue", 50))
 
-    def test_later_step_picked_when_prior_step_closed(self):
-        # Step 4 absent from the open list → it was closed → step 5 is allowed.
+    def test_later_sibling_picked_when_prior_sibling_closed(self):
         issues = [
             {"number": 51, "createdAt": "2024-01-02T00:00:00Z",
-             "title": "[#621 Step 5/6] Migrate check-workflows",
+             "title": "Later step",
              "labels": [{"name": "auto-improve:refined"}]},
         ]
-        target = self._pick(issues)
+        sub_issues_by_parent = {
+            621: [
+                {"number": 50, "state": "closed"},
+                {"number": 51, "state": "open"},
+            ],
+        }
+        target = self._pick(issues, sub_issues_by_parent)
         self.assertEqual(target, ("issue", 51))
 
-    def test_step_one_never_gated(self):
+    def test_first_sibling_never_gated(self):
         issues = [
             {"number": 51, "createdAt": "2024-01-02T00:00:00Z",
-             "title": "[#621 Step 1/6] First step",
+             "title": "First step",
              "labels": [{"name": "auto-improve:refined"}]},
         ]
-        target = self._pick(issues)
+        sub_issues_by_parent = {
+            621: [
+                {"number": 51, "state": "open"},
+            ],
+        }
+        target = self._pick(issues, sub_issues_by_parent)
         self.assertEqual(target, ("issue", 51))
 
-    def test_parse_sub_issue_step(self):
-        self.assertEqual(
-            dispatcher._parse_sub_issue_step("[#123 Step 2/5] Do a thing"),
-            (123, 2),
-        )
-        self.assertIsNone(dispatcher._parse_sub_issue_step("Just a normal title"))
-        self.assertIsNone(dispatcher._parse_sub_issue_step(""))
+    def test_issue_with_no_parent_is_not_gated(self):
+        issues = [
+            {"number": 77, "createdAt": "2024-01-02T00:00:00Z",
+             "title": "Standalone issue",
+             "labels": [{"name": "auto-improve:refined"}]},
+        ]
+        target = self._pick(issues, sub_issues_by_parent={})
+        self.assertEqual(target, ("issue", 77))
+
+    def test_gate_skips_to_any_prior_still_open(self):
+        # Step 2 closed, step 1 and step 3 open: step 3 is still gated by
+        # step 2's position (immediately prior). But since step 2 is closed,
+        # step 3 is blocked by step 1 transitively because step 1 is still
+        # the last-open sibling before step 3 in link order.
+        issues = [
+            {"number": 10, "createdAt": "2024-01-01T00:00:00Z",
+             "title": "Step 1",
+             "labels": [{"name": "auto-improve:refined"}]},
+            {"number": 30, "createdAt": "2024-01-03T00:00:00Z",
+             "title": "Step 3",
+             "labels": [{"name": "auto-improve:refined"}]},
+        ]
+        sub_issues_by_parent = {
+            621: [
+                {"number": 10, "state": "open"},
+                {"number": 20, "state": "closed"},
+                {"number": 30, "state": "open"},
+            ],
+        }
+        target = self._pick(issues, sub_issues_by_parent)
+        self.assertEqual(target, ("issue", 10))
+
+
+class TestBuildOrderingGate(unittest.TestCase):
+    def test_gate_maps_each_child_to_last_open_prior_sibling(self):
+        parents = [{"number": 900}]
+        subs = {
+            900: [
+                {"number": 10, "state": "open"},
+                {"number": 20, "state": "closed"},
+                {"number": 30, "state": "open"},
+                {"number": 40, "state": "open"},
+            ],
+        }
+
+        def fake_gh_json(cmd):
+            if "issue" in cmd and "list" in cmd:
+                return parents
+            raise AssertionError(f"unexpected _gh_json call: {cmd}")
+
+        def fake_list_sub_issues(parent_num):
+            return subs.get(parent_num, [])
+
+        with patch.object(dispatcher, "_gh_json", side_effect=fake_gh_json), \
+             patch.object(dispatcher, "list_sub_issues",
+                          side_effect=fake_list_sub_issues):
+            gate = dispatcher._build_ordering_gate()
+
+        # #10 is first — no prior sibling → not in gate.
+        self.assertNotIn(10, gate)
+        # #20 is preceded by #10 (open) → blocked by #10.
+        self.assertEqual(gate[20], (900, 10))
+        # #30 is preceded by #10 (open) and #20 (closed) →
+        # still blocked by #10 (last open prior).
+        self.assertEqual(gate[30], (900, 10))
+        # #40 is preceded by #10 (open), #20 (closed), #30 (open) →
+        # blocked by #30 (the most recent still-open prior).
+        self.assertEqual(gate[40], (900, 30))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replaces the dispatcher's title-regex ordering gate (`[#NNN Step N/M]`) with a scan of every `auto-improve:parent` issue's native sub-issues list. A sub-issue is now blocked from dispatch until its most-recent still-open prior sibling closes — regardless of title formatting.
- Drops the now-unused `_parse_sub_issue_step` helper and the cosmetic "is sub-issue of #N" log in `confirm.py` (GitHub's native sub-issues panel already tracks that relationship).
- Extends the gate test matrix to cover: non-linked issues, first sibling, middle-closed sibling, and multiple gated children under one parent.

## Motivation
The old gate only worked on titles minted by `cai_lib/actions/refine.py`. Manually-filed sub-issue trees (for example, the in-flight `audit-refactor 1/7` → `1.1/1.2/…` tree in #884) used a different title convention and fell straight through the gate, so later steps could start before their prior steps merged. GitHub's native sub-issues relationship is already the source of truth for parent/child wiring (`cai_lib/issues.py`), so we now derive ordering from it.

## Test plan
- [x] `python -m unittest discover tests` — 223 pass, 1 skipped
- [x] `python -m unittest tests.test_dispatcher -v` — all gate scenarios green
- [ ] Smoke-check a live tick after merge to confirm the audit-refactor tree dispatches in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)