### PR TITLE
auto-improve: Rescue prevention: When `cai-implement` hits 3-consecutive-`tests_failed` on a single narrow test case (path normalisation logic, regex edg

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -141,6 +141,7 @@
 | `tests/test_dup_check.py` | TODO: add description |
 | `tests/test_fsm.py` | Tests for cai_lib.fsm — states, transitions, Confidence, divert, marker, resume helpers |
 | `tests/test_implement_consecutive_failures.py` | TODO: add description |
+| `tests/test_implement_helper_extract.py` | TODO: add description |
 | `tests/test_implement_test_failure_extract.py` | TODO: add description |
 | `tests/test_lint.py` | Lint check: ruff must report zero violations |
 | `tests/test_maintain.py` | Tests for cai_lib.actions.maintain — handle_maintain confidence routing and FSM transitions |

--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -16,6 +16,7 @@ dispatcher owns queue selection.
 """
 from __future__ import annotations
 
+import ast
 import json
 import re
 import shutil
@@ -372,6 +373,104 @@ def _extract_test_failures(output: str, max_chars: int = 3000) -> str:
     if len(result) > max_chars:
         result = result[:max_chars].rstrip() + "\n\n... (truncated)"
     return result
+
+
+# Matches ``  File "<path>", line <N>, in <func>`` traceback frames.
+_TRACEBACK_FRAME_RE = re.compile(
+    r'^\s*File "([^"]+)", line (\d+), in (\S+)',
+    re.MULTILINE,
+)
+
+
+def _enclosing_function_source(
+    source: str, line: int,
+) -> tuple[str, str] | None:
+    """Return ``(func_name, func_source)`` for the innermost ``def`` /
+    ``async def`` that encloses *line* in *source*, or ``None`` when no
+    such function exists.
+
+    Uses :mod:`ast` so nested defs and class methods resolve correctly.
+    ``line`` is 1-based, matching Python traceback line numbers.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+    lines = source.splitlines()
+    best: ast.FunctionDef | ast.AsyncFunctionDef | None = None
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        end = node.end_lineno or node.lineno
+        if node.lineno <= line <= end:
+            if best is None or node.lineno >= best.lineno:
+                best = node
+    if best is None:
+        return None
+    end = best.end_lineno or best.lineno
+    src = "\n".join(lines[best.lineno - 1: end])
+    return (best.name, src)
+
+
+def _extract_referenced_helpers(
+    failure_output: str,
+    work_dir: Path,
+    max_chars: int = 2000,
+) -> str:
+    """Extract source of non-test helpers referenced by test tracebacks.
+
+    Scans *failure_output* for ``File "<path>", line <N>, in <func>``
+    frames. Skips entries under ``tests/``, absolute paths, ``..``-escapes,
+    and anything containing ``site-packages`` (stdlib / third-party). For
+    each remaining unique ``(path, func)`` pair reads
+    ``<work_dir>/<path>`` and returns the source of the function
+    enclosing line ``<N>``.
+
+    Result is Markdown suitable for inlining into a GitHub issue comment:
+    one fenced ``python`` block per helper, separated by blank lines.
+    Returns an empty string when no helpers can be resolved. Capped at
+    *max_chars*; clipped output is suffixed with ``... (truncated)``.
+
+    Added in issue #987 — the 3-consecutive-``tests_failed`` divert
+    comment previously only carried the test traceback. Pairing each
+    traceback frame with the current implementation of the helper it
+    landed in gives Opus / a human the exact context needed to diagnose
+    a narrow regression (path normalisation, regex edge case, etc.)
+    without re-reading the whole file.
+    """
+    seen: set[tuple[str, str]] = set()
+    helpers: list[str] = []
+    for m in _TRACEBACK_FRAME_RE.finditer(failure_output):
+        path, line_s, func = m.group(1), m.group(2), m.group(3)
+        if (
+            path.startswith("tests/")
+            or path.startswith("/")
+            or ".." in path.split("/")
+            or "site-packages" in path
+        ):
+            continue
+        key = (path, func)
+        if key in seen:
+            continue
+        seen.add(key)
+        try:
+            source = (work_dir / path).read_text()
+        except OSError:
+            continue
+        res = _enclosing_function_source(source, int(line_s))
+        if res is None:
+            continue
+        name, src = res
+        helpers.append(
+            f"`{path}` — `{name}` (line {line_s}):\n\n"
+            f"```python\n{src}\n```"
+        )
+    if not helpers:
+        return ""
+    joined = "\n\n".join(helpers)
+    if len(joined) > max_chars:
+        joined = joined[:max_chars].rstrip() + "\n\n... (truncated)"
+    return joined
 
 
 def _count_consecutive_tests_failed(issue_number: int) -> int:
@@ -890,6 +989,13 @@ def handle_implement(issue: dict) -> int:
                     issue.get("body", "") or ""
                 )
                 failure_summary = _extract_test_failures(failure_output)
+                helpers_block = _extract_referenced_helpers(
+                    failure_output, work_dir,
+                )
+                helpers_section = (
+                    "### Helper implementations referenced by failures\n\n"
+                    f"{helpers_block}\n\n"
+                ) if helpers_block else ""
 
                 if stored_plan_confidence == Confidence.MEDIUM:
                     comment_body = (
@@ -902,6 +1008,7 @@ def handle_implement(issue: dict) -> int:
                         f"autonomous re-planning instead of human review.\n\n"
                         "### Failing tests\n\n"
                         f"```\n{failure_summary}\n```\n\n"
+                        f"{helpers_section}"
                         "---\n"
                         "_Set by `cai implement` after "
                         f"{_MAX_TESTS_FAILED_RETRIES} consecutive "
@@ -946,6 +1053,7 @@ def handle_implement(issue: dict) -> int:
                     f"monopolising the implement loop.\n\n"
                     "### Failing tests\n\n"
                     f"```\n{failure_summary}\n```\n\n"
+                    f"{helpers_section}"
                     "---\n"
                     "_Set by `cai implement` after "
                     f"{_MAX_TESTS_FAILED_RETRIES} consecutive `tests_failed` "

--- a/docs/modules/tests.md
+++ b/docs/modules/tests.md
@@ -10,6 +10,7 @@ publish, rescue, and transcript sync. Also enforces lint hygiene.
 - `tests/test_dup_check.py` — Duplicate-check pre-triage.
 - `tests/test_fsm.py` — States, transitions, Confidence, divert helpers.
 - `tests/test_implement_consecutive_failures.py` — Implement-agent retry bookkeeping.
+- `tests/test_implement_helper_extract.py` — Helper-function extraction from test tracebacks (issue #987).
 - `tests/test_lint.py` — Ruff hygiene check.
 - `tests/test_maintain.py` — `cai-maintain` handler routing.
 - `tests/test_merge_diff.py` — Merge-diff helpers.

--- a/tests/test_implement_helper_extract.py
+++ b/tests/test_implement_helper_extract.py
@@ -1,0 +1,143 @@
+"""Tests for cai_lib.actions.implement._extract_referenced_helpers
+and _enclosing_function_source (issue #987)."""
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.actions.implement import (
+    _enclosing_function_source,
+    _extract_referenced_helpers,
+)
+
+
+_HELPER_SOURCE = textwrap.dedent(
+    """\
+    def outer(x):
+        return x + 1
+
+
+    class C:
+        def method(self, y):
+            return y * 2
+
+        def other(self):
+            def nested(z):
+                return z - 1
+            return nested(self.method(0))
+    """
+)
+
+
+class TestEnclosingFunctionSource(unittest.TestCase):
+    def test_returns_top_level_function(self):
+        res = _enclosing_function_source(_HELPER_SOURCE, 2)
+        self.assertIsNotNone(res)
+        name, src = res
+        self.assertEqual(name, "outer")
+        self.assertIn("return x + 1", src)
+
+    def test_returns_method_in_class(self):
+        res = _enclosing_function_source(_HELPER_SOURCE, 7)
+        self.assertIsNotNone(res)
+        name, src = res
+        self.assertEqual(name, "method")
+        self.assertIn("return y * 2", src)
+
+    def test_returns_innermost_nested_function(self):
+        res = _enclosing_function_source(_HELPER_SOURCE, 11)
+        self.assertIsNotNone(res)
+        name, src = res
+        self.assertEqual(name, "nested")
+        self.assertIn("return z - 1", src)
+
+    def test_returns_none_outside_any_function(self):
+        # Line 5 is the blank line between `outer` and `class C`.
+        res = _enclosing_function_source(_HELPER_SOURCE, 5)
+        self.assertIsNone(res)
+
+    def test_syntax_error_returns_none(self):
+        res = _enclosing_function_source("def bad(:\n  pass\n", 1)
+        self.assertIsNone(res)
+
+
+class TestExtractReferencedHelpers(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.work_dir = Path(self.tmp.name)
+        (self.work_dir / "cai_lib").mkdir()
+        (self.work_dir / "cai_lib" / "foo.py").write_text(_HELPER_SOURCE)
+        (self.work_dir / "tests").mkdir()
+        (self.work_dir / "tests" / "test_foo.py").write_text(
+            "def test_foo():\n    assert False\n"
+        )
+
+    def _traceback(self, frames: list[tuple[str, int, str]]) -> str:
+        lines = ["Traceback (most recent call last):"]
+        for path, line, func in frames:
+            lines.append(f'  File "{path}", line {line}, in {func}')
+            lines.append("    <body>")
+        lines.append("AssertionError: boom")
+        return "\n".join(lines)
+
+    def test_extracts_helper_source(self):
+        tb = self._traceback([
+            ("tests/test_foo.py", 2, "test_foo"),
+            ("cai_lib/foo.py", 2, "outer"),
+        ])
+        out = _extract_referenced_helpers(tb, self.work_dir)
+        self.assertIn("`cai_lib/foo.py`", out)
+        self.assertIn("`outer`", out)
+        self.assertIn("return x + 1", out)
+
+    def test_skips_test_paths(self):
+        tb = self._traceback([("tests/test_foo.py", 2, "test_foo")])
+        out = _extract_referenced_helpers(tb, self.work_dir)
+        self.assertEqual(out, "")
+
+    def test_skips_absolute_paths(self):
+        tb = self._traceback([("/usr/lib/python3.12/unittest/case.py", 10, "run")])
+        out = _extract_referenced_helpers(tb, self.work_dir)
+        self.assertEqual(out, "")
+
+    def test_skips_dotdot_paths(self):
+        tb = self._traceback([("../etc/passwd", 1, "root")])
+        out = _extract_referenced_helpers(tb, self.work_dir)
+        self.assertEqual(out, "")
+
+    def test_skips_site_packages(self):
+        tb = self._traceback([(".venv/lib/site-packages/requests/api.py", 1, "get")])
+        out = _extract_referenced_helpers(tb, self.work_dir)
+        self.assertEqual(out, "")
+
+    def test_dedupes_same_path_and_func(self):
+        tb = self._traceback([
+            ("cai_lib/foo.py", 2, "outer"),
+            ("cai_lib/foo.py", 2, "outer"),
+        ])
+        out = _extract_referenced_helpers(tb, self.work_dir)
+        # A single occurrence of the fenced block header.
+        self.assertEqual(out.count("```python"), 1)
+
+    def test_missing_file_is_ignored(self):
+        tb = self._traceback([("cai_lib/does_not_exist.py", 1, "ghost")])
+        out = _extract_referenced_helpers(tb, self.work_dir)
+        self.assertEqual(out, "")
+
+    def test_empty_output_when_no_frames(self):
+        self.assertEqual(_extract_referenced_helpers("", self.work_dir), "")
+
+    def test_respects_max_chars(self):
+        tb = self._traceback([("cai_lib/foo.py", 2, "outer")])
+        out = _extract_referenced_helpers(tb, self.work_dir, max_chars=40)
+        self.assertTrue(out.endswith("... (truncated)"))
+        self.assertLessEqual(len(out), 40 + len("\n\n... (truncated)"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#987

**Issue:** #987 — Rescue prevention: When `cai-implement` hits 3-consecutive-`tests_failed` on a single narrow test case (path normalisation logic, regex edg

## PR Summary

### What this fixes
When `cai-implement` hits 3 consecutive `tests_failed` for a narrow test case (path normalisation, regex edge case, etc.), the divert comment only contained the test traceback — giving Opus or a human reviewer no visibility into the current implementation of the failing helper without re-reading the whole file.

### What was changed
- **`cai_lib/actions/implement.py`**: Added `import ast`; added three new module-level symbols — `_TRACEBACK_FRAME_RE` (regex for traceback frames), `_enclosing_function_source` (AST-based lookup of the innermost enclosing `def`/`async def`), and `_extract_referenced_helpers` (scans traceback output, skips test/absolute/dotdot/site-packages paths, returns fenced Markdown of each referenced non-test helper); computed `helpers_block` and `helpers_section` in the 3-fail divert branch and injected `helpers_section` into both the MEDIUM-plan re-planning comment and the human-needed escalation comment.
- **`tests/test_implement_helper_extract.py`** (new): 13 unit tests covering both `_enclosing_function_source` (top-level function, class method, nested function, outside-any-function, syntax error) and `_extract_referenced_helpers` (extracts helper, skips tests/absolute/dotdot/site-packages, deduplication, missing file, empty input, max_chars truncation).

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
