### PR TITLE
auto-improve: audit-refactor 2.1: create cai_lib/audit/ package and migrate cost helpers

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -65,6 +65,9 @@
 | `cai_lib/actions/review_pr.py` | Handler for PRState.REVIEWING_CODE — runs cai-review-pr |
 | `cai_lib/actions/revise.py` | Handler for PRState.REVISION_PENDING — runs cai-revise |
 | `cai_lib/actions/triage.py` | Handler for IssueState.RAISED / TRIAGING — runs cai-triage |
+| `cai_lib/audit/__init__.py` | TODO: add description |
+| `cai_lib/audit/cost.py` | TODO: add description |
+| `cai_lib/audit/modules.py` | TODO: add description |
 | `cai_lib/cmd_agents.py` | Agent-launch cmd_* functions: analyze, audit, propose, code-audit, agent-audit, update-check, cost-optimize, external-scout |
 | `cai_lib/cmd_cycle.py` | TODO: add description |
 | `cai_lib/cmd_helpers.py` | Cross-command helpers shared between cai.py and cai_lib/actions/* |

--- a/cai.py
+++ b/cai.py
@@ -258,8 +258,10 @@ from cai_lib.config import (  # noqa: E402
 
 from cai_lib.logging_utils import (  # noqa: E402
     log_cost,  # noqa: F401
-    _get_issue_category, _log_outcome, _load_outcome_counts,
-    _load_outcome_stats, _load_cost_log, _row_ts, _build_cost_summary,
+    _get_issue_category, _log_outcome, _load_outcome_stats,
+)
+from cai_lib.audit.cost import (  # noqa: E402
+    _load_outcome_counts, _load_cost_log, _row_ts, _build_cost_summary,
 )
 
 

--- a/cai_lib/__init__.py
+++ b/cai_lib/__init__.py
@@ -57,8 +57,10 @@ from cai_lib.logging_utils import (
     log_cost,
     _get_issue_category,
     _log_outcome,
-    _load_outcome_counts,
     _load_outcome_stats,
+)
+from cai_lib.audit.cost import (
+    _load_outcome_counts,
     _load_cost_log,
     _row_ts,
     _build_cost_summary,

--- a/cai_lib/audit/__init__.py
+++ b/cai_lib/audit/__init__.py
@@ -1,0 +1,1 @@
+"""cai_lib.audit — audit-side infrastructure (cost aggregation, etc.)."""

--- a/cai_lib/audit/cost.py
+++ b/cai_lib/audit/cost.py
@@ -1,0 +1,175 @@
+"""Audit-side cost/outcome helpers (moved from cai_lib/logging_utils.py)."""
+
+import json
+from datetime import datetime, timezone
+
+from cai_lib.config import COST_LOG_PATH, OUTCOME_LOG_PATH
+
+
+def _load_outcome_counts(days: int = 90) -> dict:
+    """Read OUTCOME_LOG_PATH and return per-category {total, solved} counts.
+
+    Filters to trailing `days` days. Malformed lines are skipped silently.
+    Returns an empty dict if the file is missing or unreadable.
+    """
+    if not OUTCOME_LOG_PATH.exists():
+        return {}
+    cutoff_ts = datetime.now(timezone.utc).timestamp() - days * 86400
+    counts: dict = {}  # category -> {"total": N, "solved": N}
+    try:
+        with OUTCOME_LOG_PATH.open("r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                ts = row.get("ts", "")
+                try:
+                    row_ts = datetime.strptime(
+                        ts, "%Y-%m-%dT%H:%M:%SZ"
+                    ).replace(tzinfo=timezone.utc).timestamp()
+                except ValueError:
+                    continue
+                if row_ts < cutoff_ts:
+                    continue
+                cat = row.get("category") or "(unknown)"
+                outcome = row.get("outcome", "")
+                bucket = counts.setdefault(cat, {"total": 0, "solved": 0})
+                bucket["total"] += 1
+                if outcome == "solved":
+                    bucket["solved"] += 1
+    except OSError:
+        return {}
+    return counts
+
+
+def _load_cost_log(days: int = 7) -> list[dict]:
+    """Read COST_LOG_PATH and return rows from the last `days` days.
+
+    Each row is a dict as written by `log_cost`. Malformed lines are
+    skipped silently. Returns an empty list if the file is missing or
+    unreadable. Used by both `_build_cost_summary` (audit prompt) and
+    `cmd_cost_report` (host-facing report).
+    """
+    if not COST_LOG_PATH.exists():
+        return []
+    cutoff_ts = datetime.now(timezone.utc).timestamp() - days * 86400
+    rows: list[dict] = []
+    try:
+        with COST_LOG_PATH.open("r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                ts = row.get("ts") or ""
+                try:
+                    row_ts = datetime.strptime(
+                        ts, "%Y-%m-%dT%H:%M:%SZ",
+                    ).replace(tzinfo=timezone.utc).timestamp()
+                except ValueError:
+                    continue
+                if row_ts >= cutoff_ts:
+                    rows.append(row)
+    except Exception:
+        return []
+    return rows
+
+
+def _row_ts(row: dict) -> float:
+    """Parse a cost-log row's 'ts' field to a Unix timestamp.
+
+    Returns 0.0 on any parse failure so callers can safely compare
+    against numeric boundaries without extra error handling.
+    """
+    ts = row.get("ts") or ""
+    try:
+        return datetime.strptime(
+            ts, "%Y-%m-%dT%H:%M:%SZ",
+        ).replace(tzinfo=timezone.utc).timestamp()
+    except ValueError:
+        return 0.0
+
+
+def _primary_model(row: dict) -> str:
+    """Return the model name with the most output tokens, or ''."""
+    models = row.get("models")
+    if not models or not isinstance(models, dict):
+        return ""
+    best = max(models.items(), key=lambda kv: kv[1].get("output_tokens", 0))
+    return best[0] if best else ""
+
+
+def _build_cost_summary(days: int = 7, top_n: int = 10) -> str:
+    """Build a markdown cost summary for the cai-audit user message.
+
+    Returns an empty string if no cost rows exist for the window.
+    Otherwise emits a section with per-category aggregates and the
+    top-N most expensive individual invocations, so the audit agent
+    can spot cost outliers (a single invocation that dwarfs the
+    median, or a category that dominates total spend).
+    """
+    rows = _load_cost_log(days=days)
+    if not rows:
+        return ""
+
+    # Per-category aggregates: total cost, call count, mean cost.
+    cats: dict[str, dict] = {}
+    grand_total = 0.0
+    for r in rows:
+        cat = r.get("category") or "(unknown)"
+        cost = r.get("cost_usd") or 0.0
+        try:
+            cost = float(cost)
+        except (TypeError, ValueError):
+            cost = 0.0
+        bucket = cats.setdefault(cat, {"calls": 0, "cost": 0.0})
+        bucket["calls"] += 1
+        bucket["cost"] += cost
+        grand_total += cost
+
+    cat_lines = []
+    for cat, b in sorted(cats.items(), key=lambda kv: -kv[1]["cost"]):
+        share = (b["cost"] / grand_total * 100.0) if grand_total else 0.0
+        mean = b["cost"] / b["calls"] if b["calls"] else 0.0
+        cat_lines.append(
+            f"| {cat} | {b['calls']} | ${b['cost']:.4f} "
+            f"({share:.1f}%) | ${mean:.4f} |"
+        )
+
+    # Top-N most expensive individual invocations.
+    top = sorted(
+        rows,
+        key=lambda r: float(r.get("cost_usd") or 0.0),
+        reverse=True,
+    )[:top_n]
+    top_lines = []
+    for r in top:
+        cost = float(r.get("cost_usd") or 0.0)
+        top_lines.append(
+            f"| {r.get('ts', '')} | {r.get('category', '')} | "
+            f"{r.get('agent', '')} | {_primary_model(r)} | ${cost:.4f} | "
+            f"{r.get('num_turns', '')} | "
+            f"{(r.get('input_tokens') or 0) + (r.get('output_tokens') or 0)} |"
+        )
+
+    return (
+        f"## Cost summary (last {days}d, total ${grand_total:.4f} "
+        f"across {len(rows)} invocations)\n\n"
+        "### Per-category totals\n\n"
+        "| category | calls | total cost (share) | mean cost |\n"
+        "|---|---|---|---|\n"
+        + "\n".join(cat_lines)
+        + "\n\n"
+        f"### Top {len(top_lines)} most expensive individual invocations\n\n"
+        "| ts | category | agent | model | cost | turns | tokens |\n"
+        "|---|---|---|---|---|---|---|\n"
+        + "\n".join(top_lines)
+        + "\n"
+    )

--- a/cai_lib/audit/modules.py
+++ b/cai_lib/audit/modules.py
@@ -1,0 +1,1 @@
+"""Audit module loader — stub for future audit infrastructure."""

--- a/cai_lib/cmd_agents.py
+++ b/cai_lib/cmd_agents.py
@@ -21,8 +21,8 @@ from pathlib import Path
 from cai_lib.config import *  # noqa: F403
 from cai_lib.config import _STALE_MERGED_DAYS  # noqa: F401
 
-from cai_lib.logging_utils import (
-    log_run,
+from cai_lib.logging_utils import log_run
+from cai_lib.audit.cost import (
     _load_cost_log, _row_ts, _build_cost_summary, _load_outcome_counts,
 )
 

--- a/cai_lib/cmd_misc.py
+++ b/cai_lib/cmd_misc.py
@@ -12,7 +12,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from cai_lib.config import *  # noqa: F403,F401
-from cai_lib.logging_utils import log_run, _load_cost_log, _load_outcome_counts, _row_ts
+from cai_lib.logging_utils import log_run
+from cai_lib.audit.cost import _load_cost_log, _load_outcome_counts, _row_ts
 from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.github import (
     _gh_json, _set_labels, _transcript_dir_is_empty,

--- a/cai_lib/logging_utils.py
+++ b/cai_lib/logging_utils.py
@@ -5,6 +5,7 @@ import re
 from datetime import datetime, timezone
 
 from cai_lib.config import LOG_PATH, COST_LOG_PATH, OUTCOME_LOG_PATH
+from cai_lib.audit.cost import _load_outcome_counts
 
 
 def log_run(category: str, **fields) -> None:
@@ -69,46 +70,6 @@ def _log_outcome(issue_number: int, category: str, outcome: str, fix_attempt_cou
         pass
 
 
-def _load_outcome_counts(days: int = 90) -> dict:
-    """Read OUTCOME_LOG_PATH and return per-category {total, solved} counts.
-
-    Filters to trailing `days` days. Malformed lines are skipped silently.
-    Returns an empty dict if the file is missing or unreadable.
-    """
-    if not OUTCOME_LOG_PATH.exists():
-        return {}
-    cutoff_ts = datetime.now(timezone.utc).timestamp() - days * 86400
-    counts: dict = {}  # category -> {"total": N, "solved": N}
-    try:
-        with OUTCOME_LOG_PATH.open("r") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    row = json.loads(line)
-                except (json.JSONDecodeError, ValueError):
-                    continue
-                ts = row.get("ts", "")
-                try:
-                    row_ts = datetime.strptime(
-                        ts, "%Y-%m-%dT%H:%M:%SZ"
-                    ).replace(tzinfo=timezone.utc).timestamp()
-                except ValueError:
-                    continue
-                if row_ts < cutoff_ts:
-                    continue
-                cat = row.get("category") or "(unknown)"
-                outcome = row.get("outcome", "")
-                bucket = counts.setdefault(cat, {"total": 0, "solved": 0})
-                bucket["total"] += 1
-                if outcome == "solved":
-                    bucket["solved"] += 1
-    except OSError:
-        return {}
-    return counts
-
-
 def _load_outcome_stats(days: int = 90) -> dict:
     """Load per-category success rates from the trailing `days` days of outcome data.
 
@@ -123,132 +84,3 @@ def _load_outcome_stats(days: int = 90) -> dict:
         else:
             rates[cat] = c["solved"] / c["total"]
     return rates
-
-
-def _load_cost_log(days: int = 7) -> list[dict]:
-    """Read COST_LOG_PATH and return rows from the last `days` days.
-
-    Each row is a dict as written by `log_cost`. Malformed lines are
-    skipped silently. Returns an empty list if the file is missing or
-    unreadable. Used by both `_build_cost_summary` (audit prompt) and
-    `cmd_cost_report` (host-facing report).
-    """
-    if not COST_LOG_PATH.exists():
-        return []
-    cutoff_ts = datetime.now(timezone.utc).timestamp() - days * 86400
-    rows: list[dict] = []
-    try:
-        with COST_LOG_PATH.open("r") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    row = json.loads(line)
-                except (json.JSONDecodeError, ValueError):
-                    continue
-                ts = row.get("ts") or ""
-                try:
-                    row_ts = datetime.strptime(
-                        ts, "%Y-%m-%dT%H:%M:%SZ",
-                    ).replace(tzinfo=timezone.utc).timestamp()
-                except ValueError:
-                    continue
-                if row_ts >= cutoff_ts:
-                    rows.append(row)
-    except Exception:
-        return []
-    return rows
-
-
-def _row_ts(row: dict) -> float:
-    """Parse a cost-log row's 'ts' field to a Unix timestamp.
-
-    Returns 0.0 on any parse failure so callers can safely compare
-    against numeric boundaries without extra error handling.
-    """
-    ts = row.get("ts") or ""
-    try:
-        return datetime.strptime(
-            ts, "%Y-%m-%dT%H:%M:%SZ",
-        ).replace(tzinfo=timezone.utc).timestamp()
-    except ValueError:
-        return 0.0
-
-
-def _primary_model(row: dict) -> str:
-    """Return the model name with the most output tokens, or ''."""
-    models = row.get("models")
-    if not models or not isinstance(models, dict):
-        return ""
-    best = max(models.items(), key=lambda kv: kv[1].get("output_tokens", 0))
-    return best[0] if best else ""
-
-
-def _build_cost_summary(days: int = 7, top_n: int = 10) -> str:
-    """Build a markdown cost summary for the cai-audit user message.
-
-    Returns an empty string if no cost rows exist for the window.
-    Otherwise emits a section with per-category aggregates and the
-    top-N most expensive individual invocations, so the audit agent
-    can spot cost outliers (a single invocation that dwarfs the
-    median, or a category that dominates total spend).
-    """
-    rows = _load_cost_log(days=days)
-    if not rows:
-        return ""
-
-    # Per-category aggregates: total cost, call count, mean cost.
-    cats: dict[str, dict] = {}
-    grand_total = 0.0
-    for r in rows:
-        cat = r.get("category") or "(unknown)"
-        cost = r.get("cost_usd") or 0.0
-        try:
-            cost = float(cost)
-        except (TypeError, ValueError):
-            cost = 0.0
-        bucket = cats.setdefault(cat, {"calls": 0, "cost": 0.0})
-        bucket["calls"] += 1
-        bucket["cost"] += cost
-        grand_total += cost
-
-    cat_lines = []
-    for cat, b in sorted(cats.items(), key=lambda kv: -kv[1]["cost"]):
-        share = (b["cost"] / grand_total * 100.0) if grand_total else 0.0
-        mean = b["cost"] / b["calls"] if b["calls"] else 0.0
-        cat_lines.append(
-            f"| {cat} | {b['calls']} | ${b['cost']:.4f} "
-            f"({share:.1f}%) | ${mean:.4f} |"
-        )
-
-    # Top-N most expensive individual invocations.
-    top = sorted(
-        rows,
-        key=lambda r: float(r.get("cost_usd") or 0.0),
-        reverse=True,
-    )[:top_n]
-    top_lines = []
-    for r in top:
-        cost = float(r.get("cost_usd") or 0.0)
-        top_lines.append(
-            f"| {r.get('ts', '')} | {r.get('category', '')} | "
-            f"{r.get('agent', '')} | {_primary_model(r)} | ${cost:.4f} | "
-            f"{r.get('num_turns', '')} | "
-            f"{(r.get('input_tokens') or 0) + (r.get('output_tokens') or 0)} |"
-        )
-
-    return (
-        f"## Cost summary (last {days}d, total ${grand_total:.4f} "
-        f"across {len(rows)} invocations)\n\n"
-        "### Per-category totals\n\n"
-        "| category | calls | total cost (share) | mean cost |\n"
-        "|---|---|---|---|\n"
-        + "\n".join(cat_lines)
-        + "\n\n"
-        f"### Top {len(top_lines)} most expensive individual invocations\n\n"
-        "| ts | category | agent | model | cost | turns | tokens |\n"
-        "|---|---|---|---|---|---|---|\n"
-        + "\n".join(top_lines)
-        + "\n"
-    )


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#891

**Issue:** #891 — audit-refactor 2.1: create cai_lib/audit/ package and migrate cost helpers

## PR Summary

### What this fixes
Five cost/outcome helper functions (`_load_cost_log`, `_row_ts`, `_primary_model`, `_build_cost_summary`, `_load_outcome_counts`) were living in `cai_lib/logging_utils.py` despite being consumed exclusively by audit/cost-related code, reducing cohesion. They are relocated to a new `cai_lib/audit/cost.py` module.

### What was changed
- **`cai_lib/audit/__init__.py`** (new): package init with one-line docstring
- **`cai_lib/audit/cost.py`** (new): receives all 5 functions verbatim from `logging_utils.py`, with the minimal imports they need (`json`, `datetime`, `timezone`, `COST_LOG_PATH`, `OUTCOME_LOG_PATH`)
- **`cai_lib/audit/modules.py`** (new): minimal placeholder stub with module docstring
- **`cai_lib/logging_utils.py`**: removed the 5 moved functions; added `from cai_lib.audit.cost import _load_outcome_counts` so `_load_outcome_stats` continues to work
- **`cai_lib/__init__.py`**: split logging re-export block — `log_run`, `log_cost`, `_get_issue_category`, `_log_outcome`, `_load_outcome_stats` stay from `cai_lib.logging_utils`; `_load_outcome_counts`, `_load_cost_log`, `_row_ts`, `_build_cost_summary` now imported from `cai_lib.audit.cost`
- **`cai_lib/cmd_agents.py`**: split import block — `log_run` from `cai_lib.logging_utils`, 4 moved symbols from `cai_lib.audit.cost`
- **`cai_lib/cmd_misc.py`**: split import line — `log_run` from `cai_lib.logging_utils`, 3 moved symbols from `cai_lib.audit.cost`
- **`cai.py`**: split import block — `log_cost`, `_get_issue_category`, `_log_outcome`, `_load_outcome_stats` from `cai_lib.logging_utils`; 4 moved symbols from `cai_lib.audit.cost`

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
