### PR TITLE
auto-improve: Rescue prevention: The `cai-plan` / `cai-select` agents should be instructed to verify key structural assumptions (e.g. comment block forma

### DIFF
--- a/.claude/agents/implementation/cai-plan.md
+++ b/.claude/agents/implementation/cai-plan.md
@@ -49,6 +49,14 @@ The user message contains:
 ## Hard rules
 
 1. **Read-only.** Do not modify any files — only read and plan.
+2. **Verify structural claims before finalizing.** Before finalizing
+   your plan, verify any structural claim about a peer agent's output
+   format (e.g., comment block markers, JSON field names, literal
+   marker strings) by reading the relevant peer agent's `.md` file
+   via `Read` or `Grep`. If a structural claim cannot be verified in
+   this session, explicitly call it out as an unverified assumption
+   — `cai-select` will cap such plans at LOW confidence, forcing a
+   human gate. Verify now to avoid that outcome.
 
 ## Agent-specific efficiency guidance
 

--- a/.claude/agents/implementation/cai-select.md
+++ b/.claude/agents/implementation/cai-select.md
@@ -59,8 +59,11 @@ downgrade — **soft / non-blocking risks** do not.
 - **Substantive uncertainty** (legitimate grounds to downgrade):
   policy questions the refined issue did not answer, ambiguous
   requirements, unverified external dependencies, missing edge
-  cases, or a concrete risk of regression that the plan has not
-  addressed.
+  cases, a concrete risk of regression that the plan has not
+  addressed, or **unverified structural claims about peer agent
+  outputs** (e.g., literal marker strings, JSON field names, or
+  comment block formats asserted without citing the source file
+  and line — cap such plans at LOW, not MEDIUM).
 - **Soft / non-blocking risks** (NOT grounds to downgrade):
   - Additive JSON schema fields or other strictly
     backwards-compatible extensions to a data contract — downstream


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#994

**Issue:** #994 — Rescue prevention: The `cai-plan` / `cai-select` agents should be instructed to verify key structural assumptions (e.g. comment block forma

## PR Summary

### What this fixes
Plans that assert structural facts about peer agents (comment block markers, JSON field names) without verifying them in-session force a human gate at the `planned_to_plan_approved` stage — the exact false-positive divert that caused issue #943 to park at `:human-needed`. This adds guidance to both `cai-plan` and `cai-select` to prevent recurrence.

### What was changed
- **`.claude/agents/implementation/cai-plan.md`** — Added Hard rule 2: "Verify structural claims before finalizing." Instructs the planner to verify any structural claim about a peer agent's output format (markers, JSON fields, block structure) by reading the relevant peer agent's `.md` file via `Read`/`Grep` before finalizing the plan. If a claim cannot be verified in-session, the rule explicitly warns that `cai-select` will cap such plans at LOW confidence.
- **`.claude/agents/implementation/cai-select.md`** — Extended the "Substantive uncertainty" bullet in the "Distinguish substantive uncertainty from soft risks" section to explicitly include unverified structural claims about peer agent outputs, and specifies LOW (not MEDIUM) as the confidence cap for such plans.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
