### PR TITLE
feat(rescue): extend cai-rescue to PRs parked at :pr-human-needed

### DIFF
--- a/.claude/agents/lifecycle/cai-rescue.md
+++ b/.claude/agents/lifecycle/cai-rescue.md
@@ -1,6 +1,6 @@
 ---
 name: cai-rescue
-description: Autonomous rescue agent — decides whether a `:human-needed` divert can be resumed without admin input (including a one-shot Opus-escalation of the implement phase), and optionally proposes a prevention finding to fix the divert root cause. Used by `cai rescue`.
+description: Autonomous rescue agent — decides whether a `:human-needed` issue or `:pr-human-needed` PR divert can be resumed without admin input (including a one-shot Opus-escalation of the implement phase, issue-side only), and optionally proposes a prevention finding to fix the divert root cause. Used by `cai rescue`.
 tools: Read, Grep, Glob
 model: sonnet
 memory: project
@@ -9,10 +9,11 @@ memory: project
 # Rescue Agent
 
 You are the autonomous rescue agent for `robotsix-cai`. An auto-improve
-issue is parked at `auto-improve:human-needed` and **no admin has
-applied `human:solved`**. Your job is to read the issue and decide
-whether the divert can be resumed without human input — and if so, which
-state to resume from. The companion `cmd_rescue` driver fires the FSM
+issue is parked at `auto-improve:human-needed` or a PR is parked at
+`auto-improve:pr-human-needed`, and **no admin has applied
+`human:solved`**. Your job is to read the target and decide whether the
+divert can be resumed without human input — and if so, which state to
+resume from. The companion `cmd_rescue` driver fires the matching FSM
 transition based on your structured verdict.
 
 This is a higher-stakes companion to `cai-unblock`:
@@ -32,16 +33,21 @@ call.
 
 ## What you receive
 
-The user message begins with `Kind: issue-rescue` and is followed by
-three sections:
+The user message begins with either `Kind: issue-rescue` or
+`Kind: pr-rescue` and is followed by three sections:
 
-1. **Labels** — the FSM labels currently on the issue.
-2. **Body** — the issue text, including any stored plan block
-   (`<!-- cai-plan-start -->…<!-- cai-plan-end -->`).
+1. **Labels** — the FSM labels currently on the target.
+2. **Body** — the issue or PR text, including any stored plan block
+   (`<!-- cai-plan-start -->…<!-- cai-plan-end -->`) when present on
+   the issue side.
 3. **Comments** — the full comment thread, chronological. The most
    recent automation comment usually carries the divert reason
    (`Required confidence: HIGH` / `Reported confidence: LOW|MEDIUM`,
    etc.).
+
+The `Kind:` header tells you which submachine's resume targets apply —
+issue states for `issue-rescue`, PR states for `pr-rescue`. Never mix
+them.
 
 You also have `Read`, `Grep`, and `Glob` so you can sanity-check claims
 in the divert comment against the current source tree (e.g., confirm a
@@ -66,6 +72,10 @@ Only emit this when ALL of the following hold:
 
 ### `ATTEMPT_OPUS_IMPLEMENT`
 
+**Issue-side only.** Never emit this verdict on a `Kind: pr-rescue`
+payload — the `cmd_rescue` driver will reject it and the PR will be
+counted as `truly_human_needed`.
+
 One-shot escalation path for parks where a **sound stored plan**
 exists but the Sonnet-backed implementer gave up. On HIGH confidence,
 the runtime applies `auto-improve:opus-attempted` and fires
@@ -76,6 +86,8 @@ NOT emit this verdict again.
 
 Only emit when ALL of the following hold:
 
+- The payload is `Kind: issue-rescue` (this verdict has no meaning on
+  PRs — there is no stored plan block or implement phase to re-run).
 - The issue body contains a stored plan block
   (`<!-- cai-plan-start -->…<!-- cai-plan-end -->`). Use `Grep` to
   confirm before emitting.
@@ -130,13 +142,17 @@ cause `cmd_rescue` to act** — anything else leaves the issue
 parked. Pick `HIGH` only when both the verdict and (for
 `AUTONOMOUSLY_RESOLVABLE`) the resume target are clearly correct.
 
-## `resume_to` (issue-side targets)
+## `resume_to`
 
 Required when `verdict` is `AUTONOMOUSLY_RESOLVABLE`. Ignored for
 both `ATTEMPT_OPUS_IMPLEMENT` (the driver always uses
 `human_to_plan_approved`) and `TRULY_HUMAN_NEEDED`. Pick exactly one
-of these state names — each maps to a `human_to_<state>` transition
-in `cai_lib/fsm_transitions.py`:
+target from the submachine that matches the `Kind:` header.
+
+### Issue-side targets (`Kind: issue-rescue`)
+
+Each maps to a `human_to_<state>` transition in
+`cai_lib/fsm_transitions.py`:
 
 | State               | When to pick                                                           |
 |---------------------|------------------------------------------------------------------------|
@@ -149,6 +165,21 @@ in `cai_lib/fsm_transitions.py`:
 `REFINED` and `PLANNED` are auto-advance waypoints, not valid resume
 targets. If you want refinement re-run, pick `REFINING`. If you want
 to accept an existing plan, pick `PLAN_APPROVED`.
+
+### PR-side targets (`Kind: pr-rescue`)
+
+Each maps to a `pr_human_to_<state>` transition in
+`cai_lib/fsm_transitions.py`:
+
+| State               | When to pick                                                                   |
+|---------------------|--------------------------------------------------------------------------------|
+| `REVIEWING_CODE`    | Re-run cai-review-pr — the reviewer diverted on low confidence or a transient. |
+| `REVISION_PENDING`  | Reviewer comments are actionable and cai-revise should address them next tick. |
+| `REVIEWING_DOCS`    | Code review was fine; docs review diverted but the next pass will clear it.    |
+| `APPROVED`          | The PR is ready to merge — the merge handler will pick it up on the next tick. |
+
+`pr_human_to_merged` does not exist — merging must go through a
+reviewable state. There is no PR-side `SOLVED` or `RAISED` target.
 
 ## `prevention_finding` (optional)
 
@@ -165,9 +196,6 @@ Keep it ≤ 10 lines. Be specific — name files, agents, or thresholds
 where possible. Leave the field empty (or omit it) when no actionable
 prevention is obvious. The `cmd_rescue` driver dedups identical
 findings via SHA-256, so don't fear repetition across runs.
-
-PR-side rescues are deferred — this agent only sees `Kind:
-issue-rescue` payloads. Do not propose PR-flow remediations.
 
 ## Output format
 
@@ -194,17 +222,22 @@ the audit trail later.
 - Never emit `AUTONOMOUSLY_RESOLVABLE` or `ATTEMPT_OPUS_IMPLEMENT`
   with `LOW` or `MEDIUM` confidence — neither fires a transition,
   and both pollute the run-log counters.
+- Never emit `ATTEMPT_OPUS_IMPLEMENT` on a `Kind: pr-rescue` payload
+  — the verdict is issue-only and the driver will park the PR as
+  `truly_human_needed`.
 - Never emit `ATTEMPT_OPUS_IMPLEMENT` on an issue whose labels
   already include `auto-improve:opus-attempted` — the one-shot has
   been burned; pick `TRULY_HUMAN_NEEDED` instead.
 - Never emit `ATTEMPT_OPUS_IMPLEMENT` on an issue whose body lacks
   a stored plan block — the driver will reject the escalation and
   the park will be counted as a wasted cycle.
-- Never emit a `resume_to` outside the table above. The runtime
-  rejects unknown targets and the issue stays parked.
-- Never emit `resume_to: HUMAN_NEEDED` — the issue is already there.
+- Never emit a `resume_to` outside the table matching the target's
+  `Kind:`. The runtime rejects unknown targets and the issue/PR
+  stays parked.
+- Never emit `resume_to: HUMAN_NEEDED` or `resume_to: PR_HUMAN_NEEDED`
+  — the target is already there.
 - When `verdict` is `TRULY_HUMAN_NEEDED` or `ATTEMPT_OPUS_IMPLEMENT`,
   `resume_to` is irrelevant; the runtime ignores it.
-- Prefer leaving the issue parked over guessing. The next rescue
+- Prefer leaving the issue/PR parked over guessing. The next rescue
   pass (every 4 hours by default) gets another chance once context
   changes; a wrong resume is hard to undo.

--- a/cai.py
+++ b/cai.py
@@ -183,20 +183,19 @@ Subcommands:
                             ignored.
 
     python cai.py rescue    Autonomous counterpart to `unblock`. Scans
-                            `auto-improve:human-needed` issues that have
+                            `auto-improve:human-needed` issues and
+                            `auto-improve:pr-human-needed` PRs that have
                             NOT yet received the `human:solved` label and
-                            asks the Opus `cai-rescue` agent whether each
+                            asks the `cai-rescue` agent whether each
                             divert can be resumed without human input. On
                             a HIGH-confidence `AUTONOMOUSLY_RESOLVABLE`
                             verdict, fires the matching state transition
                             and posts an audit comment; otherwise leaves
-                            the issue parked. Optionally collects
+                            the target parked. Optionally collects
                             `prevention_finding` text from the agent and
                             publishes the survivors as
                             `auto-improve:raised` issues so recurring
                             divert patterns get fixed at the source.
-                            Issues-only in the first cut; PR-side rescues
-                            are deferred.
 
 Default schedules (all configurable via environment variables):
 

--- a/cai_lib/cmd_rescue.py
+++ b/cai_lib/cmd_rescue.py
@@ -1,21 +1,19 @@
-"""cai_lib.cmd_rescue — autonomous rescue pass for parked issues.
+"""cai_lib.cmd_rescue — autonomous rescue pass for parked issues and PRs.
 
 Counterpart to :mod:`cai_lib.cmd_unblock`. Where ``cmd_unblock`` only acts
 when an admin has explicitly applied the ``human:solved`` label,
-``cmd_rescue`` runs autonomously: it scans
-``auto-improve:human-needed`` issues that DO NOT yet carry
-``human:solved``, asks the Opus :file:`cai-rescue` agent whether each
-divert can be resumed without human input, and on a HIGH-confidence
+``cmd_rescue`` runs autonomously: it scans ``auto-improve:human-needed``
+issues and ``auto-improve:pr-human-needed`` PRs that DO NOT yet carry
+``human:solved``, asks the :file:`cai-rescue` agent whether each divert
+can be resumed without human input, and on a HIGH-confidence
 ``AUTONOMOUSLY_RESOLVABLE`` verdict fires the matching
-``human_to_<state>`` transition. Issues the agent classifies as
-``TRULY_HUMAN_NEEDED`` are left parked.
+``human_to_<state>`` / ``pr_human_to_<state>`` transition. Targets the
+agent classifies as ``TRULY_HUMAN_NEEDED`` are left parked.
 
 The pass also collects optional ``prevention_finding`` text from the
 agent and publishes the survivors as ``auto-improve:raised`` issues via
 :mod:`publish`, so that recurring divert patterns can be fixed at the
 source.
-
-Scope: this first cut handles ISSUES only — PR-side rescues are deferred.
 """
 from __future__ import annotations
 
@@ -33,15 +31,19 @@ from cai_lib.config import (
     LABEL_HUMAN_NEEDED,
     LABEL_HUMAN_SOLVED,
     LABEL_OPUS_ATTEMPTED,
+    LABEL_PR_HUMAN_NEEDED,
 )
 from cai_lib.fsm import (
     Confidence,
+    apply_pr_transition,
     apply_transition,
+    resume_pr_transition_for,
     resume_transition_for,
 )
 from cai_lib.github import (
     _gh_json,
     _post_issue_comment,
+    _post_pr_comment,
     _set_labels,
     close_issue_completed,
 )
@@ -78,8 +80,12 @@ _RESCUE_JSON_SCHEMA = {
         "resume_to": {
             "type": "string",
             "enum": [
+                # Issue-side (Kind: issue-rescue)
                 "RAISED", "REFINING", "NEEDS_EXPLORATION",
                 "PLAN_APPROVED", "SOLVED",
+                # PR-side (Kind: pr-rescue)
+                "REVIEWING_CODE", "REVIEWING_DOCS",
+                "REVISION_PENDING", "APPROVED",
             ],
         },
         "reasoning": {"type": "string"},
@@ -89,11 +95,6 @@ _RESCUE_JSON_SCHEMA = {
 }
 
 
-# TODO(rescue-pr): this pass is issues-only. PR-side parked targets
-# (auto-improve:pr-human-needed) still depend on the admin-driven
-# cmd_unblock flow; their failure modes (review-comment loops, CI
-# regressions) are different enough to warrant a follow-up rescue
-# variant rather than reusing this code path.
 def _list_unresolved_human_needed_issues() -> list[dict]:
     """Return open ``:human-needed`` issues that lack ``human:solved``.
 
@@ -131,21 +132,57 @@ def _list_unresolved_human_needed_issues() -> list[dict]:
     return out
 
 
-def _build_rescue_message(issue: dict) -> str:
+def _list_unresolved_pr_human_needed_prs() -> list[dict]:
+    """Return open ``:pr-human-needed`` PRs that lack ``human:solved``.
+
+    PR-side counterpart to :func:`_list_unresolved_human_needed_issues`:
+    candidates for autonomous rescue are the ones an admin has NOT yet
+    opted-in on via ``human:solved``.
+    """
+    try:
+        candidates = _gh_json([
+            "pr", "list",
+            "--repo", REPO,
+            "--label", LABEL_PR_HUMAN_NEEDED,
+            "--state", "open",
+            "--json", "number,title,body,labels,updatedAt,comments",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(
+            f"[cai rescue] gh pr list failed:\n{e.stderr}",
+            file=sys.stderr,
+        )
+        return []
+
+    out: list[dict] = []
+    for pr in candidates:
+        names = {
+            (lb.get("name") if isinstance(lb, dict) else lb)
+            for lb in pr.get("labels", [])
+        }
+        if LABEL_HUMAN_SOLVED in names:
+            continue
+        out.append(pr)
+    return out
+
+
+def _build_rescue_message(target: dict, *, kind: str) -> str:
     """Format the user message for the cai-rescue agent.
 
     Same shape as :func:`cmd_unblock._build_unblock_message` but with a
-    ``Kind: issue-rescue`` header so the agent knows it is the
-    autonomous-rescue mode rather than the admin-resume mode.
+    ``Kind: issue-rescue`` or ``Kind: pr-rescue`` header so the agent
+    knows it is the autonomous-rescue mode rather than the admin-resume
+    mode, and which submachine's resume targets apply.
     """
-    body = issue.get("body") or "(no body)"
+    body = target.get("body") or "(no body)"
     labels = [
         (lb.get("name") if isinstance(lb, dict) else lb)
-        for lb in issue.get("labels", [])
+        for lb in target.get("labels", [])
     ]
     labels_line = ", ".join(labels) if labels else "(none)"
 
-    comments = issue.get("comments") or []
+    comments = target.get("comments") or []
     comments_block = ""
     for c in comments:
         author = (c.get("author") or {}).get("login") or "unknown"
@@ -154,13 +191,13 @@ def _build_rescue_message(issue: dict) -> str:
         comments_block += f"\n**{author}** ({created}):\n{text}\n"
 
     return (
-        f"Kind: issue-rescue\n"
+        f"Kind: {kind}\n"
         f"\n"
         f"## Labels\n"
         f"{labels_line}\n"
         f"\n"
         f"## Body\n\n"
-        f"### #{issue['number']} — {issue.get('title', '')}\n\n"
+        f"### #{target['number']} — {target.get('title', '')}\n\n"
         f"{body}\n"
         f"\n"
         f"## Comments\n"
@@ -183,6 +220,19 @@ def _post_rescue_comment(
         f"_Reasoning:_ {reasoning}\n"
     )
     return _post_issue_comment(issue_number, body, log_prefix="cai rescue")
+
+
+def _post_pr_rescue_comment(
+    pr_number: int, *, target: str, reasoning: str,
+) -> bool:
+    """PR-side counterpart of :func:`_post_rescue_comment`."""
+    body = (
+        f"**🛟 Autonomous rescue**\n\n"
+        f"`cai rescue` resumed this PR from `:pr-human-needed` "
+        f"→ `{target}` without admin input.\n\n"
+        f"_Reasoning:_ {reasoning}\n"
+    )
+    return _post_pr_comment(pr_number, body, log_prefix="cai rescue")
 
 
 def _post_opus_escalation_comment(
@@ -375,7 +425,7 @@ def _try_rescue_issue(
     """
     issue_number = issue["number"]
 
-    user_message = _build_rescue_message(issue)
+    user_message = _build_rescue_message(issue, kind="issue-rescue")
     result = _run_claude_p(
         ["claude", "-p", "--agent", "cai-rescue",
          "--dangerously-skip-permissions",
@@ -498,18 +548,143 @@ def _try_rescue_issue(
     return "resumed"
 
 
+def _try_rescue_pr(
+    pr: dict, prevention_findings: list[dict],
+) -> Optional[str]:
+    """Attempt to resume *pr* autonomously. Returns the result tag.
+
+    PR-side mirror of :func:`_try_rescue_issue`. The
+    ``ATTEMPT_OPUS_IMPLEMENT`` verdict is issue-only (it re-runs the
+    implement phase on a stored plan) — if the agent emits it on a PR,
+    we treat it as ``truly_human_needed`` and park the PR, logging the
+    refusal so the behaviour shows up in the run counters.
+    """
+    pr_number = pr["number"]
+
+    user_message = _build_rescue_message(pr, kind="pr-rescue")
+    result = _run_claude_p(
+        ["claude", "-p", "--agent", "cai-rescue",
+         "--dangerously-skip-permissions",
+         "--json-schema", json.dumps(_RESCUE_JSON_SCHEMA)],
+        category="rescue",
+        agent="cai-rescue",
+        input=user_message,
+    )
+    if result.returncode != 0:
+        print(
+            f"[cai rescue] PR #{pr_number} agent failed "
+            f"(exit {result.returncode}):\n{result.stderr}",
+            file=sys.stderr,
+        )
+        return "agent_failed"
+
+    try:
+        payload = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(
+            f"[cai rescue] PR #{pr_number} failed to parse JSON: {exc}; "
+            f"stdout starts with: {(result.stdout or '')[:120]!r}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return "agent_failed"
+
+    verdict = (payload.get("verdict") or "").upper()
+    target = (payload.get("resume_to") or "").upper() or None
+    conf_str = (payload.get("confidence") or "").upper()
+    confidence = Confidence[conf_str] if conf_str in Confidence.__members__ else None
+    reasoning = payload.get("reasoning", "(no reasoning provided)")
+    prev_text = (payload.get("prevention_finding") or "").strip()
+    print(
+        f"[cai rescue] PR #{pr_number} verdict: {verdict or 'MISSING'} "
+        f"resume_to={target or 'MISSING'} "
+        f"confidence={conf_str or 'MISSING'} reasoning={reasoning}",
+        flush=True,
+    )
+
+    if prev_text:
+        _stage_prevention_finding(
+            prevention_findings,
+            source_issue=pr_number,
+            prev_text=prev_text,
+        )
+
+    if verdict == "ATTEMPT_OPUS_IMPLEMENT":
+        # Opus escalation reruns cai-implement on a stored plan — an
+        # issue-only concept. Leave the PR parked; the agent doc forbids
+        # this verdict on PRs, so it should only happen under drift.
+        print(
+            f"[cai rescue] PR #{pr_number} got ATTEMPT_OPUS_IMPLEMENT "
+            f"(issue-only verdict); leaving parked",
+            flush=True,
+        )
+        return "truly_human_needed"
+
+    if verdict != "AUTONOMOUSLY_RESOLVABLE":
+        return "truly_human_needed"
+
+    if confidence != Confidence.HIGH:
+        print(
+            f"[cai rescue] PR #{pr_number} confidence="
+            f"{confidence.name if confidence else 'MISSING'}; leaving parked",
+            flush=True,
+        )
+        return "low_confidence"
+
+    if not target:
+        print(
+            f"[cai rescue] PR #{pr_number} no resume_to target; leaving parked",
+            flush=True,
+        )
+        return "no_target"
+
+    transition = resume_pr_transition_for(target)
+    if transition is None:
+        print(
+            f"[cai rescue] PR #{pr_number} unknown resume target {target!r}; "
+            f"leaving parked",
+            flush=True,
+        )
+        return "no_target"
+
+    # Audit comment first — surviving a transition failure still gives
+    # an operator something to anchor on.
+    _post_pr_rescue_comment(
+        pr_number,
+        target=transition.to_state.name,
+        reasoning=reasoning,
+    )
+
+    ok = apply_pr_transition(
+        pr_number, transition.name,
+        log_prefix="cai rescue",
+    )
+    if not ok:
+        return "agent_failed"
+
+    print(
+        f"[cai rescue] PR #{pr_number} resumed via {transition.name} "
+        f"→ {transition.to_state.name}",
+        flush=True,
+    )
+    return "resumed"
+
+
 def cmd_rescue(args) -> int:
-    """Scan parked :human-needed issues and attempt autonomous resume.
+    """Scan parked :human-needed issues and :pr-human-needed PRs and
+    attempt autonomous resume.
 
     Always returns 0 unless a hard infrastructure failure occurs —
-    individual per-issue failures are recorded in counters but do not
+    individual per-target failures are recorded in counters but do not
     fail the overall run, since the next cron tick will retry.
     """
     t0 = time.monotonic()
     issues = _list_unresolved_human_needed_issues()
-    if not issues:
+    prs = _list_unresolved_pr_human_needed_prs()
+    if not issues and not prs:
         print(
-            "[cai rescue] no unresolved :human-needed issues; nothing to do",
+            "[cai rescue] no unresolved :human-needed issues or "
+            ":pr-human-needed PRs; nothing to do",
             flush=True,
         )
         log_run("rescue", repo=REPO, result="no_targets", exit=0)
@@ -519,7 +694,10 @@ def cmd_rescue(args) -> int:
     prevention_findings: list[dict] = []
     for issue in issues:
         tag = _try_rescue_issue(issue, prevention_findings) or "skipped"
-        counters[tag] = counters.get(tag, 0) + 1
+        counters[f"issue_{tag}"] = counters.get(f"issue_{tag}", 0) + 1
+    for pr in prs:
+        tag = _try_rescue_pr(pr, prevention_findings) or "skipped"
+        counters[f"pr_{tag}"] = counters.get(f"pr_{tag}", 0) + 1
 
     _publish_prevention_findings(prevention_findings)
 

--- a/tests/test_rescue_opus.py
+++ b/tests/test_rescue_opus.py
@@ -40,6 +40,17 @@ class TestRescueJsonSchema(unittest.TestCase):
         self.assertIn("AUTONOMOUSLY_RESOLVABLE", enum)
         self.assertIn("TRULY_HUMAN_NEEDED", enum)
 
+    def test_resume_to_enum_covers_issue_and_pr_states(self):
+        enum = R._RESCUE_JSON_SCHEMA["properties"]["resume_to"]["enum"]
+        # Issue-side targets.
+        for state in ("RAISED", "REFINING", "NEEDS_EXPLORATION",
+                      "PLAN_APPROVED", "SOLVED"):
+            self.assertIn(state, enum)
+        # PR-side targets.
+        for state in ("REVIEWING_CODE", "REVIEWING_DOCS",
+                      "REVISION_PENDING", "APPROVED"):
+            self.assertIn(state, enum)
+
 
 class TestIssueHasOpusAttempted(unittest.TestCase):
 
@@ -185,6 +196,101 @@ class TestTryRescueIssueDispatchesOpusBranch(unittest.TestCase):
             tag = R._try_rescue_issue(issue, prevention_findings=[])
         self.assertEqual(tag, "low_confidence")
         sched.assert_not_called()
+
+
+class TestTryRescuePr(unittest.TestCase):
+    """End-to-end: PR-side rescue wiring routes through apply_pr_transition."""
+
+    def _claude_reply(self, payload):
+        proc = mock.Mock()
+        proc.returncode = 0
+        proc.stdout = json.dumps(payload)
+        proc.stderr = ""
+        return proc
+
+    def _pr(self):
+        return {
+            "number": 77,
+            "title": "fix widget",
+            "body": "…",
+            "labels": [{"name": "auto-improve:pr-human-needed"}],
+            "comments": [],
+        }
+
+    def test_high_confidence_resume_fires_pr_transition(self):
+        pr = self._pr()
+        claude_payload = {
+            "verdict": "AUTONOMOUSLY_RESOLVABLE",
+            "confidence": "HIGH",
+            "resume_to": "REVIEWING_CODE",
+            "reasoning": "reviewer diverted on a transient; re-run review",
+        }
+        with mock.patch.object(
+            R, "_run_claude_p", return_value=self._claude_reply(claude_payload)
+        ), mock.patch.object(
+            R, "apply_pr_transition", return_value=True
+        ) as apply_pr, mock.patch.object(
+            R, "_post_pr_rescue_comment", return_value=True
+        ) as cmt:
+            tag = R._try_rescue_pr(pr, prevention_findings=[])
+        self.assertEqual(tag, "resumed")
+        apply_pr.assert_called_once()
+        self.assertEqual(apply_pr.call_args.args[1], "pr_human_to_reviewing_code")
+        cmt.assert_called_once()
+        self.assertEqual(cmt.call_args.kwargs["target"], "REVIEWING_CODE")
+
+    def test_opus_verdict_on_pr_parks_target(self):
+        pr = self._pr()
+        claude_payload = {
+            "verdict": "ATTEMPT_OPUS_IMPLEMENT",
+            "confidence": "HIGH",
+            "reasoning": "mis-targeted",
+        }
+        with mock.patch.object(
+            R, "_run_claude_p", return_value=self._claude_reply(claude_payload)
+        ), mock.patch.object(R, "apply_pr_transition") as apply_pr, \
+             mock.patch.object(R, "_schedule_opus_attempt") as sched:
+            tag = R._try_rescue_pr(pr, prevention_findings=[])
+        self.assertEqual(tag, "truly_human_needed")
+        apply_pr.assert_not_called()
+        sched.assert_not_called()
+
+    def test_low_confidence_resume_parks_pr(self):
+        pr = self._pr()
+        claude_payload = {
+            "verdict": "AUTONOMOUSLY_RESOLVABLE",
+            "confidence": "MEDIUM",
+            "resume_to": "REVIEWING_CODE",
+            "reasoning": "not sure",
+        }
+        with mock.patch.object(
+            R, "_run_claude_p", return_value=self._claude_reply(claude_payload)
+        ), mock.patch.object(R, "apply_pr_transition") as apply_pr:
+            tag = R._try_rescue_pr(pr, prevention_findings=[])
+        self.assertEqual(tag, "low_confidence")
+        apply_pr.assert_not_called()
+
+
+class TestPrHumanNeededLister(unittest.TestCase):
+    """`_list_unresolved_pr_human_needed_prs` must filter out human:solved."""
+
+    def test_filters_out_pr_with_human_solved(self):
+        resolved = {
+            "number": 1, "title": "t", "body": "",
+            "labels": [
+                {"name": "auto-improve:pr-human-needed"},
+                {"name": "human:solved"},
+            ],
+            "comments": [],
+        }
+        unresolved = {
+            "number": 2, "title": "t", "body": "",
+            "labels": [{"name": "auto-improve:pr-human-needed"}],
+            "comments": [],
+        }
+        with mock.patch.object(R, "_gh_json", return_value=[resolved, unresolved]):
+            out = R._list_unresolved_pr_human_needed_prs()
+        self.assertEqual([p["number"] for p in out], [2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `cmd_rescue` now scans both `auto-improve:human-needed` issues and `auto-improve:pr-human-needed` PRs that lack `human:solved`, mirroring the issue/PR split `cmd_unblock` already has.
- The `cai-rescue` agent now accepts `Kind: pr-rescue` payloads with a dedicated PR-side resume-target table (`REVIEWING_CODE`, `REVISION_PENDING`, `REVIEWING_DOCS`, `APPROVED`).
- `ATTEMPT_OPUS_IMPLEMENT` stays issue-only — a PR payload that emits it is parked as `truly_human_needed`.
- Run-log counters namespace as `issue_*` / `pr_*`.

## Changes
- `cai_lib/cmd_rescue.py` — add PR-side lister/rescuer/comment helpers, generalize `_build_rescue_message`, extend JSON schema.
- `.claude/agents/lifecycle/cai-rescue.md` — document PR-rescue kind, PR resume-target table, and Opus-escalation restriction; drop deferred-PR note.
- `cai.py` — update CLI help to cover PRs.
- `tests/test_rescue_opus.py` — add 4 tests (schema enum, PR happy path, Opus-on-PR park, low-confidence PR park, `human:solved` filter).

## Test plan
- [x] `pytest tests/test_rescue_opus.py` — 16 passed
- [x] `pytest tests/` (full suite, ex-lint) — 246 passed
- [x] `ruff check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)