### PR TITLE
fix(watchdog): read :locked age from claim comment, not updatedAt

### DIFF
--- a/cai_lib/watchdog.py
+++ b/cai_lib/watchdog.py
@@ -33,8 +33,39 @@ from cai_lib.github import (
     _set_labels,
     _set_pr_labels,
     _delete_issue_comment,
+    _list_lock_comments,
 )
 from cai_lib.logging_utils import log_run
+
+
+def _lock_claim_age_seconds(number: int, now: float) -> float | None:
+    """Age (seconds since ``now``) of the oldest ``cai-lock`` claim comment.
+
+    The oldest ``<!-- cai-lock owner=... acquired=... -->`` comment on an
+    issue/PR is the authoritative lock-acquisition marker: ``_acquire_remote_lock``
+    posts it atomically with the ``:locked`` label and the comment survives
+    every crash scenario the label does. Unlike the issue/PR's ``updatedAt``
+    (which GitHub bumps for CI check-runs, label churn from losing
+    lock-acquire races, and many unrelated events), this timestamp is
+    immune to self-perpetuating freshness loops: later cycles' failed
+    acquire attempts post+delete their *own* claim comments without
+    disturbing the winning-oldest one.
+
+    Returns ``None`` when no claim comment exists (the label alone is an
+    anomaly — caller should fall back to ``updatedAt``) or the comment
+    endpoint errored.
+    """
+    locks = _list_lock_comments(number)
+    if not locks:
+        return None
+    oldest = locks[0].get("created_at") or ""
+    try:
+        ts = datetime.strptime(oldest, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        ).timestamp()
+    except (ValueError, TypeError):
+        return None
+    return now - ts
 
 
 def _rollback_stale_in_progress(*, immediate: bool = False) -> list[dict]:
@@ -119,18 +150,30 @@ def _rollback_stale_in_progress(*, immediate: bool = False) -> list[dict]:
         else:
             ttl_hours = _STALE_IN_PROGRESS_HOURS
         threshold = 0 if immediate else ttl_hours * 3600
-        last_fix = fix_timestamps.get(issue_num)
-        if last_fix is not None:
-            age = now - last_fix
+        # :locked age comes from the oldest cai-lock claim comment — the
+        # authoritative acquisition marker. The log-line and updatedAt
+        # fallbacks below are unsafe for :locked: every cycle's failing
+        # _acquire_remote_lock posts+deletes a claim comment, bumping
+        # updatedAt indefinitely and hiding locks that are hours stale.
+        if lock_label == LABEL_LOCKED:
+            claim_age = _lock_claim_age_seconds(issue_num, now)
+            # Label set but no claim comment is an anomaly (acquire
+            # crashed between label and comment, or comment was deleted).
+            # Treat as stale so the watchdog can strip the orphan label.
+            age = claim_age if claim_age is not None else float("inf")
         else:
-            # No fix log line — use the issue's updatedAt as a fallback.
-            try:
-                updated = datetime.strptime(
-                    issue["updatedAt"], "%Y-%m-%dT%H:%M:%SZ"
-                ).replace(tzinfo=timezone.utc).timestamp()
-            except (ValueError, KeyError):
-                updated = 0
-            age = now - updated
+            last_fix = fix_timestamps.get(issue_num)
+            if last_fix is not None:
+                age = now - last_fix
+            else:
+                # No fix log line — use the issue's updatedAt as a fallback.
+                try:
+                    updated = datetime.strptime(
+                        issue["updatedAt"], "%Y-%m-%dT%H:%M:%SZ"
+                    ).replace(tzinfo=timezone.utc).timestamp()
+                except (ValueError, KeyError):
+                    updated = 0
+                age = now - updated
 
         if age > threshold:
             if lock_label == LABEL_REVISING:
@@ -237,20 +280,20 @@ def _rollback_stale_pr_locks(*, immediate: bool = False) -> list[dict]:
 
     for pr in prs:
         pr_num = pr["number"]
-        # No PR-side log-marker parsing (unlike the issue rollback which
-        # scans [fix]/[revise]/[maintain] lines). The PR dispatcher spans
-        # many action markers ([rebase], [fix-ci], [merge], [review_docs],
-        # …) keyed by pr=<N>, and :locked is a brief ownership window —
-        # falling back to updatedAt mirrors how the issue path falls back
-        # when no log line is found, and the short _STALE_LOCKED_HOURS
-        # TTL bounds any over-extension from a stray comment.
-        try:
-            updated = datetime.strptime(
-                pr["updatedAt"], "%Y-%m-%dT%H:%M:%SZ"
-            ).replace(tzinfo=timezone.utc).timestamp()
-        except (ValueError, KeyError):
-            updated = 0
-        age = now - updated
+        # Age comes from the oldest cai-lock claim comment — the
+        # authoritative acquisition marker. Using PR ``updatedAt`` here is
+        # unsafe: GitHub bumps it for CI check-runs, head-branch pushes,
+        # merge-conflict recomputation, and every losing _acquire_remote_lock
+        # race (post+delete of a claim comment), so a lock set hours ago
+        # can look "fresh" forever.
+        claim_age = _lock_claim_age_seconds(pr_num, now)
+        if claim_age is not None:
+            age = claim_age
+        else:
+            # Anomaly: :locked label with no claim comment (crashed acquire
+            # or manually deleted claim). Treat as stale so the watchdog
+            # can strip the orphan label.
+            age = float("inf")
 
         if age <= threshold:
             continue

--- a/docs/modules/config.md
+++ b/docs/modules/config.md
@@ -49,6 +49,13 @@ every handler and `cmd_*` function; changes here ripple everywhere.
 - **Watchdog invariant.** `_rollback_stale_in_progress` must
   remain safe to re-run; it relies on lock comments emitted by
   `github.py._acquire_remote_lock` to detect abandonment.
+- **`:locked` age comes from the claim comment, not `updatedAt`.**
+  The watchdog reads the oldest `<!-- cai-lock -->` comment's
+  `created_at` to decide whether a `:locked` label is past its TTL.
+  Using the issue/PR's `updatedAt` was a prior bug: GitHub bumps
+  `updatedAt` for CI check-runs and each cycle's losing
+  `_acquire_remote_lock` race (post+delete of a claim comment),
+  which kept hours-old locks looking "fresh" forever.
 - **CI implications.** Tests import from these files directly;
   breaking a public helper breaks ~30 tests.
 - **Cost sensitivity — indirect but central.** Logging is free;

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -24,15 +24,39 @@ def _make_issue(number, label, age_hours):
     }
 
 
+def _make_lock_claim(age_hours, owner="test-instance", comment_id=1):
+    """Build a fake cai-lock claim-comment dict ``age_hours`` old."""
+    created = datetime.now(timezone.utc) - timedelta(hours=age_hours)
+    return {
+        "id": comment_id,
+        "owner": owner,
+        "created_at": created.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
 class TestRollbackStaleInProgress(unittest.TestCase):
 
-    def _run_rollback(self, immediate, issues_by_label, set_labels_mock=None):
-        """Run _rollback_stale_in_progress with mocked gh calls."""
+    def _run_rollback(self, immediate, issues_by_label, set_labels_mock=None,
+                      lock_comments_by_number=None):
+        """Run _rollback_stale_in_progress with mocked gh calls.
+
+        ``lock_comments_by_number`` lets tests seed cai-lock claim
+        comments per issue/PR: ``{number: [{"id": int, "owner": str,
+        "created_at": "YYYY-MM-DDTHH:MM:SSZ"}, ...]}``. Lists are
+        returned oldest-first (matching the real ``_list_lock_comments``
+        contract). Omitted numbers see an empty list.
+        """
+
+        comments = lock_comments_by_number or {}
+
+        def fake_list_lock_comments(number):
+            return list(comments.get(number, []))
 
         def fake_gh_json(args, **kwargs):
             # The :locked rollback path also calls
-            # `gh api /repos/.../issues/<n>/comments` to find cai-lock
-            # claims. Treat that call as "no comments".
+            # `gh api /repos/.../issues/<n>/comments` for claim-comment
+            # deletion after a successful label strip. Treat as empty so
+            # the deletion branch no-ops in tests.
             if args and args[0] == "api":
                 return []
             # Extract the --label argument from `gh issue list ...`.
@@ -46,6 +70,8 @@ class TestRollbackStaleInProgress(unittest.TestCase):
         with patch("cai_lib.watchdog._gh_json", side_effect=fake_gh_json), \
              patch("cai_lib.watchdog._set_labels", sl), \
              patch("cai_lib.watchdog._delete_issue_comment", return_value=True), \
+             patch("cai_lib.watchdog._list_lock_comments",
+                   side_effect=fake_list_lock_comments), \
              patch("cai_lib.watchdog.log_run"), \
              patch("cai_lib.watchdog.LOG_PATH", MagicMock(exists=lambda: False)):
             return cai._rollback_stale_in_progress(immediate=immediate)
@@ -168,6 +194,9 @@ class TestRollbackStaleInProgress(unittest.TestCase):
                 cai.LABEL_LOCKED: [locked_issue],
             },
             set_labels_mock=sl_mock,
+            lock_comments_by_number={
+                701: [_make_lock_claim(age_hours=cai._STALE_LOCKED_HOURS + 0.5)],
+            },
         )
         nums = {i["number"] for i in result}
         self.assertIn(701, nums,
@@ -207,6 +236,9 @@ class TestRollbackStaleInProgress(unittest.TestCase):
                 cai.LABEL_APPLYING: [],
                 cai.LABEL_LOCKED: [locked_issue],
             },
+            lock_comments_by_number={
+                811: [_make_lock_claim(age_hours=0.1)],
+            },
         )
         nums = {i["number"] for i in result}
         self.assertNotIn(811, nums,
@@ -227,11 +259,131 @@ class TestRollbackStaleInProgress(unittest.TestCase):
                 cai.LABEL_APPLYING: [],
                 cai.LABEL_LOCKED: [locked_issue],
             },
+            lock_comments_by_number={
+                801: [_make_lock_claim(age_hours=cai._STALE_LOCKED_HOURS / 2)],
+            },
         )
         nums = {i["number"] for i in result}
         self.assertNotIn(801, nums,
                          f"fresh :locked (age < {cai._STALE_LOCKED_HOURS}h) "
                          "must NOT be rolled back")
+
+    def test_rollback_locked_uses_claim_comment_over_stale_updated_at(self):
+        """:locked rollback age must come from the oldest cai-lock comment.
+
+        Regression for the production bug where issues kept a :locked label
+        for hours because GitHub ``updatedAt`` was bumped by each cycle's
+        losing ``_acquire_remote_lock`` race (post+delete of a claim
+        comment) and by CI check-runs. The watchdog was using ``updatedAt``
+        as the freshness fallback and never crossed the TTL threshold.
+        """
+        # Issue looks "fresh" via updatedAt (5 min), but the actual cai-lock
+        # claim comment is 4 hours old → must be rolled back.
+        locked_issue = _make_issue(
+            851, cai.LABEL_LOCKED, age_hours=5 / 60.0)
+        result = self._run_rollback(
+            immediate=False,
+            issues_by_label={
+                cai.LABEL_IN_PROGRESS: [],
+                cai.LABEL_REVISING: [],
+                cai.LABEL_APPLYING: [],
+                cai.LABEL_LOCKED: [locked_issue],
+            },
+            lock_comments_by_number={
+                851: [_make_lock_claim(
+                    age_hours=cai._STALE_LOCKED_HOURS + 3.0)],
+            },
+        )
+        nums = {i["number"] for i in result}
+        self.assertIn(
+            851, nums,
+            "a :locked issue with a claim comment older than "
+            f"{cai._STALE_LOCKED_HOURS}h must be rolled back even when "
+            "updatedAt is fresh (production bug — updatedAt is tainted "
+            "by losing acquire races)",
+        )
+
+    def test_rollback_locked_ignores_stale_updated_at_when_claim_fresh(self):
+        """A fresh claim comment must protect a :locked label even if ``updatedAt`` is old.
+
+        Inverse of the regression: a healthy, actively-held lock whose
+        issue hasn't been touched for a while (e.g. a long-running
+        handler with no label churn) must NOT be rolled back.
+        """
+        locked_issue = _make_issue(
+            852, cai.LABEL_LOCKED,
+            age_hours=cai._STALE_LOCKED_HOURS + 10,  # stale updatedAt
+        )
+        result = self._run_rollback(
+            immediate=False,
+            issues_by_label={
+                cai.LABEL_IN_PROGRESS: [],
+                cai.LABEL_REVISING: [],
+                cai.LABEL_APPLYING: [],
+                cai.LABEL_LOCKED: [locked_issue],
+            },
+            lock_comments_by_number={
+                852: [_make_lock_claim(age_hours=0.05)],  # ~3 min old
+            },
+        )
+        nums = {i["number"] for i in result}
+        self.assertNotIn(
+            852, nums,
+            "a :locked issue with a fresh claim comment must NOT be "
+            "rolled back even if updatedAt is hours old",
+        )
+
+    def test_rollback_locked_uses_oldest_claim_when_many(self):
+        """When multiple claim comments exist, the oldest wins (protocol contract)."""
+        locked_issue = _make_issue(853, cai.LABEL_LOCKED, age_hours=0.1)
+        result = self._run_rollback(
+            immediate=False,
+            issues_by_label={
+                cai.LABEL_IN_PROGRESS: [],
+                cai.LABEL_REVISING: [],
+                cai.LABEL_APPLYING: [],
+                cai.LABEL_LOCKED: [locked_issue],
+            },
+            lock_comments_by_number={
+                # Oldest-first (contract of _list_lock_comments).
+                853: [
+                    _make_lock_claim(
+                        age_hours=cai._STALE_LOCKED_HOURS + 2,
+                        comment_id=1, owner="old-owner",
+                    ),
+                    _make_lock_claim(age_hours=0.02, comment_id=2,
+                                     owner="fresh-loser"),
+                ],
+            },
+        )
+        nums = {i["number"] for i in result}
+        self.assertIn(
+            853, nums,
+            "rollback must use the OLDEST claim-comment timestamp — a "
+            "fresh losing-race claim must not protect a stale winner",
+        )
+
+    def test_rollback_locked_orphan_label_stripped(self):
+        """:locked label with NO cai-lock comment is an anomaly → always strip."""
+        locked_issue = _make_issue(854, cai.LABEL_LOCKED, age_hours=0.01)
+        result = self._run_rollback(
+            immediate=False,
+            issues_by_label={
+                cai.LABEL_IN_PROGRESS: [],
+                cai.LABEL_REVISING: [],
+                cai.LABEL_APPLYING: [],
+                cai.LABEL_LOCKED: [locked_issue],
+            },
+            lock_comments_by_number={},  # no claims for #854
+        )
+        nums = {i["number"] for i in result}
+        self.assertIn(
+            854, nums,
+            "orphan :locked (label without claim comment) must be "
+            "rolled back regardless of age — the acquire protocol "
+            "guarantees label+comment are posted together, so a label "
+            "alone means a crashed/manual anomaly",
+        )
 
 
 def _make_pr(number, label, age_hours):
@@ -248,8 +400,18 @@ def _make_pr(number, label, age_hours):
 
 class TestRollbackStalePrLocks(unittest.TestCase):
 
-    def _run_pr_rollback(self, immediate, prs, set_pr_labels_mock=None):
-        """Run _rollback_stale_pr_locks with mocked gh + label calls."""
+    def _run_pr_rollback(self, immediate, prs, set_pr_labels_mock=None,
+                         lock_comments_by_number=None):
+        """Run _rollback_stale_pr_locks with mocked gh + label calls.
+
+        ``lock_comments_by_number`` seeds cai-lock claim comments per PR
+        (same shape as the issue-side helper).
+        """
+
+        comments = lock_comments_by_number or {}
+
+        def fake_list_lock_comments(number):
+            return list(comments.get(number, []))
 
         def fake_gh_json(args, **kwargs):
             # Cai-lock claim comment scan — return empty list.
@@ -266,6 +428,8 @@ class TestRollbackStalePrLocks(unittest.TestCase):
         with patch("cai_lib.watchdog._gh_json", side_effect=fake_gh_json), \
              patch("cai_lib.watchdog._set_pr_labels", spl), \
              patch("cai_lib.watchdog._delete_issue_comment", return_value=True), \
+             patch("cai_lib.watchdog._list_lock_comments",
+                   side_effect=fake_list_lock_comments), \
              patch("cai_lib.watchdog.log_run"):
             return cai._rollback_stale_pr_locks(immediate=immediate)
 
@@ -276,6 +440,9 @@ class TestRollbackStalePrLocks(unittest.TestCase):
         spl_mock = MagicMock(return_value=True)
         result = self._run_pr_rollback(
             immediate=False, prs=[pr], set_pr_labels_mock=spl_mock,
+            lock_comments_by_number={
+                901: [_make_lock_claim(age_hours=cai._STALE_LOCKED_HOURS + 0.5)],
+            },
         )
         nums = {p["number"] for p in result}
         self.assertIn(
@@ -304,12 +471,56 @@ class TestRollbackStalePrLocks(unittest.TestCase):
         """PRs within _STALE_LOCKED_HOURS must NOT be rolled back."""
         pr = _make_pr(902, cai.LABEL_LOCKED,
                       age_hours=cai._STALE_LOCKED_HOURS / 2)
-        result = self._run_pr_rollback(immediate=False, prs=[pr])
+        result = self._run_pr_rollback(
+            immediate=False, prs=[pr],
+            lock_comments_by_number={
+                902: [_make_lock_claim(age_hours=cai._STALE_LOCKED_HOURS / 2)],
+            },
+        )
         nums = {p["number"] for p in result}
         self.assertNotIn(
             902, nums,
             f"fresh :locked PR (age < {cai._STALE_LOCKED_HOURS}h) must NOT "
             "be rolled back",
+        )
+
+    def test_pr_lock_uses_claim_comment_over_stale_updated_at(self):
+        """PR :locked rollback must read the claim comment, not ``updatedAt``.
+
+        Production regression: PR #938 kept :locked for 4+ hours because
+        GitHub bumped ``updatedAt`` for CI check-runs and losing
+        lock-acquire races, while the real lock acquisition was hours old.
+        """
+        # updatedAt looks fresh (3 min), claim comment is 4h old.
+        pr = _make_pr(904, cai.LABEL_LOCKED, age_hours=3 / 60.0)
+        spl_mock = MagicMock(return_value=True)
+        result = self._run_pr_rollback(
+            immediate=False, prs=[pr], set_pr_labels_mock=spl_mock,
+            lock_comments_by_number={
+                904: [_make_lock_claim(
+                    age_hours=cai._STALE_LOCKED_HOURS + 3.0)],
+            },
+        )
+        nums = {p["number"] for p in result}
+        self.assertIn(
+            904, nums,
+            "PR rollback must use the oldest cai-lock claim comment's "
+            "created_at, not the PR's updatedAt (tainted by CI and "
+            "losing-race post/delete churn)",
+        )
+
+    def test_pr_lock_orphan_label_stripped(self):
+        """PR :locked label with no claim comment is an anomaly → strip."""
+        pr = _make_pr(905, cai.LABEL_LOCKED, age_hours=0.01)
+        result = self._run_pr_rollback(
+            immediate=False, prs=[pr],
+            lock_comments_by_number={},
+        )
+        nums = {p["number"] for p in result}
+        self.assertIn(
+            905, nums,
+            "orphan PR :locked (no claim comment) must be rolled back "
+            "regardless of age",
         )
 
     def test_immediate_true_rolls_back_fresh_pr(self):


### PR DESCRIPTION
## Summary
- Fixes stale `auto-improve:locked` labels that survived far past their 1h TTL because the watchdog used the issue/PR's `updatedAt` timestamp as its freshness signal.
- `:locked` age now comes from the oldest `<!-- cai-lock owner=... acquired=... -->` claim comment, which is the authoritative acquisition marker set atomically with the label by `_acquire_remote_lock`.
- Orphan `:locked` (label without a claim comment — impossible under the acquire protocol, so a crashed/manual anomaly) is now rolled back regardless of age.

## The production bug

Observed live (2026-04-20, now=11:40Z):

| Target | Oldest cai-lock comment | `updatedAt` | Watchdog saw |
|---|---|---|---|
| #949 | 2026-04-19T22:51Z (**13h**) | 2026-04-20T11:30Z | ~10m → skip |
| #990 | 2026-04-20T07:12Z (**4h**) | 2026-04-20T11:31Z | ~9m → skip |
| #991 | 2026-04-20T07:21Z (**4h**) | 2026-04-20T11:31Z | ~9m → skip |
| #998 | 2026-04-20T08:46Z (**3h**) | 2026-04-20T11:32Z | ~8m → skip |
| PR #938 | 2026-04-20T07:24Z (**4h**) | 2026-04-20T11:29Z | ~11m → skip |

The watchdog computed `age = now - updatedAt` and found every target ≤ 11 minutes old — well below `_STALE_LOCKED_HOURS = 1`. It skipped them on every tick.

### Why `updatedAt` was lying

`updatedAt` is bumped by many events that do NOT reflect cai lock activity:
- GitHub check-runs and commit statuses (PR #938's timeline shows no events after `07:24:14Z`, yet `updatedAt` was `11:29:35Z` — all from CI).
- Every losing `_acquire_remote_lock` race: each cycle tries to acquire, posts a `<!-- cai-lock -->` claim comment, loses to the oldest comment, and deletes its own losing claim. Both the post and the delete bump `updatedAt`.

This creates a self-perpetuating loop — the cycle itself refreshes `updatedAt` fast enough to hide the lock's actual age forever.

### Why the log-line fallback didn't catch it

`_rollback_stale_in_progress` also scans the log tail for `[fix]`, `[revise]`, `[maintain]` markers keyed by `issue=<N>`. But the live log entries for locked issues were `[implement] ... issue=1009 result=subagent_failed`, which is NOT in that filter, so the log-line path didn't match and the code fell through to the tainted `updatedAt`.

The PR-side `_rollback_stale_pr_locks` doesn't even try log lines — it goes straight to `updatedAt`.

## Fix

For `LABEL_LOCKED` only (both issue and PR paths), compute age from `_list_lock_comments(number)[0]["created_at"]` — the oldest `<!-- cai-lock -->` comment. This timestamp:
- is set atomically with the `:locked` label by `_acquire_remote_lock` in `github.py:547`,
- survives every crash scenario the label does,
- is untouched by the losing-race post/delete churn (the oldest = the winner's claim; losers post+delete their own separate comments).

The `:in-progress` / `:revising` / `:applying` paths keep the existing log-line + `updatedAt` fallback — they have different semantics (a running handler legitimately keeps bumping its log line) and weren't part of this bug.

## Test plan
- [x] `tests/test_rollback.py` — all 18 tests pass, including 6 new ones:
  - `test_rollback_locked_uses_claim_comment_over_stale_updated_at` — regression test for the production bug (fresh `updatedAt`, stale claim → rolled back).
  - `test_rollback_locked_ignores_stale_updated_at_when_claim_fresh` — inverse (stale `updatedAt`, fresh claim → NOT rolled back).
  - `test_rollback_locked_uses_oldest_claim_when_many` — winner-oldest protocol contract.
  - `test_rollback_locked_orphan_label_stripped` — label without claim is an anomaly, always rolled back.
  - `test_pr_lock_uses_claim_comment_over_stale_updated_at` — PR-side regression.
  - `test_pr_lock_orphan_label_stripped` — PR-side orphan.
- [x] Full suite — `python3 -m pytest tests/` → 430 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)