### PR TITLE
fix: use 'not planned' (not 'not-planned') for gh issue close --reason

### DIFF
--- a/.claude/agents/ops/cai-maintain.md
+++ b/.claude/agents/ops/cai-maintain.md
@@ -36,7 +36,7 @@ You are the `cai-maintain` agent. You receive a `kind:maintenance` issue body in
 - **Never call `gh pr create`**. If any operation would require a PR, skip it and emit `Confidence: LOW` with an explanation.
 - Execute operations in order. If one fails, log the failure and continue with the rest.
 - Use `gh issue edit --add-label` / `gh issue edit --remove-label` for label mutations.
-- Use `gh issue close --reason not-planned` for bulk-close operations.
+- Use `gh issue close --reason "not planned"` for bulk-close operations.
 - For workflow edits, use the `Read` tool to read the YAML file, then `Bash` with `sed` or a Python one-liner to edit it in the work directory.
 - After all operations, write a brief summary of what succeeded and what failed.
 - When `Confidence` is `MEDIUM` or `LOW`, you MUST emit a `Confidence reason:` line on its own line immediately after the `Confidence:` line. One sentence is enough; no markdown headings, block quotes, or multi-line prose — the line must match `^Confidence reason: <text>$` so `parse_confidence_reason` can extract it.

--- a/cai_lib/actions/triage.py
+++ b/cai_lib/actions/triage.py
@@ -171,7 +171,7 @@ def handle_triage(issue: dict) -> int:
         close_res = _run(
             ["gh", "issue", "close", str(issue_number),
              "--repo", REPO,
-             "--reason", "not-planned",
+             "--reason", "not planned",
              "--comment", comment],
             capture_output=True,
         )


### PR DESCRIPTION
## Summary
- `gh issue close --reason` only accepts `{completed|not planned|duplicate}`. The hyphenated form `not-planned` was rejected by gh.
- Observed in a `cai triage` run on #1008: the dup-check close path in `cai_lib/actions/triage.py` failed with `invalid argument "not-planned"` and fell through to the triage agent.
- Also fixes a stale example in `.claude/agents/ops/cai-maintain.md` that advertised the same wrong form.

## Test plan
- [ ] Trigger a dup-check duplicate close path in `cai triage` and confirm the issue closes cleanly with reason `not planned`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)