### PR TITLE
fix: close completed parents in cai-cycle to unblock queue

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -137,6 +137,7 @@
 | `tests/test_agent_staging.py` | TODO: add description |
 | `tests/test_audit_modules.py` | Tests for cai_lib.audit.modules — load_modules + coverage_check |
 | `tests/test_blocked_on.py` | TODO: add description |
+| `tests/test_close_completed_parents.py` | TODO: add description |
 | `tests/test_cmd_misc_label_sweep.py` | TODO: add description |
 | `tests/test_dispatcher.py` | Tests for the FSM dispatcher and state→handler registries |
 | `tests/test_dup_check.py` | TODO: add description |

--- a/cai_lib/cmd_cycle.py
+++ b/cai_lib/cmd_cycle.py
@@ -9,6 +9,7 @@ from cai_lib.watchdog import (
     _rollback_stale_pr_locks,
 )
 from cai_lib.dispatcher import dispatch_drain
+from cai_lib.issues import close_completed_parents
 from cai_lib.logging_utils import log_run
 
 
@@ -77,6 +78,19 @@ def cmd_cycle(args) -> int:
                         flush=True,
                     )
                 _healed.add(_num)
+
+    # Phase 0.5: close parent issues whose sub-issues are all closed.
+    # The dispatcher's ordering gate in `_build_ordering_gate` treats an
+    # open parent as a still-open prior sibling, blocking later siblings
+    # under the grandparent. If all of a parent's sub-issues closed
+    # between verify ticks, we must close it here or the queue stalls
+    # until the next verify run.
+    closed_parents = close_completed_parents(log_prefix="cai cycle")
+    if closed_parents:
+        print(
+            f"[cai cycle] closed {closed_parents} completed parent(s)",
+            flush=True,
+        )
 
     # Phase 1: TTL-based stale-lock sweep — rolls back only locks that
     # have exceeded their configured TTL (_STALE_LOCKED_HOURS etc.).

--- a/cai_lib/cmd_misc.py
+++ b/cai_lib/cmd_misc.py
@@ -19,7 +19,7 @@ from cai_lib.github import (
     _gh_json, _set_labels, _transcript_dir_is_empty,
     _find_linked_pr, _recover_stale_pr_open,
 )
-from cai_lib.issues import all_sub_issues_closed
+from cai_lib.issues import close_completed_parents
 
 
 # ---------------------------------------------------------------------------
@@ -227,47 +227,7 @@ def cmd_verify(args) -> int:
 
     # Check parent issues for completion: close parents whose
     # sub-issues are all closed.
-    try:
-        parent_issues = _gh_json([
-            "issue", "list",
-            "--repo", REPO,
-            "--label", LABEL_PARENT,
-            "--state", "open",
-            "--json", "number",
-            "--limit", "50",
-        ]) or []
-    except subprocess.CalledProcessError:
-        parent_issues = []
-
-    for _pass in range(2):
-        for parent in parent_issues:
-            if all_sub_issues_closed(parent["number"]) is True:
-                _run(
-                    ["gh", "issue", "close", str(parent["number"]),
-                     "--repo", REPO,
-                     "--comment",
-                     "All sub-issues completed. Closing parent."],
-                    capture_output=True,
-                )
-                print(
-                    f"[cai verify] parent #{parent['number']}: "
-                    f"all sub-issues done — closed",
-                    flush=True,
-                )
-        # Re-fetch before second pass: parents closed in pass 1
-        # should not be re-attempted.
-        if _pass == 0:
-            try:
-                parent_issues = _gh_json([
-                    "issue", "list",
-                    "--repo", REPO,
-                    "--label", LABEL_PARENT,
-                    "--state", "open",
-                    "--json", "number",
-                    "--limit", "50",
-                ]) or []
-            except subprocess.CalledProcessError:
-                parent_issues = []
+    close_completed_parents(log_prefix="cai verify")
 
     print(f"[cai verify] done ({transitioned} transitioned)", flush=True)
     log_run("verify", repo=REPO, checked=len(issues), transitioned=transitioned, exit=0)

--- a/cai_lib/issues.py
+++ b/cai_lib/issues.py
@@ -23,9 +23,10 @@ Note — staged migration:
 """
 
 import json
+import subprocess
 import sys
 
-from cai_lib.config import REPO
+from cai_lib.config import LABEL_PARENT, REPO
 from cai_lib.github import _gh_json
 from cai_lib.subprocess_utils import _run
 
@@ -68,8 +69,6 @@ def link_sub_issue(parent_number: int, child_id: int) -> bool:
 
     Returns True on success, False on failure.
     """
-    import subprocess  # local — only needed for the except clause
-
     try:
         _gh_json([
             "api", "--method", "POST",
@@ -92,8 +91,6 @@ def list_sub_issues(parent_number: int) -> list[dict]:
     Each entry is a dict with at least ``number``, ``title``, ``state``,
     and ``id``.  Returns an empty list on failure or if there are none.
     """
-    import subprocess  # local — only needed for the except clause
-
     try:
         result = _gh_json([
             "api", "--paginate",
@@ -114,3 +111,49 @@ def all_sub_issues_closed(parent_number: int) -> bool | None:
     if not subs:
         return None
     return all(si.get("state") == "closed" for si in subs)
+
+
+def close_completed_parents(log_prefix: str = "cai") -> int:
+    """Close parent issues whose sub-issues are all closed.
+
+    Iterates every open ``auto-improve:parent`` issue, and for each one
+    whose native sub-issues are all closed, runs ``gh issue close`` with a
+    standard comment. Runs two passes so that a parent whose only
+    remaining open child was itself a completed parent (closed during
+    pass 1) is also closed in pass 2. Returns the number of parents
+    closed.
+
+    This is called from both ``cai verify`` (as part of its routine
+    sweep) and ``cai cycle`` (every tick, before the dispatcher's
+    ordering gate is built) — keeping the gate unstuck when a parent's
+    sub-issues complete between verify runs.
+    """
+    closed = 0
+    for _pass in range(2):
+        try:
+            parents = _gh_json([
+                "issue", "list",
+                "--repo", REPO,
+                "--label", LABEL_PARENT,
+                "--state", "open",
+                "--json", "number",
+                "--limit", "50",
+            ]) or []
+        except subprocess.CalledProcessError:
+            parents = []
+        for parent in parents:
+            if all_sub_issues_closed(parent["number"]) is True:
+                _run(
+                    ["gh", "issue", "close", str(parent["number"]),
+                     "--repo", REPO,
+                     "--comment",
+                     "All sub-issues completed. Closing parent."],
+                    capture_output=True,
+                )
+                print(
+                    f"[{log_prefix}] parent #{parent['number']}: "
+                    f"all sub-issues done — closed",
+                    flush=True,
+                )
+                closed += 1
+    return closed

--- a/tests/test_close_completed_parents.py
+++ b/tests/test_close_completed_parents.py
@@ -1,0 +1,109 @@
+"""Tests for cai_lib.issues.close_completed_parents."""
+import unittest
+from unittest.mock import patch
+
+from cai_lib import issues
+
+
+class TestCloseCompletedParents(unittest.TestCase):
+    def _run(self, open_parents, subs_by_parent):
+        """Drive close_completed_parents with fake gh/list_sub_issues/_run.
+
+        *open_parents* is an initial set/list of parent numbers currently
+        open (the fake ``gh issue list --state open`` returns these; when
+        a parent is closed via the fake ``gh issue close``, it is
+        removed so the second pass sees it gone).
+
+        *subs_by_parent* maps parent_number -> list of sub-issue dicts.
+        When a parent is closed, the fake walks every OTHER parent's
+        sub-issue list and flips any entry pointing at the closed
+        number to ``state=closed`` — so nested parents can be covered
+        in a second pass.
+
+        Returns (closed_count, list_of_closed_parent_numbers).
+        """
+        live_parents = set(open_parents)
+        closed: list[int] = []
+
+        def fake_gh_json(cmd):
+            if "issue" in cmd and "list" in cmd:
+                return [{"number": p} for p in sorted(live_parents)]
+            raise AssertionError(f"unexpected _gh_json call: {cmd}")
+
+        def fake_list_sub_issues(num):
+            return subs_by_parent.get(num, [])
+
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def fake_run(cmd, **_kw):
+            if "issue" in cmd and "close" in cmd:
+                num = int(cmd[cmd.index("close") + 1])
+                closed.append(num)
+                live_parents.discard(num)
+                for subs in subs_by_parent.values():
+                    for s in subs:
+                        if s["number"] == num:
+                            s["state"] = "closed"
+            return _Result()
+
+        with patch.object(issues, "_gh_json", side_effect=fake_gh_json), \
+             patch.object(issues, "list_sub_issues",
+                          side_effect=fake_list_sub_issues), \
+             patch.object(issues, "_run", side_effect=fake_run):
+            n = issues.close_completed_parents(log_prefix="test")
+        return n, closed
+
+    def test_closes_parent_with_all_sub_issues_closed(self):
+        n, closed = self._run(
+            open_parents=[100],
+            subs_by_parent={100: [
+                {"number": 101, "state": "closed"},
+                {"number": 102, "state": "closed"},
+            ]},
+        )
+        self.assertEqual(n, 1)
+        self.assertEqual(closed, [100])
+
+    def test_skips_parent_with_open_sub_issue(self):
+        n, closed = self._run(
+            open_parents=[200],
+            subs_by_parent={200: [
+                {"number": 201, "state": "closed"},
+                {"number": 202, "state": "open"},
+            ]},
+        )
+        self.assertEqual(n, 0)
+        self.assertEqual(closed, [])
+
+    def test_skips_parent_with_no_sub_issues(self):
+        # all_sub_issues_closed returns None when the parent has no
+        # native sub-issues — the helper must NOT close it.
+        n, closed = self._run(
+            open_parents=[300],
+            subs_by_parent={300: []},
+        )
+        self.assertEqual(n, 0)
+        self.assertEqual(closed, [])
+
+    def test_two_pass_closes_nested_parent(self):
+        # Pass 1 closes #501 (its only child #510 is already closed).
+        # When #501 is closed, the #500 -> #501 entry flips to
+        # state=closed. Pass 2 then closes #500.
+        # This mirrors the real-world case of issue #885 (all its
+        # sub-issues closed, blocking siblings under #884).
+        n, closed = self._run(
+            open_parents=[500, 501],
+            subs_by_parent={
+                500: [{"number": 501, "state": "open"}],
+                501: [{"number": 510, "state": "closed"}],
+            },
+        )
+        self.assertEqual(n, 2)
+        self.assertEqual(closed, [501, 500])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- #885 shows the bug: all its sub-issues (#886–#889) are closed, but #885 itself remained OPEN, so the dispatcher's ordering gate treated it as the still-open "prior sibling" blocking every later sibling under #884 (#894, #900, #901, #905, #908).
- The parent-auto-close logic already existed in `cai verify` but ran only on the verify cron cadence. This moves the check into `cai cycle` so it runs every tick and the queue never stalls waiting for verify.
- Extracts the inline parent-close loop into `cai_lib.issues.close_completed_parents`; `cmd_verify` and `cmd_cycle` both call it now.

## Test plan

- [x] `python3 -m unittest tests.test_close_completed_parents` — 4 new tests pass (all-closed closes, open-sub skipped, no-sub-issues skipped, two-pass nested-parent closure).
- [x] Full suite: `python3 -m unittest discover tests` → 408 passed, 1 skipped.
- [x] `ruff check` clean on changed files.
- [ ] After merge: verify #885 gets auto-closed on the next `cai cycle` tick and the blocked sub-issues under #884 become eligible for pickup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)