### PR TITLE
auto-improve: Rescue prevention: When `cai implement` parks at `tests_failed` after 3 attempts, the divert comment should include the specific failing te

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -128,6 +128,7 @@
 | `tests/test_dup_check.py` | TODO: add description |
 | `tests/test_fsm.py` | Tests for cai_lib.fsm — states, transitions, Confidence, divert, marker, resume helpers |
 | `tests/test_implement_consecutive_failures.py` | TODO: add description |
+| `tests/test_implement_test_failure_extract.py` | TODO: add description |
 | `tests/test_lint.py` | Lint check: ruff must report zero violations |
 | `tests/test_maintain.py` | Tests for cai_lib.actions.maintain — handle_maintain confidence routing and FSM transitions |
 | `tests/test_merge_diff.py` | TODO: add description |

--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -280,6 +280,98 @@ def _find_existing_branch(issue_number: int) -> str | None:
     return None
 
 
+def _extract_test_failures(output: str, max_chars: int = 3000) -> str:
+    """Filter ``python -m unittest -v`` output to FAIL/ERROR sections only.
+
+    The full unittest log can be hundreds of lines of ``... ok`` entries
+    that crowd out the actual failure signal when posted into a divert
+    comment. We surface three concise pieces instead:
+
+    1. A list of failing test identifiers (``FAIL: <dotted>`` /
+       ``ERROR: <dotted>``) from the per-test status lines at the top
+       of the verbose output.
+    2. Each detailed ``FAIL:`` / ``ERROR:`` block emitted after the
+       ``===`` separators, including the traceback for that test.
+    3. The final summary line (``FAILED (failures=N, errors=M)`` or
+       ``OK``) so the divert consumer can see aggregate counts.
+
+    Result is capped at *max_chars* and suffixed with ``... (truncated)``
+    when clipped. If the input has no recognisable FAIL/ERROR markers
+    (e.g. a crash before unittest ran), the raw output is returned
+    truncated so the divert comment is never empty.
+    """
+    lines = output.splitlines()
+
+    status_re = re.compile(
+        r"^(\S+)\s+\(([^)]+)\)\s+\.\.\.\s+(FAIL|ERROR)\b"
+    )
+    block_start_re = re.compile(r"^(FAIL|ERROR):\s+")
+
+    failing_names: list[str] = []
+    for ln in lines:
+        m = status_re.match(ln)
+        if m:
+            failing_names.append(f"{m.group(3)}: {m.group(2)}")
+
+    blocks: list[str] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        if block_start_re.match(lines[i]):
+            block_lines = [lines[i]]
+            i += 1
+            while i < n:
+                # Next detailed block starts — stop so we don't swallow it.
+                if (
+                    lines[i].startswith("=====")
+                    and i + 1 < n
+                    and block_start_re.match(lines[i + 1])
+                ):
+                    break
+                # End of test session — stop before the "Ran N tests" summary.
+                if (
+                    lines[i].startswith("-----")
+                    and i + 1 < n
+                    and lines[i + 1].startswith("Ran ")
+                ):
+                    break
+                block_lines.append(lines[i])
+                i += 1
+            blocks.append("\n".join(block_lines).rstrip())
+        else:
+            i += 1
+
+    summary = ""
+    for ln in reversed(lines):
+        stripped = ln.strip()
+        if stripped.startswith("FAILED") or stripped == "OK":
+            summary = stripped
+            break
+
+    if not failing_names and not blocks:
+        truncated = output[:max_chars]
+        if len(output) > max_chars:
+            truncated += "\n\n... (truncated)"
+        return truncated
+
+    parts: list[str] = []
+    if failing_names:
+        parts.append("Failing tests:")
+        parts.extend(f"  - {name}" for name in failing_names)
+        parts.append("")
+    if blocks:
+        parts.extend(blocks)
+    if summary:
+        if parts and parts[-1] != "":
+            parts.append("")
+        parts.append(summary)
+
+    result = "\n".join(parts).rstrip()
+    if len(result) > max_chars:
+        result = result[:max_chars].rstrip() + "\n\n... (truncated)"
+    return result
+
+
 def _count_consecutive_tests_failed(issue_number: int) -> int:
     """Count trailing consecutive ``result=tests_failed`` log entries
     for *issue_number* in LOG_PATH.
@@ -721,16 +813,14 @@ def handle_implement(issue: dict) -> int:
                 # with the same double-retry guard so a transient GitHub
                 # failure does not leave the issue stuck without a lifecycle
                 # label.
-                truncated = failure_output[:3000]
-                if len(failure_output) > 3000:
-                    truncated += "\n\n... (truncated)"
+                failure_summary = _extract_test_failures(failure_output)
                 comment_body = (
                     "## Implement subagent: repeated test failures\n\n"
                     f"Regression tests failed {consecutive} consecutive times "
                     f"for this issue. Escalating to human review to avoid "
                     f"monopolising the implement loop.\n\n"
-                    "### Last test output\n\n"
-                    f"```\n{truncated}\n```\n\n"
+                    "### Failing tests\n\n"
+                    f"```\n{failure_summary}\n```\n\n"
                     "---\n"
                     "_Set by `cai implement` after "
                     f"{_MAX_TESTS_FAILED_RETRIES} consecutive `tests_failed` "

--- a/tests/test_implement_test_failure_extract.py
+++ b/tests/test_implement_test_failure_extract.py
@@ -1,0 +1,81 @@
+"""Tests for cai_lib.actions.implement._extract_test_failures."""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.actions.implement import _extract_test_failures
+
+
+_VERBOSE_OUTPUT = """test_foo (tests.test_foo.TestFoo.test_foo) ... ok
+test_bar (tests.test_bar.TestBar.test_bar) ... FAIL
+test_baz (tests.test_baz.TestBaz.test_baz) ... ERROR
+
+======================================================================
+FAIL: test_bar (tests.test_bar.TestBar.test_bar)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "tests/test_bar.py", line 42, in test_bar
+    self.assertEqual(1, 2)
+AssertionError: 1 != 2
+
+======================================================================
+ERROR: test_baz (tests.test_baz.TestBaz.test_baz)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "tests/test_baz.py", line 7, in test_baz
+    raise RuntimeError("oh no")
+RuntimeError: oh no
+
+----------------------------------------------------------------------
+Ran 3 tests in 0.002s
+
+FAILED (failures=1, errors=1)
+"""
+
+
+class TestExtractTestFailures(unittest.TestCase):
+    def test_lists_failing_test_names(self):
+        result = _extract_test_failures(_VERBOSE_OUTPUT)
+        self.assertIn("FAIL: tests.test_bar.TestBar.test_bar", result)
+        self.assertIn("ERROR: tests.test_baz.TestBaz.test_baz", result)
+
+    def test_includes_traceback_blocks(self):
+        result = _extract_test_failures(_VERBOSE_OUTPUT)
+        self.assertIn("AssertionError: 1 != 2", result)
+        self.assertIn("RuntimeError: oh no", result)
+
+    def test_includes_final_summary(self):
+        result = _extract_test_failures(_VERBOSE_OUTPUT)
+        self.assertIn("FAILED (failures=1, errors=1)", result)
+
+    def test_omits_passing_test_lines(self):
+        result = _extract_test_failures(_VERBOSE_OUTPUT)
+        self.assertNotIn("test_foo (", result)
+        self.assertNotIn("... ok", result)
+
+    def test_omits_ran_summary_divider(self):
+        result = _extract_test_failures(_VERBOSE_OUTPUT)
+        self.assertNotIn("Ran 3 tests in", result)
+
+    def test_respects_max_chars(self):
+        result = _extract_test_failures(_VERBOSE_OUTPUT, max_chars=80)
+        self.assertTrue(result.endswith("... (truncated)"))
+        # Body is clipped to max_chars then the truncation marker is appended.
+        self.assertLessEqual(len(result), 80 + len("\n\n... (truncated)"))
+
+    def test_falls_back_to_raw_when_no_markers(self):
+        raw = "some crash output with no FAIL or ERROR markers"
+        result = _extract_test_failures(raw)
+        self.assertEqual(result, raw)
+
+    def test_falls_back_truncates_raw_when_no_markers(self):
+        raw = "x" * 5000
+        result = _extract_test_failures(raw, max_chars=1000)
+        self.assertTrue(result.endswith("... (truncated)"))
+        self.assertLessEqual(len(result), 1000 + len("\n\n... (truncated)"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#941

**Issue:** #941 — Rescue prevention: When `cai implement` parks at `tests_failed` after 3 attempts, the divert comment should include the specific failing te

## PR Summary

### What this fixes
When `cai implement` parks an issue at `:human-needed` after 3 consecutive test failures, the divert comment previously included a raw truncated dump of the full unittest output (mostly `... ok` lines), making it hard for admins and rescue agents to see which tests actually failed.

### What was changed
- **`cai_lib/actions/implement.py`**: Added new helper `_extract_test_failures(output, max_chars=3000)` that filters `python -m unittest -v` output to (1) a list of failing test names, (2) each FAIL/ERROR traceback block, and (3) the final summary line — with a raw fallback for unrecognised output. Replaced the raw-truncation block in the escalation branch with a call to this helper, and updated the subheading from `### Last test output` to `### Failing tests`.
- **`tests/test_implement_test_failure_extract.py`** (new): 8 unit tests covering verbose-format parsing, truncation, omission of passing lines, and the raw-fallback path.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
