### PR TITLE
auto-improve: Rescue prevention: The planning confidence gate should distinguish between *substantive uncertainty* (policy questions, ambiguous requireme

### DIFF
--- a/.claude/agents/implementation/cai-select.md
+++ b/.claude/agents/implementation/cai-select.md
@@ -50,6 +50,39 @@ In summary: architectural disagreements between plans are tie-breakers
 that favor the plan agreeing with the refined issue's explicit choices,
 not confidence-lowering signals.
 
+## Distinguish substantive uncertainty from soft risks
+
+Before settling on MEDIUM or LOW, categorise each concern you are
+tempted to cite. Only **substantive uncertainty** warrants a
+downgrade — **soft / non-blocking risks** do not.
+
+- **Substantive uncertainty** (legitimate grounds to downgrade):
+  policy questions the refined issue did not answer, ambiguous
+  requirements, unverified external dependencies, missing edge
+  cases, or a concrete risk of regression that the plan has not
+  addressed.
+- **Soft / non-blocking risks** (NOT grounds to downgrade):
+  - Additive JSON schema fields or other strictly
+    backwards-compatible extensions to a data contract — downstream
+    consumers that have not yet been updated are a separate-issue
+    concern, not a correctness blocker for the current plan.
+  - Opinionated-but-correct operational recipes (style choices,
+    wording, example copy) that do not contradict any explicit
+    requirement in the refined issue.
+  - Cross-agent consistency concerns or downstream consumer work
+    that the refined issue explicitly scopes to a separate issue.
+  - Cosmetic or implementation-detail risks already covered by
+    the anchor-mitigation marker (line-number drift, fence
+    escaping, wording tweaks).
+
+If every concern you can articulate about the selected plan falls
+into the "soft / non-blocking" bucket, that is a HIGH-confidence
+plan — emit HIGH and briefly note in `confidence_reason` why the
+cited risks are additive or scoped out. Reserve MEDIUM / LOW for
+**genuine ambiguity or missing information** in the plan itself
+(unverified assumptions, unclear scope, missing edge cases, or the
+verbatim-content deficiency in criterion 5 below).
+
 ## How to evaluate
 
 Assess each plan on these criteria, in order of importance:

--- a/.claude/agents/lifecycle/cai-rescue.md
+++ b/.claude/agents/lifecycle/cai-rescue.md
@@ -61,10 +61,14 @@ Choose exactly one verdict:
 
 Only emit this when ALL of the following hold:
 
-- The divert reason is mechanical — a confidence-gate trip
-  (LOW/MEDIUM rather than substantive uncertainty), a transient
-  infrastructure failure, a parser glitch, or a plan-quality issue
-  that simply re-running the upstream agent will fix.
+- The divert reason is mechanical — a transient infrastructure
+  failure, a parser glitch, or a plan-quality issue that simply
+  re-running the upstream agent will fix. A confidence-gate trip
+  (LOW/MEDIUM) is only autonomously resolvable when the evidence
+  points to a parser or transcription glitch that prevented a
+  correct HIGH assignment — under the current `cai-select` guidance,
+  a genuine LOW/MEDIUM indicates substantive uncertainty and is
+  **NOT** mechanically resolvable.
 - The path forward is unambiguous — there is exactly one obvious
   resume target and no judgement call between alternatives.
 - Nothing in the divert comment, the issue body, or the comment


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#925

**Issue:** #925 — Rescue prevention: The planning confidence gate should distinguish between *substantive uncertainty* (policy questions, ambiguous requireme

## PR Summary

### What this fixes
The `cai-select` agent was downgrading confidence to MEDIUM/LOW even when the only cited concerns were additive schema fields, opinionated-but-correct recipes, or cross-agent consistency work explicitly scoped to separate issues — soft, non-blocking risks that should not gate the implement pipeline.

### What was changed
- **`.claude/agents/implementation/cai-select.md`** (written through `.cai-staging/agents/implementation/cai-select.md`): inserted a new `## Distinguish substantive uncertainty from soft risks` section between the existing "Extract settled architectural decisions first" section and "## How to evaluate". The section instructs `cai-select` to categorise each concern before downgrading — only substantive uncertainty (policy gaps, ambiguous requirements, unverified dependencies, regression risk) warrants MEDIUM/LOW; additive schema extensions, opinionated recipes, cross-agent scoping, and anchor-mitigation cosmetics do not.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
