### PR TITLE
auto-improve: Adopt claude-agent-sdk-python to replace _run_claude_p subprocess+envelope parsing

### DIFF
--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -1,5 +1,7 @@
 """Subprocess helpers extracted from cai.py."""
 
+from __future__ import annotations
+
 import asyncio
 import json
 import shutil
@@ -8,12 +10,16 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from claude_agent_sdk import ClaudeAgentOptions, query
-from claude_agent_sdk.types import (
-    AssistantMessage,
-    ResultMessage,
-    TextBlock,
-)
+try:
+    from claude_agent_sdk import ClaudeAgentOptions, query
+    from claude_agent_sdk.types import (
+        AssistantMessage,
+        ResultMessage,
+        TextBlock,
+    )
+    _SDK_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _SDK_AVAILABLE = False
 
 from cai_lib.logging_utils import log_cost
 

--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -1,12 +1,27 @@
 """Subprocess helpers extracted from cai.py."""
 
+import asyncio
 import json
+import shutil
 import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from claude_agent_sdk import ClaudeAgentOptions, query
+from claude_agent_sdk.types import (
+    AssistantMessage,
+    ResultMessage,
+    TextBlock,
+)
+
 from cai_lib.logging_utils import log_cost
+
+
+# Resolve the CLI path once at import time so the SDK reuses the
+# npm-installed `claude` binary audited in Dockerfile instead of the
+# copy bundled with the SDK wheel.
+_CLI_PATH = shutil.which("claude")
 
 
 def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
@@ -22,202 +37,241 @@ def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, text=True, **kwargs)
 
 
+def _argv_to_options(
+    argv: list[str],
+    cwd: str | None,
+) -> tuple[ClaudeAgentOptions, str]:
+    """Parse `claude -p`-style argv (``cmd[2:]``) into a ClaudeAgentOptions
+    plus a positional prompt. Recognised flags become typed fields; unknown
+    flags forward via ``extra_args`` (so ``--agent cai-dup-check`` still
+    works even though there is no typed ``agent`` field). A trailing
+    non-flag token is returned as the prompt so pre-screen call sites that
+    pass the prompt in argv (e.g. ``actions/implement.py:229``) keep working.
+    """
+    opts = ClaudeAgentOptions()
+    opts.add_dirs = []
+    opts.plugins = []
+    opts.allowed_tools = []
+    extra_args: dict[str, str | None] = {}
+    positional: list[str] = []
+
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "--dangerously-skip-permissions":
+            opts.permission_mode = "bypassPermissions"
+            i += 1
+        elif tok == "--model":
+            opts.model = argv[i + 1]
+            i += 2
+        elif tok == "--max-turns":
+            opts.max_turns = int(argv[i + 1])
+            i += 2
+        elif tok == "--max-budget-usd":
+            opts.max_budget_usd = float(argv[i + 1])
+            i += 2
+        elif tok == "--permission-mode":
+            opts.permission_mode = argv[i + 1]  # type: ignore[assignment]
+            i += 2
+        elif tok == "--allowedTools":
+            opts.allowed_tools = [t for t in argv[i + 1].split(",") if t]
+            i += 2
+        elif tok == "--add-dir":
+            opts.add_dirs.append(argv[i + 1])
+            i += 2
+        elif tok == "--plugin-dir":
+            opts.plugins.append({"type": "local", "path": argv[i + 1]})
+            i += 2
+        elif tok == "--json-schema":
+            opts.output_format = {
+                "type": "json_schema",
+                "schema": json.loads(argv[i + 1]),
+            }
+            i += 2
+        elif tok.startswith("--"):
+            flag_name = tok[2:]
+            if i + 1 < len(argv) and not argv[i + 1].startswith("--"):
+                extra_args[flag_name] = argv[i + 1]
+                i += 2
+            else:
+                extra_args[flag_name] = None
+                i += 1
+        else:
+            positional.append(tok)
+            i += 1
+
+    opts.extra_args = extra_args
+    if cwd is not None:
+        opts.cwd = cwd
+
+    # Preserve the pre-SDK auto-inject of the cai-skills plugin when the
+    # directory exists at the caller's cwd (subprocess_utils.py:59-62).
+    skills_plugin = Path(".claude/plugins/cai-skills")
+    if skills_plugin.is_dir():
+        opts.plugins.append({"type": "local", "path": str(skills_plugin)})
+
+    return opts, " ".join(positional)
+
+
+async def _collect_results(
+    prompt: str,
+    options: ClaudeAgentOptions,
+) -> tuple[list[ResultMessage], str]:
+    """Drive ``query()`` to completion.
+
+    Returns ``(result_messages, last_non_empty_assistant_text)``. Collects
+    every ResultMessage (forward-compat: today the CLI emits exactly one)
+    and records the final non-empty ``AssistantMessage`` TextBlock so the
+    priority-4 stdout-salvage path can fall back to it when ``result`` is
+    absent (e.g. ``subtype == "error_max_budget_usd"``).
+    """
+    results: list[ResultMessage] = []
+    last_assistant = ""
+    async for msg in query(prompt=prompt, options=options):
+        if isinstance(msg, ResultMessage):
+            results.append(msg)
+        elif isinstance(msg, AssistantMessage):
+            parts = [
+                b.text for b in msg.content
+                if isinstance(b, TextBlock) and b.text.strip()
+            ]
+            if parts:
+                last_assistant = "".join(parts).strip()
+    return results, last_assistant
+
+
 def _run_claude_p(
     cmd: list[str],
     *,
     category: str,
     agent: str = "",
+    input: str | None = None,
+    cwd: str | None = None,
     **kwargs,
 ) -> subprocess.CompletedProcess:
-    """Run a `claude -p` command and record its cost.
+    """Run a ``claude -p`` command via the Claude Agent SDK and record its cost.
 
-    `cmd` is the full argv. The wrapper injects `--output-format json
-    --verbose` so claude-code returns the cost/usage bookkeeping for
-    the run. With `--verbose`, claude-code emits a JSON **array** of
-    stream events (`system` → `assistant` → `user` → `result`); the
-    `result` element holds `total_cost_usd`, `usage`, `duration_ms`,
-    `result` text, etc. We extract that element, log a cost row, and
-    rewrite `CompletedProcess.stdout` to just the `result` text — so
-    existing callers that pipe `proc.stdout` to `publish.py` or print
-    it keep working unchanged.
+    ``cmd[0]`` must be ``"claude"`` and ``cmd[1]`` must be ``"-p"``;
+    ``cmd[2:]`` is parsed into a ``ClaudeAgentOptions`` by
+    ``_argv_to_options`` (recognised flags become typed fields, unknown
+    flags forward via ``extra_args``). ``input`` becomes the SDK
+    ``prompt=`` argument; when absent, a trailing non-flag argv token is
+    used instead (the implement pre-screen pattern at
+    ``actions/implement.py:229``).
 
-    `category` labels the row by top-level cai command (e.g.
-    "analyze", "implement", "audit"). `agent` records the subagent name
-    (e.g. "cai-implement") if applicable.
+    The returned ``CompletedProcess`` mirrors the pre-SDK contract:
+      - ``.stdout`` carries ``structured_output`` (JSON-encoded) when
+        ``--json-schema`` succeeded; ``""`` on ``subtype ==
+        "error_max_structured_output_retries"`` with a diagnostic stderr
+        line; ``result`` text otherwise; falling back to the last
+        assistant text when ``result`` is absent.
+      - ``.returncode`` is 1 on any exception or when ``is_error`` is
+        True; 0 otherwise.
 
-    On JSON parse failure or a missing `result` event, no cost row is
-    written, the original stdout is left in place, and a one-line
-    warning is printed to stderr so this silent-drop failure mode is
-    noisy. Never raises.
+    Cost rows carry exactly the same keys as the pre-SDK version (``ts``,
+    ``category``, ``agent``, ``cost_usd``, ``duration_ms``,
+    ``duration_api_ms``, ``num_turns``, ``session_id``, ``exit``,
+    ``is_error``, the four flat token keys, and an optional ``models``
+    per-model rollup). ``subagents`` / ``parent_cost_usd`` are
+    intentionally dropped — the CLI format emits exactly one result event
+    so there is nothing to attribute, and those pre-SDK code paths were
+    dead in production (0/628 rows).
     """
-    # Inject --output-format json --verbose right after `claude -p`
-    # (positions 0 and 1). --verbose is required for claude-code to
-    # populate the `usage` field; with it, the output becomes a JSON
-    # array of stream events instead of a single envelope dict.
     if len(cmd) < 2 or cmd[0] != "claude" or cmd[1] != "-p":
         raise ValueError("_run_claude_p requires cmd[:2] == ['claude', '-p']")
-    plugin_dir = Path(".claude/plugins/cai-skills")
-    plugin_flags: list[str] = (
-        ["--plugin-dir", str(plugin_dir)] if plugin_dir.is_dir() else []
-    )
-    full_cmd = (
-        cmd[:2]
-        + ["--output-format", "json", "--verbose"]
-        + plugin_flags
-        + cmd[2:]
-    )
 
-    # Force capture so we can parse the JSON envelope. Callers that
-    # previously did not capture (only cmd_init) get back the result
-    # text in `.stdout` — they can print it themselves if needed.
-    kwargs.setdefault("capture_output", True)
-    proc = _run(full_cmd, **kwargs)
+    # Honour the legacy ``timeout=`` kwarg (``actions/explore.py`` uses it
+    # as a 30-minute cap); silently discard other ``subprocess.run``
+    # kwargs we previously inherited via ``**kwargs``.
+    timeout = kwargs.pop("timeout", None)
 
-    # Parse the JSON envelope and write the cost row. Belt and braces
-    # — never let log writes break the actual command flow.
+    options, positional_prompt = _argv_to_options(cmd[2:], cwd=cwd)
+    if _CLI_PATH:
+        options.cli_path = _CLI_PATH
+
+    prompt = input if input is not None else positional_prompt
+
     try:
-        parsed = json.loads(proc.stdout) if proc.stdout else None
-    except (json.JSONDecodeError, ValueError):
-        parsed = None
-
-    # Two shapes are tolerated:
-    #   1. dict   — legacy `--output-format json` (no --verbose) returns
-    #      a single envelope object. Kept for forward/backward compat.
-    #   2. list   — current `--output-format json --verbose` returns a
-    #      JSON array of stream events; the cost data lives on the
-    #      element with `"type": "result"`.
-    envelope: dict | None = None
-    subagent_results: list[dict] = []
-    if isinstance(parsed, dict):
-        envelope = parsed
-    elif isinstance(parsed, list):
-        result_events = [
-            e for e in parsed
-            if isinstance(e, dict) and e.get("type") == "result"
-        ]
-        # The last result event is the parent (top-level) result;
-        # earlier ones are subagent results.
-        envelope = result_events[-1] if result_events else None
-        subagent_results = result_events[:-1] if len(result_events) > 1 else []
-
-    if envelope is None:
-        # Don't fail the caller, but make the silent-drop loud so a
-        # future shape change in claude-code surfaces immediately
-        # instead of leaving cai-cost.jsonl mysteriously empty.
-        preview = (proc.stdout or "")[:120].replace("\n", " ")
-        print(
-            f"[cai cost] could not extract cost envelope from claude -p "
-            f"({category}/{agent}); stdout starts with: {preview!r}",
-            file=sys.stderr,
-            flush=True,
-        )
-
-    if isinstance(envelope, dict):
-        usage = envelope.get("usage") or {}
-        # claude-code's `usage` may be either a flat dict (input_tokens,
-        # output_tokens, cache_*_input_tokens) or a nested per-model
-        # dict. Record both shapes when available.
-        flat_keys = (
-            "input_tokens",
-            "output_tokens",
-            "cache_creation_input_tokens",
-            "cache_read_input_tokens",
-        )
-        flat = {k: usage[k] for k in flat_keys if isinstance(usage.get(k), (int, float))}
-        models = {
-            k: v for k, v in usage.items()
-            if isinstance(v, dict) and any(fk in v for fk in flat_keys)
-        }
-
-        # -- Subagent token aggregation --
-        subagent_rows: list[dict] = []
-        combined = dict(flat)  # start with parent tokens
-        for sr in subagent_results:
-            sr_usage = sr.get("usage") or {}
-            sr_flat = {k: sr_usage[k] for k in flat_keys if isinstance(sr_usage.get(k), (int, float))}
-            if sr_flat:
-                for k in flat_keys:
-                    if k in sr_flat:
-                        combined[k] = combined.get(k, 0) + sr_flat[k]
-                sr_entry: dict = dict(sr_flat)
-                sr_entry["cost_usd"] = sr.get("total_cost_usd")
-                subagent_rows.append(sr_entry)
-
-        row = {
-            "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "category": category,
-            "agent": agent,
-            "cost_usd": envelope.get("total_cost_usd"),
-            "duration_ms": envelope.get("duration_ms"),
-            "duration_api_ms": envelope.get("duration_api_ms"),
-            "num_turns": envelope.get("num_turns"),
-            "session_id": envelope.get("session_id"),
-            "exit": proc.returncode,
-            "is_error": bool(envelope.get("is_error", proc.returncode != 0)),
-        }
-        row.update(combined)
-        if models:
-            row["models"] = models
-        if subagent_rows:
-            sub_cost_sum = sum(float(s.get("cost_usd") or 0.0) for s in subagent_rows)
-            total = float(envelope.get("total_cost_usd") or 0.0)
-            row["parent_cost_usd"] = round(total - sub_cost_sum, 6)
-            row["subagents"] = subagent_rows
-        log_cost(row)
-
-        # Rewrite stdout so callers see a sensible final value. Priority:
-        #
-        #   1. `structured_output` — present when the caller passed
-        #      `--json-schema` and the Agent SDK's constrained-decoding
-        #      path succeeded. This is the *validated* payload; the
-        #      free-form `result` text in the same envelope contains
-        #      the model's reasoning and will not parse as JSON (bug
-        #      behind #729 / #695 — gate-critical agents read the wrong
-        #      field). Serialize it back so existing `json.loads(stdout)`
-        #      callers keep working unchanged.
-        #   2. `error_max_structured_output_retries` subtype — the
-        #      constrained-decoding retry loop gave up. Log it explicitly
-        #      so the caller's empty-output branch gets a clear reason,
-        #      and leave stdout empty.
-        #   3. `result` string — the normal free-form path for callers
-        #      without `--json-schema`.
-        #   4. Last assistant text — fallback when `result` is absent
-        #      (e.g. subtype=error_max_budget_usd drops that field).
-        subtype = envelope.get("subtype")
-        structured = envelope.get("structured_output")
-        if structured is not None:
-            proc.stdout = json.dumps(structured)
-        elif subtype == "error_max_structured_output_retries":
-            print(
-                f"[cai cost] structured output retries exhausted "
-                f"({category}/{agent}); schema was not satisfied",
-                file=sys.stderr,
-                flush=True,
+        if timeout is not None:
+            results, last_assistant = asyncio.run(
+                asyncio.wait_for(
+                    _collect_results(prompt, options), timeout=timeout,
+                )
             )
-            proc.stdout = ""
-        elif "result" in envelope and isinstance(envelope["result"], str):
-            proc.stdout = envelope["result"]
-        elif isinstance(parsed, list):
-            salvaged = _last_assistant_text(parsed)
-            if salvaged:
-                proc.stdout = salvaged
+        else:
+            results, last_assistant = asyncio.run(
+                _collect_results(prompt, options)
+            )
+    except Exception as exc:  # noqa: BLE001
+        preview = str(exc)[:200].replace("\n", " ")
+        print(
+            f"[cai cost] claude-agent-sdk query failed "
+            f"({category}/{agent}): {preview}",
+            file=sys.stderr, flush=True,
+        )
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=1, stdout="", stderr=str(exc),
+        )
 
-    return proc
+    if not results:
+        preview = (last_assistant or "")[:120].replace("\n", " ")
+        print(
+            f"[cai cost] no ResultMessage from claude-agent-sdk "
+            f"({category}/{agent}); last assistant starts with: {preview!r}",
+            file=sys.stderr, flush=True,
+        )
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=1, stdout=last_assistant or "", stderr="",
+        )
 
+    result = results[-1]
+    usage = result.usage or {}
+    flat_keys = (
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+    )
+    flat = {
+        k: usage[k] for k in flat_keys
+        if isinstance(usage.get(k), (int, float))
+    }
+    models = result.model_usage if isinstance(result.model_usage, dict) else {}
+    returncode = 1 if result.is_error else 0
 
-def _last_assistant_text(events: list) -> str:
-    """Return the concatenated text of the final assistant event, or ''."""
-    for event in reversed(events):
-        if not isinstance(event, dict) or event.get("type") != "assistant":
-            continue
-        message = event.get("message") or {}
-        content = message.get("content") or []
-        parts = [
-            item.get("text", "")
-            for item in content
-            if isinstance(item, dict) and item.get("type") == "text"
-        ]
-        text = "".join(parts).strip()
-        if text:
-            return text
-    return ""
+    row = {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "category": category,
+        "agent": agent,
+        "cost_usd": result.total_cost_usd,
+        "duration_ms": result.duration_ms,
+        "duration_api_ms": result.duration_api_ms,
+        "num_turns": result.num_turns,
+        "session_id": result.session_id,
+        "exit": returncode,
+        "is_error": bool(result.is_error),
+    }
+    row.update(flat)
+    if models:
+        row["models"] = models
+    log_cost(row)
+
+    # Priority: structured_output → error_max_structured_output_retries →
+    # result text → last-assistant salvage.
+    if result.structured_output is not None:
+        stdout = json.dumps(result.structured_output)
+    elif result.subtype == "error_max_structured_output_retries":
+        print(
+            f"[cai cost] structured output retries exhausted "
+            f"({category}/{agent}); schema was not satisfied",
+            file=sys.stderr, flush=True,
+        )
+        stdout = ""
+    elif isinstance(result.result, str):
+        stdout = result.result
+    else:
+        stdout = last_assistant
+
+    return subprocess.CompletedProcess(
+        args=cmd, returncode=returncode, stdout=stdout, stderr="",
+    )

--- a/docs/modules/config.md
+++ b/docs/modules/config.md
@@ -21,8 +21,9 @@ every handler and `cmd_*` function; changes here ripple everywhere.
 - [`cai_lib/subprocess_utils.py`](../../cai_lib/subprocess_utils.py)
   — `_run(cmd, **kwargs)` is the subprocess wrapper with timeout
   and logging; `_run_claude_p(…)` launches a headless claude-code
-  session and returns events; `_last_assistant_text(events)`
-  extracts the final assistant message.
+  session via the Claude Agent SDK and returns a CompletedProcess
+  with `.stdout` containing the result; `_argv_to_options(argv, cwd)`
+  parses command-line arguments into SDK options.
 - [`cai_lib/watchdog.py`](../../cai_lib/watchdog.py) —
   `_rollback_stale_in_progress(immediate)` rolls back orphaned
   issue `:in-progress` / `:revising` labels;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
     "PyYAML>=6",
+    "claude-agent-sdk>=0.1.63",
 ]
 
 [tool.ruff]

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -1,144 +1,140 @@
-"""Tests for cai_lib.subprocess_utils — envelope parsing in _run_claude_p.
+"""Tests for cai_lib.subprocess_utils — ResultMessage parsing in _run_claude_p.
 
-Focus: the stdout rewrite priority order when a claude -p invocation
-returns a JSON envelope. The rules a gate-critical agent depends on:
+Focus: the stdout rewrite priority order when a ``claude -p`` invocation
+returns a ResultMessage via the claude-agent-sdk ``query()`` async
+iterator. The rules a gate-critical agent depends on:
 
-  1. `structured_output` (from --json-schema constrained decoding) wins
-     over the free-form `result` text, because the free-form text
+  1. ``structured_output`` (from ``--json-schema`` constrained decoding)
+     wins over the free-form ``result`` text, because the free-form text
      contains the model's reasoning and won't json.loads — this was the
      root cause of the #729 (cai-select) and #695 (cai-triage) failures.
-  2. `error_max_structured_output_retries` subtype surfaces as an empty
+  2. ``error_max_structured_output_retries`` subtype surfaces as an empty
      stdout + a dedicated log line so callers' emptiness check fires.
-  3. Without a schema, the `result` text still wins (unchanged).
+  3. Without a schema, the ``result`` text still wins (unchanged).
 """
 import json
 import os
-import subprocess
 import sys
 import unittest
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from claude_agent_sdk.types import ResultMessage
 
-def _envelope_list(**result_fields) -> str:
-    """Build a claude-p --output-format json --verbose response body.
 
-    The real CLI emits a JSON array of stream events; the final
-    element has type=result and carries cost/structured-output data.
-    """
-    return json.dumps([
-        {"type": "system"},
-        {"type": "result", **result_fields},
-    ])
+def _mk_result(**fields) -> ResultMessage:
+    """Build a ResultMessage with sane defaults for required fields."""
+    return ResultMessage(
+        subtype=fields.pop("subtype", "success"),
+        duration_ms=fields.pop("duration_ms", 1),
+        duration_api_ms=fields.pop("duration_api_ms", 1),
+        is_error=fields.pop("is_error", False),
+        num_turns=fields.pop("num_turns", 1),
+        session_id=fields.pop("session_id", "s1"),
+        total_cost_usd=fields.pop("total_cost_usd", 0.1),
+        usage=fields.pop("usage", {"input_tokens": 10, "output_tokens": 5}),
+        result=fields.pop("result", None),
+        structured_output=fields.pop("structured_output", None),
+    )
+
+
+def _mock_query(*messages):
+    """Return an async-generator replacement for cai_lib.subprocess_utils.query."""
+    async def _gen(*, prompt, options=None, transport=None):
+        for m in messages:
+            yield m
+    return _gen
 
 
 class TestRunClaudePEnvelope(unittest.TestCase):
-    """_run_claude_p rewrites proc.stdout based on envelope priority."""
-
-    def _mock_run(self, stdout: str, returncode: int = 0, stderr: str = ""):
-        return subprocess.CompletedProcess(
-            args=["claude", "-p"], returncode=returncode,
-            stdout=stdout, stderr=stderr,
-        )
+    """_run_claude_p rewrites proc.stdout based on ResultMessage priority."""
 
     @patch("cai_lib.subprocess_utils.log_cost")
-    @patch("cai_lib.subprocess_utils._run")
-    def test_structured_output_wins_over_result(self, mock_run, _mock_log):
+    def test_structured_output_wins_over_result(self, _mock_log):
         """When --json-schema succeeded, structured_output must override result text.
 
         This is the #729 / #695 regression: the model's reasoning lives
-        in `result`, and the validated payload lives in `structured_output`.
-        Callers use json.loads(stdout), so stdout must be the validated
-        payload — not the prose the model produced.
+        in ``result``, and the validated payload lives in
+        ``structured_output``. Callers use ``json.loads(stdout)``, so
+        stdout must be the validated payload — not the prose the model
+        produced.
         """
+        from cai_lib import subprocess_utils
         from cai_lib.subprocess_utils import _run_claude_p
 
         validated = {"plan": "do X", "confidence": "HIGH",
                      "confidence_reason": "sound"}
         reasoning = "Routed **APPLY** (HIGH). Plan looks correct."
-        mock_run.return_value = self._mock_run(_envelope_list(
-            subtype="success",
+        msg = _mk_result(
             structured_output=validated,
             result=reasoning,
-            total_cost_usd=0.1,
-            usage={"input_tokens": 10, "output_tokens": 5},
-        ))
-
-        proc = _run_claude_p(
-            ["claude", "-p", "--agent", "cai-select",
-             "--json-schema", "{}"],
-            category="plan.select", agent="cai-select",
         )
+        with patch.object(subprocess_utils, "query", _mock_query(msg)):
+            proc = _run_claude_p(
+                ["claude", "-p", "--agent", "cai-select",
+                 "--json-schema", "{}"],
+                category="plan.select", agent="cai-select",
+            )
 
-        # stdout must be the validated JSON payload, not the reasoning.
         self.assertEqual(json.loads(proc.stdout), validated)
         self.assertNotIn("Routed", proc.stdout)
 
     @patch("cai_lib.subprocess_utils.log_cost")
-    @patch("cai_lib.subprocess_utils._run")
-    def test_retries_exhausted_leaves_stdout_empty(self, mock_run, _mock_log):
+    def test_retries_exhausted_leaves_stdout_empty(self, _mock_log):
         """error_max_structured_output_retries → empty stdout + diagnostic log."""
+        from cai_lib import subprocess_utils
         from cai_lib.subprocess_utils import _run_claude_p
 
-        mock_run.return_value = self._mock_run(_envelope_list(
+        msg = _mk_result(
             subtype="error_max_structured_output_retries",
+            is_error=True,
             result="I couldn't match the schema sorry",
             total_cost_usd=0.2,
-            usage={"input_tokens": 10, "output_tokens": 5},
-        ))
+        )
+        with patch.object(subprocess_utils, "query", _mock_query(msg)):
+            with patch("builtins.print") as mock_print:
+                proc = _run_claude_p(
+                    ["claude", "-p", "--agent", "cai-triage",
+                     "--json-schema", "{}"],
+                    category="triage", agent="cai-triage",
+                )
 
-        with patch("builtins.print") as mock_print:
-            proc = _run_claude_p(
-                ["claude", "-p", "--agent", "cai-triage",
-                 "--json-schema", "{}"],
-                category="triage", agent="cai-triage",
-            )
-
-        # stdout empty so the caller's "no output" guard triggers.
         self.assertEqual(proc.stdout, "")
-        # A dedicated log line names the failure mode.
         printed = " ".join(str(c) for c in mock_print.call_args_list)
         self.assertIn("structured output retries exhausted", printed)
 
     @patch("cai_lib.subprocess_utils.log_cost")
-    @patch("cai_lib.subprocess_utils._run")
-    def test_result_text_used_when_no_schema(self, mock_run, _mock_log):
+    def test_result_text_used_when_no_schema(self, _mock_log):
         """Without --json-schema the envelope has no structured_output; use result."""
+        from cai_lib import subprocess_utils
         from cai_lib.subprocess_utils import _run_claude_p
 
-        mock_run.return_value = self._mock_run(_envelope_list(
-            subtype="success",
-            result="plain agent output",
-            total_cost_usd=0.05,
-            usage={"input_tokens": 10, "output_tokens": 5},
-        ))
-
-        proc = _run_claude_p(
-            ["claude", "-p", "--agent", "cai-plan"],
-            category="plan.plan", agent="cai-plan",
-        )
+        msg = _mk_result(result="plain agent output", total_cost_usd=0.05)
+        with patch.object(subprocess_utils, "query", _mock_query(msg)):
+            proc = _run_claude_p(
+                ["claude", "-p", "--agent", "cai-plan"],
+                category="plan.plan", agent="cai-plan",
+            )
 
         self.assertEqual(proc.stdout, "plain agent output")
 
     @patch("cai_lib.subprocess_utils.log_cost")
-    @patch("cai_lib.subprocess_utils._run")
-    def test_structured_output_none_falls_through_to_result(self, mock_run, _mock_log):
+    def test_structured_output_none_falls_through_to_result(self, _mock_log):
         """structured_output: null must not be treated as present."""
+        from cai_lib import subprocess_utils
         from cai_lib.subprocess_utils import _run_claude_p
 
-        mock_run.return_value = self._mock_run(_envelope_list(
-            subtype="success",
+        msg = _mk_result(
             structured_output=None,
             result="fallback text",
             total_cost_usd=0.05,
-            usage={"input_tokens": 10, "output_tokens": 5},
-        ))
-
-        proc = _run_claude_p(
-            ["claude", "-p", "--agent", "cai-plan"],
-            category="plan.plan", agent="cai-plan",
         )
+        with patch.object(subprocess_utils, "query", _mock_query(msg)):
+            proc = _run_claude_p(
+                ["claude", "-p", "--agent", "cai-plan"],
+                category="plan.plan", agent="cai-plan",
+            )
 
         self.assertEqual(proc.stdout, "fallback text")
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1015

**Issue:** #1015 — Adopt claude-agent-sdk-python to replace _run_claude_p subprocess+envelope parsing

## PR Summary

### What this fixes
`cai_lib/subprocess_utils.py::_run_claude_p` was a 180-line hand-rolled JSON envelope parser around `claude -p --output-format json --verbose`. This replaces it with a clean SDK-driven implementation using `claude_agent_sdk.query()`, eliminating brittle shape-guessing, dead subagent-attribution code, and the manual argv injection.

### What was changed
- **`pyproject.toml`**: added `"claude-agent-sdk>=0.1.63"` to `[project].dependencies`
- **`cai_lib/subprocess_utils.py`**: full rewrite — added `_argv_to_options()` (argv→`ClaudeAgentOptions` parser), `_collect_results()` (async SDK driver), rewrote `_run_claude_p()` to use `asyncio.run(_collect_results(...))` instead of subprocess; deleted `_last_assistant_text()`; kept `_run()` unchanged; dropped dead `subagents[]`/`parent_cost_usd` cost-row paths
- **`tests/test_subprocess_utils.py`**: full rewrite — patches `cai_lib.subprocess_utils.query` with an async generator yielding `ResultMessage` dataclasses; all 4 behavioural assertions preserved and passing

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
