### PR TITLE
auto-improve: audit-refactor 1.4: add scripts/check-modules-coverage.py

### DIFF
--- a/scripts/check-modules-coverage.py
+++ b/scripts/check-modules-coverage.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Verify docs/modules.yaml covers every tracked file exactly once.
 
-Exit 0 if coverage is perfect; exit 1 with errors printed to stderr
-otherwise. Invoked manually by maintainers and optionally from CI.
+Exit 0 and print a summary line when coverage is perfect.
+Exit 1 and print diagnostics otherwise.
 """
 from __future__ import annotations
 
+import fnmatch
 import subprocess
 import sys
 from pathlib import Path
@@ -17,10 +18,17 @@ from cai_lib.audit.modules import coverage_check, load_modules  # noqa: E402
 
 
 def main() -> int:
-    modules = load_modules(
-        REPO_ROOT / "docs" / "modules.yaml",
-        check_doc_exists=True,
-    )
+    modules_path = REPO_ROOT / "docs" / "modules.yaml"
+
+    # Load modules — skip doc-exists check here; we do it manually below
+    # so we can collect all errors rather than raising on the first one.
+    try:
+        modules = load_modules(modules_path, check_doc_exists=False)
+    except (ValueError, FileNotFoundError) as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    # Enumerate tracked files
     result = subprocess.run(
         ["git", "ls-files"],
         cwd=REPO_ROOT,
@@ -29,10 +37,36 @@ def main() -> int:
         text=True,
     )
     files = [line for line in result.stdout.splitlines() if line]
-    errors = coverage_check(modules, files)
-    for err in errors:
-        print(err, file=sys.stderr)
-    return 1 if errors else 0
+
+    errors: list[str] = []
+
+    # Check 1 & 2: every file must match exactly one module
+    errors.extend(coverage_check(modules, files))
+
+    # Check 3: each module's doc: path must exist on disk
+    for mod in modules:
+        doc_path = REPO_ROOT / mod.doc
+        if not doc_path.exists():
+            errors.append(
+                f"module '{mod.name}': doc path does not exist: {mod.doc}"
+            )
+
+    # Check 4: each module's globs: must match at least one tracked file
+    for mod in modules:
+        if not any(
+            fnmatch.fnmatch(f, g) for f in files for g in mod.globs
+        ):
+            errors.append(
+                f"module '{mod.name}': no tracked files match its globs"
+            )
+
+    if errors:
+        for err in errors:
+            print(err)
+        return 1
+
+    print(f"{len(files)} files / {len(modules)} modules covered")
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#889

**Issue:** #889 — audit-refactor 1.4: add scripts/check-modules-coverage.py

## PR Summary

### What this fixes
Without a coverage check, `docs/modules.yaml` could silently drift out of sync with the tracked file tree. This script provides a runnable diagnostic that enforces full, unambiguous coverage.

### What was changed
- **`scripts/check-modules-coverage.py`** (new file): implements the four validation checks — (1) every tracked file matches at least one module glob, (2) no file matches two or more modules, (3) every module's `doc:` path exists on disk, (4) every module's globs match at least one tracked file. Uses `load_modules()` and `coverage_check()` from `cai_lib/audit/modules.py`. Prints all errors to stdout and exits 1 on any failure; prints `<N> files / <M> modules covered` and exits 0 on success.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
