### PR TITLE
auto-improve: Rescue prevention: **cai-merge should not penalize changes applied by pipeline agents as confidence-reducers when it characterizes those ch

### DIFF
--- a/.claude/agents/review/cai-merge.md
+++ b/.claude/agents/review/cai-merge.md
@@ -243,6 +243,55 @@ the user message:
   do not downgrade to **medium** on a scope concern that the
   wrapper itself pre-approved.
 
+### Exemption: wrapper-injected pre-authorized pipeline co-edits
+
+The merge wrapper (`cai_lib/actions/merge.py`) sometimes prepends a
+`## Pre-authorized pipeline co-edits` section to the user message,
+**between the issue body and the PR changes** (next to the
+requeue exemption block above). The wrapper emits that section
+only when it has deterministically detected one or more files
+that the pre-merge pipeline already authorized — by parsing the
+PR comment history for `**File(s):**` lines under `### Finding:`
+blocks (in `## cai pre-merge review — <sha>` comments) or under
+`### Fixed: stale_docs` blocks (in `## cai docs review (applied)
+— <sha>` comments). You do **not** need to detect any heading,
+parse any `### Finding:` or `### Fixed:` block, or scan the PR
+comment history yourself — if the section is absent, no
+pipeline-co-edit exemption applies.
+
+When a `## Pre-authorized pipeline co-edits` section is present
+in the user message:
+
+- Treat every file listed there as in-scope for this PR. Do not
+  downgrade confidence for scope-only reasons on those files —
+  including "scope broader than the issue asks for", "new files
+  not mentioned in the issue", and "PR adds new test files or
+  docstrings". The pre-merge pipeline already approved each of
+  those files as a direct consequence of running `cai-review-pr`
+  and `cai-review-docs`.
+- The exemption covers **scope only**. Correctness, completeness,
+  unaddressed review comments, and workflow-file
+  (`.github/workflows/`) rules still apply in full. A pipeline
+  co-edit to a file under `.github/workflows/` is still
+  disqualifying.
+- This wrapper-injected list takes precedence over the soft
+  exemption sections above (`### Exemption: reviewer-recommended
+  co-changes`, `### Exemption: docs-reviewer co-edits`). Those
+  sections remain as a safety net for the rare case where the
+  wrapper cannot extract a path from a non-canonical comment, but
+  you should always trust the wrapper-injected list when it is
+  present — and you must never downgrade a PR to MEDIUM solely
+  because a file in the injected list is "outside the issue's
+  stated scope". Issue #928 parked three times in a row on
+  exactly that mistake (the merger's own reasoning called the
+  changes "legitimate pipeline work" each time, yet still capped
+  the verdict at MEDIUM); this exemption exists specifically to
+  prevent that loop.
+- If a pipeline co-edit is the *only* soft concern standing
+  between the PR and a **high** verdict, emit **high** — do not
+  downgrade to **medium** on a scope concern that the pipeline
+  itself introduced.
+
 ## Output format
 
 Emit exactly this structured block — nothing else:

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -151,6 +151,7 @@
 | `tests/test_maintain.py` | Tests for cai_lib.actions.maintain — handle_maintain confidence routing and FSM transitions |
 | `tests/test_merge_agent_deletion_guard.py` | TODO: add description |
 | `tests/test_merge_diff.py` | TODO: add description |
+| `tests/test_merge_pipeline_coedits.py` | TODO: add description |
 | `tests/test_merge_requeue_exemption.py` | TODO: add description |
 | `tests/test_multistep.py` | Tests for multi-step plan support |
 | `tests/test_orphaned_prs.py` | TODO: add description |

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -195,6 +195,164 @@ def _build_requeue_exemption_block(issue_body: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Pipeline co-edits scope exemption (wrapper-driven, issue #990).
+#
+# When the pre-merge pipeline runs, ``cai-review-pr`` and
+# ``cai-review-docs`` may identify files outside the issue's stated
+# scope that nonetheless need to be edited as ripple effects (e.g.
+# ``README.md`` help text, ``cai.py`` docstrings,
+# ``scripts/generate-index.sh``). The pipeline either commits those
+# edits directly (``cai-review-docs``) or asks the revise agent to
+# apply them (``cai-review-pr``). Either way, by the time the merge
+# agent runs, those files appear in the PR diff and would naively be
+# flagged as scope creep.
+#
+# The agent prompt has soft exemptions for both cases (see
+# ``cai-merge.md``: ``Exemption: reviewer-recommended co-changes``
+# and ``Exemption: docs-reviewer co-edits``), but the agent applied
+# them inconsistently — most visibly on issue #928, which parked
+# three times in a row at MEDIUM despite the merger's own reasoning
+# calling the changes "legitimate pipeline work" each time. Each
+# park burnt a rescue cycle and a re-evaluation Opus call.
+#
+# We detect the condition **structurally, in Python**, mirroring the
+# requeue exemption above:
+#
+#   1. Walk every PR comment looking for the two pipeline review
+#      headings: ``## cai docs review (applied) - <sha>`` and
+#      ``## cai pre-merge review - <sha>`` (the non-clean variant —
+#      ``(clean)`` headings have no findings to extract).
+#   2. Inside each matching comment body, find every ``**File(s):**``
+#      line and split its value on commas, stripping ``(lines X-Y)``
+#      decorations and surrounding backticks.
+#   3. Emit a ``## Pre-authorized pipeline co-edits`` markdown block
+#      naming the deduplicated path list (first-seen order) so the
+#      merge agent receives an explicit authoritative list of
+#      pipeline-approved files instead of having to scan comment
+#      history itself.
+#
+# When no qualifying comments or paths are found the helper returns
+# the empty string, leaving ``user_message`` byte-identical to the
+# pre-#990 form for ordinary PRs. See the ``Exemption: wrapper-
+# injected pre-authorized pipeline co-edits`` section in
+# ``cai-merge.md`` for the complementary agent-side rule.
+# ---------------------------------------------------------------------------
+_PIPELINE_REVIEW_HEADING_DOCS_APPLIED = "## cai docs review (applied)"
+_PIPELINE_REVIEW_HEADING_PRE_MERGE = "## cai pre-merge review"
+_PIPELINE_REVIEW_HEADING_PRE_MERGE_CLEAN = "## cai pre-merge review (clean)"
+
+_FILES_LINE_RE = re.compile(
+    r"^\*\*File\(s\):\*\*\s+(.+)$", re.MULTILINE
+)
+_FILES_LINE_PARENTHETICAL_TAIL_RE = re.compile(r"\s*\([^)]*\)\s*$")
+
+
+def _is_pipeline_coedit_comment_body(body: str) -> bool:
+    """Return ``True`` when *body*'s first line is a pipeline review
+    heading whose contents may carry ``**File(s):**`` paths.
+
+    Matches::
+
+        ## cai docs review (applied) - <sha>
+        ## cai pre-merge review - <sha>
+
+    Excludes::
+
+        ## cai docs review (clean) - <sha>
+        ## cai pre-merge review (clean) - <sha>
+
+    Clean review comments have no ``### Finding:`` or ``### Fixed:``
+    blocks so they cannot contribute paths.
+    """
+    if not body:
+        return False
+    first_line = body.lstrip().split("\n", 1)[0]
+    if first_line.startswith(_PIPELINE_REVIEW_HEADING_DOCS_APPLIED):
+        return True
+    if (
+        first_line.startswith(_PIPELINE_REVIEW_HEADING_PRE_MERGE)
+        and not first_line.startswith(
+            _PIPELINE_REVIEW_HEADING_PRE_MERGE_CLEAN
+        )
+    ):
+        return True
+    return False
+
+
+def _extract_paths_from_files_line(value: str) -> list[str]:
+    """Parse a ``**File(s):**`` value into a list of clean paths.
+
+    Splits *value* on commas, strips trailing parenthetical
+    decorations like ``(lines 35-37)``, removes surrounding
+    backticks, and discards empty tokens. Order is preserved.
+    """
+    out: list[str] = []
+    for raw in value.split(","):
+        token = raw.strip()
+        token = _FILES_LINE_PARENTHETICAL_TAIL_RE.sub("", token).strip()
+        token = token.strip("`").strip()
+        if token:
+            out.append(token)
+    return out
+
+
+def _build_pipeline_coedits_exemption_block(
+    all_comments: list[dict],
+) -> str:
+    """Return a pre-authorized pipeline-coedits markdown block, or
+    ``""`` when no qualifying paths are found in *all_comments*.
+
+    Walks every comment in *all_comments*, keeps only those whose
+    body starts with a qualifying pipeline review heading (see
+    :func:`_is_pipeline_coedit_comment_body`), extracts every
+    ``**File(s):**`` line, and concatenates the per-line path
+    lists. The combined list is deduplicated while preserving
+    first-seen order so repeated runs produce a stable block.
+
+    Returns ``""`` when *all_comments* is empty, no comment
+    qualifies, or no qualifying comment yields any path. In that
+    case the merge ``user_message`` is byte-identical to the
+    pre-#990 form for ordinary first-attempt PRs.
+    """
+    if not all_comments:
+        return ""
+
+    seen: set[str] = set()
+    unique_paths: list[str] = []
+    for comment in all_comments:
+        body = comment.get("body") or ""
+        if not _is_pipeline_coedit_comment_body(body):
+            continue
+        for match in _FILES_LINE_RE.finditer(body):
+            for path in _extract_paths_from_files_line(match.group(1)):
+                if path not in seen:
+                    seen.add(path)
+                    unique_paths.append(path)
+
+    if not unique_paths:
+        return ""
+
+    bullet_list = "\n".join(f"- `{p}`" for p in unique_paths)
+    return (
+        "## Pre-authorized pipeline co-edits\n\n"
+        "The pre-merge pipeline (`cai-review-pr` and "
+        "`cai-review-docs`) has already cited the following files "
+        "as in-scope for this PR — either as `### Finding:` blocks "
+        "asking the revise agent to update them, or as "
+        "`### Fixed: stale_docs` blocks where `cai-review-docs` "
+        "directly committed the edit:\n\n"
+        f"{bullet_list}\n\n"
+        "**Treat every file in this list as in-scope for this PR.** "
+        "Do not downgrade confidence for scope-only reasons on these "
+        "files (e.g. \"scope broader than the issue asks\", \"new "
+        "files not mentioned in the issue\", \"PR adds new test "
+        "files or docstrings\"). Correctness, completeness, "
+        "unaddressed review comments, and workflow-file "
+        "(`.github/workflows/`) rules still apply in full.\n\n"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Unauthorized agent-file deletion guard (issue #1024).
 #
 # When ``cai-review-docs`` co-edits follow a rename/consolidation it
@@ -672,6 +830,9 @@ def handle_merge(pr: dict) -> int:
     requeue_block = _build_requeue_exemption_block(
         issue_full.get("body") or ""
     )
+    pipeline_coedits_block = _build_pipeline_coedits_exemption_block(
+        all_comments
+    )
 
     user_message = (
         f"## Linked issue\n\n"
@@ -679,6 +840,7 @@ def handle_merge(pr: dict) -> int:
         f"{issue_full.get('title', '')}\n\n"
         f"{issue_full.get('body') or '(no body)'}\n\n"
         f"{requeue_block}"
+        f"{pipeline_coedits_block}"
         f"## PR changes\n\n"
         f"```diff\n{pr_diff}\n```\n\n"
         f"## PR comments\n\n"

--- a/tests/test_merge_pipeline_coedits.py
+++ b/tests/test_merge_pipeline_coedits.py
@@ -1,0 +1,253 @@
+"""Tests for the _build_pipeline_coedits_exemption_block helper in
+cai_lib.actions.merge.
+
+The helper drives the wrapper-side pipeline co-edits scope
+exemption — see the ``Pipeline co-edits scope exemption`` comment
+block in ``cai_lib/actions/merge.py`` and the matching
+``Exemption: wrapper-injected pre-authorized pipeline co-edits``
+section in ``.claude/agents/review/cai-merge.md``.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+
+from cai_lib.actions.merge import (
+    _build_pipeline_coedits_exemption_block,
+    _is_pipeline_coedit_comment_body,
+    _extract_paths_from_files_line,
+)
+
+
+def _comment(body: str) -> dict:
+    """Wrap a body string in a minimal comment-shaped dict."""
+    return {"body": body}
+
+
+_DOCS_APPLIED_BODY = (
+    "## cai docs review (applied) \u2014 deadbeefcafebabe\n"
+    "\n"
+    "Summary line.\n"
+    "\n"
+    "### Fixed: stale_docs\n"
+    "\n"
+    "**File(s):** README.md, docs/cli.md, cai.py\n"
+    "\n"
+    "**Description:** doc drift fixed.\n"
+    "\n"
+    "**What was changed:** updated references.\n"
+    "\n"
+    "---\n"
+    "_Documentation updated automatically by `cai review-docs`._\n"
+)
+
+_PRE_MERGE_FINDINGS_BODY = (
+    "## cai pre-merge review \u2014 abc123def456\n"
+    "\n"
+    "### Finding: missing_co_change\n"
+    "\n"
+    "**File(s):** scripts/generate-index.sh, CODEBASE_INDEX.md\n"
+    "\n"
+    "**Description:** missing references.\n"
+    "\n"
+    "**Suggested fix:** add them.\n"
+)
+
+_PRE_MERGE_CLEAN_BODY = (
+    "## cai pre-merge review (clean) \u2014 0123456789abcdef\n"
+    "\n"
+    "No ripple effects found.\n"
+)
+
+_DOCS_CLEAN_BODY = (
+    "## cai docs review (clean) \u2014 0123456789abcdef\n"
+    "\n"
+    "No documentation updates needed.\n"
+)
+
+
+class TestIsPipelineCoeditCommentBody(unittest.TestCase):
+
+    def test_empty_body_is_false(self):
+        self.assertFalse(_is_pipeline_coedit_comment_body(""))
+
+    def test_docs_applied_is_true(self):
+        self.assertTrue(
+            _is_pipeline_coedit_comment_body(_DOCS_APPLIED_BODY)
+        )
+
+    def test_docs_clean_is_false(self):
+        self.assertFalse(
+            _is_pipeline_coedit_comment_body(_DOCS_CLEAN_BODY)
+        )
+
+    def test_pre_merge_findings_is_true(self):
+        self.assertTrue(
+            _is_pipeline_coedit_comment_body(_PRE_MERGE_FINDINGS_BODY)
+        )
+
+    def test_pre_merge_clean_is_false(self):
+        self.assertFalse(
+            _is_pipeline_coedit_comment_body(_PRE_MERGE_CLEAN_BODY)
+        )
+
+    def test_unrelated_comment_is_false(self):
+        self.assertFalse(
+            _is_pipeline_coedit_comment_body(
+                "Just a plain comment from a human reviewer."
+            )
+        )
+
+    def test_leading_whitespace_tolerated(self):
+        self.assertTrue(
+            _is_pipeline_coedit_comment_body(
+                "\n\n" + _DOCS_APPLIED_BODY
+            )
+        )
+
+
+class TestExtractPathsFromFilesLine(unittest.TestCase):
+
+    def test_simple_comma_split(self):
+        self.assertEqual(
+            _extract_paths_from_files_line("README.md, docs/cli.md, cai.py"),
+            ["README.md", "docs/cli.md", "cai.py"],
+        )
+
+    def test_strips_parenthetical_line_decorations(self):
+        self.assertEqual(
+            _extract_paths_from_files_line(
+                "CLAUDE.md (lines 35-37), docs/agents.md (lines 58-65)"
+            ),
+            ["CLAUDE.md", "docs/agents.md"],
+        )
+
+    def test_strips_surrounding_backticks(self):
+        self.assertEqual(
+            _extract_paths_from_files_line(
+                "`.claude/agents/audit/cai-agent-audit.md`"
+            ),
+            [".claude/agents/audit/cai-agent-audit.md"],
+        )
+
+    def test_skips_empty_tokens(self):
+        self.assertEqual(
+            _extract_paths_from_files_line("README.md, , , cai.py,"),
+            ["README.md", "cai.py"],
+        )
+
+
+class TestBuildPipelineCoeditsExemptionBlock(unittest.TestCase):
+
+    def test_empty_comments_returns_empty(self):
+        self.assertEqual(
+            _build_pipeline_coedits_exemption_block([]), ""
+        )
+
+    def test_no_pipeline_comments_returns_empty(self):
+        self.assertEqual(
+            _build_pipeline_coedits_exemption_block(
+                [_comment("Plain human comment."),
+                 _comment("## Implement subagent: did things")]
+            ),
+            "",
+        )
+
+    def test_only_clean_pipeline_comments_returns_empty(self):
+        self.assertEqual(
+            _build_pipeline_coedits_exemption_block(
+                [_comment(_PRE_MERGE_CLEAN_BODY),
+                 _comment(_DOCS_CLEAN_BODY)]
+            ),
+            "",
+        )
+
+    def test_docs_applied_emits_block_with_paths(self):
+        result = _build_pipeline_coedits_exemption_block(
+            [_comment(_DOCS_APPLIED_BODY)]
+        )
+        self.assertTrue(
+            result.startswith("## Pre-authorized pipeline co-edits")
+        )
+        self.assertIn("- `README.md`", result)
+        self.assertIn("- `docs/cli.md`", result)
+        self.assertIn("- `cai.py`", result)
+        self.assertIn(
+            "**Treat every file in this list as in-scope", result
+        )
+        self.assertIn("`.github/workflows/`", result)
+        # Block must end with a blank line so the subsequent
+        # "## PR changes" header is separated from the exemption
+        # body when concatenated into the user message.
+        self.assertTrue(result.endswith("\n\n"))
+
+    def test_pre_merge_findings_emits_block_with_paths(self):
+        result = _build_pipeline_coedits_exemption_block(
+            [_comment(_PRE_MERGE_FINDINGS_BODY)]
+        )
+        self.assertTrue(
+            result.startswith("## Pre-authorized pipeline co-edits")
+        )
+        self.assertIn("- `scripts/generate-index.sh`", result)
+        self.assertIn("- `CODEBASE_INDEX.md`", result)
+
+    def test_dedupe_preserves_first_seen_order(self):
+        # Same file cited in two comments — should appear once,
+        # at the position of its first appearance.
+        comments = [
+            _comment(_DOCS_APPLIED_BODY),  # README.md, docs/cli.md, cai.py
+            _comment(_PRE_MERGE_FINDINGS_BODY),  # generate-index.sh, CODEBASE_INDEX.md
+            _comment(
+                "## cai docs review (applied) \u2014 newersha\n"
+                "\n"
+                "### Fixed: stale_docs\n"
+                "\n"
+                "**File(s):** README.md, scripts/check-modules-coverage.py\n"
+            ),
+        ]
+        result = _build_pipeline_coedits_exemption_block(comments)
+        # README.md appears exactly once.
+        self.assertEqual(result.count("- `README.md`"), 1)
+        # Order: README.md (from first comment) before
+        # CODEBASE_INDEX.md (from second), before
+        # scripts/check-modules-coverage.py (from third).
+        readme_pos = result.find("- `README.md`")
+        idx_pos = result.find("- `CODEBASE_INDEX.md`")
+        new_pos = result.find("- `scripts/check-modules-coverage.py`")
+        self.assertLess(readme_pos, idx_pos)
+        self.assertLess(idx_pos, new_pos)
+
+    def test_block_concatenates_cleanly_with_pr_changes_header(self):
+        """End-to-end: simulate user_message concatenation to verify
+        spacing.
+
+        Ensures the helper's output sits correctly between the
+        issue body (which ends with ``\\n\\n``) and the
+        ``## PR changes\\n\\n`` header without collapsing or
+        multiplying blank lines.
+        """
+        block = _build_pipeline_coedits_exemption_block(
+            [_comment(_DOCS_APPLIED_BODY)]
+        )
+        # Mirrors the user_message pattern in handle_merge.
+        message = (
+            "## Linked issue\n\n"
+            "some body\n\n"
+            ""  # requeue_block (absent for this PR)
+            f"{block}"
+            "## PR changes\n\n"
+            "```diff\n(diff)\n```\n"
+        )
+        # Exactly one blank line between the exemption block end
+        # and the PR changes header.
+        self.assertIn(
+            "rules still apply in full.\n\n## PR changes\n\n",
+            message,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#990

**Issue:** #990 — Rescue prevention: **cai-merge should not penalize changes applied by pipeline agents as confidence-reducers when it characterizes those ch

## PR Summary

### What this fixes
Issue #990: `cai-merge` was parking PRs at MEDIUM confidence even when its own reasoning called pipeline-applied changes "legitimate pipeline work" — most visibly on issue #928, which required three rescue cycles. The root cause was that soft prompt exemptions for `cai-review-docs` and `cai-review-pr` co-edits were applied inconsistently by the agent.

### What was changed
- **`cai_lib/actions/merge.py`**: Added `_build_pipeline_coedits_exemption_block()` and two helpers (`_is_pipeline_coedit_comment_body`, `_extract_paths_from_files_line`) plus four module-level constants/regexes. The helper structurally parses PR comment history for `**File(s):**` lines in qualifying pipeline review headings and emits a `## Pre-authorized pipeline co-edits` markdown block. Wired the helper into `handle_merge`'s `user_message` assembly between the requeue block and `## PR changes`.
- **`.claude/agents/review/cai-merge.md`** (via staging at `.cai-staging/agents/review/cai-merge.md`): Added a new `### Exemption: wrapper-injected pre-authorized pipeline co-edits` section after the existing wrapper-injected scope section. The section instructs the agent to honor the wrapper-injected file list without re-scanning comment history.
- **`tests/test_merge_pipeline_coedits.py`**: New test file covering all three helpers — empty comments, no-pipeline headings, clean-only comments, docs-applied, pre-merge findings, multi-comment deduplication, parenthetical stripping, and end-to-end `user_message` concatenation.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
