### PR TITLE
auto-improve: Rescue prevention: **cai-plan should forbid abstract target text in Write/Edit instructions.**

### DIFF
--- a/.claude/agents/implementation/cai-plan.md
+++ b/.claude/agents/implementation/cai-plan.md
@@ -49,6 +49,26 @@ The user message contains:
 ## Hard rules
 
 1. **Read-only.** Do not modify any files — only read and plan.
+2. **Verbatim Edit/Write content — no prose placeholders.** Every
+   plan step that calls for an `Edit` or `Write` MUST include the
+   **exact final text** the fix agent will emit — either the full
+   file body (for `Write`) or both `old_string` and `new_string`
+   literals (for `Edit`). Prose summaries such as "rewritten
+   docstring keeping only the surviving paragraphs", "update the
+   config block to use the new schema", or "remove the outdated
+   paragraphs and tighten the wording" are **forbidden** — they
+   force the fix agent to improvise and drop plan confidence from
+   HIGH to MEDIUM at the `cai-select` gate (see issue #910 for a
+   textbook divert caused by exactly this pattern). Before you
+   emit the plan, run this **self-check on every step**:
+   > Does this Edit/Write step contain the literal output the fix
+   > agent will type, or only a prose description of it?
+   If the answer is "prose description", rewrite the step to
+   include the literal text inside a fenced code block. If a
+   verbatim block would be prohibitively long (e.g. a full-file
+   rewrite of a >500-line file), split the `Write` into a
+   sequence of targeted `Edit`s, each with literal `old_string` /
+   `new_string` pairs.
 
 ## Agent-specific efficiency guidance
 
@@ -78,7 +98,10 @@ Produce your plan in exactly this structure:
 - **`path/to/file`**: <what to change and why>
 
 ### Detailed steps
-1. <step 1 — be specific: name the function, the line range, the exact change>
+1. <step 1 — be specific: name the function, the line range, the
+   exact change. For any Edit/Write step, include the literal
+   final text inside a fenced code block; prose placeholders such
+   as "rewritten docstring" or "updated config" are forbidden.>
 2. <step 2>
 ...
 

--- a/.claude/agents/implementation/cai-select.md
+++ b/.claude/agents/implementation/cai-select.md
@@ -34,6 +34,20 @@ Assess each plan on these criteria, in order of importance:
 4. **Specificity:** Is the plan concrete enough for a fix agent to
    follow without guessing? Does it name exact files, functions,
    and changes?
+5. **Verbatim Edit/Write content:** Every plan step that calls for
+   an `Edit` or `Write` MUST include the exact final text the fix
+   agent will emit — the full file body (for `Write`) or both
+   `old_string` and `new_string` literals (for `Edit`). Prose
+   summaries such as "rewritten docstring keeping only the
+   surviving paragraphs", "update the config block to use the new
+   schema", or "remove the outdated paragraphs" count as **missing
+   content** — they force the fix agent to improvise and are the
+   single largest driver of MEDIUM-confidence plans that get parked
+   at the `planned_to_plan_approved` gate. **Cap any such plan's
+   confidence at MEDIUM.** If the best available plan suffers from
+   this, emit MEDIUM and cite the specific offending step(s) in
+   `confidence_reason`; if both candidate plans suffer from it,
+   emit LOW and flag the critical missing text in `note`.
 
 ## Output format
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#917

**Issue:** #917 — Rescue prevention: **cai-plan should forbid abstract target text in Write/Edit instructions.**

## PR Summary

### What this fixes
Issue #917 identified that `cai-plan` allowed plan steps to describe Edit/Write content in prose rather than literal text, causing fix agents to improvise and dropping plan confidence from HIGH to MEDIUM at the `cai-select` gate — the root cause of the issue #910 divert.

### What was changed
- **`.cai-staging/agents/implementation/cai-plan.md`** — Added hard rule #2 ("Verbatim Edit/Write content — no prose placeholders") requiring every Edit/Write step to include the exact final text the fix agent will emit, with an embedded self-check question. Updated the Detailed-steps template line to explicitly forbid prose placeholders.
- **`.cai-staging/agents/implementation/cai-select.md`** — Added criterion #5 ("Verbatim Edit/Write content") that caps confidence at MEDIUM when a plan uses prose summaries instead of literal Edit/Write content, and at LOW when both candidate plans suffer from the same deficiency. Both files are written via the `.cai-staging/agents/implementation/` staging directory as required by the claude-code write protection rules.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
