### PR TITLE
chore(deps): declare runtime deps in pyproject and install in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # Phase A — first runnable container.
 #
 # Base image is python:3.12-slim. Node.js is installed via apt so we can
-# install the @anthropic-ai/claude-code CLI globally. The backend itself
-# is plain Python (stdlib only at this stage) and shells out to `claude -p`
-# in autonomous mode.
+# install the @anthropic-ai/claude-code CLI globally. The backend is plain
+# Python; runtime dependencies are declared in pyproject.toml's
+# [project].dependencies and installed via `pip install` after the clone
+# step below. It shells out to `claude -p` in autonomous mode.
 
 FROM python:3.12-slim
 
@@ -136,5 +137,18 @@ RUN git clone "${CAI_GIT_URL}" /app \
     && git -C /app checkout "${CAI_GIT_REF}" \
     && chmod +x /app/entrypoint.sh \
     && mkdir -p /app/.claude/agent-memory/shared
+
+# Install Python runtime dependencies declared in pyproject.toml.
+# We install system-wide (as root) rather than per-user so the cai user
+# and any future root-invoked scripts both pick them up from site-packages.
+# The project itself is not installed — cai.py runs directly from /app —
+# so we extract the dependencies list and feed it to pip via a requirements
+# file, keeping pyproject.toml as the single source of truth.
+USER root
+RUN python -c "import tomllib; print('\n'.join(tomllib.load(open('/app/pyproject.toml','rb'))['project']['dependencies']))" \
+        > /tmp/requirements.txt \
+    && pip install --no-cache-dir --root-user-action=ignore -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt
+USER cai
 
 CMD ["/app/entrypoint.sh"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[project]
+name = "robotsix-cai"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "PyYAML>=6",
+]
+
 [tool.ruff]
 line-length = 120
 


### PR DESCRIPTION
## Summary
- Lifts the stdlib-only constraint noted in the Dockerfile header.
- Adds `[project]` section to `pyproject.toml` with `PyYAML>=6` so audit modules parsing agent frontmatter can `import yaml`.
- Dockerfile extracts the dependency list from `pyproject.toml` post-clone and pip-installs it system-wide, keeping pyproject as the single source of truth.

## Motivation
Issue #886 (audit-refactor 1.1) introduces `cai_lib/audit/modules.py` with `import yaml`, which failed test discovery in the `cai-implement` worktree because the base image was stdlib-only. Rather than force that module to reimplement YAML parsing, we allow real dependencies.

## Test plan
- [ ] `docker compose build` succeeds against this branch
- [ ] `python -c "import yaml"` works as the `cai` user inside the container
- [ ] cai-implement run for issue #886 proceeds past the `ModuleNotFoundError: yaml` failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)