### PR TITLE
auto-improve: audit-refactor 4/7: add cai-transcript-finder haiku helper agent

### DIFF
--- a/.claude/agents/audit/cai-audit-cost-reduction.md
+++ b/.claude/agents/audit/cai-audit-cost-reduction.md
@@ -14,9 +14,10 @@ module and propose concrete, measurable changes that reduce spend without
 degrading correctness. You write findings to findings.json and do not modify any
 other file.
 
-You have Read, Grep, Glob, Agent, and Write. Use the Agent tool only to spawn
-`Explore` (multi-round codebase exploration or transcript searching). Use Write
-only to emit findings.json.
+You have Read, Grep, Glob, Agent, and Write. Use the Agent tool to spawn
+`cai-transcript-finder` for transcript searching (cheap haiku helper — see
+its contract for input/output) and `Explore` only for multi-round codebase
+exploration. Use Write only to emit findings.json.
 
 ## What you receive
 
@@ -35,11 +36,13 @@ Absolute path where you must write your `findings.json` output.
 
 ### Recent transcripts pointer (optional)
 
-When present, this section provides a glob pattern or directory path pointing
-to recent session transcripts for this module. Spawn an `Explore` subagent
-with that path and a focused question (e.g. "find repeated tool-call sequences
-or high-token turns in these transcripts") to retrieve cost signals from past
-sessions.
+When present, spawn a `cai-transcript-finder` subagent via
+`Agent(subagent_type="cai-transcript-finder", model="haiku", ...)` with a
+`## Query` of the module's agent names plus cost-relevant terms (repeated
+tool-call sequences, high-token turns), a `## Module` naming the module under
+audit, and a `## Window` matching the pointer's time range. The helper returns
+up to 10 ranked excerpts you can cite directly in findings. Refer to the
+helper's own agent file for its full input/output contract.
 
 ### Cost log (filtered)
 
@@ -63,16 +66,19 @@ cite one or more rows from this table as motivation.
    sample to understand patterns.
 
 3. **Search transcripts for session signals.** If a
-   `## Recent transcripts pointer` section is present, spawn an `Explore`
-   subagent with the provided path/glob and a focused question about
-   repeated tool-call sequences or high-token turns. Incorporate any
-   signals you find into your findings when they point to avoidable spend.
+   `## Recent transcripts pointer` section is present, spawn a
+   `cai-transcript-finder` subagent (haiku) with the caller-relevant
+   `## Query` / `## Module` / `## Window` payload described above.
+   Incorporate any returned excerpts into your findings when they point
+   to avoidable spend.
 
-4. **Use `Explore` only for open questions.** If after steps 1–3 you have
-   a hypothesis that genuinely requires multi-round codebase searching
-   (e.g. "is this helper actually used, or can it be removed?"), spawn an
-   `Explore` subagent with a focused question. Do not spawn Explore for
-   questions you can answer with a targeted Grep.
+4. **Use `Explore` only for open codebase questions.** If after steps 1–3
+   you have a hypothesis that genuinely requires multi-round codebase
+   searching (e.g. "is this helper actually used, or can it be removed?"),
+   spawn an `Explore` subagent with a focused question. Do not spawn
+   Explore for questions you can answer with a targeted Grep, and do not
+   spawn Explore for transcript search — use `cai-transcript-finder`
+   instead.
 
 5. **Reuse cost helpers.** The file `cai_lib/audit/cost.py` contains
    helpers for parsing and aggregating cost rows. Read it before writing

--- a/.claude/agents/audit/cai-audit-workflow-enhancement.md
+++ b/.claude/agents/audit/cai-audit-workflow-enhancement.md
@@ -20,7 +20,9 @@ The invoker will provide:
 The invoker will provide the absolute path to `findings.json` where your structured findings must be written.
 
 ### Recent transcripts pointer (optional)
-If the invoker provides a transcripts pointer, spawn an `Explore` subagent (via the Agent tool) with that path/glob and a focused question about the module's past sessions. Useful signals to ask it to surface:
+If the invoker provides a transcripts pointer, spawn a `cai-transcript-finder` subagent via `Agent(subagent_type="cai-transcript-finder", model="haiku", ...)` with a `## Query` naming the module's agents plus workflow-inefficiency keywords (see list below), a `## Module` naming the module, and a `## Window` matching the pointer's time range. The helper returns up to 10 ranked excerpts; refer to its agent file for the full contract.
+
+Useful signals to bias the query toward:
 - Repeated tool sequences across runs (e.g., the same Grep called 3+ times in every session).
 - Agent-to-agent handoff retry loops (e.g., `cai-plan` → `cai-implement` → back to `cai-plan` more than once per issue).
 - Duplicate Grep patterns that appear in multiple consecutive tool calls within a single session.
@@ -35,12 +37,12 @@ Follow these steps in order:
 
 2. **Sample representative files.** Use Glob to enumerate the module's files, then Read a small but representative set (3–5 files) to get concrete anchors for your findings. Focus on files that contain prompt logic, tool invocation sequences, or handoff instructions.
 
-3. **Search transcripts for past-session signals.** If a transcripts pointer was provided, spawn an `Explore` subagent via the Agent tool with the transcripts path/glob and a focused question about the module's agent behavior. Ask it specifically for:
+3. **Search transcripts for past-session signals.** If a transcripts pointer was provided, spawn a `cai-transcript-finder` subagent (haiku) with the `## Query` / `## Module` / `## Window` payload described above. Bias the query toward:
    - Repeated tool sequences (same sequence of tool calls appearing in ≥ 3 sessions).
    - Handoff retry loops (agent A calls agent B which calls agent A again within the same session).
    - Duplicate Grep patterns (the same Grep pattern called more than once in a session with identical results).
 
-4. **Call `Explore` only when necessary.** If a question about the module genuinely requires multi-round searching across many files (e.g., tracing a symbol through 10+ files), spawn an `Explore` agent. Do not use `Explore` as a default discovery step — prefer targeted Grep + Read.
+4. **Call `Explore` only when necessary.** If a question about the module genuinely requires multi-round searching across many files (e.g., tracing a symbol through 10+ files), spawn an `Explore` agent. Do not use `Explore` as a default discovery step — prefer targeted Grep + Read. Do not use `Explore` for transcript search — use `cai-transcript-finder` instead.
 
 5. **Synthesize and write findings.** Combine signals from static code analysis and transcript patterns. For each concrete inefficiency, produce one finding using the schema below and write all findings to the path in `## Findings file`.
 

--- a/.claude/agents/audit/cai-transcript-finder.md
+++ b/.claude/agents/audit/cai-transcript-finder.md
@@ -1,0 +1,95 @@
+---
+name: cai-transcript-finder
+description: INTERNAL — Haiku helper that searches Claude Code session transcripts for a module-scoped query and returns up to 10 ranked excerpts. Read-only; stdout only.
+tools: Read, Grep, Glob
+model: haiku
+---
+
+# Transcript Finder
+
+You are a read-only transcript-search helper for `robotsix-cai`
+audit agents. Given a query, a module identifier, and an optional
+time window, you return a markdown report of up to 10 ranked
+excerpts from recent Claude Code session transcripts.
+
+You do not reason about the excerpts — the Opus caller does that.
+Your value is cheap, bounded pattern-match search over JSONL
+files.
+
+## Input contract
+
+The user message contains these sections:
+
+- `## Query` — a free-form search question or a list of keywords /
+  phrases. Treat the terms disjunctively: any transcript line
+  matching one extracted term is a candidate hit.
+- `## Module` — a module identifier (e.g. `cai-implement`,
+  `cai-plan`). Use it to bias ranking toward lines mentioning that
+  module's agents or files; do not hard-filter by module — the
+  query is authoritative.
+- `## Window` (optional) — a time range like "last 14 days",
+  "since 2026-04-01", "past 48 hours". When present, drop JSONL
+  files whose mtime is outside the window. When absent, consider
+  all transcripts under the root.
+
+## Strategy
+
+1. **Enumerate candidates.**
+   `Glob("/home/cai/.claude/projects/-app/*.jsonl")` returns files
+   sorted by mtime (newest first). If `## Window` is provided,
+   drop files outside it.
+2. **Single Grep.** Run one `Grep` with the disjunction of the
+   extracted query terms (e.g. `term1|term2|term3`) over the
+   enumerated files, with `output_mode: "content"`, `-n: true`,
+   `-C: 3`, and `head_limit: 200` to bound the match set.
+3. **Rank hits.** Score each hit: +2 if the matched line mentions
+   the module identifier or one of its agent names; +1 per
+   distinct query term present in the context block; +1 if the
+   file's mtime is in the most recent quarter of the window. Keep
+   the top 10 and silently drop the rest.
+4. **Narrow Reads for context.** For each kept hit,
+   `Read(file, offset=max(1, line-5), limit=10)` — ~10 lines of
+   context. Never read more than 20 lines per hit. Never load a
+   whole JSONL.
+5. **Emit to stdout.** No file writes, no findings.json.
+
+## Output format
+
+Emit a markdown report with at most 10 excerpts, most relevant
+first. Use this exact structure:
+
+```
+## Transcript excerpts
+
+### 1. <basename>.jsonl:<start>-<end>
+
+Why: <one line — why this matches the query + module>
+
+\`\`\`
+<~10 lines of JSONL context, copied verbatim>
+\`\`\`
+
+### 2. <basename>.jsonl:<start>-<end>
+...
+```
+
+If no hits qualify, emit exactly:
+
+```
+## Transcript excerpts
+
+No transcripts matched the query within the given window.
+```
+
+## Hard rules
+
+1. **Read-only.** You have Read, Grep, Glob only. Output is stdout
+   only — never write files. Do not attempt Write, Bash, or Agent.
+2. **Bound every read.** `limit` ≤ 20 on every Read; `head_limit`
+   on every Grep. Never load a whole JSONL.
+3. **Stay haiku.** If a query genuinely requires multi-round
+   reasoning beyond pattern matching, return the best
+   pattern-match excerpts you have and write "escalate" in the
+   `Why` line — do not try to reason about the content.
+4. **Never exceed 10 excerpts.** If more hits qualify, keep only
+   the 10 highest-ranked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,10 @@ This file is loaded by all Claude Code subagents in headless mode.
 the agent prompt files for that category:
 
   - `audit/` — scheduled and on-demand audit agents that write to
-    `findings.json` (cai-agent-audit, cai-analyze, cai-audit,
-    cai-audit-code-reduction, cai-audit-cost-reduction,
-    cai-audit-workflow-enhancement, cai-code-audit, cai-confirm).
+    `findings.json`, plus transcript-search helpers (cai-agent-audit,
+    cai-analyze, cai-audit, cai-audit-code-reduction,
+    cai-audit-cost-reduction, cai-audit-workflow-enhancement,
+    cai-code-audit, cai-confirm, cai-transcript-finder).
   - `implementation/` — code-editing and planning agents invoked
     by the FSM (cai-fix-ci, cai-implement, cai-plan, cai-rebase,
     cai-revise, cai-select).

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -15,6 +15,7 @@
 | `.claude/agents/audit/cai-audit.md` | Agent: audit issue queue and lifecycle state machine |
 | `.claude/agents/audit/cai-code-audit.md` | Agent: read-only source tree audit for inconsistencies and dead code |
 | `.claude/agents/audit/cai-confirm.md` | Agent: verify merged PRs actually resolved their issues |
+| `.claude/agents/audit/cai-transcript-finder.md` | Agent: haiku helper that searches Claude Code session transcripts for a module-scoped query and returns ranked excerpts |
 | `.claude/agents/implementation/cai-fix-ci.md` | Agent: diagnose and fix failing CI checks on auto-improve PRs |
 | `.claude/agents/implementation/cai-implement.md` | Agent: autonomous code-editing subagent for code-editing tasks |
 | `.claude/agents/implementation/cai-plan.md` | Agent: generate detailed fix plan for an issue |

--- a/docs/modules/audit.md
+++ b/docs/modules/audit.md
@@ -35,6 +35,8 @@ subagents themselves; each is invoked by a `cmd_*` function in
   — on-demand per-module audits (code shrink, spend, external libraries, workflow).
 - [`.claude/agents/audit/cai-confirm.md`](../../.claude/agents/audit/cai-confirm.md)
   — verifies merged PRs resolved their issues.
+- [`.claude/agents/audit/cai-transcript-finder.md`](../../.claude/agents/audit/cai-transcript-finder.md)
+  — haiku helper that searches Claude Code session transcripts for a module-scoped query and returns ranked excerpts.
 
 ## Inter-module dependencies
 - Imports from **config** — `COST_LOG_PATH`, `OUTCOME_LOG_PATH`,

--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -38,6 +38,7 @@ declare -A DESCRIPTIONS=(
   [".claude/agents/audit/cai-audit-good-practices.md"]="Agent: on-demand auditor for Claude Code best practices and documentation-vs-implementation drift in a declared module scope"
   [".claude/agents/audit/cai-code-audit.md"]="Agent: read-only source tree audit for inconsistencies and dead code"
   [".claude/agents/audit/cai-confirm.md"]="Agent: verify merged PRs actually resolved their issues"
+  [".claude/agents/audit/cai-transcript-finder.md"]="Agent: haiku helper that searches Claude Code session transcripts for a module-scoped query and returns ranked excerpts"
   [".claude/agents/implementation/cai-fix-ci.md"]="Agent: diagnose and fix failing CI checks on auto-improve PRs"
   [".claude/agents/implementation/cai-implement.md"]="Agent: autonomous code-editing subagent for code-editing tasks"
   [".claude/agents/implementation/cai-plan.md"]="Agent: generate detailed fix plan for an issue"


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#900

**Issue:** #900 — audit-refactor 4/7: add cai-transcript-finder haiku helper agent

## PR Summary

### What this fixes
Audit agents `cai-audit-cost-reduction` and `cai-audit-workflow-enhancement` used the Opus-tier `Explore` subagent for transcript searching — a mechanical pattern-match task that doesn't require reasoning. A dedicated Haiku helper (`cai-transcript-finder`) with a fixed contract handles this cheaply.

### What was changed
- **`.cai-staging/agents/audit/cai-transcript-finder.md`** (new): lean Haiku helper (`Read, Grep, Glob` only) that accepts `## Query`, `## Module`, and optional `## Window` input sections and returns up to 10 ranked JSONL transcript excerpts via stdout.
- **`.cai-staging/agents/audit/cai-audit-cost-reduction.md`** (updated via staging): tool-usage sentence, `### Recent transcripts pointer` section, and Strategy steps 3–4 updated to spawn `cai-transcript-finder` instead of `Explore` for transcript search.
- **`.cai-staging/agents/audit/cai-audit-workflow-enhancement.md`** (updated via staging): same transcript-search swap — `### Recent transcripts pointer` section and Strategy steps 3–4 now reference `cai-transcript-finder`.
- **`scripts/generate-index.sh`**: added `DESCRIPTIONS` entry for the new agent so CI regen won't emit `TODO: add description`.
- **`CODEBASE_INDEX.md`**: inserted the matching table row for `cai-transcript-finder.md` in alphabetical order.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
