### PR TITLE
feat(rescue): one-shot Opus escalation for stuck :human-needed issues

### DIFF
--- a/.claude/agents/lifecycle/cai-rescue.md
+++ b/.claude/agents/lifecycle/cai-rescue.md
@@ -1,8 +1,8 @@
 ---
 name: cai-rescue
-description: Autonomous rescue agent — decides whether a `:human-needed` divert can be resumed without admin input, and optionally proposes a prevention finding to fix the divert root cause. Used by `cai rescue`.
+description: Autonomous rescue agent — decides whether a `:human-needed` divert can be resumed without admin input (including a one-shot Opus-escalation of the implement phase), and optionally proposes a prevention finding to fix the divert root cause. Used by `cai rescue`.
 tools: Read, Grep, Glob
-model: opus
+model: sonnet
 memory: project
 ---
 
@@ -64,6 +64,44 @@ Only emit this when ALL of the following hold:
 - Nothing in the divert comment, the issue body, or the comment
   thread cites a need for a human decision.
 
+### `ATTEMPT_OPUS_IMPLEMENT`
+
+One-shot escalation path for parks where a **sound stored plan**
+exists but the Sonnet-backed implementer gave up. On HIGH confidence,
+the runtime applies `auto-improve:opus-attempted` and fires
+`human_to_plan_approved`; the next `cai implement` tick re-runs the
+implement phase on the same plan with `--model claude-opus-4-7`. The
+label is a single-use gate — a second park on the same issue must
+NOT emit this verdict again.
+
+Only emit when ALL of the following hold:
+
+- The issue body contains a stored plan block
+  (`<!-- cai-plan-start -->…<!-- cai-plan-end -->`). Use `Grep` to
+  confirm before emitting.
+- The labels list on the issue does NOT already include
+  `auto-improve:opus-attempted` (the one-shot has been burned).
+- The divert reason is implementer-side horsepower, not ambiguity:
+  - the spike-marker branch of `cai-implement` (divert comment
+    titled "Implement subagent: needs human review" or
+    "Implement subagent: repeated test failures"),
+  - the Haiku pre-screen emitting `spike` on an issue whose stored
+    plan is clearly concrete (pre-screen mis-classification), or
+  - the 3-consecutive-`tests_failed` escalation, where the plan is
+    plausible but Sonnet could not produce passing tests.
+- The plan still matches the current source tree — spot-check one
+  or two file paths or symbols it names via `Read`/`Grep` to
+  confirm they exist and the plan has not drifted.
+- Nothing in the divert comment or body cites a need for a human
+  decision — if Sonnet asked a policy question, Opus will ask the
+  same one. Pick `TRULY_HUMAN_NEEDED` instead.
+
+When in doubt between `AUTONOMOUSLY_RESOLVABLE` and
+`ATTEMPT_OPUS_IMPLEMENT`: prefer `AUTONOMOUSLY_RESOLVABLE` with
+`resume_to: PLAN_APPROVED` — it is the cheaper first retry. Reserve
+the Opus escalation for parks where the Sonnet implementer has
+visibly struggled, not for first-time transient failures.
+
 ### `TRULY_HUMAN_NEEDED`
 
 Default to this whenever the divert comment cites or implies any of:
@@ -87,16 +125,18 @@ a truly-stuck issue) are far more expensive than false negatives
 ## Confidence
 
 Emit `LOW`, `MEDIUM`, or `HIGH`. **Only HIGH-confidence
-`AUTONOMOUSLY_RESOLVABLE` verdicts cause `cmd_rescue` to fire a
-transition** — anything else leaves the issue parked. Pick `HIGH`
-only when both the verdict and the resume target are clearly
-correct.
+`AUTONOMOUSLY_RESOLVABLE` and `ATTEMPT_OPUS_IMPLEMENT` verdicts
+cause `cmd_rescue` to act** — anything else leaves the issue
+parked. Pick `HIGH` only when both the verdict and (for
+`AUTONOMOUSLY_RESOLVABLE`) the resume target are clearly correct.
 
 ## `resume_to` (issue-side targets)
 
-Required when `verdict` is `AUTONOMOUSLY_RESOLVABLE`. Ignored
-otherwise. Pick exactly one of these state names — each maps to a
-`human_to_<state>` transition in `cai_lib/fsm_transitions.py`:
+Required when `verdict` is `AUTONOMOUSLY_RESOLVABLE`. Ignored for
+both `ATTEMPT_OPUS_IMPLEMENT` (the driver always uses
+`human_to_plan_approved`) and `TRULY_HUMAN_NEEDED`. Pick exactly one
+of these state names — each maps to a `human_to_<state>` transition
+in `cai_lib/fsm_transitions.py`:
 
 | State               | When to pick                                                           |
 |---------------------|------------------------------------------------------------------------|
@@ -136,9 +176,9 @@ conforming to this schema:
 
 ```
 {
-  "verdict": "AUTONOMOUSLY_RESOLVABLE | TRULY_HUMAN_NEEDED",
+  "verdict": "AUTONOMOUSLY_RESOLVABLE | ATTEMPT_OPUS_IMPLEMENT | TRULY_HUMAN_NEEDED",
   "confidence": "LOW | MEDIUM | HIGH",
-  "resume_to": "<STATE_NAME>",      // required when verdict is AUTONOMOUSLY_RESOLVABLE
+  "resume_to": "<STATE_NAME>",      // required when verdict is AUTONOMOUSLY_RESOLVABLE; ignored otherwise
   "reasoning": "≤3 sentences explaining your verdict",
   "prevention_finding": "<markdown>"  // optional; empty string when none
 }
@@ -151,14 +191,20 @@ the audit trail later.
 
 ## Hard rules
 
-- Never emit `AUTONOMOUSLY_RESOLVABLE` with `LOW` or `MEDIUM`
-  confidence — it has no effect, and it pollutes the run-log
-  counters.
+- Never emit `AUTONOMOUSLY_RESOLVABLE` or `ATTEMPT_OPUS_IMPLEMENT`
+  with `LOW` or `MEDIUM` confidence — neither fires a transition,
+  and both pollute the run-log counters.
+- Never emit `ATTEMPT_OPUS_IMPLEMENT` on an issue whose labels
+  already include `auto-improve:opus-attempted` — the one-shot has
+  been burned; pick `TRULY_HUMAN_NEEDED` instead.
+- Never emit `ATTEMPT_OPUS_IMPLEMENT` on an issue whose body lacks
+  a stored plan block — the driver will reject the escalation and
+  the park will be counted as a wasted cycle.
 - Never emit a `resume_to` outside the table above. The runtime
   rejects unknown targets and the issue stays parked.
 - Never emit `resume_to: HUMAN_NEEDED` — the issue is already there.
-- When `verdict` is `TRULY_HUMAN_NEEDED`, `resume_to` is irrelevant;
-  the runtime ignores it.
+- When `verdict` is `TRULY_HUMAN_NEEDED` or `ATTEMPT_OPUS_IMPLEMENT`,
+  `resume_to` is irrelevant; the runtime ignores it.
 - Prefer leaving the issue parked over guessing. The next rescue
   pass (every 4 hours by default) gets another chance once context
   changes; a wrong resume is hard to undo.

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -125,6 +125,7 @@
 | `tests/test_plan.py` | TODO: add description |
 | `tests/test_pr_bounce.py` | TODO: add description |
 | `tests/test_publish.py` | Tests for publish.py issue publishing |
+| `tests/test_rescue_opus.py` | Tests for cai_lib.cmd_rescue — Opus-escalation verdict plumbing, schema, and one-shot label guard |
 | `tests/test_retroactive_sweep.py` | TODO: add description |
 | `tests/test_revise_filter.py` | TODO: add description |
 | `tests/test_rollback.py` | Tests for rollback functionality |

--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -32,9 +32,16 @@ from cai_lib.config import (
     LABEL_PR_OPEN,
     LABEL_REFINED,
     LABEL_HUMAN_NEEDED,
+    LABEL_OPUS_ATTEMPTED,
     LABEL_RAISED,
     LOG_PATH,
 )
+
+# Model ID passed to ``claude -p --model`` when the Opus-escalation
+# label is present on the issue. Kept in one place so the next Opus
+# release only needs to touch this constant (and the matching pin in
+# claude-code's declarative agent files).
+_OPUS_MODEL_ID = "claude-opus-4-7"
 from cai_lib.github import (
     _gh_json,
     _set_labels,
@@ -528,11 +535,21 @@ def handle_implement(issue: dict) -> int:
                 + "---\n\n"
                 + _build_implement_user_message(issue, attempt_history_block)
             )
+        opus_escalation = LABEL_OPUS_ATTEMPTED in label_names
+        claude_cmd = ["claude", "-p", "--agent", "cai-implement"]
+        if opus_escalation:
+            claude_cmd += ["--model", _OPUS_MODEL_ID]
+            print(
+                f"[cai implement] #{issue_number} carries "
+                f"{LABEL_OPUS_ATTEMPTED}; invoking cai-implement with "
+                f"--model {_OPUS_MODEL_ID}",
+                flush=True,
+            )
+        claude_cmd += ["--dangerously-skip-permissions",
+                       "--add-dir", str(work_dir)]
         print(f"[cai implement] running cai-implement subagent for {work_dir}", flush=True)
         agent = _run_claude_p(
-            ["claude", "-p", "--agent", "cai-implement",
-             "--dangerously-skip-permissions",
-             "--add-dir", str(work_dir)],
+            claude_cmd,
             category="implement",
             agent="cai-implement",
             input=user_message,

--- a/cai_lib/cmd_rescue.py
+++ b/cai_lib/cmd_rescue.py
@@ -26,28 +26,50 @@ import sys
 import time
 from typing import Optional
 
+from cai_lib.cmd_helpers_issues import _extract_stored_plan
+
 from cai_lib.config import (
     REPO,
     LABEL_HUMAN_NEEDED,
     LABEL_HUMAN_SOLVED,
+    LABEL_OPUS_ATTEMPTED,
 )
 from cai_lib.fsm import (
     Confidence,
     apply_transition,
     resume_transition_for,
 )
-from cai_lib.github import _gh_json, _post_issue_comment, close_issue_completed
+from cai_lib.github import (
+    _gh_json,
+    _post_issue_comment,
+    _set_labels,
+    close_issue_completed,
+)
 from cai_lib.logging_utils import log_run
 from cai_lib.subprocess_utils import _run_claude_p
 
 
 # JSON schema for the cai-rescue verdict (forced via --json-schema).
+#
+# The ``ATTEMPT_OPUS_IMPLEMENT`` verdict is a one-shot escalation path
+# for parks where a stored plan exists but the Sonnet-backed
+# cai-implement run gave up (spike marker, repeated test failures, no
+# diff). The rescue driver applies ``LABEL_OPUS_ATTEMPTED`` and fires
+# ``human_to_plan_approved`` so the next dispatcher tick re-runs
+# implement on the same plan — this time with ``--model
+# claude-opus-4-7`` (see :mod:`cai_lib.actions.implement`). The label
+# also gates re-escalation: a second park on the same issue will not
+# emit ATTEMPT_OPUS_IMPLEMENT again.
 _RESCUE_JSON_SCHEMA = {
     "type": "object",
     "properties": {
         "verdict": {
             "type": "string",
-            "enum": ["AUTONOMOUSLY_RESOLVABLE", "TRULY_HUMAN_NEEDED"],
+            "enum": [
+                "AUTONOMOUSLY_RESOLVABLE",
+                "ATTEMPT_OPUS_IMPLEMENT",
+                "TRULY_HUMAN_NEEDED",
+            ],
         },
         "confidence": {
             "type": "string",
@@ -161,6 +183,101 @@ def _post_rescue_comment(
         f"_Reasoning:_ {reasoning}\n"
     )
     return _post_issue_comment(issue_number, body, log_prefix="cai rescue")
+
+
+def _post_opus_escalation_comment(
+    issue_number: int, *, reasoning: str,
+) -> bool:
+    """Post the audit comment for an Opus-escalation rescue.
+
+    Distinct wording from ``_post_rescue_comment`` because this path
+    both resumes AND swaps models — operators reading the audit trail
+    should see the escalation called out explicitly.
+    """
+    body = (
+        f"**🛟 Autonomous rescue — Opus escalation**\n\n"
+        f"`cai rescue` resumed this issue from `:human-needed` "
+        f"→ `PLAN_APPROVED` and marked it `{LABEL_OPUS_ATTEMPTED}` so "
+        f"the next `cai implement` run uses Opus instead of Sonnet.\n\n"
+        f"_Reasoning:_ {reasoning}\n\n"
+        f"_This is a one-shot escalation — if the Opus run also parks "
+        f"at `:human-needed`, rescue will not re-escalate._\n"
+    )
+    return _post_issue_comment(issue_number, body, log_prefix="cai rescue")
+
+
+def _issue_has_opus_attempted(issue: dict) -> bool:
+    """Return True if *issue* already carries ``LABEL_OPUS_ATTEMPTED``."""
+    for lb in issue.get("labels", []) or []:
+        name = lb.get("name") if isinstance(lb, dict) else lb
+        if name == LABEL_OPUS_ATTEMPTED:
+            return True
+    return False
+
+
+def _schedule_opus_attempt(
+    issue: dict, *, reasoning: str,
+) -> Optional[str]:
+    """Stamp ``LABEL_OPUS_ATTEMPTED`` and fire ``human_to_plan_approved``.
+
+    Returns the result tag for run-log counters:
+      - ``"opus_already_attempted"`` — label already present; leaving parked.
+      - ``"opus_no_plan"``           — no stored plan to re-run; leaving parked.
+      - ``"opus_attempt_scheduled"`` — label + transition applied.
+      - ``"agent_failed"``           — label or transition call failed.
+    """
+    issue_number = issue["number"]
+
+    if _issue_has_opus_attempted(issue):
+        print(
+            f"[cai rescue] #{issue_number} already carries "
+            f"{LABEL_OPUS_ATTEMPTED}; refusing second escalation",
+            flush=True,
+        )
+        return "opus_already_attempted"
+
+    if _extract_stored_plan(issue.get("body") or "") is None:
+        print(
+            f"[cai rescue] #{issue_number} has no stored plan; "
+            f"cannot escalate to Opus-implement",
+            file=sys.stderr, flush=True,
+        )
+        return "opus_no_plan"
+
+    # Audit comment first — surviving the transition error gives an
+    # operator something to anchor on if the FSM call later fails.
+    _post_opus_escalation_comment(issue_number, reasoning=reasoning)
+
+    if not _set_labels(
+        issue_number,
+        add=[LABEL_OPUS_ATTEMPTED],
+        log_prefix="cai rescue",
+    ):
+        print(
+            f"[cai rescue] #{issue_number} failed to apply "
+            f"{LABEL_OPUS_ATTEMPTED}; aborting escalation",
+            file=sys.stderr, flush=True,
+        )
+        return "agent_failed"
+
+    current_labels = [
+        (lb.get("name") if isinstance(lb, dict) else lb)
+        for lb in issue.get("labels", []) or []
+    ]
+    ok = apply_transition(
+        issue_number, "human_to_plan_approved",
+        current_labels=current_labels,
+        log_prefix="cai rescue",
+    )
+    if not ok:
+        return "agent_failed"
+
+    print(
+        f"[cai rescue] #{issue_number} Opus escalation scheduled "
+        f"(→ PLAN_APPROVED, {LABEL_OPUS_ATTEMPTED})",
+        flush=True,
+    )
+    return "opus_attempt_scheduled"
 
 
 def _stage_prevention_finding(
@@ -308,6 +425,17 @@ def _try_rescue_issue(
             source_issue=issue_number,
             prev_text=prev_text,
         )
+
+    if verdict == "ATTEMPT_OPUS_IMPLEMENT":
+        if confidence != Confidence.HIGH:
+            print(
+                f"[cai rescue] #{issue_number} ATTEMPT_OPUS_IMPLEMENT at "
+                f"{confidence.name if confidence else 'MISSING'} confidence; "
+                f"refusing escalation",
+                flush=True,
+            )
+            return "low_confidence"
+        return _schedule_opus_attempt(issue, reasoning=reasoning)
 
     if verdict != "AUTONOMOUSLY_RESOLVABLE":
         return "truly_human_needed"

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -143,6 +143,12 @@ LABEL_PR_HUMAN_NEEDED = "auto-improve:pr-human-needed" # PRState.PR_HUMAN_NEEDED
 # divert. Replaces the previous "any admin comment triggers resume" model,
 # which fired on incidental questions and ambiguous replies.
 LABEL_HUMAN_SOLVED = "human:solved"
+# Single-use marker that `cai rescue` sets when it escalates a stuck
+# issue to an Opus-backed re-run of the implement phase. Signals the
+# downstream `cai-implement` handler to pass `--model claude-opus-4-7`,
+# and prevents a second escalation on the same issue if the Opus run
+# also parks at :human-needed.
+LABEL_OPUS_ATTEMPTED = "auto-improve:opus-attempted"
 LABEL_TRIAGING         = "auto-improve:triaging"
 LABEL_KIND_CODE        = "kind:code"
 LABEL_KIND_MAINTENANCE = "kind:maintenance"

--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -117,6 +117,7 @@ declare -A DESCRIPTIONS=(
   ["tests/test_dispatcher.py"]="Tests for the FSM dispatcher and state→handler registries"
   ["tests/test_fsm.py"]="Tests for cai_lib.fsm — states, transitions, Confidence, divert, marker, resume helpers"
   ["tests/test_unblock.py"]="Tests for cai_lib.cmd_unblock — admin-comment filtering and agent input formatting"
+  ["tests/test_rescue_opus.py"]="Tests for cai_lib.cmd_rescue — Opus-escalation verdict plumbing, schema, and one-shot label guard"
   ["tests/test_lint.py"]="Lint check: ruff must report zero violations"
   ["tests/test_multistep.py"]="Tests for multi-step plan support"
   ["tests/test_parse.py"]="Tests for parse.py signal extraction"

--- a/tests/test_rescue_opus.py
+++ b/tests/test_rescue_opus.py
@@ -1,0 +1,191 @@
+"""Tests for the Opus-escalation path in :mod:`cai_lib.cmd_rescue`.
+
+Covers the deterministic pieces added alongside the
+``ATTEMPT_OPUS_IMPLEMENT`` verdict: the schema, the
+``_issue_has_opus_attempted`` helper, the ``_schedule_opus_attempt``
+driver, and the end-to-end plumbing in ``_try_rescue_issue`` (via a
+mocked ``claude -p`` call).
+
+The heavy live-container path (invoking the Sonnet ``cai-rescue``
+subagent and the Opus ``cai-implement`` subagent) is deliberately out
+of scope — these tests only guard the glue.
+"""
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib import cmd_rescue as R  # noqa: E402
+from cai_lib.config import LABEL_OPUS_ATTEMPTED  # noqa: E402
+
+
+_PLAN_BLOCK = (
+    "<!-- cai-plan-start -->\n"
+    "## Selected Implementation Plan\n\n"
+    "Do the thing.\n"
+    "<!-- cai-plan-end -->\n"
+)
+
+
+class TestRescueJsonSchema(unittest.TestCase):
+    """The JSON schema must advertise the new verdict."""
+
+    def test_attempt_opus_implement_in_verdict_enum(self):
+        enum = R._RESCUE_JSON_SCHEMA["properties"]["verdict"]["enum"]
+        self.assertIn("ATTEMPT_OPUS_IMPLEMENT", enum)
+        # Existing verdicts must still be accepted.
+        self.assertIn("AUTONOMOUSLY_RESOLVABLE", enum)
+        self.assertIn("TRULY_HUMAN_NEEDED", enum)
+
+
+class TestIssueHasOpusAttempted(unittest.TestCase):
+
+    def test_detects_label_on_issue(self):
+        issue = {"labels": [{"name": "auto-improve:human-needed"},
+                            {"name": LABEL_OPUS_ATTEMPTED}]}
+        self.assertTrue(R._issue_has_opus_attempted(issue))
+
+    def test_missing_label(self):
+        issue = {"labels": [{"name": "auto-improve:human-needed"}]}
+        self.assertFalse(R._issue_has_opus_attempted(issue))
+
+    def test_accepts_string_label_shape(self):
+        # Some gh JSON shapes return raw strings rather than dicts.
+        issue = {"labels": [LABEL_OPUS_ATTEMPTED]}
+        self.assertTrue(R._issue_has_opus_attempted(issue))
+
+    def test_empty_labels(self):
+        self.assertFalse(R._issue_has_opus_attempted({"labels": []}))
+        self.assertFalse(R._issue_has_opus_attempted({}))
+
+
+class TestScheduleOpusAttempt(unittest.TestCase):
+
+    def _issue(self, *, labels=None, body=_PLAN_BLOCK):
+        return {
+            "number": 42,
+            "title": "widget broke",
+            "body": body,
+            "labels": labels or [{"name": "auto-improve:human-needed"}],
+            "comments": [],
+        }
+
+    def test_refuses_second_escalation(self):
+        issue = self._issue(labels=[
+            {"name": "auto-improve:human-needed"},
+            {"name": LABEL_OPUS_ATTEMPTED},
+        ])
+        with mock.patch.object(R, "_set_labels") as set_labels, \
+             mock.patch.object(R, "apply_transition") as apply_t, \
+             mock.patch.object(R, "_post_opus_escalation_comment") as cmt:
+            tag = R._schedule_opus_attempt(issue, reasoning="r")
+        self.assertEqual(tag, "opus_already_attempted")
+        set_labels.assert_not_called()
+        apply_t.assert_not_called()
+        cmt.assert_not_called()
+
+    def test_refuses_when_no_stored_plan(self):
+        issue = self._issue(body="no plan block here")
+        with mock.patch.object(R, "_set_labels") as set_labels, \
+             mock.patch.object(R, "apply_transition") as apply_t, \
+             mock.patch.object(R, "_post_opus_escalation_comment") as cmt:
+            tag = R._schedule_opus_attempt(issue, reasoning="r")
+        self.assertEqual(tag, "opus_no_plan")
+        set_labels.assert_not_called()
+        apply_t.assert_not_called()
+        cmt.assert_not_called()
+
+    def test_happy_path_stamps_label_and_fires_transition(self):
+        issue = self._issue()
+        with mock.patch.object(R, "_set_labels", return_value=True) as set_labels, \
+             mock.patch.object(R, "apply_transition", return_value=True) as apply_t, \
+             mock.patch.object(R, "_post_opus_escalation_comment", return_value=True) as cmt:
+            tag = R._schedule_opus_attempt(issue, reasoning="plan looks sound")
+        self.assertEqual(tag, "opus_attempt_scheduled")
+        # Comment is posted BEFORE labels/transition so the audit trail
+        # survives a partial failure.
+        cmt.assert_called_once()
+        self.assertEqual(cmt.call_args.kwargs["reasoning"], "plan looks sound")
+        # Label stamp.
+        set_labels.assert_called_once()
+        self.assertEqual(
+            set_labels.call_args.kwargs["add"], [LABEL_OPUS_ATTEMPTED]
+        )
+        # FSM transition.
+        apply_t.assert_called_once()
+        self.assertEqual(apply_t.call_args.args[1], "human_to_plan_approved")
+
+    def test_propagates_label_apply_failure(self):
+        issue = self._issue()
+        with mock.patch.object(R, "_set_labels", return_value=False), \
+             mock.patch.object(R, "apply_transition") as apply_t, \
+             mock.patch.object(R, "_post_opus_escalation_comment", return_value=True):
+            tag = R._schedule_opus_attempt(issue, reasoning="r")
+        self.assertEqual(tag, "agent_failed")
+        # FSM transition must NOT fire when the label stamp failed.
+        apply_t.assert_not_called()
+
+
+class TestTryRescueIssueDispatchesOpusBranch(unittest.TestCase):
+    """End-to-end: verdict=ATTEMPT_OPUS_IMPLEMENT routes to the Opus scheduler."""
+
+    def _claude_reply(self, payload):
+        proc = mock.Mock()
+        proc.returncode = 0
+        proc.stdout = json.dumps(payload)
+        proc.stderr = ""
+        return proc
+
+    def test_high_confidence_opus_verdict_schedules_escalation(self):
+        issue = {
+            "number": 7,
+            "title": "t",
+            "body": _PLAN_BLOCK,
+            "labels": [{"name": "auto-improve:human-needed"}],
+            "comments": [],
+        }
+        claude_payload = {
+            "verdict": "ATTEMPT_OPUS_IMPLEMENT",
+            "confidence": "HIGH",
+            "reasoning": "plan concrete; sonnet hit repeated test failures",
+        }
+        with mock.patch.object(
+            R, "_run_claude_p", return_value=self._claude_reply(claude_payload)
+        ), mock.patch.object(
+            R, "_schedule_opus_attempt", return_value="opus_attempt_scheduled"
+        ) as sched:
+            tag = R._try_rescue_issue(issue, prevention_findings=[])
+        self.assertEqual(tag, "opus_attempt_scheduled")
+        sched.assert_called_once()
+        # Reasoning is piped through to the comment-writer.
+        self.assertEqual(
+            sched.call_args.kwargs["reasoning"],
+            "plan concrete; sonnet hit repeated test failures",
+        )
+
+    def test_low_confidence_opus_verdict_parks(self):
+        issue = {
+            "number": 8,
+            "title": "t",
+            "body": _PLAN_BLOCK,
+            "labels": [{"name": "auto-improve:human-needed"}],
+            "comments": [],
+        }
+        claude_payload = {
+            "verdict": "ATTEMPT_OPUS_IMPLEMENT",
+            "confidence": "MEDIUM",  # below HIGH — must not act.
+            "reasoning": "not sure",
+        }
+        with mock.patch.object(
+            R, "_run_claude_p", return_value=self._claude_reply(claude_payload)
+        ), mock.patch.object(R, "_schedule_opus_attempt") as sched:
+            tag = R._try_rescue_issue(issue, prevention_findings=[])
+        self.assertEqual(tag, "low_confidence")
+        sched.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- New `ATTEMPT_OPUS_IMPLEMENT` verdict for `cai-rescue`: stamps
  `auto-improve:opus-attempted` and fires `human_to_plan_approved`
  so the next `cai implement` tick re-runs the stored plan with
  `--model claude-opus-4-7`.
- The label is the idempotency gate — a second park on the same issue
  cannot re-escalate, capping per-issue Opus cost at one retry.
- `cai-rescue` downgraded from Opus → Sonnet. It is now a pure
  classifier; Opus horsepower is spent in the implementer, not the
  decider.

## Why

Complex multi-file issues like #880 sometimes park at `:human-needed`
after the Sonnet implementer hits the spike marker or 3 consecutive
`tests_failed`. When the stored plan is concrete and the divert
reason is implementer-side horsepower (not ambiguity), it's worth
one Opus retry before leaving the issue for a human.

## Scope guardrails baked in

- Only HIGH-confidence `ATTEMPT_OPUS_IMPLEMENT` verdicts act.
- Verdict refused when the stored-plan block is missing.
- Verdict refused when `auto-improve:opus-attempted` already present
  (both at the schema level via the rescue prompt and defensively in
  `_schedule_opus_attempt`).
- Audit comment posted BEFORE label/FSM writes so the trail survives
  a partial failure.

## Files touched

- `cai_lib/config.py` — `LABEL_OPUS_ATTEMPTED` constant.
- `cai_lib/cmd_rescue.py` — schema extended, `_schedule_opus_attempt`
  helper, new verdict branch in `_try_rescue_issue`.
- `cai_lib/actions/implement.py` — passes `--model claude-opus-4-7`
  when the issue carries `LABEL_OPUS_ATTEMPTED`.
- `.claude/agents/lifecycle/cai-rescue.md` — `model: opus → sonnet`,
  new verdict documented with eligibility rules and hard rules.
- `tests/test_rescue_opus.py` — schema, helper, scheduler (happy
  path + 3 failure modes), and end-to-end routing tests.
- `scripts/generate-index.sh` + `CODEBASE_INDEX.md` — index entry
  for the new test file.

## Test plan

- [x] `python -m unittest tests.test_rescue_opus -v` — 11 new tests pass.
- [x] `python -m unittest discover -s tests` — 234 tests pass, 1 skipped
      (ruff not installed in dev env; CI will run lint).
- [ ] Live container smoke: pick one parked `:human-needed` issue with
      a stored plan, manually run `cai rescue`, verify the comment +
      label + FSM transition fire and that the next implement tick
      invokes `claude -p --agent cai-implement --model claude-opus-4-7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)