### PR TITLE
auto-improve: cai-review-docs.md contains outdated statement about file deletion

### DIFF
--- a/.claude/agents/review/cai-review-docs.md
+++ b/.claude/agents/review/cai-review-docs.md
@@ -144,11 +144,15 @@ tracked source file whose status in the stat summary is `A` (added),
   For each file that IS in the manifest: if `docs/modules.yaml`
   contains an exact-match glob for the deleted path, remove that
   glob. Remove the bullet from the narrative's `## Entry points`
-  list. If this leaves the module with zero `globs`, emit a
-  `### Finding: stale_docs` block requesting removal of the
-  now-empty module entry and its narrative file — your tool set
-  cannot delete files, so the wrapper / human handles the actual
-  `rm`. Do not attempt workarounds.
+  list. If this leaves the module with zero `globs`, remove the
+  module entry from `docs/modules.yaml` with `Edit`, and delete
+  the narrative file using the `.cai-staging/files-delete/`
+  tombstone mechanism — write an empty tombstone file to
+  `<work_dir>/.cai-staging/files-delete/<relative-path>` (e.g.
+  `.cai-staging/files-delete/docs/modules/<name>.md`) and the
+  wrapper will delete the target after your session exits. See
+  CLAUDE.md ("Deleting arbitrary repo files") for full details.
+  Emit a `### Fixed: stale_docs` block documenting the removal.
 
 Files with status `M` (edited in place, no rename/delete) do NOT
 require a module-index update.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#965

**Issue:** #965 — cai-review-docs.md contains outdated statement about file deletion

## PR Summary

### What this fixes
Line 149-151 of `cai-review-docs.md` stated "your tool set cannot delete files, so the wrapper / human handles the actual `rm`" — but this became false once PR #963 added the `.cai-staging/files-delete/` tombstone mechanism. When an empty-`globs` module is encountered after a file deletion, the agent can now handle the narrative file removal itself rather than deferring to a human.

### What was changed
- **`.claude/agents/review/cai-review-docs.md`** (via staging): Replaced the outdated "your tool set cannot delete files, so the wrapper / human handles the actual `rm`. Do not attempt workarounds." text with instructions to remove the module entry from `docs/modules.yaml` using `Edit`, then delete the narrative file by writing an empty tombstone to `.cai-staging/files-delete/<relative-path>`, and emit a `### Fixed: stale_docs` block documenting the removal.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
