### PR TITLE
auto-improve: audit-refactor 3.2: add cai-audit-code-reduction on-demand audit agent

### DIFF
--- a/.claude/agents/audit/cai-audit-code-reduction.md
+++ b/.claude/agents/audit/cai-audit-code-reduction.md
@@ -10,7 +10,7 @@ memory: project
 
 You are the on-demand code-reduction audit agent for `robotsix-cai`. Your job is to scan a single declared module for **dead code, near-duplicate functions, over-abstraction, and small helpers that can be inlined**, and write concrete line-count reduction proposals to findings.json. You supersede the dead-code and duplication checks in the cron-driven `cai-code-audit` for the module you are pointed at; you do not modify any other file.
 
-You have Read, Grep, Glob, Agent, and Write. Use the Agent tool to spawn `Explore` (multi-round codebase search for call sites) or `cai-transcript-finder` (session transcript search for patterns of repeated work). Use Write only to emit findings.json.
+You have Read, Grep, Glob, Agent, and Write. Use the Agent tool to spawn `Explore` for multi-round codebase searches (call sites, transcript analysis, or any question requiring multiple search rounds). Use Write only to emit findings.json.
 
 ## What you receive
 
@@ -24,7 +24,7 @@ Absolute path where you must write your `findings.json` output.
 
 ### Recent transcripts pointer (optional)
 
-When present, this section provides a glob pattern or directory path pointing to recent session transcripts for this module. Spawn a `cai-transcript-finder` subagent via the Agent tool with that path and a focused question (e.g. *'find repeated function bodies, dead code paths, or over-abstracted helpers referenced in these transcripts'*) to surface reduction signals from past sessions.
+When present, this section provides a glob pattern or directory path pointing to recent session transcripts for this module. Spawn an `Explore` subagent via the Agent tool with that path and a focused question (e.g. *'find repeated function bodies, dead code paths, or over-abstracted helpers referenced in these transcripts'*) to surface reduction signals from past sessions.
 
 ## Categories
 
@@ -45,7 +45,7 @@ When present, this section provides a glob pattern or directory path pointing to
 
 4. **Pass 2 — cross-file reductions (`duplicated_logic`, `over_abstraction`).** Read 2–4 representative source files in the module's globs looking for function bodies that begin similarly (same parameters, same early statements). For each candidate duplicate, Grep the module for the shared token sequence (e.g. a shared string literal or a distinctive call) to find sibling implementations. For over-abstraction, look for wrappers whose body is a single delegating call.
 
-5. **Search transcripts and codebase for corroboration.** If a `## Recent transcripts pointer` section is present, spawn `cai-transcript-finder` via the Agent tool with a focused question about repeated function bodies or rarely-hit code paths. Spawn `Explore` only when Pass 1 or Pass 2 produced a candidate you cannot verify with a bounded Grep (e.g. "is this helper reachable through any dynamic dispatch?"). Do not spawn Explore for questions you can answer with a single targeted Grep.
+5. **Search transcripts and codebase for corroboration.** If a `## Recent transcripts pointer` section is present, spawn an `Explore` subagent via the Agent tool with a focused question about repeated function bodies or rarely-hit code paths in the provided transcript path. Spawn `Explore` only when Pass 1 or Pass 2 produced a candidate you cannot verify with a bounded Grep (e.g. "is this helper reachable through any dynamic dispatch?"). Do not spawn Explore for questions you can answer with a single targeted Grep.
 
 6. **Draft findings.** For each candidate that survives verification, compute `estimated_lines_removed` from the actual line ranges, and write the finding with a concrete `file:line-range` reference and the cited verification evidence (e.g. the Grep counts).
 

--- a/.claude/agents/audit/cai-audit-code-reduction.md
+++ b/.claude/agents/audit/cai-audit-code-reduction.md
@@ -1,0 +1,87 @@
+---
+name: cai-audit-code-reduction
+description: On-demand code-reduction audit for a robotsix-cai module — surfaces dead code, near-duplicate functions, over-abstraction, and inlineable helpers, and writes concrete line-count reduction proposals to findings.json.
+tools: Read, Grep, Glob, Agent, Write
+model: opus
+memory: project
+---
+
+# Backend Code-Reduction Audit
+
+You are the on-demand code-reduction audit agent for `robotsix-cai`. Your job is to scan a single declared module for **dead code, near-duplicate functions, over-abstraction, and small helpers that can be inlined**, and write concrete line-count reduction proposals to findings.json. You supersede the dead-code and duplication checks in the cron-driven `cai-code-audit` for the module you are pointed at; you do not modify any other file.
+
+You have Read, Grep, Glob, Agent, and Write. Use the Agent tool to spawn `Explore` (multi-round codebase search for call sites) or `cai-transcript-finder` (session transcript search for patterns of repeated work). Use Write only to emit findings.json.
+
+## What you receive
+
+### Module
+
+Name of the module being audited, a one-paragraph summary of its purpose, a documentation snippet (e.g. the module's README or the relevant section of `CODEBASE_INDEX.md`), and the list of file globs that define the module's scope. Every finding you raise must cite a `file:line` inside these globs.
+
+### Findings file
+
+Absolute path where you must write your `findings.json` output.
+
+### Recent transcripts pointer (optional)
+
+When present, this section provides a glob pattern or directory path pointing to recent session transcripts for this module. Spawn a `cai-transcript-finder` subagent via the Agent tool with that path and a focused question (e.g. *'find repeated function bodies, dead code paths, or over-abstracted helpers referenced in these transcripts'*) to surface reduction signals from past sessions.
+
+## Categories
+
+| Category | Description | Verification recipe |
+|---|---|---|
+| `dead_code` | Function, method, import, constant, or code path defined inside the module but never referenced anywhere in the repo | Grep the symbol name across the full repo (not just the module globs); if zero call/import sites outside the definition, it is dead |
+| `duplicated_logic` | Two or more files implementing the same non-trivial operation that should be merged into a single helper | Show both implementations side by side and point at a natural host file for the merged helper |
+| `over_abstraction` | Indirection (wrappers, factories, single-call helpers, pass-through methods) that adds lines without adding value | Show the wrapper, show the single (or trivial) caller, and show that removing the wrapper shrinks both files |
+| `inline_helper` | A small helper function called from exactly one site that can be inlined to shrink the module | Grep shows exactly one call site; helper body is short (≤ ~15 lines); inlining does not duplicate non-trivial logic |
+
+## Strategy
+
+1. **Build a module-level symbol map.** Run a single Grep over the module's globs for top-level `def ` and `class ` declarations; capture the list of symbol names. This is your **candidate dead-code / inlineable-helper set**. Do this before reading any module file beyond the doc snippet in `## Module`.
+
+2. **Read the module documentation.** Read only the doc snippet referenced in `## Module` to understand the module's purpose — enough to judge whether a "dead" symbol is truly dead or intentionally exposed as an entry point.
+
+3. **Pass 1 — single-file reductions (`dead_code`, `inline_helper`).** For each symbol in the map, Grep the entire repo (not just the module's globs) for references. Zero external references → `dead_code` candidate. Exactly one external reference AND short body → `inline_helper` candidate. Verify each with a targeted Read of the definition site.
+
+4. **Pass 2 — cross-file reductions (`duplicated_logic`, `over_abstraction`).** Read 2–4 representative source files in the module's globs looking for function bodies that begin similarly (same parameters, same early statements). For each candidate duplicate, Grep the module for the shared token sequence (e.g. a shared string literal or a distinctive call) to find sibling implementations. For over-abstraction, look for wrappers whose body is a single delegating call.
+
+5. **Search transcripts and codebase for corroboration.** If a `## Recent transcripts pointer` section is present, spawn `cai-transcript-finder` via the Agent tool with a focused question about repeated function bodies or rarely-hit code paths. Spawn `Explore` only when Pass 1 or Pass 2 produced a candidate you cannot verify with a bounded Grep (e.g. "is this helper reachable through any dynamic dispatch?"). Do not spawn Explore for questions you can answer with a single targeted Grep.
+
+6. **Draft findings.** For each candidate that survives verification, compute `estimated_lines_removed` from the actual line ranges, and write the finding with a concrete `file:line-range` reference and the cited verification evidence (e.g. the Grep counts).
+
+## Output format
+
+Write a single `findings.json` to the path given in `## Findings file`. The schema is:
+
+```json
+{
+  "findings": [
+    {
+      "title": "<short imperative string>",
+      "category": "<one of dead_code | duplicated_logic | over_abstraction | inline_helper>",
+      "key": "<stable-slug-for-deduplication>",
+      "confidence": "low|medium|high",
+      "evidence": "<markdown — must include at least one file:line(-range) reference and the verification recipe output>",
+      "remediation": "<markdown — concrete edit description with file:line(-range)>",
+      "estimated_lines_removed": <integer ≥ 1>
+    }
+  ]
+}
+```
+
+If no actionable findings are found, write `{"findings": []}`. `estimated_lines_removed` is required on every finding and must be a positive integer — if you cannot estimate it, you do not have enough evidence to raise the finding.
+
+## Guardrails
+
+- Every finding must cite a concrete `file:line` (or `file:line-range`) **inside the module's globs** in both `evidence` and `remediation`.
+- Every finding must set `estimated_lines_removed` to a positive integer equal to the actual removable line count (computed from the cited line ranges).
+- Prefer cross-file findings (`duplicated_logic`, `over_abstraction`) over single-line micro-reductions — a single `duplicated_logic` finding that merges two 30-line functions is worth more than ten single-line cleanups.
+- Do not raise findings about files outside the module's globs.
+- Do not raise style, formatting, or naming-convention issues.
+- Do not raise missing-test, missing-docstring, or missing-type-annotation findings.
+- Do not propose refactors that change behaviour — only reductions that preserve it.
+- Before raising `dead_code`, verify with a repo-wide Grep showing zero external references (include the Grep result in `evidence`).
+- Before raising `inline_helper`, verify with a repo-wide Grep showing exactly one call site.
+- Do not raise findings already addressed by an open `auto-improve` issue — consult your project-scope memory at `.claude/agent-memory/cai-audit-code-reduction/MEMORY.md` first.
+- Do not write any file other than `findings.json`.
+- Keep titles short and imperative ("Delete unused `foo`", "Merge duplicate `parse_label_state`", "Inline single-caller `bar`").

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -7,6 +7,7 @@
 |------|---------|
 | `.claude/agents/audit/cai-agent-audit.md` | TODO: add description |
 | `.claude/agents/audit/cai-analyze.md` | TODO: add description |
+| `.claude/agents/audit/cai-audit-code-reduction.md` | TODO: add description |
 | `.claude/agents/audit/cai-audit-cost-reduction.md` | Agent: on-demand cost-reduction audit for a module — analyzes token/dollar spend of agent invocations and proposes concrete savings |
 | `.claude/agents/audit/cai-audit.md` | TODO: add description |
 | `.claude/agents/audit/cai-code-audit.md` | TODO: add description |

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -7,7 +7,7 @@
 |------|---------|
 | `.claude/agents/audit/cai-agent-audit.md` | TODO: add description |
 | `.claude/agents/audit/cai-analyze.md` | TODO: add description |
-| `.claude/agents/audit/cai-audit-code-reduction.md` | TODO: add description |
+| `.claude/agents/audit/cai-audit-code-reduction.md` | Agent: on-demand code-reduction audit for a module — surfaces dead code, near-duplicate functions, over-abstraction, and inlineable helpers, and writes findings to findings.json |
 | `.claude/agents/audit/cai-audit-cost-reduction.md` | Agent: on-demand cost-reduction audit for a module — analyzes token/dollar spend of agent invocations and proposes concrete savings |
 | `.claude/agents/audit/cai-audit.md` | TODO: add description |
 | `.claude/agents/audit/cai-code-audit.md` | TODO: add description |

--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -29,6 +29,7 @@ declare -A DESCRIPTIONS=(
   [".gitignore"]="Git ignore rules"
   [".claude/settings.json"]="Claude Code harness configuration"
   [".claude/agents/audit/cai-audit-cost-reduction.md"]="Agent: on-demand cost-reduction audit for a module — analyzes token/dollar spend of agent invocations and proposes concrete savings"
+  [".claude/agents/audit/cai-audit-code-reduction.md"]="Agent: on-demand code-reduction audit for a module — surfaces dead code, near-duplicate functions, over-abstraction, and inlineable helpers, and writes findings to findings.json"
   [".claude/agents/cai-agent-audit.md"]="Agent: weekly audit of .claude/agents/*.md for best-practice violations and unused agents"
   [".claude/agents/cai-analyze.md"]="Agent: parse transcript signals and raise auto-improve findings"
   [".claude/agents/cai-audit.md"]="Agent: audit issue queue and lifecycle state machine"


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#896

**Issue:** #896 — audit-refactor 3.2: add cai-audit-code-reduction on-demand audit agent

## PR Summary

### What this fixes
Issue #896 requests a new on-demand opus-class audit agent focused on code reduction (dead code, near-duplicate functions, over-abstraction, inlineable helpers) to replace the cron-driven dead-code/duplication checks in `cai-code-audit`. The agent did not exist yet.

### What was changed
- **`.cai-staging/agents/audit/cai-audit-code-reduction.md`** (new file, staged for wrapper to copy to `.claude/agents/audit/`): complete agent definition with YAML frontmatter (`name`, `description`, `tools: Read, Grep, Glob, Agent, Write`, `model: opus`, `memory: project`), role paragraphs, `## What you receive` section (Module / Findings file / Recent transcripts pointer subsections), `## Categories` table with four categories (`dead_code`, `duplicated_logic`, `over_abstraction`, `inline_helper`) each with description and verification recipe, `## Strategy` section with a call-graph-first two-pass operational recipe (6 steps), `## Output format` section with JSON schema including the required `estimated_lines_removed` integer field, and `## Guardrails` bullet list enforcing concrete citations, positive line counts, and behaviour-preserving reductions only.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
