### PR TITLE
auto-improve: Rescue prevention: When `cai-update-check` or any raising agent files an issue with `kind:maintenance`, the pipeline should verify that a `

### DIFF
--- a/.claude/agents/lifecycle/cai-triage.md
+++ b/.claude/agents/lifecycle/cai-triage.md
@@ -108,6 +108,11 @@ Rules:
   directly. Omit otherwise.
 - `ops` is required when `skip_confidence=HIGH` AND `routing_decision=APPLY`.
   Provide an ordered markdown list of operations for `cai-maintain` to execute.
-  Omit otherwise.
+  Valid operations are: `label add <issue_number> <label>`,
+  `label remove <issue_number> <label>`, `close <issue_number>`,
+  or `workflow edit <file_path> <key> <value>`. Each operation must appear on
+  its own line in the markdown list. Invalid ops blocks (prose, implement-style
+  steps, or empty lists) will be rescued and re-routed to `:refining` as
+  `kind:code` instead. Omit otherwise.
 - Do not write code, diffs, or remediation prose outside of `plan` / `ops`.
 - Do not propose new labels or lifecycle states.

--- a/cai_lib/actions/triage.py
+++ b/cai_lib/actions/triage.py
@@ -9,6 +9,7 @@ calling :func:`handle_triage`.
 from __future__ import annotations
 
 import json
+import re
 import sys
 import time
 
@@ -75,6 +76,44 @@ _TRIAGE_JSON_SCHEMA = {
     },
     "required": ["routing_decision", "routing_confidence", "kind", "reasoning"],
 }
+
+
+# ---------------------------------------------------------------------------
+# Maintenance-ops validator
+# ---------------------------------------------------------------------------
+
+# Regex for lines recognised by cai-maintain (see
+# .claude/agents/ops/cai-maintain.md). Valid ops (with optional markdown
+# list bullet):
+#   label add <issue_number> <label>
+#   label remove <issue_number> <label>
+#   close <issue_number>
+#   workflow edit <file_path> <key> <value>
+_MAINTENANCE_OP_LINE_RE = re.compile(
+    r"^\s*(?:[-*+]\s+|\d+[.)]\s+)?"
+    r"(?:label\s+(?:add|remove)\s+\d+"
+    r"|close\s+\d+"
+    r"|workflow\s+edit\s+\S+)",
+    re.IGNORECASE,
+)
+
+
+def _ops_body_has_valid_maintenance_op(ops_body: str | None) -> bool:
+    """Return True when *ops_body* contains at least one line that parses
+    as a cai-maintain op.
+
+    Used by :func:`handle_triage` to reject APPLY verdicts whose ops
+    block is pure prose or implement-style steps — those would divert
+    cai-maintain to ``:human-needed`` on the first "No Ops block found"
+    check (issue #981). When the check fails the triage handler
+    re-routes the issue into the REFINE pathway with ``kind:code``,
+    preventing the structural mismatch at the source.
+    """
+    if not ops_body:
+        return False
+    return any(
+        _MAINTENANCE_OP_LINE_RE.match(line) for line in ops_body.splitlines()
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -287,7 +326,21 @@ def handle_triage(issue: dict) -> int:
             action_taken = "plan_approve"
         else:  # decision == "APPLY"
             ops_body = tool_input.get("ops")
-            if ops_body:
+            if not _ops_body_has_valid_maintenance_op(ops_body):
+                # The triage agent emitted APPLY+maintenance with HIGH
+                # SkipConfidence but the ops body contains no valid
+                # cai-maintain op lines (prose or implement-style
+                # steps). Re-route as kind:code into the REFINE
+                # pathway — otherwise cai-maintain would immediately
+                # divert to :human-needed with "No Ops block found"
+                # (issue #981).
+                kind_label = LABEL_KIND_CODE
+                action_taken = _fallthrough_to_refine(
+                    "with HIGH SkipConfidence but ops body contains no "
+                    "valid cai-maintain operation lines — re-routing as "
+                    "kind:code to the implement pathway"
+                )
+            else:
                 existing_body = issue.get("body") or ""
                 stripped_body = _strip_stored_plan_block(existing_body)
                 ops_section = (
@@ -299,18 +352,18 @@ def handle_triage(issue: dict) -> int:
                      "--repo", REPO, "--body", new_body],
                     capture_output=True, check=True,
                 )
-            apply_transition(
-                issue_number, "triaging_to_applying",
-                current_labels=[LABEL_TRIAGING],
-                log_prefix="cai triage",
-            )
-            _set_labels(issue_number, add=[kind_label], log_prefix="cai triage")
-            print(
-                f"[cai triage] #{issue_number}: APPLY with HIGH SkipConfidence "
-                f"— advancing to applying",
-                flush=True,
-            )
-            action_taken = "applying"
+                apply_transition(
+                    issue_number, "triaging_to_applying",
+                    current_labels=[LABEL_TRIAGING],
+                    log_prefix="cai triage",
+                )
+                _set_labels(issue_number, add=[kind_label], log_prefix="cai triage")
+                print(
+                    f"[cai triage] #{issue_number}: APPLY with HIGH SkipConfidence "
+                    f"— advancing to applying",
+                    flush=True,
+                )
+                action_taken = "applying"
     else:
         # REFINE or any unrecognised decision → fall through to REFINE.
         apply_transition(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ Handler registry (issue states):
 
 | State | Handler file | Role |
 |---|---|---|
-| `RAISED` / `TRIAGING` | `cai_lib/actions/triage.py` | Pre-check for duplicates/resolved issues via `cai-dup-check` (closes at HIGH confidence). Then classify the issue (REFINE / PLAN_APPROVE / APPLY / HUMAN). PLAN_APPROVE / APPLY at HIGH SkipConfidence skips ahead to `:plan-approved` or `:applying`. |
+| `RAISED` / `TRIAGING` | `cai_lib/actions/triage.py` | Pre-check for duplicates/resolved issues via `cai-dup-check` (closes at HIGH confidence). Then classify the issue (REFINE / PLAN_APPROVE / APPLY / HUMAN). PLAN_APPROVE at HIGH SkipConfidence skips ahead to `:plan-approved`; APPLY at HIGH SkipConfidence with valid maintenance ops skips ahead to `:applying`. APPLY verdicts with invalid ops blocks (prose or empty) are rescued and re-routed to `:refining` with `kind:code` instead. |
 | `REFINING` | `cai_lib/actions/refine.py` | Rewrite the issue into a structured plan with steps, verification, and scope guardrails. |
 | `NEEDS_EXPLORATION` | `cai_lib/actions/explore.py` | Run `cai-explore` to investigate an under-specified issue and route back to `:refining`. |
 | `REFINED` / `PLANNING` / `PLANNED` | `cai_lib/actions/plan.py` | Run plan + select, store the plan in the issue body, then apply the confidence gate: HIGH auto-promotes to `:plan-approved`; MEDIUM with explicit anchor-based risk mitigation also auto-promotes; others (MEDIUM without marker, LOW, or missing) divert to `:human-needed` with a pending marker and a comment explaining the confidence reason (e.g., unverified assumptions, ambiguous scope). |

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -19,6 +19,7 @@ from cai_lib.config import (
     LABEL_PLANNING, LABEL_PLANNED,
     LABEL_HUMAN_NEEDED, LABEL_PARENT, LABEL_TRIAGING,
     LABEL_APPLYING, LABEL_APPLIED,
+    LABEL_KIND_CODE, LABEL_KIND_MAINTENANCE,
 )
 
 
@@ -817,6 +818,136 @@ class TestTriagingHandlerPairCheck(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertIn("triaging_to_refining", transitions_called)
         self.assertNotIn("triaging_to_plan_approved", transitions_called)
+
+
+class TestTriagingHandlerOpsValidation(unittest.TestCase):
+    """handle_triage() must reject APPLY+maintenance verdicts whose ops
+    body is prose rather than cai-maintain op lines, re-routing the
+    issue into the REFINE pathway with kind:code (issue #981)."""
+
+    def _make_issue(self, number=981):
+        return {
+            "number": number,
+            "title": "Pin claude-code version",
+            "body": "Some best-practice finding.",
+            "labels": [{"name": LABEL_TRIAGING}],
+        }
+
+    def test_ops_validator_accepts_valid_op_lines(self):
+        from cai_lib.actions.triage import _ops_body_has_valid_maintenance_op
+        self.assertTrue(_ops_body_has_valid_maintenance_op(
+            "1. label add 42 kind:code\n"))
+        self.assertTrue(_ops_body_has_valid_maintenance_op(
+            "- close 12"))
+        self.assertTrue(_ops_body_has_valid_maintenance_op(
+            "label remove 7 stale"))
+        self.assertTrue(_ops_body_has_valid_maintenance_op(
+            "workflow edit .github/workflows/a.yml on push"))
+
+    def test_ops_validator_rejects_prose_and_empty(self):
+        from cai_lib.actions.triage import _ops_body_has_valid_maintenance_op
+        self.assertFalse(_ops_body_has_valid_maintenance_op(
+            "1. Open the Dockerfile and locate @latest\n"
+            "2. Replace with @2.1.114 in the npm install line\n"))
+        self.assertFalse(_ops_body_has_valid_maintenance_op(None))
+        self.assertFalse(_ops_body_has_valid_maintenance_op(""))
+
+    def test_apply_with_prose_ops_reroutes_to_refine_as_code(self):
+        """APPLY+maintenance+HIGH with implement-style prose in ``ops``
+        must fall through to REFINE and apply kind:code (not kind:maintenance)."""
+        import json
+        import subprocess
+        from unittest import mock
+        import cai_lib.actions.triage as T
+
+        verdict = {
+            "routing_decision": "APPLY",
+            "routing_confidence": "HIGH",
+            "kind": "maintenance",
+            "skip_confidence": "HIGH",
+            "reasoning": "maintenance-looking update",
+            "ops": (
+                "1. Open the Dockerfile\n"
+                "2. Replace @latest with @2.1.114\n"
+            ),
+        }
+        fake_result = subprocess.CompletedProcess(
+            args=["claude"], returncode=0,
+            stdout=json.dumps(verdict), stderr="",
+        )
+        transitions_called = []
+
+        def fake_apply_transition(issue_number, transition_name, **kwargs):
+            transitions_called.append(transition_name)
+            return True
+
+        labels_added = []
+
+        def fake_set_labels(issue_number, *, add=(), remove=(), log_prefix="cai"):
+            labels_added.extend(add)
+            return True
+
+        with mock.patch.object(T, "_run_claude_p", return_value=fake_result), \
+             mock.patch.object(T, "apply_transition", side_effect=fake_apply_transition), \
+             mock.patch.object(T, "_set_labels", side_effect=fake_set_labels), \
+             mock.patch.object(T, "check_duplicate_or_resolved", return_value=None), \
+             mock.patch.object(T, "log_run"):
+            rc = T.handle_triage(self._make_issue())
+
+        self.assertEqual(rc, 0)
+        self.assertIn("triaging_to_refining", transitions_called)
+        self.assertNotIn("triaging_to_applying", transitions_called)
+        self.assertIn(LABEL_KIND_CODE, labels_added)
+        self.assertNotIn(LABEL_KIND_MAINTENANCE, labels_added)
+
+    def test_apply_with_valid_ops_still_reaches_applying(self):
+        """APPLY+maintenance+HIGH with genuine cai-maintain op lines
+        must still transition to :applying and apply kind:maintenance."""
+        import json
+        import subprocess
+        from unittest import mock
+        import cai_lib.actions.triage as T
+
+        verdict = {
+            "routing_decision": "APPLY",
+            "routing_confidence": "HIGH",
+            "kind": "maintenance",
+            "skip_confidence": "HIGH",
+            "reasoning": "valid maintenance ops",
+            "ops": "1. label add 981 kind:maintenance\n2. close 981\n",
+        }
+        fake_result = subprocess.CompletedProcess(
+            args=["claude"], returncode=0,
+            stdout=json.dumps(verdict), stderr="",
+        )
+        fake_run = subprocess.CompletedProcess(
+            args=["gh"], returncode=0, stdout="", stderr="",
+        )
+        transitions_called = []
+
+        def fake_apply_transition(issue_number, transition_name, **kwargs):
+            transitions_called.append(transition_name)
+            return True
+
+        labels_added = []
+
+        def fake_set_labels(issue_number, *, add=(), remove=(), log_prefix="cai"):
+            labels_added.extend(add)
+            return True
+
+        with mock.patch.object(T, "_run_claude_p", return_value=fake_result), \
+             mock.patch.object(T, "_run", return_value=fake_run), \
+             mock.patch.object(T, "apply_transition", side_effect=fake_apply_transition), \
+             mock.patch.object(T, "_set_labels", side_effect=fake_set_labels), \
+             mock.patch.object(T, "check_duplicate_or_resolved", return_value=None), \
+             mock.patch.object(T, "log_run"):
+            rc = T.handle_triage(self._make_issue())
+
+        self.assertEqual(rc, 0)
+        self.assertIn("triaging_to_applying", transitions_called)
+        self.assertNotIn("triaging_to_refining", transitions_called)
+        self.assertIn(LABEL_KIND_MAINTENANCE, labels_added)
+        self.assertNotIn(LABEL_KIND_CODE, labels_added)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#981

**Issue:** #981 — Rescue prevention: When `cai-update-check` or any raising agent files an issue with `kind:maintenance`, the pipeline should verify that a `

## PR Summary

### What this fixes
When `cai-triage` emits an `APPLY`+`kind:maintenance`+`HIGH` verdict whose `ops` block is prose or implement-style steps (not valid `cai-maintain` op lines), the issue would reach `cai-maintain` with no parseable ops and immediately divert to `:human-needed`. This adds a validator that catches that mismatch at the triage step.

### What was changed
- **`cai_lib/actions/triage.py`**: added `import re`; defined `_MAINTENANCE_OP_LINE_RE` regex (matches `label add/remove <N>`, `close <N>`, `workflow edit <path>` lines with optional markdown bullets) and `_ops_body_has_valid_maintenance_op()` helper; guarded the `APPLY` branch of `handle_triage` so that when the ops body contains no valid cai-maintain op lines, `kind_label` is forced to `LABEL_KIND_CODE` and the issue re-routes to REFINE via the existing `_fallthrough_to_refine` closure.
- **`tests/test_fsm.py`**: added `LABEL_KIND_CODE, LABEL_KIND_MAINTENANCE` to the `cai_lib.config` import; added `TestTriagingHandlerOpsValidation` class with four tests covering the validator (valid ops, prose/empty), the invalid-ops re-route path, and the happy-path `triaging_to_applying` path.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
