### PR TITLE
feat(audit): docs/modules.yaml schema + loader (audit-refactor 1.1)

### DIFF
--- a/docs/modules.yaml
+++ b/docs/modules.yaml
@@ -1,14 +1,25 @@
-# Module index — owned and maintained by cai-review-docs.
-# On every PR that adds, renames, or deletes a tracked file, cai-review-docs
-# updates this file and the matching docs/modules/<name>.md narrative.
+# docs/modules.yaml — audit-refactor module registry (step 1.1).
 #
-# Schema:
-#   modules:
-#     - name:    short identifier (matches narrative filename stem)
-#       summary: one-line summary of the module's purpose
-#       globs:   list of fnmatch-style patterns, repo-root-relative,
-#                that enumerate the files belonging to this module
-#       doc:     path to the per-module narrative markdown file
+# Each entry defines one logical "module" (group of files) that the
+# cai audit pipeline can target. The loader lives at
+# cai_lib/audit/modules.py.
+#
+# Coverage rules enforced by future audit stages (not this step):
+#   - Every tracked file (git ls-files) must match exactly one module.
+#   - Zero matches or 2+ matches are coverage failures.
+#
+# Per-entry authoring rules:
+#   - `name`:    kebab-case, unique across the file; used as the
+#                `--module` argument to `cai audit`.
+#   - `summary`: single-line description surfaced to audit agents.
+#   - `doc`:     path to narrative markdown (relative to this file's
+#                directory, i.e. docs/). Files will be created in a
+#                later audit-refactor step; the loader's existence
+#                check is OFF by default in step 1.1.
+#   - `globs`:   gitignore-style patterns (fnmatch semantics) matched
+#                against the tracked-file list. Must be a non-empty
+#                list of strings.
+
 modules:
   - name: dispatcher-cli
     summary: Top-level CLI entry point and root-level shims.


### PR DESCRIPTION
## Summary

Step 1.1 of the audit-refactor series — establishes the shared `docs/modules.yaml` schema and a Python loader that future audit stages (loop driver, doc agent, coverage script) all consume.

- Replace `cai_lib/audit/modules.py` stub with a real PyYAML-backed `load_modules()` + `coverage_check()` (inline `isinstance` validators, per the admin's plan-approved guidance).
- Add `docs/modules.yaml` with the schema documented in the file header plus two skeleton entries (`cai-lib-core`, `tests`).
- Add `tests/test_audit_modules.py` (7 cases: valid roundtrip, duplicate name, missing field, doc-existence flag, plus 3 coverage-check cases).

PyYAML install is already in `pyproject.toml` + `Dockerfile` (merged via #939), so no Dockerfile change in this PR — the plan's Step 1 is a no-op now.

Closes #886

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('docs/modules.yaml'))"` — exits 0
- [x] `python -c "from cai_lib.audit.modules import ModuleEntry, load_modules, coverage_check"` — exits 0
- [x] `python -m unittest tests.test_audit_modules -v` — 7/7 pass
- [x] `python -m unittest discover tests` — 254/254 pass (no regressions)
- [x] `python -m ruff check cai_lib/audit/modules.py tests/test_audit_modules.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)