### PR TITLE
feat(locking): cross-instance ownership lock via auto-improve:locked

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -125,6 +125,7 @@
 | `tests/test_plan.py` | TODO: add description |
 | `tests/test_pr_bounce.py` | TODO: add description |
 | `tests/test_publish.py` | Tests for publish.py issue publishing |
+| `tests/test_remote_lock.py` | TODO: add description |
 | `tests/test_rescue_opus.py` | Tests for cai_lib.cmd_rescue — Opus-escalation verdict plumbing, schema, and one-shot label guard |
 | `tests/test_retroactive_sweep.py` | TODO: add description |
 | `tests/test_revise_filter.py` | TODO: add description |

--- a/cai.py
+++ b/cai.py
@@ -220,11 +220,15 @@ The container runs `entrypoint.sh`, which executes `cai.py cycle` once
 synchronously at startup (driving the full issue-solving pipeline:
 verify → confirm → drain PRs → refine → plan → implement loop), then hands
 off to supercronic. Each cron tick is a fresh process. The pipeline is
-driven by a single `CAI_CYCLE_SCHEDULE` cron line; a flock in
-`cmd_cycle` serializes overlapping runs so issues are processed one
-at a time. Orthogonal tasks (analyze, audit, propose, update-check,
-health-report, cost-optimize, check-workflows, code-audit, agent-audit,
-external-scout) keep their own schedules and are not run at startup.
+driven by a single `CAI_CYCLE_SCHEDULE` cron line; cross-instance
+serialization is handled GitHub-side via an `auto-improve:locked`
+ownership lock (label + a `<!-- cai-lock owner=... -->` claim comment,
+acquired at every dispatch entry) so two cai instances — on the same
+host or across hosts — cannot advance the same issue/PR concurrently.
+A stale-lock watchdog expires the lock after 1h. Orthogonal tasks
+(analyze, audit, propose, update-check, health-report, cost-optimize,
+check-workflows, code-audit, agent-audit, external-scout) keep their
+own schedules and are not run at startup.
 
 The gh auth check is done once per subcommand invocation. We want a
 clear error message in docker logs if credentials ever disappear from

--- a/cai_lib/__init__.py
+++ b/cai_lib/__init__.py
@@ -46,9 +46,13 @@ from cai_lib.config import (
     LABEL_APPLIED,
     LABEL_HUMAN_NEEDED,
     LABEL_PR_HUMAN_NEEDED,
+    LABEL_LOCKED,
+    INSTANCE_ID,
+    CAI_LOCK_COMMENT_RE,
     _STALE_IN_PROGRESS_HOURS,
     _STALE_REVISING_HOURS,
     _STALE_APPLYING_HOURS,
+    _STALE_LOCKED_HOURS,
     _STALE_MERGED_DAYS,
 )
 
@@ -104,8 +108,9 @@ __all__ = [
     "LABEL_REFINING", "LABEL_PLANNING",
     "LABEL_APPLYING", "LABEL_APPLIED",
     "LABEL_HUMAN_NEEDED", "LABEL_PR_HUMAN_NEEDED",
+    "LABEL_LOCKED", "INSTANCE_ID", "CAI_LOCK_COMMENT_RE",
     "_STALE_IN_PROGRESS_HOURS", "_STALE_REVISING_HOURS", "_STALE_APPLYING_HOURS",
-    "_STALE_MERGED_DAYS",
+    "_STALE_LOCKED_HOURS", "_STALE_MERGED_DAYS",
     # logging
     "log_run", "log_cost",
     "_get_issue_category", "_log_outcome", "_load_outcome_counts",

--- a/cai_lib/cmd_cycle.py
+++ b/cai_lib/cmd_cycle.py
@@ -1,6 +1,4 @@
 """Cycle and dispatch entry-points for the cai pipeline."""
-import fcntl
-import os
 import sys
 import time
 
@@ -21,40 +19,18 @@ def _run_step(name: str, handler, args) -> int:
         return 1
 
 
-_CYCLE_LOCK_PATH = f"/tmp/cai-cycle-{REPO.replace('/', '-')}.lock"
-
-
 def cmd_cycle(args) -> int:
-    """One cycle tick under a non-blocking flock.
-
-    Delegates to :func:`_cmd_cycle_inner`, which reconciles labels,
-    runs audit, and dispatches a single actionable issue/PR via the
-    FSM dispatcher. The flock on ``_CYCLE_LOCK_PATH`` (per-repo) ensures
-    overlapping supercronic fires don't step on each other.
-    """
-    lock_fd = os.open(_CYCLE_LOCK_PATH, os.O_CREAT | os.O_RDWR, 0o644)
-    try:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except BlockingIOError:
-        os.close(lock_fd)
-        print("[cai cycle] another cycle is already running; skipping this tick",
-              flush=True)
-        return 0
-
-    try:
-        return _cmd_cycle_inner(args)
-    finally:
-        try:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-        finally:
-            os.close(lock_fd)
-
-
-def _cmd_cycle_inner(args) -> int:
     """One cycle tick: restart-recovery + dispatch one actionable issue/PR.
 
-    Verify and audit run on their own cron cadences (CAI_VERIFY_SCHEDULE,
-    CAI_AUDIT_SCHEDULE) — the cycle is purely restart-recovery + dispatch.
+    Cross-instance serialization is enforced GitHub-side via the
+    ``auto-improve:locked`` ownership lock acquired at every dispatch
+    entry (see :func:`cai_lib.github._acquire_remote_lock`); two cai
+    containers — on the same host or across hosts — cannot advance the
+    same issue/PR concurrently. A stale-lock watchdog expires the lock
+    after ``_STALE_LOCKED_HOURS`` so a crashed handler cannot strand a
+    target. Verify and audit run on their own cron cadences
+    (CAI_VERIFY_SCHEDULE, CAI_AUDIT_SCHEDULE) — the cycle itself is
+    purely restart-recovery + dispatch.
     """
     print("[cai cycle] starting cycle tick", flush=True)
     t0 = time.monotonic()

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -1,6 +1,9 @@
 """cai_lib.config — shared constants and path definitions."""
 
 import os
+import re
+import socket
+import uuid
 from pathlib import Path
 
 
@@ -77,6 +80,25 @@ def _resolve_machine_id() -> str:
 
 
 MACHINE_ID: str = _resolve_machine_id()
+
+
+def _resolve_instance_id() -> str:
+    """Globally-unique owner tag for ``auto-improve:locked`` claims.
+
+    Three parts so two cai containers on the same host never generate
+    the same tag: ``<machine_id>-<hostname>-<pid>``. Falls back to a
+    uuid4 hex when ``MACHINE_ID`` is empty so we never emit an
+    ambiguous empty prefix.
+    """
+    mid = MACHINE_ID or uuid.uuid4().hex[:12]
+    return f"{mid}-{socket.gethostname()}-{os.getpid()}"
+
+
+# Per-process owner tag posted in ``cai-lock`` claim comments. Resolved
+# at import time so a single container has one stable identity for its
+# lifetime (used by both the cycle process and any direct dispatch_*
+# callers within the same process).
+INSTANCE_ID: str = _resolve_instance_id()
 
 
 def transcript_sync_enabled() -> bool:
@@ -169,6 +191,21 @@ LABEL_PR_CI_FAILING       = "pr:ci-failing"        # PRState.CI_FAILING
 # on their decision (`label:needs-human-review`). Issue #216.
 LABEL_PR_NEEDS_HUMAN = "needs-human-review"
 
+# Cross-instance ownership lock. Orthogonal to the FSM state labels
+# (:in-progress, :applying, :revising, …) — :locked marks which cai
+# instance currently owns the issue/PR and serializes work across
+# containers/hosts. Acquired via _acquire_remote_lock at dispatch entry
+# and released via _release_remote_lock; expired by the watchdog after
+# _STALE_LOCKED_HOURS so a crashed handler can't strand a target forever.
+LABEL_LOCKED = "auto-improve:locked"
+
+# Marker comment used as the first-writer-wins arbiter for :locked. The
+# oldest comment matching this regex on an issue/PR identifies the lock
+# owner; ties are broken by GitHub comment id (monotonic).
+CAI_LOCK_COMMENT_RE = re.compile(
+    r"<!--\s*cai-lock\s+owner=(?P<owner>\S+)\s+acquired=(?P<acquired>\S+)\s*-->"
+)
+
 
 # ---------------------------------------------------------------------------
 # Run log
@@ -187,6 +224,11 @@ OUTCOME_LOG_PATH = Path("/var/log/cai/cai-outcomes.jsonl")
 _STALE_IN_PROGRESS_HOURS = 6
 _STALE_REVISING_HOURS = 1
 _STALE_APPLYING_HOURS = 2
+# Time-to-live for a remote ownership lock (LABEL_LOCKED). The watchdog
+# expires :locked after this many hours so a crashed handler cannot
+# strand a target indefinitely. 1h is short enough that recovery is
+# operational; long enough that legitimate handlers reliably finish first.
+_STALE_LOCKED_HOURS = 1
 # _STALE_NO_ACTION_DAYS retired — no-action issues are now closed, not relabeled
 _STALE_MERGED_DAYS = 14
 

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -30,7 +30,11 @@ from cai_lib.fsm import (
     IssueState, PRState,
     get_issue_state, get_pr_state,
 )
-from cai_lib.github import _gh_json
+from cai_lib.github import (
+    _gh_json,
+    _acquire_remote_lock,
+    _release_remote_lock,
+)
 from cai_lib.issues import list_sub_issues
 
 
@@ -250,7 +254,14 @@ def dispatch_issue(issue_number: int) -> int:
 
     print(f"[cai dispatch] issue #{issue_number} at {state.name} → {handler.__name__}",
           flush=True)
-    return handler(issue)
+    if not _acquire_remote_lock("issue", issue_number):
+        print(f"[cai dispatch] issue #{issue_number}: lock busy, yielding",
+              flush=True)
+        return 0
+    try:
+        return handler(issue)
+    finally:
+        _release_remote_lock("issue", issue_number)
 
 
 def dispatch_pr(pr_number: int) -> int:
@@ -289,9 +300,16 @@ def dispatch_pr(pr_number: int) -> int:
               f"mergeable={pr.get('mergeable')} / "
               f"mergeStateStatus={pr.get('mergeStateStatus')} → "
               f"{entry} → handle_rebase", flush=True)
-        apply_pr_transition(pr_number, entry, current_pr=pr,
-                            log_prefix="cai dispatch")
-        return handle_rebase(pr)
+        if not _acquire_remote_lock("pr", pr_number):
+            print(f"[cai dispatch] PR #{pr_number}: lock busy, yielding",
+                  flush=True)
+            return 0
+        try:
+            apply_pr_transition(pr_number, entry, current_pr=pr,
+                                log_prefix="cai dispatch")
+            return handle_rebase(pr)
+        finally:
+            _release_remote_lock("pr", pr_number)
 
     handler = _pr_registry().get(state)
     if handler is None:
@@ -301,7 +319,14 @@ def dispatch_pr(pr_number: int) -> int:
 
     print(f"[cai dispatch] PR #{pr_number} at {state.name} → {handler.__name__}",
           flush=True)
-    return handler(pr)
+    if not _acquire_remote_lock("pr", pr_number):
+        print(f"[cai dispatch] PR #{pr_number}: lock busy, yielding",
+              flush=True)
+        return 0
+    try:
+        return handler(pr)
+    finally:
+        _release_remote_lock("pr", pr_number)
 
 
 def _pick_oldest_actionable_target(
@@ -523,122 +548,163 @@ def _drive_target_to_completion(
 
     Every ``(kind, number)`` visited is added to ``touched`` so the outer
     drain won't re-pick the same target later in the same tick.
+
+    Lock lifecycle: an outer ``try/finally`` wraps the whole drive so a
+    single ``_release_remote_lock`` covers every exit path (returns *and*
+    uncaught exceptions). The only manual release/acquire pair sits at
+    the issue↔PR hop, where the old target must be released before the
+    new one is acquired (a ``finally``-only pattern can't sequence that).
+    The inner per-dispatch acquire/release wrappers in ``dispatch_*``
+    are no-ops while ``held`` is set thanks to the refcount in
+    ``_HELD_LOCKS``.
     """
     import time
     import traceback
 
     worst_rc = 0
     ci_polled = False
+    held: tuple[str, int] | None = None
 
-    for _ in range(_INNER_LOOP_CAP):
+    try:
         touched.add((kind, number))
-
-        # --- Pre-dispatch state ---
-        if kind == "issue":
-            pre_state = _fetch_issue_state(number)
-            if pre_state is None:
-                return worst_rc
-            if pre_state not in actionable_issue_states():
-                print(f"[cai dispatch] issue #{number} at "
-                      f"{pre_state.name} — terminal/parked, drive done",
-                      flush=True)
-                return worst_rc
-        else:
-            info = _fetch_pr_state_info(number)
-            if info is None:
-                return worst_rc
-            pre_state, _pre_pr = info
-            if pre_state not in actionable_pr_states():
-                print(f"[cai dispatch] PR #{number} at "
-                      f"{pre_state.name} — terminal/parked, drive done",
-                      flush=True)
-                return worst_rc
-
-        # --- Dispatch one handler step ---
-        try:
-            rc = dispatch_issue(number) if kind == "issue" else dispatch_pr(number)
-        except Exception:
-            traceback.print_exc()
-            print(f"[cai dispatch] handler for {kind} #{number} raised; "
-                  "stopping drive", flush=True)
-            return max(worst_rc, 1)
-        worst_rc = max(worst_rc, rc)
-
-        # --- Post-dispatch state ---
-        if kind == "issue":
-            post_state = _fetch_issue_state(number)
-            if post_state is None:
-                return worst_rc
-            # Issue→PR hop: issue advanced to PR state — drive the linked PR.
-            if post_state == IssueState.PR:
-                linked = _linked_open_pr_number(number)
-                if linked is not None and ("pr", linked) not in touched:
-                    print(f"[cai dispatch] issue #{number} advanced to PR — "
-                          f"following PR #{linked}", flush=True)
-                    kind, number = "pr", linked
-                    ci_polled = False
-                    continue
-                # No linked open PR found (orphan) or already driven.
-                return worst_rc
-            if post_state == pre_state:
-                # Handler ran but did not advance state → blocked.
-                print(f"[cai dispatch] issue #{number} at "
-                      f"{post_state.name}: no state change — blocked, "
-                      f"moving on", flush=True)
-                return worst_rc
-            # State advanced on the same issue — keep driving.
-            continue
-
-        # kind == "pr"
-        post_info = _fetch_pr_state_info(number)
-        if post_info is None:
+        if not _acquire_remote_lock(kind, number):
+            print(f"[cai dispatch] {kind} #{number}: lock busy at drive "
+                  "entry, yielding", flush=True)
             return worst_rc
-        post_state, post_pr = post_info
+        held = (kind, number)
 
-        # PR merged → hop back to the linked issue (now at MERGED) so
-        # confirm runs in the same drive.
-        if post_pr.get("mergedAt") or post_state == PRState.MERGED:
-            issue_num = _issue_number_from_pr_branch(post_pr)
-            if issue_num is not None and ("issue", issue_num) not in touched:
-                print(f"[cai dispatch] PR #{number} merged — following "
-                      f"back to issue #{issue_num}", flush=True)
-                kind, number = "issue", issue_num
-                ci_polled = False
-                continue
-            return worst_rc
+        for _ in range(_INNER_LOOP_CAP):
+            touched.add((kind, number))
 
-        if post_state != pre_state:
-            ci_polled = False
-            continue
-
-        # No state change on a PR. Brief CI poll before giving up.
-        if not ci_polled and _pr_ci_pending(post_pr):
-            print(f"[cai dispatch] PR #{number} at {post_state.name}: CI "
-                  f"pending — polling up to {_CI_POLL_MAX_SECONDS}s",
-                  flush=True)
-            waited = 0
-            while waited < _CI_POLL_MAX_SECONDS:
-                time.sleep(_CI_POLL_INTERVAL_SECONDS)
-                waited += _CI_POLL_INTERVAL_SECONDS
+            # --- Pre-dispatch state ---
+            if kind == "issue":
+                pre_state = _fetch_issue_state(number)
+                if pre_state is None:
+                    return worst_rc
+                if pre_state not in actionable_issue_states():
+                    print(f"[cai dispatch] issue #{number} at "
+                          f"{pre_state.name} — terminal/parked, drive done",
+                          flush=True)
+                    return worst_rc
+            else:
                 info = _fetch_pr_state_info(number)
                 if info is None:
                     return worst_rc
-                _, polled_pr = info
-                if not _pr_ci_pending(polled_pr):
-                    print(f"[cai dispatch] PR #{number}: CI settled after "
-                          f"{waited}s — retrying dispatch", flush=True)
-                    break
-            ci_polled = True
-            continue
+                pre_state, _pre_pr = info
+                if pre_state not in actionable_pr_states():
+                    print(f"[cai dispatch] PR #{number} at "
+                          f"{pre_state.name} — terminal/parked, drive done",
+                          flush=True)
+                    return worst_rc
 
-        print(f"[cai dispatch] PR #{number} at {post_state.name}: no state "
-              f"change and no CI to wait on — blocked, moving on",
-              flush=True)
-        return worst_rc
+            # --- Dispatch one handler step ---
+            try:
+                rc = dispatch_issue(number) if kind == "issue" else dispatch_pr(number)
+            except Exception:
+                traceback.print_exc()
+                print(f"[cai dispatch] handler for {kind} #{number} raised; "
+                      "stopping drive", flush=True)
+                return max(worst_rc, 1)
+            worst_rc = max(worst_rc, rc)
 
-    print(f"[cai dispatch] inner driver hit cap "
-          f"({_INNER_LOOP_CAP}) on {kind} #{number}", flush=True)
-    return max(worst_rc, 1)
+            # --- Post-dispatch state ---
+            if kind == "issue":
+                post_state = _fetch_issue_state(number)
+                if post_state is None:
+                    return worst_rc
+                # Issue→PR hop: issue advanced to PR state — drive the linked PR.
+                if post_state == IssueState.PR:
+                    linked = _linked_open_pr_number(number)
+                    if linked is not None and ("pr", linked) not in touched:
+                        print(f"[cai dispatch] issue #{number} advanced to PR — "
+                              f"following PR #{linked}", flush=True)
+                        # Manual release/acquire — finally can't sequence
+                        # release-old-then-acquire-new across a continue.
+                        if held is not None:
+                            _release_remote_lock(*held)
+                            held = None
+                        kind, number = "pr", linked
+                        if not _acquire_remote_lock(kind, number):
+                            print(f"[cai dispatch] {kind} #{number}: lock "
+                                  "busy after issue→PR hop, yielding",
+                                  flush=True)
+                            return worst_rc
+                        held = (kind, number)
+                        ci_polled = False
+                        continue
+                    # No linked open PR found (orphan) or already driven.
+                    return worst_rc
+                if post_state == pre_state:
+                    # Handler ran but did not advance state → blocked.
+                    print(f"[cai dispatch] issue #{number} at "
+                          f"{post_state.name}: no state change — blocked, "
+                          f"moving on", flush=True)
+                    return worst_rc
+                # State advanced on the same issue — keep driving.
+                continue
+
+            # kind == "pr"
+            post_info = _fetch_pr_state_info(number)
+            if post_info is None:
+                return worst_rc
+            post_state, post_pr = post_info
+
+            # PR merged → hop back to the linked issue (now at MERGED) so
+            # confirm runs in the same drive.
+            if post_pr.get("mergedAt") or post_state == PRState.MERGED:
+                issue_num = _issue_number_from_pr_branch(post_pr)
+                if issue_num is not None and ("issue", issue_num) not in touched:
+                    print(f"[cai dispatch] PR #{number} merged — following "
+                          f"back to issue #{issue_num}", flush=True)
+                    if held is not None:
+                        _release_remote_lock(*held)
+                        held = None
+                    kind, number = "issue", issue_num
+                    if not _acquire_remote_lock(kind, number):
+                        print(f"[cai dispatch] {kind} #{number}: lock "
+                              "busy after PR→issue hop, yielding",
+                              flush=True)
+                        return worst_rc
+                    held = (kind, number)
+                    ci_polled = False
+                    continue
+                return worst_rc
+
+            if post_state != pre_state:
+                ci_polled = False
+                continue
+
+            # No state change on a PR. Brief CI poll before giving up.
+            if not ci_polled and _pr_ci_pending(post_pr):
+                print(f"[cai dispatch] PR #{number} at {post_state.name}: CI "
+                      f"pending — polling up to {_CI_POLL_MAX_SECONDS}s",
+                      flush=True)
+                waited = 0
+                while waited < _CI_POLL_MAX_SECONDS:
+                    time.sleep(_CI_POLL_INTERVAL_SECONDS)
+                    waited += _CI_POLL_INTERVAL_SECONDS
+                    info = _fetch_pr_state_info(number)
+                    if info is None:
+                        return worst_rc
+                    _, polled_pr = info
+                    if not _pr_ci_pending(polled_pr):
+                        print(f"[cai dispatch] PR #{number}: CI settled after "
+                              f"{waited}s — retrying dispatch", flush=True)
+                        break
+                ci_polled = True
+                continue
+
+            print(f"[cai dispatch] PR #{number} at {post_state.name}: no state "
+                  f"change and no CI to wait on — blocked, moving on",
+                  flush=True)
+            return worst_rc
+
+        print(f"[cai dispatch] inner driver hit cap "
+              f"({_INNER_LOOP_CAP}) on {kind} #{number}", flush=True)
+        return max(worst_rc, 1)
+    finally:
+        if held is not None:
+            _release_remote_lock(*held)
 
 
 def dispatch_drain(max_iter: int = _DEFAULT_DRAIN_MAX_ITER) -> int:

--- a/cai_lib/github.py
+++ b/cai_lib/github.py
@@ -5,11 +5,15 @@ import os
 import re
 import subprocess
 import sys
+import time
+
+from datetime import datetime, timezone
 
 from cai_lib.config import (
     REPO, TRANSCRIPT_DIR,
     LABEL_IN_PROGRESS, LABEL_PR_OPEN, LABEL_MERGE_BLOCKED,
     LABEL_REVISING, LABEL_RAISED, LABEL_REFINED,
+    LABEL_LOCKED, INSTANCE_ID, CAI_LOCK_COMMENT_RE,
 )
 from cai_lib.logging_utils import log_run
 from cai_lib.subprocess_utils import _run
@@ -457,6 +461,214 @@ def _close_orphaned_prs(*, log_prefix: str = "cai") -> list[dict]:
         closed_rows.append({"pr": pr_number, "issue": issue_number})
 
     return closed_rows
+
+
+# ---------------------------------------------------------------------------
+# Cross-instance ownership lock — auto-improve:locked
+# ---------------------------------------------------------------------------
+#
+# Problem: nothing prevents two cai containers (different hosts, or two
+# containers on the same host) from picking up the same issue/PR in the
+# same tick. Local flock is per-container, FSM label transitions are
+# non-atomic gh edits. Solution: a first-writer-wins remote lock keyed
+# on the LABEL_LOCKED label plus a ``<!-- cai-lock owner=... -->`` claim
+# comment, with the oldest claim comment as the arbiter.
+#
+# _HELD_LOCKS is a refcount map (NOT a set) because the drain driver
+# wraps the whole drive in a lock, then dispatch_issue/dispatch_pr also
+# wrap their own dispatch — when the inner wrapper releases, the outer
+# drive must still hold. Refcount lets the inner acquire/release pair
+# bump and decrement without touching GitHub.
+_HELD_LOCKS: dict[tuple[str, int], int] = {}
+
+# Stabilization-poll constants. After posting our claim comment we poll
+# the comment list until two consecutive fetches return the same ordered
+# set of cai-lock comments, mitigating GitHub's read-after-write replica
+# lag (seen as both instances thinking they are the oldest claim).
+_LOCK_STABILIZE_TIMEOUT_S = 3.0
+_LOCK_STABILIZE_INTERVAL_S = 0.5
+
+
+def _delete_issue_comment(comment_id: int, *, log_prefix: str = "cai lock") -> bool:
+    """Best-effort delete of an issue/PR comment via the REST API.
+
+    GitHub uses a single ``/repos/{owner}/{repo}/issues/comments/{id}``
+    endpoint for both issue comments and the issue-level comments on
+    PRs (the ``cai-lock`` claims are always posted there). Failures are
+    logged but swallowed — the watchdog finishes any cleanup the
+    release path could not.
+    """
+    result = _run(
+        ["gh", "api", "-X", "DELETE",
+         f"/repos/{REPO}/issues/comments/{comment_id}"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"[{log_prefix}] failed to delete comment {comment_id}: "
+            f"{result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def _list_lock_comments(number: int) -> list[dict]:
+    """Return ``cai-lock`` claim comments on issue/PR ``number``, ordered oldest-first.
+
+    Uses the issues comments endpoint (works for both issues and PRs —
+    the issue-level comments on a PR live there). Sort key is
+    ``(created_at, id)`` so a same-millisecond tie still has a
+    deterministic winner via the monotonic comment id.
+    """
+    try:
+        comments = _gh_json([
+            "api", f"/repos/{REPO}/issues/{number}/comments",
+            "--paginate",
+        ]) or []
+    except subprocess.CalledProcessError:
+        return []
+    out: list[dict] = []
+    for c in comments:
+        body = c.get("body", "") or ""
+        m = CAI_LOCK_COMMENT_RE.search(body)
+        if not m:
+            continue
+        out.append({
+            "id": c.get("id"),
+            "owner": m.group("owner"),
+            "created_at": c.get("created_at", ""),
+        })
+    out.sort(key=lambda c: (c.get("created_at", ""), c.get("id", 0)))
+    return out
+
+
+def _acquire_remote_lock(kind: str, number: int) -> bool:
+    """Attempt to acquire the cross-instance lock on issue/PR ``number``.
+
+    Returns True when this process now owns the lock, False when another
+    instance won the race (the caller must yield without dispatching).
+    Re-entry is idempotent: a second call from the same process bumps a
+    refcount and returns True without any GitHub round-trip.
+
+    Protocol:
+      1. Add LABEL_LOCKED via the appropriate label helper.
+      2. Post a ``<!-- cai-lock owner=INSTANCE_ID acquired=... -->``
+         claim comment.
+      3. Poll the lock-comment list until two consecutive snapshots
+         agree (or the timeout elapses), to dampen GitHub
+         read-after-write replica lag.
+      4. The owner of the oldest comment wins; losers strip
+         LABEL_LOCKED and delete their losing claim comment.
+    """
+    key = (kind, number)
+    if key in _HELD_LOCKS:
+        _HELD_LOCKS[key] += 1
+        return True
+
+    if kind == "issue":
+        labelled = _set_labels(number, add=[LABEL_LOCKED], log_prefix="cai lock")
+    else:
+        labelled = _set_pr_labels(number, add=[LABEL_LOCKED], log_prefix="cai lock")
+    if not labelled:
+        return False
+
+    acquired = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    body = f"<!-- cai-lock owner={INSTANCE_ID} acquired={acquired} -->"
+    posted = (_post_issue_comment if kind == "issue" else _post_pr_comment)(
+        number, body, log_prefix="cai lock"
+    )
+    if not posted:
+        # Couldn't post — strip the label so we don't strand the target
+        # behind a label nobody can release without watchdog help.
+        if kind == "issue":
+            _set_labels(number, remove=[LABEL_LOCKED], log_prefix="cai lock")
+        else:
+            _set_pr_labels(number, remove=[LABEL_LOCKED], log_prefix="cai lock")
+        return False
+
+    locks = _stabilize_lock_comments(number)
+
+    if not locks:
+        # Replica still lagging or list endpoint failed entirely. Treat
+        # as "did not acquire" rather than risk two instances both thinking
+        # they own the target — and clean up so the watchdog isn't needed.
+        if kind == "issue":
+            _set_labels(number, remove=[LABEL_LOCKED], log_prefix="cai lock")
+        else:
+            _set_pr_labels(number, remove=[LABEL_LOCKED], log_prefix="cai lock")
+        return False
+
+    winner = locks[0]["owner"]
+    if winner == INSTANCE_ID:
+        _HELD_LOCKS[key] = 1
+        print(f"[cai lock] acquired {kind} #{number}", flush=True)
+        return True
+
+    # Lost the race. Delete only our own claim comment; do NOT remove
+    # LABEL_LOCKED — the winner's comment is still the oldest and the
+    # label belongs to them. The winner removes the label on release;
+    # the watchdog removes it after _STALE_LOCKED_HOURS if the winner
+    # crashes.
+    for entry in locks:
+        if entry.get("owner") == INSTANCE_ID and entry.get("id") is not None:
+            _delete_issue_comment(int(entry["id"]))
+    print(
+        f"[cai lock] lost {kind} #{number} to {winner}",
+        flush=True,
+    )
+    return False
+
+
+def _stabilize_lock_comments(number: int) -> list[dict]:
+    """Poll the cai-lock comment list until two consecutive snapshots agree.
+
+    Closes GitHub's read-after-write replica-lag window between posting
+    a claim and reading the ordered set of claims. Returns the last
+    snapshot when the timeout elapses without convergence.
+    """
+    deadline = time.monotonic() + _LOCK_STABILIZE_TIMEOUT_S
+    prev: list[dict] = _list_lock_comments(number)
+    while time.monotonic() < deadline:
+        time.sleep(_LOCK_STABILIZE_INTERVAL_S)
+        curr = _list_lock_comments(number)
+        # Compare ordered (id, owner) tuples — created_at can drift if
+        # GitHub rewrites timestamps server-side, but ids are stable.
+        prev_key = [(c.get("id"), c.get("owner")) for c in prev]
+        curr_key = [(c.get("id"), c.get("owner")) for c in curr]
+        if prev_key == curr_key and curr:
+            return curr
+        prev = curr
+    return prev
+
+
+def _release_remote_lock(kind: str, number: int) -> bool:
+    """Release a previously-acquired ownership lock. Idempotent.
+
+    Decrements the refcount; only performs GitHub cleanup (delete claim
+    comment + remove label) when the count reaches zero, which lets the
+    drain-level outer acquire keep the lock while inner dispatch_*
+    wrappers acquire/release around their own work.
+    """
+    key = (kind, number)
+    if key not in _HELD_LOCKS:
+        return True
+    _HELD_LOCKS[key] -= 1
+    if _HELD_LOCKS[key] > 0:
+        return True
+
+    locks = _list_lock_comments(number)
+    for entry in locks:
+        if entry.get("owner") == INSTANCE_ID and entry.get("id") is not None:
+            _delete_issue_comment(int(entry["id"]))
+
+    if kind == "issue":
+        _set_labels(number, remove=[LABEL_LOCKED], log_prefix="cai lock")
+    else:
+        _set_pr_labels(number, remove=[LABEL_LOCKED], log_prefix="cai lock")
+
+    del _HELD_LOCKS[key]
+    return True
 
 
 def close_issue_completed(

--- a/cai_lib/watchdog.py
+++ b/cai_lib/watchdog.py
@@ -19,13 +19,16 @@ from cai_lib.config import (
     LABEL_IN_PROGRESS,
     LABEL_REVISING,
     LABEL_APPLYING,
+    LABEL_LOCKED,
     LABEL_RAISED,
     LABEL_REFINED,
+    CAI_LOCK_COMMENT_RE,
     _STALE_IN_PROGRESS_HOURS,
     _STALE_REVISING_HOURS,
     _STALE_APPLYING_HOURS,
+    _STALE_LOCKED_HOURS,
 )
-from cai_lib.github import _gh_json, _set_labels
+from cai_lib.github import _gh_json, _set_labels, _delete_issue_comment
 from cai_lib.logging_utils import log_run
 
 
@@ -39,7 +42,7 @@ def _rollback_stale_in_progress(*, immediate: bool = False) -> list[dict]:
     Returns the list of issues that were rolled back.
     """
     all_issues = []
-    for lock_label in (LABEL_IN_PROGRESS, LABEL_REVISING, LABEL_APPLYING):
+    for lock_label in (LABEL_IN_PROGRESS, LABEL_REVISING, LABEL_APPLYING, LABEL_LOCKED):
         try:
             issues = _gh_json([
                 "issue", "list",
@@ -100,6 +103,8 @@ def _rollback_stale_in_progress(*, immediate: bool = False) -> list[dict]:
             ttl_hours = _STALE_REVISING_HOURS
         elif lock_label == LABEL_APPLYING:
             ttl_hours = _STALE_APPLYING_HOURS
+        elif lock_label == LABEL_LOCKED:
+            ttl_hours = _STALE_LOCKED_HOURS
         else:
             ttl_hours = _STALE_IN_PROGRESS_HOURS
         threshold = 0 if immediate else ttl_hours * 3600
@@ -128,6 +133,31 @@ def _rollback_stale_in_progress(*, immediate: bool = False) -> list[dict]:
                     remove=[LABEL_APPLYING],
                     log_prefix="cai audit",
                 )
+            elif lock_label == LABEL_LOCKED:
+                # Ownership lock: orthogonal to FSM state — only strip the
+                # :locked label and delete any cai-lock claim comments.
+                # The FSM state label (:in-progress, :revising, …) stays
+                # untouched so the regular per-state TTL still applies.
+                ok = _set_labels(
+                    issue_num,
+                    remove=[LABEL_LOCKED],
+                    log_prefix="cai audit",
+                )
+                if ok:
+                    try:
+                        comments = _gh_json([
+                            "api", f"/repos/{REPO}/issues/{issue_num}/comments",
+                            "--paginate",
+                        ]) or []
+                    except subprocess.CalledProcessError:
+                        comments = []
+                    for c in comments:
+                        body = c.get("body", "") or ""
+                        if CAI_LOCK_COMMENT_RE.search(body):
+                            cid = c.get("id")
+                            if cid is not None:
+                                _delete_issue_comment(int(cid),
+                                                      log_prefix="cai audit")
             else:
                 # In-progress lock: roll back to :refined.
                 # Audit-originated issues carry an "audit" source tag so they

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -100,7 +100,34 @@ def _pr(number: int, label: str | None, merged: bool = False,
     }
 
 
-class TestDispatchIssue(unittest.TestCase):
+class _LockNoopMixin:
+    """Patch the cross-instance ownership lock helpers to no-ops.
+
+    Production dispatch acquires LABEL_LOCKED via gh on entry and releases
+    it on exit. These tests stub the lock so the existing happy-path
+    routing assertions don't have to thread a fake gh comments backend
+    through every test. The dedicated lock semantics live in
+    tests/test_remote_lock.py.
+    """
+
+    def setUp(self):
+        self._lock_acq = patch.object(
+            dispatcher, "_acquire_remote_lock", return_value=True
+        )
+        self._lock_rel = patch.object(
+            dispatcher, "_release_remote_lock", return_value=True
+        )
+        self._lock_acq.start()
+        self._lock_rel.start()
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+        self._lock_acq.stop()
+        self._lock_rel.stop()
+
+
+class TestDispatchIssue(_LockNoopMixin, unittest.TestCase):
     """dispatch_issue fetches the issue and routes by FSM label."""
 
     def _run_routing(self, label: str, expected_state: IssueState):
@@ -152,7 +179,7 @@ class TestDispatchIssue(unittest.TestCase):
 # dispatch_pr routing
 # ---------------------------------------------------------------------------
 
-class TestDispatchPR(unittest.TestCase):
+class TestDispatchPR(_LockNoopMixin, unittest.TestCase):
     """dispatch_pr fetches the PR and routes by FSM label / merged flag."""
 
     def _run_routing(self, pr: dict, expected_state: PRState):
@@ -254,7 +281,7 @@ class TestDispatchPR(unittest.TestCase):
 # dispatch_drain (and the dispatch_oldest_actionable alias)
 # ---------------------------------------------------------------------------
 
-class TestDispatchOldestActionable(unittest.TestCase):
+class TestDispatchOldestActionable(_LockNoopMixin, unittest.TestCase):
     """Picks the oldest (by createdAt) across issues + PRs and drives each
     picked target end-to-end before moving on to the next."""
 
@@ -380,7 +407,7 @@ class TestDispatchOldestActionable(unittest.TestCase):
         dp.assert_not_called()
 
 
-class TestDispatchDrain(unittest.TestCase):
+class TestDispatchDrain(_LockNoopMixin, unittest.TestCase):
     """dispatch_drain picks oldest target, drives it end-to-end, repeats
     until the queue is empty or the per-drain cap is hit."""
 

--- a/tests/test_remote_lock.py
+++ b/tests/test_remote_lock.py
@@ -1,0 +1,269 @@
+"""Tests for cai_lib.github._acquire_remote_lock / _release_remote_lock and
+the dispatcher's drive-time integration.
+
+The lock is exercised against an in-memory fake gh backend so the test is
+deterministic and doesn't need network access. The fake stores per-target
+labels and comments and serves them back through the same _gh_json /
+_set_labels / _post_*_comment / _delete_issue_comment seams that the
+production code uses.
+
+Note on hostname/PID resolution: ``INSTANCE_ID`` is computed at import
+time from the running PID, so tests that simulate two instances must
+monkeypatch ``cai_lib.config.INSTANCE_ID`` AND ``cai_lib.github.INSTANCE_ID``
+between calls (github.py imports the symbol by name).
+"""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib import dispatcher, github
+from cai_lib.config import LABEL_LOCKED
+from cai_lib.fsm import IssueState
+
+
+class _FakeGitHub:
+    """In-memory backend for issues/PRs with labels + comments.
+
+    Comment ids are monotonic. created_at is a synthetic ISO8601 timestamp
+    that increments per post so ordering is deterministic.
+    """
+
+    def __init__(self):
+        # number -> {"labels": set, "comments": [{id, body, created_at}]}
+        self.targets: dict[int, dict] = {}
+        self._next_id = 1
+        self._tick = 0
+
+    def _ensure(self, number: int) -> dict:
+        return self.targets.setdefault(
+            number, {"labels": set(), "comments": []}
+        )
+
+    def list_comments(self, number: int) -> list[dict]:
+        return list(self._ensure(number)["comments"])
+
+    def post_comment(self, number: int, body: str) -> int:
+        self._tick += 1
+        cid = self._next_id
+        self._next_id += 1
+        self._ensure(number)["comments"].append({
+            "id": cid,
+            "body": body,
+            "created_at": f"2026-04-19T00:00:{self._tick:02d}Z",
+        })
+        return cid
+
+    def delete_comment(self, comment_id: int) -> bool:
+        for t in self.targets.values():
+            t["comments"] = [c for c in t["comments"] if c["id"] != comment_id]
+        return True
+
+    def add_label(self, number: int, label: str) -> bool:
+        self._ensure(number)["labels"].add(label)
+        return True
+
+    def remove_label(self, number: int, label: str) -> bool:
+        self._ensure(number)["labels"].discard(label)
+        return True
+
+
+def _install_fake(fake: _FakeGitHub):
+    """Return a list of patcher contexts that wire ``fake`` into github.*.
+
+    Use as ``with contextlib.ExitStack() as stack: [stack.enter_context(p) for p in _install_fake(fake)]``.
+    """
+    def fake_set_labels(number, *, add=(), remove=(), log_prefix="cai"):
+        for lb in add:
+            fake.add_label(number, lb)
+        for lb in remove:
+            fake.remove_label(number, lb)
+        return True
+
+    def fake_set_pr_labels(number, *, add=(), remove=(), log_prefix="cai"):
+        for lb in add:
+            fake.add_label(number, lb)
+        for lb in remove:
+            fake.remove_label(number, lb)
+        return True
+
+    def fake_post_issue_comment(number, body, *, log_prefix="cai"):
+        fake.post_comment(number, body)
+        return True
+
+    def fake_post_pr_comment(number, body, *, log_prefix="cai"):
+        fake.post_comment(number, body)
+        return True
+
+    def fake_delete(comment_id, *, log_prefix="cai"):
+        return fake.delete_comment(comment_id)
+
+    def fake_gh_json(args):
+        # Only the comments-list call goes through here for the lock helpers.
+        # Args look like ["api", "/repos/.../issues/<n>/comments", "--paginate"].
+        if len(args) >= 2 and args[0] == "api" and "/comments" in args[1]:
+            # Parse /repos/<owner>/<repo>/issues/<n>/comments
+            path_parts = args[1].split("/")
+            try:
+                idx = path_parts.index("issues")
+                number = int(path_parts[idx + 1])
+            except (ValueError, IndexError):
+                return []
+            return fake.list_comments(number)
+        return []
+
+    return [
+        patch.object(github, "_set_labels", side_effect=fake_set_labels),
+        patch.object(github, "_set_pr_labels", side_effect=fake_set_pr_labels),
+        patch.object(github, "_post_issue_comment", side_effect=fake_post_issue_comment),
+        patch.object(github, "_post_pr_comment", side_effect=fake_post_pr_comment),
+        patch.object(github, "_delete_issue_comment", side_effect=fake_delete),
+        patch.object(github, "_gh_json", side_effect=fake_gh_json),
+    ]
+
+
+class TestAcquireRelease(unittest.TestCase):
+    def setUp(self):
+        # Make stabilization poll fast — patch its constants.
+        self._stab_timeout = patch.object(
+            github, "_LOCK_STABILIZE_TIMEOUT_S", 0.05
+        )
+        self._stab_interval = patch.object(
+            github, "_LOCK_STABILIZE_INTERVAL_S", 0.01
+        )
+        self._stab_timeout.start()
+        self._stab_interval.start()
+        # Reset module-level refcount between tests.
+        github._HELD_LOCKS.clear()
+
+    def tearDown(self):
+        self._stab_timeout.stop()
+        self._stab_interval.stop()
+        github._HELD_LOCKS.clear()
+
+    def _with_fake(self, fake):
+        from contextlib import ExitStack
+        stack = ExitStack()
+        for p in _install_fake(fake):
+            stack.enter_context(p)
+        return stack
+
+    def test_acquire_happy_path(self):
+        fake = _FakeGitHub()
+        with self._with_fake(fake):
+            with patch.object(github, "INSTANCE_ID", "instance-A"):
+                ok = github._acquire_remote_lock("issue", 42)
+        self.assertTrue(ok)
+        self.assertIn(("issue", 42), github._HELD_LOCKS)
+        target = fake.targets[42]
+        self.assertIn(LABEL_LOCKED, target["labels"])
+        # Exactly one cai-lock comment, owned by us.
+        lock_comments = [
+            c for c in target["comments"] if "cai-lock" in c["body"]
+        ]
+        self.assertEqual(len(lock_comments), 1)
+        self.assertIn("owner=instance-A", lock_comments[0]["body"])
+
+    def test_acquire_idempotent_refcount(self):
+        fake = _FakeGitHub()
+        with self._with_fake(fake):
+            with patch.object(github, "INSTANCE_ID", "instance-A"):
+                self.assertTrue(github._acquire_remote_lock("issue", 7))
+                self.assertTrue(github._acquire_remote_lock("issue", 7))
+                self.assertEqual(github._HELD_LOCKS[("issue", 7)], 2)
+                # Only one comment posted across two acquires.
+                lock_comments = [
+                    c for c in fake.targets[7]["comments"]
+                    if "cai-lock" in c["body"]
+                ]
+                self.assertEqual(len(lock_comments), 1)
+                # First release decrements but does NOT clean up.
+                github._release_remote_lock("issue", 7)
+                self.assertEqual(github._HELD_LOCKS[("issue", 7)], 1)
+                self.assertIn(LABEL_LOCKED, fake.targets[7]["labels"])
+                # Second release does the GitHub cleanup.
+                github._release_remote_lock("issue", 7)
+                self.assertNotIn(("issue", 7), github._HELD_LOCKS)
+                self.assertNotIn(LABEL_LOCKED, fake.targets[7]["labels"])
+                self.assertEqual(
+                    [c for c in fake.targets[7]["comments"] if "cai-lock" in c["body"]],
+                    [],
+                )
+
+    def test_two_instances_one_issue(self):
+        """Second acquirer sees its claim is not the oldest and yields."""
+        fake = _FakeGitHub()
+        with self._with_fake(fake):
+            # Instance A wins.
+            with patch.object(github, "INSTANCE_ID", "instance-A"):
+                self.assertTrue(github._acquire_remote_lock("issue", 99))
+            # Simulate a fresh second process: clear refcount (per-process state).
+            github._HELD_LOCKS.clear()
+            # Instance B contends.
+            with patch.object(github, "INSTANCE_ID", "instance-B"):
+                ok = github._acquire_remote_lock("issue", 99)
+        self.assertFalse(ok, "B should lose the race")
+        self.assertNotIn(("issue", 99), github._HELD_LOCKS)
+        # Exactly one cai-lock comment remains (A's), label still present
+        # because A still holds it.
+        lock_comments = [
+            c for c in fake.targets[99]["comments"] if "cai-lock" in c["body"]
+        ]
+        self.assertEqual(len(lock_comments), 1)
+        self.assertIn("owner=instance-A", lock_comments[0]["body"])
+        self.assertIn(LABEL_LOCKED, fake.targets[99]["labels"])
+
+    def test_release_idempotent_when_not_held(self):
+        # No setup, no acquire — release on an empty refcount is a no-op.
+        github._HELD_LOCKS.clear()
+        ok = github._release_remote_lock("issue", 1234)
+        self.assertTrue(ok)
+
+
+class TestDispatcherLockIntegration(unittest.TestCase):
+    """The drain driver must release the lock on every exit path —
+    including uncaught handler exceptions — via the outer try/finally.
+    """
+
+    def setUp(self):
+        github._HELD_LOCKS.clear()
+
+    def tearDown(self):
+        github._HELD_LOCKS.clear()
+
+    def test_drain_skips_when_acquire_fails(self):
+        touched: set = set()
+        with patch.object(dispatcher, "_acquire_remote_lock", return_value=False), \
+             patch.object(dispatcher, "_release_remote_lock") as rel, \
+             patch.object(dispatcher, "_fetch_issue_state") as fetch, \
+             patch.object(dispatcher, "dispatch_issue") as di:
+            rc = dispatcher._drive_target_to_completion("issue", 1, touched)
+        self.assertEqual(rc, 0)
+        # Touched marks the target so the outer drain doesn't re-pick it.
+        self.assertIn(("issue", 1), touched)
+        di.assert_not_called()
+        fetch.assert_not_called()
+        # No release because we never held it.
+        rel.assert_not_called()
+
+    def test_drive_releases_on_handler_exception(self):
+        """When dispatch_issue raises mid-loop, the finally must still release."""
+        touched: set = set()
+        # Force one loop iteration that calls dispatch_issue and raises.
+        with patch.object(dispatcher, "_acquire_remote_lock", return_value=True), \
+             patch.object(dispatcher, "_release_remote_lock") as rel, \
+             patch.object(dispatcher, "_fetch_issue_state",
+                          return_value=IssueState.REFINING), \
+             patch.object(dispatcher, "dispatch_issue",
+                          side_effect=RuntimeError("boom")):
+            rc = dispatcher._drive_target_to_completion("issue", 1, touched)
+        # Driver swallowed the exception and returned.
+        self.assertEqual(rc, 1)
+        # Critical: release MUST have been called by the finally.
+        rel.assert_called_once_with("issue", 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -26,16 +26,26 @@ def _make_issue(number, label, age_hours):
 
 class TestRollbackStaleInProgress(unittest.TestCase):
 
-    def _run_rollback(self, immediate, issues_by_label):
+    def _run_rollback(self, immediate, issues_by_label, set_labels_mock=None):
         """Run _rollback_stale_in_progress with mocked gh calls."""
 
         def fake_gh_json(args, **kwargs):
-            # Extract the --label argument
-            label = args[args.index("--label") + 1]
-            return issues_by_label.get(label, [])
+            # The :locked rollback path also calls
+            # `gh api /repos/.../issues/<n>/comments` to find cai-lock
+            # claims. Treat that call as "no comments".
+            if args and args[0] == "api":
+                return []
+            # Extract the --label argument from `gh issue list ...`.
+            if "--label" in args:
+                label = args[args.index("--label") + 1]
+                return issues_by_label.get(label, [])
+            return []
+
+        sl = set_labels_mock if set_labels_mock is not None else MagicMock(return_value=True)
 
         with patch("cai_lib.watchdog._gh_json", side_effect=fake_gh_json), \
-             patch("cai_lib.watchdog._set_labels", return_value=True), \
+             patch("cai_lib.watchdog._set_labels", sl), \
+             patch("cai_lib.watchdog._delete_issue_comment", return_value=True), \
              patch("cai_lib.watchdog.log_run"), \
              patch("cai_lib.watchdog.LOG_PATH", MagicMock(exists=lambda: False)):
             return cai._rollback_stale_in_progress(immediate=immediate)
@@ -138,6 +148,66 @@ class TestRollbackStaleInProgress(unittest.TestCase):
         nums = {i["number"] for i in result}
         self.assertNotIn(601, nums,
                          "1h-old :applying should NOT be rolled back (TTL=2h)")
+
+    def test_rollback_locked_stale(self):
+        """:locked issues older than _STALE_LOCKED_HOURS get the lock stripped.
+
+        The watchdog must NOT touch the FSM state label (:locked is
+        orthogonal). Verify by checking that _set_labels was called
+        with remove=[LABEL_LOCKED] and no add=.
+        """
+        locked_issue = _make_issue(701, cai.LABEL_LOCKED,
+                                   age_hours=cai._STALE_LOCKED_HOURS + 0.5)
+        sl_mock = MagicMock(return_value=True)
+        result = self._run_rollback(
+            immediate=False,
+            issues_by_label={
+                cai.LABEL_IN_PROGRESS: [],
+                cai.LABEL_REVISING: [],
+                cai.LABEL_APPLYING: [],
+                cai.LABEL_LOCKED: [locked_issue],
+            },
+            set_labels_mock=sl_mock,
+        )
+        nums = {i["number"] for i in result}
+        self.assertIn(701, nums,
+                      f"{cai._STALE_LOCKED_HOURS + 0.5}h-old :locked should "
+                      f"be rolled back (TTL={cai._STALE_LOCKED_HOURS}h)")
+        # Verify the call removed only LABEL_LOCKED and did not add any
+        # FSM state label.
+        called = False
+        for call in sl_mock.call_args_list:
+            kwargs = call.kwargs
+            if kwargs.get("remove") == [cai.LABEL_LOCKED]:
+                called = True
+                self.assertFalse(
+                    kwargs.get("add"),
+                    "watchdog must not add an FSM state label when "
+                    "rolling back :locked (orthogonal lock)",
+                )
+        self.assertTrue(
+            called,
+            "watchdog must call _set_labels with remove=[LABEL_LOCKED]",
+        )
+
+    def test_rollback_locked_fresh(self):
+        """:locked issues within the TTL window must NOT be rolled back."""
+        # Half the TTL — well within the window.
+        locked_issue = _make_issue(801, cai.LABEL_LOCKED,
+                                   age_hours=cai._STALE_LOCKED_HOURS / 2)
+        result = self._run_rollback(
+            immediate=False,
+            issues_by_label={
+                cai.LABEL_IN_PROGRESS: [],
+                cai.LABEL_REVISING: [],
+                cai.LABEL_APPLYING: [],
+                cai.LABEL_LOCKED: [locked_issue],
+            },
+        )
+        nums = {i["number"] for i in result}
+        self.assertNotIn(801, nums,
+                         f"fresh :locked (age < {cai._STALE_LOCKED_HOURS}h) "
+                         "must NOT be rolled back")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #880.

Replace the per-container `fcntl.flock` in `cmd_cycle` with a remote GitHub-side ownership lock so two `cai` instances on different hosts cannot advance the same issue/PR concurrently.

- New `auto-improve:locked` label + `<!-- cai-lock owner=... acquired=... -->` claim comment posted by the owner.
- Oldest-claim-comment wins; tie-breaker is comment id.
- `INSTANCE_ID = <machine_id>-<hostname>-<pid>` keeps two containers on the same host distinct.
- Stabilization poll after posting (~3s) closes GitHub's read-after-write replica-lag window.
- `_HELD_LOCKS` is a refcount dict so the drain driver's outer acquire nests correctly with the inner `dispatch_*` wrappers.
- Single `try/finally` in `_drive_target_to_completion` covers every exit path **including uncaught handler exceptions** (per the comment-thread amendment); only the issue↔PR hop sites manually pair release-old-then-acquire-new.
- Watchdog expires `:locked` after `_STALE_LOCKED_HOURS = 1h`; expiry only strips `:locked` and `cai-lock` claim comments and leaves the FSM state label untouched (the lock is orthogonal).
- `cmd_cycle` flock + `_CYCLE_LOCK_PATH` deleted; `_cmd_cycle_inner` inlined into `cmd_cycle`.

## Test plan

- [x] `python -m unittest discover -s tests` — 242 tests pass.
- [x] New `tests/test_remote_lock.py` covers happy-path acquire, refcount idempotency, two-instance race (loser yields without stripping the winner's label), idempotent release, drain-skip when acquire fails, and **release on handler exception** (the new finally pattern).
- [x] `tests/test_rollback.py` extended with `test_rollback_locked_stale` (asserts `_set_labels` is called with `remove=[LABEL_LOCKED]` and **no** `add=`) and `test_rollback_locked_fresh`.
- [x] `tests/test_dispatcher.py`: existing routing tests get a `_LockNoopMixin` so the new dispatch-entry acquire is transparent to them.
- [x] No new ruff violations against `pyproject.toml` (61 pre-existing baseline unchanged).

Refs damien-robotsix/robotsix-cai#880

🤖 Generated with [Claude Code](https://claude.com/claude-code)