### PR TITLE
auto-improve: Rescue prevention: **`cai-review-docs` should verify file existence before acting on deletions.** Before removing references to a file, the

### DIFF
--- a/.claude/agents/review/cai-review-docs.md
+++ b/.claude/agents/review/cai-review-docs.md
@@ -46,6 +46,11 @@ In the user message, in order:
 4. **PR changes (stat summary)** — a `git diff origin/main..HEAD --stat`
    summary showing which files changed and how many lines. The full
    unified diff is **not** included — explore the clone directly.
+5. **Authoritative deletion manifest** — a deterministic list of files
+   this PR actually deletes, computed by the wrapper using
+   `git diff --name-only --diff-filter=D` and verified against the work
+   directory. This is the **single source of truth** for deletions —
+   use it instead of inferring deletions from the stat summary.
 
 ## What to check
 
@@ -125,23 +130,25 @@ tracked source file whose status in the stat summary is `A` (added),
   use the new path. If the rename crosses module boundaries, remove
   the entry from the source module and add it to the target module
   (including glob and narrative bullet in each).
-- **Deleted file.** **First verify the file is actually absent
-  from the work directory** by running
-  `Glob("<path>", path="<work_dir>")` (expect zero matches) or
-  `Read("<work_dir>/<path>")` (expect an error). `git diff --stat`
-  showing "N lines removed" is NOT proof of deletion — a file can
-  have all its lines removed-then-readded in the same diff, or the
-  stat may be read incorrectly. If Glob returns a match or Read
-  succeeds, the file still exists: abort the deletion flow, treat
-  the file as status `M`, and make no module-index edits for it.
-  Only if the file is confirmed absent do the following: If
-  `docs/modules.yaml` contains an exact-match glob for the deleted
-  path, remove that glob. Remove the bullet from the narrative's
-  `## Entry points` list. If this leaves the module with zero
-  `globs`, emit a `### Finding: stale_docs` block requesting
-  removal of the now-empty module entry and its narrative file —
-  your tool set cannot delete files, so the wrapper / human
-  handles the actual `rm`. Do not attempt workarounds.
+- **Deleted file.** **A file counts as deleted ONLY if it appears
+  in the `## Authoritative deletion manifest` block in the user
+  message above.** That block is computed deterministically by the
+  wrapper (`git diff --name-only --diff-filter=D`, verified against
+  the work directory) and is the single source of truth for
+  deletions. Do NOT infer deletions from the `## PR changes (stat
+  summary)` block — a large `-` count there is not proof of
+  deletion: a diff with all lines removed-then-readded, a
+  renamed-in-place file, or a misread stat column can all look
+  like a deletion in `--stat`. If a file is NOT in the manifest,
+  treat it as status `M` and make no module-index edits for it.
+  For each file that IS in the manifest: if `docs/modules.yaml`
+  contains an exact-match glob for the deleted path, remove that
+  glob. Remove the bullet from the narrative's `## Entry points`
+  list. If this leaves the module with zero `globs`, emit a
+  `### Finding: stale_docs` block requesting removal of the
+  now-empty module entry and its narrative file — your tool set
+  cannot delete files, so the wrapper / human handles the actual
+  `rm`. Do not attempt workarounds.
 
 Files with status `M` (edited in place, no rename/delete) do NOT
 require a module-index update.
@@ -187,11 +194,11 @@ After each modification, emit a `### Fixed: stale_docs` block whose
    verify `--foo` is documented).
 5. For every rename, `Grep` the full work directory for the old name across
    `.md`, `.py`, `.sh`, `.yml`, and `.yaml` — this catches stale README lines,
-   docstrings, inline comments, help strings, and workflow comments. For any
-   file you believe was **deleted** by the PR, first confirm its absence via
-   `Glob("<path>", path="<work_dir>")` or `Read("<work_dir>/<path>")` before
-   removing any reference to it. If the file still exists, leave its
-   references alone (see Hard rule 9).
+   docstrings, inline comments, help strings, and workflow comments. The
+   **only** files you may treat as deleted are those listed in the
+   `## Authoritative deletion manifest` block of the user message. For every
+   other file — including ones whose `--stat` line count dropped to zero —
+   the file is still present: leave its references alone (see Hard rule 9).
 6. Use `Glob("docs/**/*.md", path="<work_dir>")` and read `README.md` to check
    prose against the post-PR code.
 7. For each stale reference, **directly edit the file** using `Edit` or
@@ -293,21 +300,23 @@ them inline — they are automatically converted to separate GitHub issues.
    "Updating `.claude/agents/*.md`" section of the work-directory block above.
    The wrapper will copy it back automatically. Emit a `### Fixed: stale_docs`
    block as usual after staging the fix.
-9. **Verify file existence before acting on deletions.** Before removing
-   any reference to a file you believe was deleted by the PR — whether
-   in prose, docstrings, comments, help strings, `docs/modules.yaml`
-   globs, or module narratives — confirm the file is actually gone
-   from the work directory using `Glob("<path>", path="<work_dir>")`
-   (zero matches) or `Read("<work_dir>/<path>")` (must error). The
-   `git diff --stat` summary listing a file with only `-` lines is NOT
-   conclusive proof of deletion: a diff with all lines removed-and-
-   readded, a misread of the stat column, or a renamed-in-place file
-   can all look like a deletion. If Glob returns a match or Read
-   succeeds, treat the file as still present and make NO deletion-
-   driven edits that assume it is gone. This rule applies globally
-   to every removal of a reference based on the belief that a file
-   was deleted. Violating it caused the out-of-scope edits to
-   `cai_lib/__init__.py` and `scripts/generate-index.sh` in PR #950.
+9. **The authoritative deletion manifest is the sole source of truth
+   for deletions.** The user message contains an
+   `## Authoritative deletion manifest` block listing the exact files
+   this PR deletes (computed by
+   `git diff --name-only --diff-filter=D` and verified absent by the
+   wrapper). Never remove a reference to a file — in prose,
+   docstrings, comments, help strings, `docs/modules.yaml` globs, or
+   module narratives — unless that file is explicitly listed in the
+   manifest. The `## PR changes (stat summary)` block is NOT
+   conclusive evidence: a diff with all lines removed-and-readded, a
+   renamed-in-place file, or a misread `--stat` column can all look
+   like a deletion there. If you are tempted to remove a reference
+   based on the stat summary alone, stop and cross-check the
+   manifest; if the path is absent from the manifest, leave the
+   reference in place. Violating this rule caused the out-of-scope
+   edits to `cai_lib/__init__.py` and `scripts/generate-index.sh` in
+   PR #950 / issue #960.
 
 ## Agent-specific efficiency guidance
 

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -154,6 +154,7 @@
 | `tests/test_remote_lock.py` | TODO: add description |
 | `tests/test_rescue_opus.py` | Tests for cai_lib.cmd_rescue — Opus-escalation verdict plumbing, schema, and one-shot label guard |
 | `tests/test_retroactive_sweep.py` | TODO: add description |
+| `tests/test_review_docs_manifest.py` | TODO: add description |
 | `tests/test_revise_filter.py` | TODO: add description |
 | `tests/test_rollback.py` | Tests for rollback functionality |
 | `tests/test_subprocess_utils.py` | TODO: add description |

--- a/cai_lib/actions/review_docs.py
+++ b/cai_lib/actions/review_docs.py
@@ -38,6 +38,55 @@ _DOCS_REVIEW_COMMENT_HEADING_CLEAN = "## cai docs review (clean)"
 _DOCS_REVIEW_COMMENT_HEADING_APPLIED = "## cai docs review (applied)"
 
 
+def _build_deletion_manifest_block(work_dir: Path) -> str:
+    """Return the authoritative deletion manifest block for the
+    ``cai-review-docs`` user message.
+
+    Computes the set of files this PR removes vs ``origin/main``
+    using ``git diff --name-only --diff-filter=D``, cross-verifies
+    that each reported path is actually absent from ``work_dir``
+    (guarding against pathological `diff` output), and renders a
+    Markdown block the agent consumes as the single source of
+    truth for deletions.
+
+    Established by issue #960 / PR #950: without a deterministic
+    manifest, the agent inferred deletions from ``git diff --stat``
+    and removed live references to still-present files.
+    """
+    del_result = _git(
+        work_dir, "diff", "origin/main..HEAD",
+        "--name-only", "--diff-filter=D",
+        check=False,
+    )
+    raw_paths = [
+        line.strip()
+        for line in (del_result.stdout or "").splitlines()
+        if line.strip()
+    ]
+    verified_deleted = [p for p in raw_paths if not (work_dir / p).exists()]
+    if verified_deleted:
+        manifest_lines = "\n".join(f"- `{p}`" for p in verified_deleted)
+        return (
+            "## Authoritative deletion manifest\n\n"
+            "The following files are deleted by this PR vs "
+            "`origin/main` (verified by "
+            "`git diff --name-only --diff-filter=D` **and** confirmed "
+            "absent from the work directory). This list is the "
+            "**single source of truth** for deletions — do NOT infer "
+            "deletions from the stat summary above; any file NOT in "
+            "this list is still present in the work directory and "
+            "must be treated as status `M`:\n\n"
+            f"{manifest_lines}\n\n"
+        )
+    return (
+        "## Authoritative deletion manifest\n\n"
+        "This PR deletes no files vs `origin/main`. Do NOT remove "
+        "any reference on the assumption that a file was deleted — "
+        "the `--stat` summary above only shows line-count deltas, "
+        "not deletions.\n\n"
+    )
+
+
 def handle_review_docs(pr: dict) -> int:
     """Run cai-review-docs on *pr* (already at PRState.REVIEWING_DOCS)."""
     t0 = time.monotonic()
@@ -148,6 +197,15 @@ def handle_review_docs(pr: dict) -> int:
             "(no changes vs origin/main)"
         )
 
+        # Authoritative deletion manifest (issue #960): the exact set
+        # of files this PR actually removes vs origin/main, determined
+        # by `git diff --name-only --diff-filter=D` and cross-verified
+        # against the work directory. The agent consumes this list as
+        # the single source of truth for deletions, instead of guessing
+        # from the --stat summary (which was the false-premise failure
+        # mode in PR #950).
+        deletion_manifest_block = _build_deletion_manifest_block(work_dir)
+
         author_login = pr.get("author", {}).get("login", "unknown")
         issue_block = _fetch_linked_issue_block(pr.get("body", ""))
         user_message = (
@@ -162,6 +220,7 @@ def handle_review_docs(pr: dict) -> int:
             + issue_block
             + "## PR changes (stat summary)\n\n"
             + f"```\n{pr_stat}\n```\n\n"
+            + deletion_manifest_block
             + "The full unified diff is **not** included — it is a "
             + "large token sink. The PR branch is checked out in the "
             + f"work directory at `{work_dir}`. Use `Read`, `Grep`, "

--- a/tests/test_review_docs_manifest.py
+++ b/tests/test_review_docs_manifest.py
@@ -1,0 +1,80 @@
+"""Tests for ``cai_lib.actions.review_docs._build_deletion_manifest_block``.
+
+Established by issue #960: the wrapper must pass the agent a
+deterministic list of deleted files, not let the agent guess from
+``git diff --stat``. These tests lock down the manifest rendering
+contract.
+"""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.actions import review_docs  # noqa: E402
+
+
+def _fake_git_result(stdout: str) -> SimpleNamespace:
+    return SimpleNamespace(stdout=stdout, stderr="", returncode=0)
+
+
+class TestDeletionManifestBlock(unittest.TestCase):
+
+    def _make_tmp(self) -> Path:
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(tmp, ignore_errors=True))
+        return tmp
+
+    def test_empty_output_renders_no_deletions_block(self):
+        tmp = self._make_tmp()
+        with patch.object(review_docs, "_git",
+                          return_value=_fake_git_result("")):
+            block = review_docs._build_deletion_manifest_block(tmp)
+        self.assertIn("## Authoritative deletion manifest", block)
+        self.assertIn("This PR deletes no files", block)
+
+    def test_deleted_paths_render_as_bullets(self):
+        tmp = self._make_tmp()
+        # Note: paths intentionally NOT created on disk, so the
+        # existence-cross-check keeps them in the manifest.
+        stdout = "cai_lib/dead.py\nscripts/gone.sh\n"
+        with patch.object(review_docs, "_git",
+                          return_value=_fake_git_result(stdout)):
+            block = review_docs._build_deletion_manifest_block(tmp)
+        self.assertIn("- `cai_lib/dead.py`", block)
+        self.assertIn("- `scripts/gone.sh`", block)
+        self.assertIn("single source of truth", block)
+
+    def test_still_present_files_are_filtered_out(self):
+        tmp = self._make_tmp()
+        # Seed a file that git claims is deleted but which is actually
+        # present in the work dir — the pathological case the defensive
+        # cross-check exists to guard against.
+        present = tmp / "cai_lib" / "still_here.py"
+        present.parent.mkdir(parents=True, exist_ok=True)
+        present.write_text("# real\n")
+        stdout = "cai_lib/still_here.py\nscripts/gone.sh\n"
+        with patch.object(review_docs, "_git",
+                          return_value=_fake_git_result(stdout)):
+            block = review_docs._build_deletion_manifest_block(tmp)
+        self.assertNotIn("cai_lib/still_here.py", block)
+        self.assertIn("- `scripts/gone.sh`", block)
+
+    def test_blank_lines_in_git_output_are_ignored(self):
+        tmp = self._make_tmp()
+        stdout = "\ncai_lib/dead.py\n\n"
+        with patch.object(review_docs, "_git",
+                          return_value=_fake_git_result(stdout)):
+            block = review_docs._build_deletion_manifest_block(tmp)
+        self.assertIn("- `cai_lib/dead.py`", block)
+        # No empty bullets.
+        self.assertNotIn("- ``", block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#960

**Issue:** #960 — Rescue prevention: **`cai-review-docs` should verify file existence before acting on deletions.** Before removing references to a file, the

## PR Summary

### What this fixes
`cai-review-docs` was inferring file deletions from `git diff --stat` output, which is not conclusive proof of deletion — leading to false-premise edits that removed live references in PR #950. This fix computes a deterministic deletion manifest wrapper-side and passes it to the agent as the sole source of truth.

### What was changed
- **`cai_lib/actions/review_docs.py`**: Added `_build_deletion_manifest_block(work_dir)` helper that runs `git diff --name-only --diff-filter=D`, cross-verifies each path is absent from the work directory, and renders a `## Authoritative deletion manifest` Markdown block. Wired the block into the `handle_review_docs` user message, inserted after the stat summary.
- **`.claude/agents/review/cai-review-docs.md`** (via staging): Rewrote the "Deleted file" index-maintenance bullet, step 5 of "How to work", and Hard rule 9 to direct the agent to use the manifest as the single source of truth for deletions instead of guessing from `--stat`.
- **`tests/test_review_docs_manifest.py`** (new): Four unit tests covering empty output, deleted-paths rendering, still-present-file filtering, and blank-line handling in `_build_deletion_manifest_block`.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
