### PR TITLE
fix(cai-comment-filter): clean pre-merge review supersedes earlier findings

### DIFF
--- a/.claude/agents/review/cai-comment-filter.md
+++ b/.claude/agents/review/cai-comment-filter.md
@@ -68,6 +68,15 @@ of the following is true:
    "done", "fixed", "addressed", "resolved", "agreed", or similar
    affirmations that the concern has been handled.
 
+6. **Later clean pre-merge review supersedes**: A LATER comment
+   (higher `_idx`) starts with `## cai pre-merge review (clean)` —
+   this means the pre-merge reviewer re-ran after the revise
+   subagent's response and found nothing to address at the newer
+   SHA. Treat ALL earlier `## cai pre-merge review —` findings as
+   resolved, whether the revise subagent addressed them directly
+   or deferred them as out-of-scope (the clean verdict at a later
+   SHA is authoritative).
+
 A comment is **unresolved** if NONE of the above apply — including
 human comments that predate a rebase commit, because a rebase does
 not address the comment's concern.

--- a/tests/test_revise_filter.py
+++ b/tests/test_revise_filter.py
@@ -47,6 +47,23 @@ NO_CHANGES_MARKER = _make_comment(4, "damien-robotsix",
                                    "Reviewed `parse()` signature — annotation not warranted.",
                                    "2026-04-01T23:00:00Z")
 
+# (e) A pre-merge review finding that revise deferred as out-of-scope.
+#     On its own this would look unresolved (diff doesn't address it),
+#     but a LATER `(clean)` pre-merge review supersedes it — see rule 6.
+PREMERGE_FINDING = _make_comment(
+    5, "damien-robotsix",
+    "## cai pre-merge review — abc1234\n\n"
+    "### Finding: missing_co_change\n\n"
+    "File X references symbol Y but isn't updated.",
+    "2026-04-02T10:00:00Z",
+)
+
+PREMERGE_CLEAN = _make_comment(
+    6, "damien-robotsix",
+    "## cai pre-merge review (clean) — def5678\n\nNo ripple effects found.",
+    "2026-04-02T11:00:00Z",
+)
+
 
 def _mock_claude_p_returning(payload: dict):
     """Return a mock subprocess.CompletedProcess that looks like a cai-comment-filter result."""
@@ -99,6 +116,19 @@ class TestFilterCommentsWithHaiku(unittest.TestCase):
         with run_p, claude_p:
             result = _filter_comments_with_haiku(
                 [COVERED_COMMENT, NO_CHANGES_MARKER], pr_number=42,
+            )
+        self.assertEqual(result, [])
+
+    def test_clean_premerge_review_supersedes_earlier_finding(self):
+        """A later `(clean)` pre-merge review should cause the haiku to treat
+        earlier `## cai pre-merge review —` findings as resolved, even if the
+        diff doesn't address them (the revise subagent may have deferred them
+        as out-of-scope and the clean re-review at the newer SHA is
+        authoritative)."""
+        run_p, claude_p = self._patch_run({"unresolved": []})
+        with run_p, claude_p:
+            result = _filter_comments_with_haiku(
+                [PREMERGE_FINDING, PREMERGE_CLEAN], pr_number=42,
             )
         self.assertEqual(result, [])
 


### PR DESCRIPTION
## Summary

- Add classification rule 6 to `cai-comment-filter`: a later `## cai pre-merge review (clean)` comment supersedes all earlier `## cai pre-merge review —` findings, mirroring how rule 4's `## Revise subagent: no additional changes` marker already supersedes earlier human comments.
- Add a regression test (`test_clean_premerge_review_supersedes_earlier_finding`) in `tests/test_revise_filter.py`.

## Motivation

PR #1045 got stuck at `APPROVED → handle_merge` with `has unaddressed review comments; skipping` even though the most recent pre-merge review was clean.

Timeline on #1045:
1. `## cai pre-merge review — 078fec5` (finding)
2. `## Revision summary` (addressed)
3. `## cai pre-merge review — a94e266` (finding about a file outside this PR's scope)
4. `## Revision summary` (**deferred as out-of-scope**, pushed c58fff5)
5. `## cai pre-merge review (clean) — c58fff5` ← clean at the new SHA
6. `## cai docs review (applied) — 2c66d7c`

Rule 3 only marks a pre-merge finding resolved when the diff addresses it. Since #3 was deferred, the diff doesn't satisfy rule 3 — so the filter kept flagging it as unresolved. But a subsequent `(clean)` pre-merge review at a newer SHA is strictly stronger evidence: the reviewer agent re-ran and found nothing to address. It should supersede earlier findings exactly the way the `no additional changes` marker does.

## Test plan

- [x] Existing filter tests still pass (`python -m unittest tests.test_revise_filter -v` — 10/10).
- [x] New test `test_clean_premerge_review_supersedes_earlier_finding` encodes the expected contract.
- [ ] Once merged, the next dispatch tick on #1045 should progress past the merge gate (or any similar stuck PR where a later `(clean)` review followed an earlier deferred finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)