### PR TITLE
auto-improve: Rescue prevention: In `cai_lib/actions/merge.py` (or the `cai-merge` agent prompt), consider adding a "scope expansion" exception clause: w

### DIFF
--- a/.claude/agents/review/cai-merge.md
+++ b/.claude/agents/review/cai-merge.md
@@ -204,6 +204,45 @@ and the latest `## cai docs review` comment is either `(clean) —
 do not downgrade to **medium** on a scope concern that the pipeline
 itself introduced.
 
+### Exemption: wrapper-injected pre-authorized scope
+
+The merge wrapper (`cai_lib/actions/merge.py`) sometimes prepends a
+`## Pre-authorized scope expansion` section to the user message,
+**between the issue body and the PR changes**. The wrapper emits
+that section only when it has deterministically detected that the
+issue was re-queued by `cai-confirm` after a prior merged PR was
+judged **unsolved**, and has extracted the replacement plan's
+authorized file list from the stored `<!-- cai-plan-start -->`
+block's `### Files to change`. You do **not** need to detect any
+marker, parse the plan, or reason about re-queue attempts
+yourself — if the section is absent, no re-queue exemption applies.
+
+When a `## Pre-authorized scope expansion` section is present in
+the user message:
+
+- Treat every file listed there as in-scope for this PR. Do not
+  downgrade confidence for scope-only reasons on those files —
+  including "scope broader than the issue asks for", "new files
+  not mentioned in the issue", and "PR adds new test files or
+  docstrings". The plan-selection gate already approved the
+  broadening as a direct response to the prior unsolved verdict.
+- The exemption covers **scope only**. Correctness, completeness,
+  unaddressed review comments, and workflow-file
+  (`.github/workflows/`) rules still apply in full. A re-queue PR
+  that expands scope but fails to address the original remediation
+  should still `hold` on completeness grounds, not on scope
+  grounds. A re-queue PR that edits a file under
+  `.github/workflows/` is still disqualifying.
+- Files not listed in the pre-authorized block AND not covered by
+  one of the other exemptions above (`.cai/pr-context.md`,
+  `docs/**`, `CODEBASE_INDEX.md`, reviewer-recommended co-changes,
+  docs-reviewer co-edits) are still scope creep and disqualify a
+  `high` verdict.
+- If a pre-authorized scope expansion is the *only* soft concern
+  standing between the PR and a **high** verdict, emit **high** —
+  do not downgrade to **medium** on a scope concern that the
+  wrapper itself pre-approved.
+
 ## Output format
 
 Emit exactly this structured block — nothing else:

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -147,6 +147,7 @@
 | `tests/test_lint.py` | Lint check: ruff must report zero violations |
 | `tests/test_maintain.py` | Tests for cai_lib.actions.maintain — handle_maintain confidence routing and FSM transitions |
 | `tests/test_merge_diff.py` | TODO: add description |
+| `tests/test_merge_requeue_exemption.py` | TODO: add description |
 | `tests/test_multistep.py` | Tests for multi-step plan support |
 | `tests/test_orphaned_prs.py` | TODO: add description |
 | `tests/test_parse.py` | Tests for parse.py signal extraction |

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -36,6 +36,7 @@ from cai_lib.cmd_helpers import (
     _parse_iso_ts,
     _is_bot_comment,
     _fetch_review_comments,
+    _extract_stored_plan,
 )
 from cai_lib.actions.revise import _filter_comments_with_haiku
 from cai_lib.logging_utils import log_run
@@ -81,6 +82,121 @@ _MERGE_JSON_SCHEMA = {
     },
     "required": ["confidence", "action", "reasoning"],
 }
+
+
+# ---------------------------------------------------------------------------
+# Re-queue scope-expansion exemption (wrapper-driven).
+#
+# When ``cai-confirm`` judges a prior merged PR unsolved it appends a
+# ``## Confirm re-queue (attempt N)`` block to the issue body and
+# re-routes the issue back through refine/plan. The replacement plan
+# is expected to be meaningfully different from the prior attempt —
+# often broader (new helpers, new files, new tests) — precisely
+# because the narrower previous attempt failed. Without an exemption
+# the merge agent would downgrade the new PR on scope grounds even
+# though the plan-selection gate already approved the broader scope.
+#
+# We detect the condition **structurally, in Python**, rather than
+# teaching the agent to parse markers at inference time:
+#
+#   1. Search the issue body for the ``## Confirm re-queue (attempt
+#      N)`` producer marker (deterministically emitted by
+#      ``cai_lib/actions/confirm.py`` — see ``_requeue_block``).
+#   2. Extract the stored plan body via ``_extract_stored_plan``.
+#   3. Pull the backticked ``path/with.ext`` tokens out of the plan's
+#      ``### Files to change`` section (same regex shape used by
+#      ``_plan_targets_only_docs`` in ``cai_lib/actions/plan.py``).
+#   4. Emit a ``## Pre-authorized scope expansion`` markdown block
+#      naming those files. The block is injected into the merge
+#      agent's ``user_message`` between the issue body and the PR
+#      diff, so the agent receives an explicit authoritative list of
+#      pre-approved files instead of having to detect a marker or
+#      parse a plan itself.
+#
+# When any precondition fails (no marker, no plan, no section, no
+# paths) the helper returns the empty string, and ``user_message``
+# is assembled exactly as before — backward-compatible for every
+# ordinary first-attempt PR. See ``cai-merge.md`` for the
+# complementary agent-side rule.
+# ---------------------------------------------------------------------------
+_REQUEUE_MARKER_RE = re.compile(
+    r"^## Confirm re-queue \(attempt \d+\)", re.MULTILINE
+)
+
+_REQUEUE_FILES_SECTION_RE = re.compile(
+    r"^###\s+Files\s+to\s+change\s*$\n(.*?)(?=^###\s|\Z)",
+    re.IGNORECASE | re.DOTALL | re.MULTILINE,
+)
+
+_REQUEUE_FILES_PATH_RE = re.compile(
+    r"`([^`\s]+/[^`\s]*\.[A-Za-z0-9]+)`"
+)
+
+
+def _build_requeue_exemption_block(issue_body: str) -> str:
+    """Return a pre-authorized-scope markdown block, or ``""`` when
+    the re-queue exemption does not apply to *issue_body*.
+
+    Returns ``""`` when:
+
+    * the ``## Confirm re-queue (attempt N)`` marker is absent
+      (ordinary first-attempt PR),
+    * the issue body has no extractable stored plan block,
+    * the stored plan has no ``### Files to change`` section, or
+    * that section contains no backticked ``path/with.ext`` tokens.
+
+    Otherwise returns a markdown block of the form::
+
+        ## Pre-authorized scope expansion
+
+        This issue was re-queued by `cai-confirm` ...
+
+        - `path/to/file_a.py`
+        - `path/to/file_b.py`
+
+        **Treat every file in this list as in-scope for this PR.** ...
+
+    Extracted paths are deduplicated while preserving first-seen
+    order so the injected block stays stable across repeated runs.
+    """
+    if not issue_body or not _REQUEUE_MARKER_RE.search(issue_body):
+        return ""
+
+    plan_text = _extract_stored_plan(issue_body)
+    if not plan_text:
+        return ""
+
+    section = _REQUEUE_FILES_SECTION_RE.search(plan_text)
+    if not section:
+        return ""
+
+    paths = _REQUEUE_FILES_PATH_RE.findall(section.group(1))
+    if not paths:
+        return ""
+
+    seen: set[str] = set()
+    unique_paths: list[str] = []
+    for p in paths:
+        if p not in seen:
+            seen.add(p)
+            unique_paths.append(p)
+
+    bullet_list = "\n".join(f"- `{p}`" for p in unique_paths)
+    return (
+        "## Pre-authorized scope expansion\n\n"
+        "This issue was re-queued by `cai-confirm` after a prior "
+        "merged PR was judged **unsolved**. The plan-selection gate "
+        "has already approved the following expanded file scope for "
+        "this attempt:\n\n"
+        f"{bullet_list}\n\n"
+        "**Treat every file in this list as in-scope for this PR.** "
+        "Do not downgrade confidence for scope-only reasons on these "
+        "files (e.g. \"scope broader than the issue asks\", \"new "
+        "files not mentioned in the issue\", \"PR adds new test "
+        "files or docstrings\"). Correctness, completeness, "
+        "unaddressed review comments, and workflow-file "
+        "(`.github/workflows/`) rules still apply in full.\n\n"
+    )
 
 
 def _assemble_diff(raw_diff: str, max_len: int) -> str:
@@ -373,11 +489,16 @@ def handle_merge(pr: dict) -> int:
         "\n\n---\n\n".join(comment_texts) if comment_texts else "(no comments)"
     )
 
+    requeue_block = _build_requeue_exemption_block(
+        issue_full.get("body") or ""
+    )
+
     user_message = (
         f"## Linked issue\n\n"
         f"### #{issue_full.get('number', issue_number)} \u2014 "
         f"{issue_full.get('title', '')}\n\n"
         f"{issue_full.get('body') or '(no body)'}\n\n"
+        f"{requeue_block}"
         f"## PR changes\n\n"
         f"```diff\n{pr_diff}\n```\n\n"
         f"## PR comments\n\n"

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -38,6 +38,10 @@ from cai_lib.cmd_helpers import (
     _fetch_review_comments,
     _extract_stored_plan,
 )
+from cai_lib.actions.plan import (
+    _FILES_TO_CHANGE_SECTION_RE,
+    _FILES_TO_CHANGE_PATH_RE,
+)
 from cai_lib.actions.revise import _filter_comments_with_haiku
 from cai_lib.logging_utils import log_run
 
@@ -104,8 +108,9 @@ _MERGE_JSON_SCHEMA = {
 #      ``cai_lib/actions/confirm.py`` — see ``_requeue_block``).
 #   2. Extract the stored plan body via ``_extract_stored_plan``.
 #   3. Pull the backticked ``path/with.ext`` tokens out of the plan's
-#      ``### Files to change`` section (same regex shape used by
-#      ``_plan_targets_only_docs`` in ``cai_lib/actions/plan.py``).
+#      ``### Files to change`` section using ``_FILES_TO_CHANGE_SECTION_RE``
+#      and ``_FILES_TO_CHANGE_PATH_RE`` imported from
+#      ``cai_lib/actions/plan.py`` (shared with ``_plan_targets_only_docs``).
 #   4. Emit a ``## Pre-authorized scope expansion`` markdown block
 #      naming those files. The block is injected into the merge
 #      agent's ``user_message`` between the issue body and the PR
@@ -122,16 +127,6 @@ _MERGE_JSON_SCHEMA = {
 _REQUEUE_MARKER_RE = re.compile(
     r"^## Confirm re-queue \(attempt \d+\)", re.MULTILINE
 )
-
-_REQUEUE_FILES_SECTION_RE = re.compile(
-    r"^###\s+Files\s+to\s+change\s*$\n(.*?)(?=^###\s|\Z)",
-    re.IGNORECASE | re.DOTALL | re.MULTILINE,
-)
-
-_REQUEUE_FILES_PATH_RE = re.compile(
-    r"`([^`\s]+/[^`\s]*\.[A-Za-z0-9]+)`"
-)
-
 
 def _build_requeue_exemption_block(issue_body: str) -> str:
     """Return a pre-authorized-scope markdown block, or ``""`` when
@@ -166,11 +161,11 @@ def _build_requeue_exemption_block(issue_body: str) -> str:
     if not plan_text:
         return ""
 
-    section = _REQUEUE_FILES_SECTION_RE.search(plan_text)
+    section = _FILES_TO_CHANGE_SECTION_RE.search(plan_text)
     if not section:
         return ""
 
-    paths = _REQUEUE_FILES_PATH_RE.findall(section.group(1))
+    paths = _FILES_TO_CHANGE_PATH_RE.findall(section.group(1))
     if not paths:
         return ""
 

--- a/tests/test_merge_requeue_exemption.py
+++ b/tests/test_merge_requeue_exemption.py
@@ -1,0 +1,146 @@
+"""Tests for the _build_requeue_exemption_block helper in cai_lib.actions.merge.
+
+The helper drives the wrapper-side confirm re-queue scope-expansion
+exemption — see the ``Re-queue scope-expansion exemption`` comment
+block in ``cai_lib/actions/merge.py`` and the matching
+``Exemption: wrapper-injected pre-authorized scope`` section in
+``.claude/agents/review/cai-merge.md``.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.actions.merge import _build_requeue_exemption_block
+
+
+def _issue_body(marker: bool, plan: str | None) -> str:
+    """Assemble a synthetic issue body for the test fixtures."""
+    parts = ["# Issue title", "", "Some description."]
+    if plan is not None:
+        parts.extend([
+            "",
+            "<!-- cai-plan-start -->",
+            "## Selected Implementation Plan",
+            plan,
+            "<!-- cai-plan-end -->",
+        ])
+    if marker:
+        parts.extend([
+            "",
+            "## Confirm re-queue (attempt 1)",
+            "",
+            "Fix confirmed unsolved. Re-queued for another attempt.",
+        ])
+    return "\n".join(parts)
+
+
+_PLAN_WITH_FILES = """### Summary
+
+Do the thing.
+
+### Files to change
+
+- **`cai_lib/actions/merge.py`**: add helper
+- **`tests/test_merge_requeue_exemption.py`**: new tests
+
+### Detailed steps
+
+Step 1 — ...
+"""
+
+
+class TestBuildRequeueExemptionBlock(unittest.TestCase):
+
+    def test_empty_body_returns_empty(self):
+        self.assertEqual(_build_requeue_exemption_block(""), "")
+
+    def test_no_requeue_marker_returns_empty(self):
+        body = _issue_body(marker=False, plan=_PLAN_WITH_FILES)
+        self.assertEqual(_build_requeue_exemption_block(body), "")
+
+    def test_marker_without_plan_returns_empty(self):
+        body = _issue_body(marker=True, plan=None)
+        self.assertEqual(_build_requeue_exemption_block(body), "")
+
+    def test_marker_with_plan_but_no_files_section_returns_empty(self):
+        plan_no_files = "### Summary\n\nDo it.\n\n### Detailed steps\n\n..."
+        body = _issue_body(marker=True, plan=plan_no_files)
+        self.assertEqual(_build_requeue_exemption_block(body), "")
+
+    def test_marker_with_files_section_but_no_paths_returns_empty(self):
+        plan_prose_only = (
+            "### Files to change\n\n"
+            "- Update the relevant helpers.\n"
+            "- Add a new test.\n\n"
+            "### Detailed steps\n\n..."
+        )
+        body = _issue_body(marker=True, plan=plan_prose_only)
+        self.assertEqual(_build_requeue_exemption_block(body), "")
+
+    def test_happy_path_emits_block_with_all_paths(self):
+        body = _issue_body(marker=True, plan=_PLAN_WITH_FILES)
+        result = _build_requeue_exemption_block(body)
+        self.assertTrue(result.startswith("## Pre-authorized scope expansion"))
+        self.assertIn("- `cai_lib/actions/merge.py`", result)
+        self.assertIn("- `tests/test_merge_requeue_exemption.py`", result)
+        self.assertIn("**Treat every file in this list as in-scope", result)
+        self.assertIn("`.github/workflows/`", result)
+        # Block must end with a blank line so the subsequent
+        # "## PR changes" header is separated from the exemption body
+        # when concatenated into the user message.
+        self.assertTrue(result.endswith("\n\n"))
+
+    def test_paths_deduplicated_preserving_order(self):
+        plan_with_dupes = (
+            "### Files to change\n\n"
+            "- **`cai_lib/actions/merge.py`**: step A\n"
+            "- **`tests/test_merge_requeue_exemption.py`**: step B\n"
+            "- **`cai_lib/actions/merge.py`**: step C (same file, later step)\n\n"
+            "### Detailed steps\n\n..."
+        )
+        body = _issue_body(marker=True, plan=plan_with_dupes)
+        result = _build_requeue_exemption_block(body)
+        # Only one bullet per file.
+        self.assertEqual(result.count("- `cai_lib/actions/merge.py`"), 1)
+        # First-seen order preserved: merge.py appears before the test.
+        merge_pos = result.find("- `cai_lib/actions/merge.py`")
+        test_pos = result.find(
+            "- `tests/test_merge_requeue_exemption.py`"
+        )
+        self.assertLess(merge_pos, test_pos)
+
+    def test_multiple_requeue_attempts_also_match(self):
+        """Body containing attempt 2 (not just attempt 1) still qualifies."""
+        body = _issue_body(marker=False, plan=_PLAN_WITH_FILES)
+        body += "\n\n## Confirm re-queue (attempt 2)\n\nSecond retry."
+        result = _build_requeue_exemption_block(body)
+        self.assertTrue(result.startswith("## Pre-authorized scope expansion"))
+
+    def test_block_concatenates_cleanly_with_pr_changes_header(self):
+        """End-to-end: simulate user_message concatenation to verify spacing.
+
+        Ensures the helper's output sits correctly between the issue body
+        (which ends with ``\\n\\n``) and the ``## PR changes\\n\\n`` header
+        without collapsing or multiplying blank lines.
+        """
+        body = _issue_body(marker=True, plan=_PLAN_WITH_FILES)
+        block = _build_requeue_exemption_block(body)
+        # Mirrors the user_message pattern in handle_merge.
+        message = (
+            "## Linked issue\n\n"
+            "some body\n\n"
+            f"{block}"
+            "## PR changes\n\n"
+            "```diff\n(diff)\n```\n"
+        )
+        # Exactly one blank line between the exemption block end and
+        # the PR changes header.
+        self.assertIn(
+            "rules still apply in full.\n\n## PR changes\n\n", message
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1001

**Issue:** #1001 — Rescue prevention: In `cai_lib/actions/merge.py` (or the `cai-merge` agent prompt), consider adding a "scope expansion" exception clause: w

## PR Summary

### What this fixes
When `cai-confirm` judges a prior merged PR unsolved and re-queues the issue, the replacement plan is often broader in scope (new files, new tests) because the narrower first attempt failed. Without a scope-expansion exemption, `cai-merge` would downgrade the new PR's confidence on scope grounds even though the plan-selection gate already approved the wider scope — causing unnecessary `:human-needed` parks.

### What was changed
- **`cai_lib/actions/merge.py`**: Added `_extract_stored_plan` to the `cai_lib.cmd_helpers` import; introduced three module-level regexes (`_REQUEUE_MARKER_RE`, `_REQUEUE_FILES_SECTION_RE`, `_REQUEUE_FILES_PATH_RE`) and the `_build_requeue_exemption_block(issue_body)` helper that deterministically detects re-queued issues and returns a pre-formatted `## Pre-authorized scope expansion` markdown block (or `""` for ordinary PRs); injected the block into the `user_message` assembly in `handle_merge` between the issue body and `## PR changes`.
- **`.cai-staging/agents/review/cai-merge.md`** (staged for `.claude/agents/review/cai-merge.md`): Added a `### Exemption: wrapper-injected pre-authorized scope` subsection immediately before `## Output format`, instructing the agent to honor the wrapper-injected pre-authorization block when present.
- **`tests/test_merge_requeue_exemption.py`** (new): Unit tests covering empty input, missing marker, missing plan block, missing `### Files to change` section, no backticked paths, happy path, path deduplication with order preservation, multiple attempt numbers, and injection-boundary spacing.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
