### PR TITLE
auto-improve: cai cycle force-unlocks fresh locks via immediate=True, can kill in-flight handlers

### DIFF
--- a/cai_lib/cmd_cycle.py
+++ b/cai_lib/cmd_cycle.py
@@ -78,15 +78,18 @@ def cmd_cycle(args) -> int:
                     )
                 _healed.add(_num)
 
-    # Phase 1: restart recovery — force-rollback any stuck locks left
-    # behind by a previous run that crashed mid-handler. Covers both
-    # issue-side FSM/ownership locks and PR-side ownership locks.
-    rolled_back = _rollback_stale_in_progress(immediate=True)
+    # Phase 1: TTL-based stale-lock sweep — rolls back only locks that
+    # have exceeded their configured TTL (_STALE_LOCKED_HOURS etc.).
+    # NOTE: immediate=True is NOT used here; that path bypasses TTLs and
+    # is reserved for explicit container-restart recovery where every
+    # in-flight lock is guaranteed orphaned.  Normal cron ticks must use
+    # TTL-based detection so live handlers are not killed.
+    rolled_back = _rollback_stale_in_progress()
     if rolled_back:
         nums = ", ".join(f"#{i['number']}" for i in rolled_back)
         print(f"[cai cycle] recovered {len(rolled_back)} stale lock(s): {nums}",
               flush=True)
-    rolled_back_prs = _rollback_stale_pr_locks(immediate=True)
+    rolled_back_prs = _rollback_stale_pr_locks()
     if rolled_back_prs:
         nums = ", ".join(f"#{p['number']}" for p in rolled_back_prs)
         print(

--- a/cai_lib/watchdog.py
+++ b/cai_lib/watchdog.py
@@ -40,9 +40,15 @@ from cai_lib.logging_utils import log_run
 def _rollback_stale_in_progress(*, immediate: bool = False) -> list[dict]:
     """Deterministic rollback: :in-progress, :revising, or :applying issues with no recent activity.
 
-    When ``immediate=True`` every locked issue is rolled back regardless of age
-    (used by ``cmd_cycle`` on container restart where all in-flight locks are
-    guaranteed to be orphaned).
+    TTL-based (normal operation): each state's configured threshold applies
+    (``_STALE_IN_PROGRESS_HOURS``, ``_STALE_REVISING_HOURS``,
+    ``_STALE_APPLYING_HOURS``, ``_STALE_LOCKED_HOURS``).
+
+    When ``immediate=True`` every locked issue is rolled back regardless of age.
+    This path is reserved for **explicit container-restart recovery** where all
+    in-flight locks are guaranteed orphaned.  It must NOT be used on normal
+    hourly cron ticks — doing so kills live handlers whose lock age is below
+    the TTL.
 
     Returns the list of issues that were rolled back.
     """

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -190,6 +190,30 @@ class TestRollbackStaleInProgress(unittest.TestCase):
             "watchdog must call _set_labels with remove=[LABEL_LOCKED]",
         )
 
+    def test_rollback_locked_10min_not_rolled_back(self):
+        """A 10-minute-old :locked issue must NOT be rolled back without immediate=True.
+
+        This is the exact scenario observed live (age ~0.1h against TTL=1h):
+        cmd_cycle was calling _rollback_stale_in_progress(immediate=True),
+        which bypassed TTLs and killed active handlers.  With immediate=False
+        (the correct call from cmd_cycle), a 10-min-old lock must survive.
+        """
+        locked_issue = _make_issue(811, cai.LABEL_LOCKED, age_hours=0.1)  # ~6 min
+        result = self._run_rollback(
+            immediate=False,
+            issues_by_label={
+                cai.LABEL_IN_PROGRESS: [],
+                cai.LABEL_REVISING: [],
+                cai.LABEL_APPLYING: [],
+                cai.LABEL_LOCKED: [locked_issue],
+            },
+        )
+        nums = {i["number"] for i in result}
+        self.assertNotIn(811, nums,
+                         "0.1h-old :locked must NOT be rolled back "
+                         f"(TTL={cai._STALE_LOCKED_HOURS}h) — "
+                         "cmd_cycle must use TTL-based path, not immediate=True")
+
     def test_rollback_locked_fresh(self):
         """:locked issues within the TTL window must NOT be rolled back."""
         # Half the TTL — well within the window.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#946

**Issue:** #946 — cai cycle force-unlocks fresh locks via immediate=True, can kill in-flight handlers

## PR Summary

### What this fixes
Every `cai cycle` tick was calling `_rollback_stale_in_progress(immediate=True)` and `_rollback_stale_pr_locks(immediate=True)`, which set the staleness threshold to 0 and rolled back **all** in-progress/locked issues regardless of age — killing active handlers that had been running for as little as 6 minutes (well under the 1-hour `_STALE_LOCKED_HOURS` TTL).

### What was changed
- **`cai_lib/cmd_cycle.py`**: Removed `immediate=True` from both Phase 1 rollback calls (`_rollback_stale_in_progress()` and `_rollback_stale_pr_locks()`); updated the Phase 1 comment to explain why `immediate=True` must not be used on normal cron ticks.
- **`cai_lib/watchdog.py`**: Expanded the `_rollback_stale_in_progress` docstring to explicitly state that `immediate=True` is reserved for container-restart recovery where all locks are guaranteed orphaned, and must not be called from hourly cron ticks.
- **`tests/test_rollback.py`**: Added `test_rollback_locked_10min_not_rolled_back` — tests that a 0.1h-old `:locked` issue (matching the exact age from the live incident) is not rolled back when called without `immediate=True`.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
