### PR TITLE
auto-improve: Rescue prevention: When an `ATTEMPT_OPUS_IMPLEMENT` rescue fires, the `auto-improve:opus-attempted` label should be retained on the issue e

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -137,6 +137,7 @@
 | `tests/test_agent_staging.py` | TODO: add description |
 | `tests/test_audit_modules.py` | Tests for cai_lib.audit.modules — load_modules + coverage_check |
 | `tests/test_blocked_on.py` | TODO: add description |
+| `tests/test_cmd_misc_label_sweep.py` | TODO: add description |
 | `tests/test_dispatcher.py` | Tests for the FSM dispatcher and state→handler registries |
 | `tests/test_dup_check.py` | TODO: add description |
 | `tests/test_fsm.py` | Tests for cai_lib.fsm — states, transitions, Confidence, divert, marker, resume helpers |

--- a/cai_lib/cmd_misc.py
+++ b/cai_lib/cmd_misc.py
@@ -36,6 +36,11 @@ _ALL_MANAGED_ISSUE_LABELS: frozenset[str] = frozenset({
     LABEL_HUMAN_NEEDED, LABEL_PR_HUMAN_NEEDED,
     LABEL_TRIAGING, LABEL_MERGE_BLOCKED,
     LABEL_HUMAN_SOLVED, LABEL_KIND_CODE, LABEL_KIND_MAINTENANCE,
+    # Opus one-shot marker set by `cai rescue` when it escalates a
+    # stuck issue to Opus-backed implement. Must survive the hourly
+    # sweep so the next rescue pass can detect the one-shot has
+    # already been burned and refuse a second escalation (#944).
+    LABEL_OPUS_ATTEMPTED,
     "auto-improve", "audit", "check-workflows", "check-workflows:raised",
 })
 

--- a/tests/test_cmd_misc_label_sweep.py
+++ b/tests/test_cmd_misc_label_sweep.py
@@ -1,0 +1,77 @@
+"""Regression tests for the cai-managed label whitelist in cmd_misc.
+
+Tracking issue #944: the hourly `_issue_label_sweep` strips any
+``auto-improve:*`` label that isn't in ``_ALL_MANAGED_ISSUE_LABELS``.
+``auto-improve:opus-attempted`` was missing from that whitelist, so the
+one-shot Opus-escalation marker set by ``cai rescue`` did not survive
+the next sweep — breaking the second-escalation guard. These tests
+pin the whitelist membership and the sweep behaviour.
+"""
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib import cmd_misc as M  # noqa: E402
+from cai_lib.config import LABEL_OPUS_ATTEMPTED  # noqa: E402
+
+
+class TestManagedIssueLabelsWhitelist(unittest.TestCase):
+    """The cai-managed whitelist must include every cai-owned label."""
+
+    def test_opus_attempted_label_is_whitelisted(self):
+        # Issue #944: without this entry, the hourly sweep strips the
+        # label and the one-shot Opus-escalation guard becomes a no-op.
+        self.assertIn(LABEL_OPUS_ATTEMPTED, M._ALL_MANAGED_ISSUE_LABELS)
+
+
+class TestIssueLabelSweepRetainsOpusAttempted(unittest.TestCase):
+    """``_issue_label_sweep`` must NOT remove ``LABEL_OPUS_ATTEMPTED``."""
+
+    def test_sweep_does_not_strip_opus_attempted(self):
+        issue = {
+            "number": 42,
+            "labels": [
+                {"name": "auto-improve"},
+                {"name": "auto-improve:human-needed"},
+                {"name": LABEL_OPUS_ATTEMPTED},
+            ],
+        }
+        # ``_issue_label_sweep`` queries ``gh`` three times (once per
+        # base namespace: auto-improve, audit, check-workflows). Seed
+        # the first reply with the issue and the other two empty.
+        with mock.patch.object(
+            M, "_gh_json", side_effect=[[issue], [], []]
+        ), mock.patch.object(M, "_set_labels") as sl:
+            M._issue_label_sweep()
+
+        # No labels on the issue are "stale" once the whitelist is
+        # correct, so ``_set_labels`` must not be invoked at all.
+        sl.assert_not_called()
+
+    def test_sweep_still_strips_unmanaged_labels(self):
+        # Sanity: a bogus ``auto-improve:legacy`` label must still be
+        # flagged as stale so we don't accidentally disable the sweep.
+        issue = {
+            "number": 43,
+            "labels": [
+                {"name": "auto-improve"},
+                {"name": "auto-improve:legacy-garbage"},
+                {"name": LABEL_OPUS_ATTEMPTED},
+            ],
+        }
+        with mock.patch.object(
+            M, "_gh_json", side_effect=[[issue], [], []]
+        ), mock.patch.object(M, "_set_labels", return_value=True) as sl:
+            M._issue_label_sweep()
+
+        sl.assert_called_once()
+        removed = sl.call_args.kwargs["remove"]
+        self.assertIn("auto-improve:legacy-garbage", removed)
+        self.assertNotIn(LABEL_OPUS_ATTEMPTED, removed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#944

**Issue:** #944 — Rescue prevention: When an `ATTEMPT_OPUS_IMPLEMENT` rescue fires, the `auto-improve:opus-attempted` label should be retained on the issue e

## PR Summary

### What this fixes
The hourly `_issue_label_sweep()` in `cai_lib/cmd_misc.py` was stripping `auto-improve:opus-attempted` because that label was missing from the `_ALL_MANAGED_ISSUE_LABELS` whitelist. This broke the one-shot Opus-escalation guard in `cai rescue`: once the sweep silently removed the label, the next rescue run could not detect the escalation had already been burned and would attempt a second Opus escalation.

### What was changed
- **`cai_lib/cmd_misc.py`**: Added `LABEL_OPUS_ATTEMPTED` to the `_ALL_MANAGED_ISSUE_LABELS` frozenset (with a comment explaining its purpose and the issue reference), so the hourly sweep no longer strips this label.
- **`tests/test_cmd_misc_label_sweep.py`** (new): Regression tests that (a) assert `LABEL_OPUS_ATTEMPTED` is in the whitelist and (b) verify `_issue_label_sweep()` does not call `_set_labels(remove=…)` for a whitelisted label, while still confirming genuinely unmanaged labels are still stripped.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
