### PR TITLE
fix(watchdog): reap stale :locked on PRs, not just issues

### DIFF
--- a/cai_lib/__init__.py
+++ b/cai_lib/__init__.py
@@ -83,7 +83,10 @@ from cai_lib.github import (
     _build_implement_user_message,
 )
 
-from cai_lib.watchdog import _rollback_stale_in_progress
+from cai_lib.watchdog import (
+    _rollback_stale_in_progress,
+    _rollback_stale_pr_locks,
+)
 
 from cai_lib.cmd_implement import _parse_decomposition
 
@@ -122,6 +125,7 @@ __all__ = [
     "_set_labels", "_issue_has_label", "_build_issue_block", "_build_implement_user_message",
     # watchdog
     "_rollback_stale_in_progress",
+    "_rollback_stale_pr_locks",
     # cmd_implement
     "_parse_decomposition",
     # fsm

--- a/cai_lib/cmd_agents.py
+++ b/cai_lib/cmd_agents.py
@@ -32,7 +32,10 @@ from cai_lib.github import (
     _gh_json, _set_labels, close_issue_not_planned, _recover_stale_pr_open,
     _close_orphaned_prs,
 )
-from cai_lib.watchdog import _rollback_stale_in_progress
+from cai_lib.watchdog import (
+    _rollback_stale_in_progress,
+    _rollback_stale_pr_locks,
+)
 from cai_lib.cmd_helpers import _work_directory_block
 from cai_lib import transcript_sync
 
@@ -658,6 +661,18 @@ def cmd_audit(args) -> int:
 
     # Step 1: Deterministic rollback of stale :in-progress issues.
     rolled_back = _rollback_stale_in_progress()
+
+    # Step 1a: Same TTL-based sweep for PR-side :locked stragglers. The
+    # issue-side helper only lists `gh issue list`, so PRs whose
+    # dispatcher crashed mid-handler would otherwise strand the
+    # ownership lock until manual cleanup.
+    rolled_back_pr_locks = _rollback_stale_pr_locks()
+    if rolled_back_pr_locks:
+        nums = ", ".join(f"#{p['number']}" for p in rolled_back_pr_locks)
+        print(
+            f"[cai audit] cleared stale :locked on PRs: {nums}",
+            flush=True,
+        )
 
     # Step 1b: Delete orphaned auto-improve/* branches with no open PR
     #           (covers merged/closed-PR branches and branches with no PR at all).

--- a/cai_lib/cmd_cycle.py
+++ b/cai_lib/cmd_cycle.py
@@ -4,7 +4,10 @@ import time
 
 from cai_lib.config import *  # noqa: E402,F403
 from cai_lib.github import _gh_json, _set_labels
-from cai_lib.watchdog import _rollback_stale_in_progress
+from cai_lib.watchdog import (
+    _rollback_stale_in_progress,
+    _rollback_stale_pr_locks,
+)
 from cai_lib.dispatcher import dispatch_drain
 from cai_lib.logging_utils import log_run
 
@@ -76,12 +79,21 @@ def cmd_cycle(args) -> int:
                 _healed.add(_num)
 
     # Phase 1: restart recovery — force-rollback any stuck locks left
-    # behind by a previous run that crashed mid-handler.
+    # behind by a previous run that crashed mid-handler. Covers both
+    # issue-side FSM/ownership locks and PR-side ownership locks.
     rolled_back = _rollback_stale_in_progress(immediate=True)
     if rolled_back:
         nums = ", ".join(f"#{i['number']}" for i in rolled_back)
         print(f"[cai cycle] recovered {len(rolled_back)} stale lock(s): {nums}",
               flush=True)
+    rolled_back_prs = _rollback_stale_pr_locks(immediate=True)
+    if rolled_back_prs:
+        nums = ", ".join(f"#{p['number']}" for p in rolled_back_prs)
+        print(
+            f"[cai cycle] recovered {len(rolled_back_prs)} stale PR lock(s): "
+            f"{nums}",
+            flush=True,
+        )
 
     # Phase 2: dispatch a single actionable issue/PR via the FSM dispatcher.
     # Note: :applied → :solved bookkeeping is handled by handle_applied in

--- a/cai_lib/watchdog.py
+++ b/cai_lib/watchdog.py
@@ -28,7 +28,12 @@ from cai_lib.config import (
     _STALE_APPLYING_HOURS,
     _STALE_LOCKED_HOURS,
 )
-from cai_lib.github import _gh_json, _set_labels, _delete_issue_comment
+from cai_lib.github import (
+    _gh_json,
+    _set_labels,
+    _set_pr_labels,
+    _delete_issue_comment,
+)
 from cai_lib.logging_utils import log_run
 
 
@@ -182,5 +187,105 @@ def _rollback_stale_in_progress(*, immediate: bool = False) -> list[dict]:
                     f"(removed {lock_label}, stale {age / 3600:.1f}h)",
                     flush=True,
                 )
+
+    return rolled_back
+
+
+def _rollback_stale_pr_locks(*, immediate: bool = False) -> list[dict]:
+    """PR-side counterpart for stale ``auto-improve:locked`` cleanup.
+
+    The issue-side :func:`_rollback_stale_in_progress` only queries
+    ``gh issue list``, so PRs whose dispatcher crashed mid-handler can
+    strand the ownership lock indefinitely — there is no TTL sweep and
+    no restart sweep for them. This helper closes that gap: it lists
+    open PRs carrying ``LABEL_LOCKED``, and for each one older than
+    ``_STALE_LOCKED_HOURS`` (or every one when ``immediate=True``), it
+    strips the label and deletes any ``<!-- cai-lock ... -->`` claim
+    comments. The FSM pipeline label (``pr:reviewing-code`` etc.) is
+    orthogonal and left untouched — only the ownership lock is cleared.
+
+    Returns the list of PRs that were rolled back.
+    """
+    try:
+        prs = _gh_json([
+            "pr", "list",
+            "--repo", REPO,
+            "--label", LABEL_LOCKED,
+            "--state", "open",
+            "--json", "number,title,updatedAt,createdAt,labels",
+            "--limit", "100",
+        ]) or []
+    except subprocess.CalledProcessError as e:
+        print(
+            f"[cai audit] gh pr list ({LABEL_LOCKED}) failed:\n{e.stderr}",
+            file=sys.stderr,
+        )
+        return []
+
+    if not prs:
+        return []
+
+    now = datetime.now(timezone.utc).timestamp()
+    threshold = 0 if immediate else _STALE_LOCKED_HOURS * 3600
+    rolled_back: list[dict] = []
+
+    for pr in prs:
+        pr_num = pr["number"]
+        # No PR-side log-marker parsing (unlike the issue rollback which
+        # scans [fix]/[revise]/[maintain] lines). The PR dispatcher spans
+        # many action markers ([rebase], [fix-ci], [merge], [review_docs],
+        # …) keyed by pr=<N>, and :locked is a brief ownership window —
+        # falling back to updatedAt mirrors how the issue path falls back
+        # when no log line is found, and the short _STALE_LOCKED_HOURS
+        # TTL bounds any over-extension from a stray comment.
+        try:
+            updated = datetime.strptime(
+                pr["updatedAt"], "%Y-%m-%dT%H:%M:%SZ"
+            ).replace(tzinfo=timezone.utc).timestamp()
+        except (ValueError, KeyError):
+            updated = 0
+        age = now - updated
+
+        if age <= threshold:
+            continue
+
+        ok = _set_pr_labels(
+            pr_num,
+            remove=[LABEL_LOCKED],
+            log_prefix="cai audit",
+        )
+        if not ok:
+            continue
+
+        # Delete this PR's cai-lock claim comments, if any. Same endpoint
+        # as the issue path — GitHub posts PR-level issue comments at
+        # /repos/.../issues/<N>/comments.
+        try:
+            comments = _gh_json([
+                "api", f"/repos/{REPO}/issues/{pr_num}/comments",
+                "--paginate",
+            ]) or []
+        except subprocess.CalledProcessError:
+            comments = []
+        for c in comments:
+            body = c.get("body", "") or ""
+            if CAI_LOCK_COMMENT_RE.search(body):
+                cid = c.get("id")
+                if cid is not None:
+                    _delete_issue_comment(int(cid), log_prefix="cai audit")
+
+        rolled_back.append(pr)
+        log_run(
+            "audit",
+            action="stale_lock_rollback",
+            pr=pr_num,
+            lock_label=LABEL_LOCKED,
+            stale_hours=f"{age / 3600:.1f}",
+        )
+        print(
+            f"[cai audit] rolled back PR #{pr_num} "
+            f"(removed {LABEL_LOCKED}, stale {age / 3600:.1f}h)",
+            flush=True,
+        )
 
     return rolled_back

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -210,5 +210,94 @@ class TestRollbackStaleInProgress(unittest.TestCase):
                          "must NOT be rolled back")
 
 
+def _make_pr(number, label, age_hours):
+    """Build a minimal fake PR dict with updatedAt set to age_hours ago."""
+    updated = datetime.now(timezone.utc) - timedelta(hours=age_hours)
+    return {
+        "number": number,
+        "title": f"Test PR {number}",
+        "updatedAt": updated.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "createdAt": updated.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "labels": [{"name": label}],
+    }
+
+
+class TestRollbackStalePrLocks(unittest.TestCase):
+
+    def _run_pr_rollback(self, immediate, prs, set_pr_labels_mock=None):
+        """Run _rollback_stale_pr_locks with mocked gh + label calls."""
+
+        def fake_gh_json(args, **kwargs):
+            # Cai-lock claim comment scan — return empty list.
+            if args and args[0] == "api":
+                return []
+            # gh pr list --label ... → return the seeded PRs.
+            if args and args[0] == "pr" and args[1] == "list":
+                return prs
+            return []
+
+        spl = (set_pr_labels_mock if set_pr_labels_mock is not None
+               else MagicMock(return_value=True))
+
+        with patch("cai_lib.watchdog._gh_json", side_effect=fake_gh_json), \
+             patch("cai_lib.watchdog._set_pr_labels", spl), \
+             patch("cai_lib.watchdog._delete_issue_comment", return_value=True), \
+             patch("cai_lib.watchdog.log_run"):
+            return cai._rollback_stale_pr_locks(immediate=immediate)
+
+    def test_stale_pr_lock_rolled_back(self):
+        """A PR older than _STALE_LOCKED_HOURS gets its :locked stripped."""
+        pr = _make_pr(901, cai.LABEL_LOCKED,
+                      age_hours=cai._STALE_LOCKED_HOURS + 0.5)
+        spl_mock = MagicMock(return_value=True)
+        result = self._run_pr_rollback(
+            immediate=False, prs=[pr], set_pr_labels_mock=spl_mock,
+        )
+        nums = {p["number"] for p in result}
+        self.assertIn(
+            901, nums,
+            f"{cai._STALE_LOCKED_HOURS + 0.5}h-old :locked PR should be "
+            f"rolled back (TTL={cai._STALE_LOCKED_HOURS}h)",
+        )
+        # Verify _set_pr_labels was called with remove=[LABEL_LOCKED] and
+        # no add=.
+        called = False
+        for call in spl_mock.call_args_list:
+            kwargs = call.kwargs
+            if kwargs.get("remove") == [cai.LABEL_LOCKED]:
+                called = True
+                self.assertFalse(
+                    kwargs.get("add"),
+                    "watchdog must not add an FSM state label when "
+                    "rolling back :locked on a PR",
+                )
+        self.assertTrue(
+            called,
+            "watchdog must call _set_pr_labels with remove=[LABEL_LOCKED]",
+        )
+
+    def test_fresh_pr_lock_not_rolled_back(self):
+        """PRs within _STALE_LOCKED_HOURS must NOT be rolled back."""
+        pr = _make_pr(902, cai.LABEL_LOCKED,
+                      age_hours=cai._STALE_LOCKED_HOURS / 2)
+        result = self._run_pr_rollback(immediate=False, prs=[pr])
+        nums = {p["number"] for p in result}
+        self.assertNotIn(
+            902, nums,
+            f"fresh :locked PR (age < {cai._STALE_LOCKED_HOURS}h) must NOT "
+            "be rolled back",
+        )
+
+    def test_immediate_true_rolls_back_fresh_pr(self):
+        """immediate=True must roll back even fresh :locked PRs (restart)."""
+        pr = _make_pr(903, cai.LABEL_LOCKED, age_hours=0.01)
+        result = self._run_pr_rollback(immediate=True, prs=[pr])
+        nums = {p["number"] for p in result}
+        self.assertIn(
+            903, nums,
+            "immediate=True must roll back :locked PRs regardless of age",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `_rollback_stale_in_progress` only queries `gh issue list`, so PRs whose dispatcher crashed mid-handler would strand `auto-improve:locked` indefinitely — no TTL sweep and no restart sweep.
- Add `_rollback_stale_pr_locks` mirroring the issue-side `:locked` branch for PRs (lists via `gh pr list`, strips via `_set_pr_labels`, deletes cai-lock claim comments using the shared `/issues/<N>/comments` endpoint).
- Wire it into `cmd_cycle` restart recovery (`immediate=True`) and `cmd_audit` periodic sweep alongside the existing issue rollback.

## Test plan
- [x] `python -m unittest tests.test_rollback -v` — 11/11 pass, including 3 new PR-side cases (stale rolled back, fresh preserved, `immediate=True` on restart).
- [ ] Observe a real `cai cycle` restart log and confirm "recovered N stale PR lock(s)" line fires when applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)