### PR TITLE
auto-improve: Merge worker repeatedly dispatches against human PR #945 returning not_bot_branch

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -151,6 +151,7 @@
 | `tests/test_maintain.py` | Tests for cai_lib.actions.maintain — handle_maintain confidence routing and FSM transitions |
 | `tests/test_merge_agent_deletion_guard.py` | TODO: add description |
 | `tests/test_merge_diff.py` | TODO: add description |
+| `tests/test_merge_non_bot_branch.py` | TODO: add description |
 | `tests/test_merge_pipeline_coedits.py` | TODO: add description |
 | `tests/test_merge_requeue_exemption.py` | TODO: add description |
 | `tests/test_multistep.py` | Tests for multi-step plan support |

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -581,12 +581,34 @@ def handle_merge(pr: dict) -> int:
     branch = pr.get("headRefName", "")
     title = pr["title"]
 
-    # Safety filter 1: only bot PRs.
+    # Safety filter 1: only bot PRs. Park non-bot branches as
+    # PR_HUMAN_NEEDED (via ``approved_to_human``) so the dispatcher
+    # stops re-routing them to ``handle_merge`` every drain tick —
+    # a human admin must merge manually. Without this transition a
+    # human-authored PR carrying ``pr:approved`` would be picked up
+    # forever, logging ``result=not_bot_branch`` once per tick
+    # (see issue #1013).
     m = _BOT_BRANCH_RE.match(branch)
     if not m:
         print(
-            f"[cai merge] PR #{pr_number}: non-bot branch {branch!r}; skipping",
+            f"[cai merge] PR #{pr_number}: non-bot branch {branch!r}; "
+            f"parking as PR_HUMAN_NEEDED",
             flush=True,
+        )
+        _run(
+            ["gh", "pr", "comment", str(pr_number),
+             "--repo", REPO, "--body",
+             f"This PR is on branch `{branch}`, which is not an "
+             f"`auto-improve/<issue>-…` bot branch, so the `cai merge` "
+             f"worker cannot auto-merge it. Moving to "
+             f"`pr:human-needed` — a human admin must merge this PR "
+             f"manually. Re-applying `pr:approved` will just re-enter "
+             f"this state."],
+            capture_output=True,
+        )
+        apply_pr_transition(
+            pr_number, "approved_to_human",
+            log_prefix="cai merge",
         )
         log_run("merge", repo=REPO, pr=pr_number,
                 result="not_bot_branch", exit=0)

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -615,7 +615,7 @@ def handle_merge(pr: dict) -> int:
         return 0
     issue_number = int(m.group(1))
 
-    # Safety filter 4: unmergeable PRs (conflicts).
+    # Safety filter 2: unmergeable PRs (conflicts).
     mergeable = pr.get("mergeable", "")
     if mergeable == "CONFLICTING":
         print(
@@ -627,7 +627,7 @@ def handle_merge(pr: dict) -> int:
                 result="conflicting", exit=0)
         return 0
 
-    # Safety filter 2: linked issue must be in :pr-open state.
+    # Safety filter 3: linked issue must be in :pr-open state.
     try:
         issue = _gh_json([
             "issue", "view", str(issue_number),
@@ -674,7 +674,7 @@ def handle_merge(pr: dict) -> int:
     # the unaddressed-comments / CI / merge-agent gates below catch
     # anything that genuinely needs another look.
 
-    # Safety filter 3: unaddressed review comments → let revise handle.
+    # Safety filter 4: unaddressed review comments → let revise handle.
     # Mirror the revise subcommand's filter logic via the shared helper
     # so a "no additional changes" reply correctly suppresses the loop.
     all_comments = list(pr.get("comments", []))

--- a/tests/test_merge_non_bot_branch.py
+++ b/tests/test_merge_non_bot_branch.py
@@ -1,0 +1,95 @@
+"""Regression test for the non-bot branch park path in handle_merge.
+
+Issue #1013: when a human-authored PR carrying ``pr:approved`` (admin
+applied the label hoping for auto-merge) sat on a non-``auto-improve/``
+branch, ``handle_merge`` logged ``result=not_bot_branch`` and returned
+0 without changing state, so the dispatcher re-routed the same PR to
+``handle_merge`` on every drain tick. The fix applies the
+``approved_to_human`` PR transition so the PR parks at
+``PR_HUMAN_NEEDED``.
+"""
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.actions import merge as merge_mod
+
+
+def _pr_non_bot(number: int = 945) -> dict:
+    return {
+        "number": number,
+        "title": "Human-authored PR on a non-bot branch",
+        "headRefName": "feat/audit-modules-loader-886",
+        "headRefOid": "deadbeefcafef00d",
+        "labels": [{"name": "pr:approved"}],
+        "state": "OPEN",
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "mergedAt": None,
+        "comments": [],
+        "reviews": [],
+        "createdAt": "2024-01-01T00:00:00Z",
+    }
+
+
+class TestHandleMergeNonBotBranch(unittest.TestCase):
+    """Non-bot branches must park via approved_to_human, not loop forever."""
+
+    def test_non_bot_branch_parks_as_human_needed(self):
+        pr = _pr_non_bot()
+        run_mock = MagicMock()
+        run_mock.return_value.returncode = 0
+        run_mock.return_value.stdout = ""
+        run_mock.return_value.stderr = ""
+        transition_mock = MagicMock(return_value=True)
+        log_mock = MagicMock()
+
+        with patch.object(merge_mod, "_run", run_mock), \
+             patch.object(merge_mod, "apply_pr_transition", transition_mock), \
+             patch.object(merge_mod, "log_run", log_mock):
+            rc = merge_mod.handle_merge(pr)
+
+        self.assertEqual(rc, 0)
+        transition_mock.assert_called_once()
+        args, kwargs = transition_mock.call_args
+        self.assertEqual(args[0], 945)
+        self.assertEqual(args[1], "approved_to_human")
+
+        # A single comment is posted explaining the park.
+        gh_comment_calls = [
+            call for call in run_mock.call_args_list
+            if call.args and call.args[0][:3] == ["gh", "pr", "comment"]
+        ]
+        self.assertEqual(len(gh_comment_calls), 1)
+        body_arg_idx = gh_comment_calls[0].args[0].index("--body") + 1
+        body = gh_comment_calls[0].args[0][body_arg_idx]
+        self.assertIn("feat/audit-modules-loader-886", body)
+        self.assertIn("pr:human-needed", body)
+
+        # Telemetry log tag preserved for audit compatibility.
+        log_call_kwargs = log_mock.call_args.kwargs
+        self.assertEqual(log_call_kwargs.get("result"), "not_bot_branch")
+        self.assertEqual(log_call_kwargs.get("exit"), 0)
+
+    def test_non_bot_branch_does_not_call_merge_agent(self):
+        """Park must fire *before* any _run_claude_p invocation."""
+        pr = _pr_non_bot()
+        run_mock = MagicMock()
+        run_mock.return_value.returncode = 0
+        claude_mock = MagicMock()
+
+        with patch.object(merge_mod, "_run", run_mock), \
+             patch.object(merge_mod, "_run_claude_p", claude_mock), \
+             patch.object(merge_mod, "apply_pr_transition",
+                          MagicMock(return_value=True)), \
+             patch.object(merge_mod, "log_run", MagicMock()):
+            merge_mod.handle_merge(pr)
+
+        claude_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1013

**Issue:** #1013 — Merge worker repeatedly dispatches against human PR #945 returning not_bot_branch

## PR Summary

### What this fixes
When a human-authored PR carries the `pr:approved` label on a non-`auto-improve/*` branch, `handle_merge` was returning 0 without changing any state, causing the dispatcher to re-route the same PR to `handle_merge` on every drain tick (logging `result=not_bot_branch` once per hour indefinitely, as observed for PR #945).

### What was changed
- **`cai_lib/actions/merge.py`**: In the "Safety filter 1" block, replaced the silent `return 0` with a `_run` call posting an explanatory `gh pr comment` and a call to `apply_pr_transition(pr_number, "approved_to_human", log_prefix="cai merge")` so the PR moves to `pr:human-needed` after the first encounter and is no longer picked up by the dispatcher. The existing `result="not_bot_branch"` log tag is preserved.
- **`tests/test_merge_non_bot_branch.py`**: New regression test with two cases — one verifying the `approved_to_human` transition and comment are called, one verifying `_run_claude_p` is never invoked on a non-bot-branch PR.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
