### PR TITLE
auto-improve: Rescue prevention: Maintenance issues whose body contains only a `cai-plan-start` block and no `Ops:` block should either (a) have `cai-mai

### DIFF
--- a/.claude/agents/ops/cai-maintain.md
+++ b/.claude/agents/ops/cai-maintain.md
@@ -7,7 +7,7 @@ tools:
   - Read
 ---
 
-You are the `cai-maintain` agent. You receive a `kind:maintenance` issue body in the user message. Your job is to read the `Ops:` block, execute each operation, and emit a structured result.
+You are the `cai-maintain` agent. You receive a `kind:maintenance` issue body in the user message. Your job is to read the `Ops:` block (or synthesise one from a stored plan block when no literal `Ops:` header is present), execute each operation, and emit a structured result.
 
 ## Your task
 
@@ -16,6 +16,13 @@ You are the `cai-maintain` agent. You receive a `kind:maintenance` issue body in
    - `label remove <issue_number> <label>` — remove a label from an issue
    - `close <issue_number>` — close an issue as not-planned
    - `workflow edit <file_path> <key> <value>` — edit a key in a workflow YAML file
+
+   **Plan-block fallback (issue #986).** If no `Ops:` header is present but the issue body contains a `<!-- cai-plan-start -->…<!-- cai-plan-end -->` block, read the block contents and synthesise an Ops list from them:
+   - Map each clearly-described maintenance action in the plan to exactly one of the four op forms above.
+   - Prose phrases like "Close issue #927 as duplicate of #923" → `close 927`; "add `foo` label to #42" → `label add 42 foo`; "remove `stale` label from #88" → `label remove 88 stale`; "set the `minutes` key of `.github/workflows/x.yml` to 30" → `workflow edit .github/workflows/x.yml minutes 30`.
+   - When an action does NOT map cleanly to one of the four forms (requires a PR, edits source code, changes branch protection, or is pure narrative with no operational meaning), **do NOT synthesise an op for it** — it is evidence the plan cannot be executed by this agent.
+   - When synthesis produces at least one valid op line, emit an `Ops-source: inferred` line in your output (see the Output format) so the handler can select a relaxed FSM gate.
+   - When synthesis produces zero valid op lines, skip execution and emit `Confidence: LOW` with `Confidence reason: No Ops block found in issue body and plan block could not be mapped to maintenance ops.`
 
 2. Execute each operation via `gh` CLI commands. Use the `REPO` environment variable if set, or derive it from the git remote. The canonical repo is `damien-robotsix/robotsix-cai`.
 
@@ -33,6 +40,7 @@ You are the `cai-maintain` agent. You receive a `kind:maintenance` issue body in
 - For workflow edits, use the `Read` tool to read the YAML file, then `Bash` with `sed` or a Python one-liner to edit it in the work directory.
 - After all operations, write a brief summary of what succeeded and what failed.
 - When `Confidence` is `MEDIUM` or `LOW`, you MUST emit a `Confidence reason:` line on its own line immediately after the `Confidence:` line. One sentence is enough; no markdown headings, block quotes, or multi-line prose — the line must match `^Confidence reason: <text>$` so `parse_confidence_reason` can extract it.
+- When you synthesised the op list from the plan block (step 1 fallback), you MUST emit an `Ops-source: inferred` line on its own line anywhere in the output. The line must match `^Ops-source:\s*inferred\s*$` (case-insensitive) so the handler can detect it and select the relaxed `applying_to_applied_inferred_ops` transition. Omit the line entirely when the Ops came from an explicit `Ops:` header — the handler will use the default HIGH-threshold transition.
 
 ## Output format
 
@@ -48,6 +56,9 @@ You are the `cai-maintain` agent. You receive a `kind:maintenance` issue body in
 
 Confidence: HIGH|MEDIUM|LOW
 Confidence reason: <one-line explanation, required when Confidence is MEDIUM or LOW>
+Ops-source: inferred
 ```
 
-If the `Ops:` block is missing or empty, emit `Confidence: LOW` followed by `Confidence reason: No Ops block found in issue body.`
+The `Ops-source: inferred` line is required only when the op list was synthesised from a plan block. Omit it when the Ops came from an explicit `Ops:` header.
+
+If the `Ops:` block is missing AND no plan block can be mapped to ops, emit `Confidence: LOW` followed by `Confidence reason: No Ops block found in issue body and plan block could not be mapped to maintenance ops.`

--- a/cai_lib/actions/maintain.py
+++ b/cai_lib/actions/maintain.py
@@ -2,7 +2,13 @@
 
 ``handle_maintain``  — runs cai-maintain against an ``:applying`` issue and
                        advances it to ``:applied`` (HIGH confidence) or
-                       ``:human-needed`` (MEDIUM / LOW / missing).
+                       ``:human-needed`` (MEDIUM / LOW / missing). When the
+                       agent emits an ``Ops-source: inferred`` marker
+                       (issue #986 — Ops synthesised from a plan block
+                       because no explicit ``Ops:`` header was present),
+                       the handler picks the relaxed sibling transition
+                       ``applying_to_applied_inferred_ops`` whose gate
+                       accepts MEDIUM confidence.
 
 ``handle_applied``   — advances an ``:applied`` issue deterministically to
                        ``:solved`` and closes it on GitHub.  No agent needed;
@@ -10,6 +16,7 @@
 """
 from __future__ import annotations
 
+import re
 import shutil
 import time
 import uuid
@@ -26,6 +33,24 @@ from cai_lib.fsm import (
 from cai_lib.github import _build_issue_block, close_issue_completed
 from cai_lib.logging_utils import log_run
 from cai_lib.subprocess_utils import _run, _run_claude_p
+
+
+# Matches the marker emitted by cai-maintain when the op list was
+# synthesised from a stored plan block because no explicit ``Ops:``
+# header was present on the issue body (issue #986). When present,
+# :func:`handle_maintain` selects the relaxed
+# ``applying_to_applied_inferred_ops`` transition (MEDIUM gate).
+_OPS_SOURCE_INFERRED_RE = re.compile(
+    r"^\s*Ops-source:\s*inferred\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _ops_source_is_inferred(text: str) -> bool:
+    """Return True iff *text* contains a well-formed ``Ops-source: inferred`` line."""
+    if not text:
+        return False
+    return _OPS_SOURCE_INFERRED_RE.search(text) is not None
 
 
 def handle_maintain(issue: dict) -> int:
@@ -98,9 +123,27 @@ def handle_maintain(issue: dict) -> int:
     # Parse confidence and apply FSM transition.
     confidence = parse_confidence(result.stdout)
     confidence_reason = parse_confidence_reason(result.stdout)
+
+    # Pick the relaxed sibling transition when the agent signalled that
+    # it synthesised the Ops list from a plan block (issue #986). The
+    # sibling's only difference from the default is its MEDIUM confidence
+    # gate — labels move identically. Plans with an explicit ``Ops:``
+    # header stay on the default HIGH-threshold transition.
+    ops_inferred = _ops_source_is_inferred(result.stdout)
+    transition_name = (
+        "applying_to_applied_inferred_ops" if ops_inferred
+        else "applying_to_applied"
+    )
+    if ops_inferred:
+        print(
+            f"[cai maintain] #{issue_number}: Ops-source: inferred — "
+            f"using relaxed transition {transition_name!r} (MEDIUM gate)",
+            flush=True,
+        )
+
     ok, diverted = apply_transition_with_confidence(
         issue_number,
-        "applying_to_applied",
+        transition_name,
         confidence,
         current_labels=issue_labels,
         log_prefix="cai maintain",
@@ -111,6 +154,7 @@ def handle_maintain(issue: dict) -> int:
     outcome = "diverted_to_human" if diverted else ("applied" if ok else "failed")
     log_run("maintain", repo=REPO, issue=issue_number,
             confidence=str(confidence), result=outcome, duration=dur,
+            ops_source=("inferred" if ops_inferred else "explicit"),
             exit=0 if ok else 1)
     return 0 if ok else 1
 

--- a/cai_lib/fsm_transitions.py
+++ b/cai_lib/fsm_transitions.py
@@ -86,6 +86,17 @@ ISSUE_TRANSITIONS: list[Transition] = [
     Transition("applying_to_applied",       IssueState.APPLYING,      IssueState.APPLIED,
                labels_remove=[LABEL_APPLYING],   labels_add=[LABEL_APPLIED],
                min_confidence=Confidence.HIGH),
+    # Relaxed threshold (#986): when cai-maintain synthesised the Ops
+    # from a stored plan block because no explicit `Ops:` header was
+    # present on the issue body, it emits an `Ops-source: inferred`
+    # marker and the handler picks this sibling transition so a
+    # successful inferred-ops execution at MEDIUM confidence still
+    # advances to :applied rather than parking at :human-needed. The
+    # only difference from applying_to_applied is the min_confidence
+    # gate (MEDIUM instead of HIGH); labels move identically.
+    Transition("applying_to_applied_inferred_ops", IssueState.APPLYING, IssueState.APPLIED,
+               labels_remove=[LABEL_APPLYING],   labels_add=[LABEL_APPLIED],
+               min_confidence=Confidence.MEDIUM),
     Transition("applying_to_human",         IssueState.APPLYING,      IssueState.HUMAN_NEEDED,
                labels_remove=[LABEL_APPLYING],   labels_add=[LABEL_HUMAN_NEEDED]),
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,7 +62,7 @@ Issues still enter the pipeline the same way: `cai analyze`, `cai propose`, `cai
 | `human:solved` | Admin-applied signal to resume FSM for parked issues/PRs (unblocking) |
 | `blocked-on:<N>` | Suppresses dispatch and rescue on this issue/PR while issue `#<N>` is open. Multiple blockers may be declared by applying the label once per blocker. The label is a hint, not a state change — it never clears itself. (Self-blocking cycles result in both issues staying skipped; no cycle detection is performed.) |
 | `kind:code` | Issue is a code fix (vs. kind:maintenance) |
-| `kind:maintenance` | Issue is a maintenance operation (requires `Ops:` block in body) |
+| `kind:maintenance` | Issue is a maintenance operation (requires `Ops:` block, or a `cai-plan-start` block from which Ops can be synthesized) |
 | `pr:reviewing-code` | PR is in code review (review-pr handler); a new SHA lands here on any push |
 | `pr:revision-pending` | Review-pr handler posted findings; revise handler will address them |
 | `pr:reviewing-docs` | Code review clean; docs review is next |
@@ -98,7 +98,7 @@ For review and planning agents (`cai-code-audit`, `cai-external-scout`, `cai-git
 
 `cai-review-docs` is a special review agent that can edit documentation: it has `Edit` and `Write` tools to fix stale docs directly, and the wrapper automatically commits and pushes any changes to the same PR branch (not to a new isolated branch).
 
-`cai-maintain` is a maintenance agent that executes operations (label mutations, bulk-close, workflow YAML edits) declared in the `Ops:` block of a `kind:maintenance` issue. It runs `gh` CLI commands to perform administrative tasks and emits a Confidence level for transition gating.
+`cai-maintain` is a maintenance agent that executes operations (label mutations, bulk-close, workflow YAML edits) declared in the `Ops:` block (explicit or synthesized from a stored `cai-plan-start` block per issue #986) of a `kind:maintenance` issue. It runs `gh` CLI commands to perform administrative tasks and emits a Confidence level for transition gating.
 
 ### Clone agents
 

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -22,6 +22,7 @@ stateDiagram-v2
     TRIAGING --> PLAN_APPROVED : triaging_to_plan_approved [caller-gated]
     TRIAGING --> APPLYING : triaging_to_applying [caller-gated]
     APPLYING --> APPLIED : applying_to_applied [≥HIGH]
+    APPLYING --> APPLIED : applying_to_applied_inferred_ops [≥MEDIUM]
     APPLYING --> HUMAN_NEEDED : applying_to_human [≥HIGH]
     APPLIED --> SOLVED : applied_to_solved [≥HIGH]
     REFINING --> REFINED : refining_to_refined [≥HIGH]

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -188,6 +188,35 @@ class TestPlannedToPlanApprovedMitigated(unittest.TestCase):
         self.assertEqual(default.min_confidence, Confidence.HIGH)
 
 
+class TestApplyingToAppliedInferredOps(unittest.TestCase):
+    """#986 — MEDIUM-gated sibling of applying_to_applied for inferred-ops runs."""
+
+    def test_inferred_ops_transition_accepts_medium(self):
+        t = find_transition("applying_to_applied_inferred_ops")
+        self.assertEqual(t.min_confidence, Confidence.MEDIUM)
+        self.assertTrue(t.accepts(Confidence.HIGH))
+        self.assertTrue(t.accepts(Confidence.MEDIUM))
+        self.assertFalse(t.accepts(Confidence.LOW))
+        self.assertFalse(t.accepts(None))
+
+    def test_inferred_ops_shares_label_move(self):
+        default = find_transition("applying_to_applied")
+        inferred = find_transition("applying_to_applied_inferred_ops")
+        self.assertEqual(default.from_state, inferred.from_state)
+        self.assertEqual(default.to_state, inferred.to_state)
+        self.assertEqual(default.labels_add, inferred.labels_add)
+        self.assertEqual(default.labels_remove, inferred.labels_remove)
+        # Only the threshold differs between the two siblings.
+        self.assertEqual(default.min_confidence, Confidence.HIGH)
+        self.assertEqual(inferred.min_confidence, Confidence.MEDIUM)
+
+    def test_default_transition_still_requires_high(self):
+        # Regression guard: the inferred-ops sibling must not replace the
+        # HIGH-gated default — both must coexist, one for each path.
+        default = find_transition("applying_to_applied")
+        self.assertEqual(default.min_confidence, Confidence.HIGH)
+
+
 class TestApplyTransition(unittest.TestCase):
 
     def _recording_set_labels(self):

--- a/tests/test_maintain.py
+++ b/tests/test_maintain.py
@@ -33,14 +33,20 @@ def _make_clone_result(rc=0):
     return r
 
 
-def _make_agent_result(confidence="HIGH", rc=0, reason=None):
+def _make_agent_result(confidence="HIGH", rc=0, reason=None, ops_source=None):
     r = MagicMock()
     reason_line = ""
     if confidence in ("MEDIUM", "LOW"):
         default_reason = "Some operations could not be verified." if reason is None else reason
         reason_line = f"Confidence reason: {default_reason}\n"
+    ops_source_line = ""
+    if ops_source == "inferred":
+        ops_source_line = "Ops-source: inferred\n"
     r.returncode = rc
-    r.stdout = f"## Maintenance Summary\n\nConfidence: {confidence}\n{reason_line}"
+    r.stdout = (
+        f"## Maintenance Summary\n\nConfidence: {confidence}\n"
+        f"{reason_line}{ops_source_line}"
+    )
     r.stderr = ""
     return r
 
@@ -132,6 +138,77 @@ class TestHandleMaintainLowConfidence(unittest.TestCase):
         self.assertTrue(
             human_calls,
             f"Expected divert to HUMAN_NEEDED; got calls: {label_calls}"
+        )
+
+
+class TestHandleMaintainInferredOps(unittest.TestCase):
+    """MEDIUM confidence + Ops-source: inferred → :applied transition fires (#986)."""
+
+    def test_inferred_ops_medium_advances_to_applied(self):
+        issue = _make_applying_issue()
+        label_calls = []
+
+        def fake_set_labels(issue_number, *, add=(), remove=(), log_prefix="cai"):
+            label_calls.append({"issue_number": issue_number,
+                                 "add": list(add), "remove": list(remove)})
+            return True
+
+        with patch("cai_lib.actions.maintain._run", return_value=_make_clone_result()), \
+             patch("cai_lib.actions.maintain._run_claude_p",
+                   return_value=_make_agent_result("MEDIUM", ops_source="inferred")), \
+             patch("cai_lib.actions.maintain.shutil.rmtree"), \
+             patch("cai_lib.actions.maintain.log_run"), \
+             patch("cai_lib.github._set_labels", side_effect=fake_set_labels), \
+             patch("cai_lib.github._post_issue_comment", return_value=True):
+            from cai_lib.actions.maintain import handle_maintain
+            rc = handle_maintain(issue)
+
+        self.assertEqual(rc, 0)
+        applied_calls = [c for c in label_calls
+                         if LABEL_APPLIED in c["add"] and LABEL_APPLYING in c["remove"]]
+        self.assertTrue(
+            applied_calls,
+            "Expected relaxed transition to move :applying → :applied on "
+            "MEDIUM + Ops-source: inferred; got calls: "
+            f"{label_calls}"
+        )
+        human_calls = [c for c in label_calls
+                       if LABEL_HUMAN_NEEDED in c["add"] and LABEL_APPLYING in c["remove"]]
+        self.assertFalse(
+            human_calls,
+            "MEDIUM + inferred must NOT divert to :human-needed; "
+            f"got calls: {label_calls}"
+        )
+
+    def test_medium_without_inferred_marker_still_diverts(self):
+        # Regression guard: a bare MEDIUM (no Ops-source marker) must
+        # continue to divert to :human-needed via the default
+        # applying_to_applied transition (HIGH gate).
+        issue = _make_applying_issue()
+        label_calls = []
+
+        def fake_set_labels(issue_number, *, add=(), remove=(), log_prefix="cai"):
+            label_calls.append({"issue_number": issue_number,
+                                 "add": list(add), "remove": list(remove)})
+            return True
+
+        with patch("cai_lib.actions.maintain._run", return_value=_make_clone_result()), \
+             patch("cai_lib.actions.maintain._run_claude_p",
+                   return_value=_make_agent_result("MEDIUM")), \
+             patch("cai_lib.actions.maintain.shutil.rmtree"), \
+             patch("cai_lib.actions.maintain.log_run"), \
+             patch("cai_lib.github._set_labels", side_effect=fake_set_labels), \
+             patch("cai_lib.github._post_issue_comment", return_value=True):
+            from cai_lib.actions.maintain import handle_maintain
+            rc = handle_maintain(issue)
+
+        self.assertEqual(rc, 0)
+        human_calls = [c for c in label_calls
+                       if LABEL_HUMAN_NEEDED in c["add"] and LABEL_APPLYING in c["remove"]]
+        self.assertTrue(
+            human_calls,
+            "Expected MEDIUM without inferred marker to divert to "
+            f":human-needed; got calls: {label_calls}"
         )
 
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#986

**Issue:** #986 — Rescue prevention: Maintenance issues whose body contains only a `cai-plan-start` block and no `Ops:` block should either (a) have `cai-mai

## PR Summary

### What this fixes
Maintenance issues that reach `:applying` with only a `<!-- cai-plan-start -->` block and no literal `Ops:` header would always fail (the agent emitted `Confidence: LOW` with "No Ops block found"), causing a `:human-needed` divert. This fix teaches `cai-maintain` to synthesise ops from the stored plan block when no explicit `Ops:` header is present, and adds a relaxed sibling FSM transition (`applying_to_applied_inferred_ops`, `min_confidence=MEDIUM`) so a successful inferred-ops run advances to `:applied` instead of parking at `:human-needed`.

### What was changed
- **`.cai-staging/agents/ops/cai-maintain.md`** — full rewrite: adds plan-block fallback (synthesise ops from `<!-- cai-plan-start -->…<!-- cai-plan-end -->` when no `Ops:` header is present) and requires the agent to emit `Ops-source: inferred` on its own line when synthesis was used
- **`cai_lib/fsm_transitions.py`** — inserted sibling `Transition("applying_to_applied_inferred_ops", ..., min_confidence=Confidence.MEDIUM)` immediately after `applying_to_applied` per the `fsm-transition-threshold-relaxation` shared memory pattern
- **`cai_lib/actions/maintain.py`** — added `import re`, `_OPS_SOURCE_INFERRED_RE` regex, `_ops_source_is_inferred()` helper; `handle_maintain` now detects the marker and picks `"applying_to_applied_inferred_ops"` (MEDIUM gate) instead of `"applying_to_applied"` (HIGH gate) when inferred; adds `ops_source` field to `log_run`
- **`tests/test_maintain.py`** — extended `_make_agent_result` with `ops_source` parameter; added `TestHandleMaintainInferredOps` with two tests: MEDIUM + `Ops-source: inferred` advances to `:applied`, and bare MEDIUM (no marker) continues to divert to `:human-needed`

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
