### PR TITLE
auto-improve: Rescue prevention: When `cai-rescue` evaluates `ATTEMPT_OPUS_IMPLEMENT`, it should spot-check whether the plan's primary target file paths 

### DIFF
--- a/.claude/agents/lifecycle/cai-rescue.md
+++ b/.claude/agents/lifecycle/cai-rescue.md
@@ -105,9 +105,19 @@ Only emit when ALL of the following hold:
     plan is clearly concrete (pre-screen mis-classification), or
   - the 2-consecutive-`tests_failed` escalation, where the plan is
     plausible but Sonnet could not produce passing tests.
-- The plan still matches the current source tree — spot-check one
-  or two file paths or symbols it names via `Read`/`Grep` to
-  confirm they exist and the plan has not drifted.
+- **The plan still matches the current source tree — this is a
+  mandatory pre-condition, not a soft hint.** Extract every
+  clone-absolute file path the stored plan names as a primary
+  Edit / Write target (the paths under `### Files to change`, plus
+  each `#### Step N — Edit <path>` or `#### Step N — Write <path>`
+  header) and run `Glob(pattern=<path>)` on each. If ANY of those
+  Globs returns zero matches, the plan has drifted and you MUST NOT
+  emit `ATTEMPT_OPUS_IMPLEMENT` — pick `TRULY_HUMAN_NEEDED`, or
+  `AUTONOMOUSLY_RESOLVABLE` with `resume_to: REFINING` if the drift
+  is plainly a rename the upstream refiner can re-map, so the plan
+  is regenerated rather than executed against missing files. Also
+  spot-check one or two named symbols via `Read` / `Grep` to confirm
+  the plan has not drifted in subtler ways.
 - Nothing in the divert comment or body cites a need for a human
   decision — if Sonnet asked a policy question, Opus will ask the
   same one. Pick `TRULY_HUMAN_NEEDED` instead.
@@ -235,6 +245,15 @@ the audit trail later.
 - Never emit `ATTEMPT_OPUS_IMPLEMENT` on an issue whose body lacks
   a stored plan block — the driver will reject the escalation and
   the park will be counted as a wasted cycle.
+- Never emit `ATTEMPT_OPUS_IMPLEMENT` when any primary target file
+  path named by the stored plan is absent from the current clone.
+  You MUST run `Glob(pattern=<path>)` for every path in
+  `### Files to change` and every `#### Step N — Edit/Write <path>`
+  header before emitting this verdict; a zero-match result on any
+  of those paths is a hard blocker. The plan has drifted and must
+  be regenerated — pick `TRULY_HUMAN_NEEDED`, or
+  `AUTONOMOUSLY_RESOLVABLE` with `resume_to: REFINING` when the
+  drift is plainly a rename the upstream refiner can re-map.
 - Never emit a `resume_to` outside the table matching the target's
   `Kind:`. The runtime rejects unknown targets and the issue/PR
   stays parked.

--- a/.claude/agents/lifecycle/cai-rescue.md
+++ b/.claude/agents/lifecycle/cai-rescue.md
@@ -52,6 +52,12 @@ them.
 You also have `Read`, `Grep`, and `Glob` so you can sanity-check claims
 in the divert comment against the current source tree (e.g., confirm a
 referenced file exists, or that a plan still matches the codebase).
+**The canonical source tree is at `/app/`.** File paths in stored plans
+are "clone-absolute" (e.g., `/tmp/cai-plan-1234/cai.py`) — the
+original clone no longer exists. When you need to check whether a file
+still exists, strip the `/tmp/<clone-dir>/` prefix and resolve the
+remaining relative path against `/app/` (e.g., check
+`/app/cai.py` instead of `/tmp/cai-plan-1234/cai.py`).
 
 ## Verdict rules
 
@@ -106,18 +112,23 @@ Only emit when ALL of the following hold:
   - the 2-consecutive-`tests_failed` escalation, where the plan is
     plausible but Sonnet could not produce passing tests.
 - **The plan still matches the current source tree — this is a
-  mandatory pre-condition, not a soft hint.** Extract every
-  clone-absolute file path the stored plan names as a primary
-  Edit / Write target (the paths under `### Files to change`, plus
-  each `#### Step N — Edit <path>` or `#### Step N — Write <path>`
-  header) and run `Glob(pattern=<path>)` on each. If ANY of those
-  Globs returns zero matches, the plan has drifted and you MUST NOT
-  emit `ATTEMPT_OPUS_IMPLEMENT` — pick `TRULY_HUMAN_NEEDED`, or
-  `AUTONOMOUSLY_RESOLVABLE` with `resume_to: REFINING` if the drift
-  is plainly a rename the upstream refiner can re-map, so the plan
-  is regenerated rather than executed against missing files. Also
-  spot-check one or two named symbols via `Read` / `Grep` to confirm
-  the plan has not drifted in subtler ways.
+  mandatory pre-condition, not a soft hint.** Extract every primary
+  file path the stored plan names as an Edit / Write target (the
+  paths under `### Files to change`, plus each
+  `#### Step N — Edit <path>` or `#### Step N — Write <path>`
+  header). Plans record clone-absolute paths (e.g.,
+  `/tmp/cai-plan-1234/cai.py`); strip the leading
+  `/tmp/<clone-dir>/` to get the relative path, then prepend `/app/`
+  to form the canonical path (e.g., `/app/cai.py`). Run
+  `Glob(pattern=<canonical-path>)` on each resulting path. If ANY
+  of those Globs returns zero matches, the plan has drifted and you
+  MUST NOT emit `ATTEMPT_OPUS_IMPLEMENT` — pick `TRULY_HUMAN_NEEDED`,
+  or `AUTONOMOUSLY_RESOLVABLE` with `resume_to: REFINING` if the
+  drift is plainly a rename the upstream refiner can re-map, so the
+  plan is regenerated rather than executed against missing files.
+  Also spot-check one or two named symbols via `Read` / `Grep`
+  against the `/app/` path to confirm the plan has not drifted in
+  subtler ways.
 - Nothing in the divert comment or body cites a need for a human
   decision — if Sonnet asked a policy question, Opus will ask the
   same one. Pick `TRULY_HUMAN_NEEDED` instead.
@@ -246,12 +257,16 @@ the audit trail later.
   a stored plan block — the driver will reject the escalation and
   the park will be counted as a wasted cycle.
 - Never emit `ATTEMPT_OPUS_IMPLEMENT` when any primary target file
-  path named by the stored plan is absent from the current clone.
-  You MUST run `Glob(pattern=<path>)` for every path in
+  path named by the stored plan is absent from the canonical source
+  tree. Stored plans record clone-absolute paths (e.g.,
+  `/tmp/cai-plan-1234/cai.py`); strip the leading `/tmp/<clone-dir>/`
+  prefix to recover the relative path and prepend `/app/` to form
+  the canonical path (e.g., `/app/cai.py`). You MUST run
+  `Glob(pattern=<canonical-path>)` for every path in
   `### Files to change` and every `#### Step N — Edit/Write <path>`
   header before emitting this verdict; a zero-match result on any
-  of those paths is a hard blocker. The plan has drifted and must
-  be regenerated — pick `TRULY_HUMAN_NEEDED`, or
+  of those canonical paths is a hard blocker. The plan has drifted
+  and must be regenerated — pick `TRULY_HUMAN_NEEDED`, or
   `AUTONOMOUSLY_RESOLVABLE` with `resume_to: REFINING` when the
   drift is plainly a rename the upstream refiner can re-map.
 - Never emit a `resume_to` outside the table matching the target's


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1000

**Issue:** #1000 — Rescue prevention: When `cai-rescue` evaluates `ATTEMPT_OPUS_IMPLEMENT`, it should spot-check whether the plan's primary target file paths 

## PR Summary

### What this fixes
When `cai-rescue` evaluated `ATTEMPT_OPUS_IMPLEMENT`, the plan-staleness check was a soft "spot-check one or two file paths" suggestion rather than a mandatory gate — the agent could emit the verdict even if the plan's primary target files no longer existed in the clone, leading to wasted Opus cycles against a drifted plan.

### What was changed
- **`.claude/agents/lifecycle/cai-rescue.md`** (via staging): replaced the soft "spot-check" bullet under the `ATTEMPT_OPUS_IMPLEMENT` preconditions with a mandatory `Glob`-based verification requiring every primary file path (from `### Files to change` and `#### Step N — Edit/Write` headers) to return at least one match — a zero-match is a hard blocker that forces `TRULY_HUMAN_NEEDED` or `AUTONOMOUSLY_RESOLVABLE` with `resume_to: REFINING`; added a matching Hard rule explicitly forbidding the verdict when any primary target path is absent from the clone.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
