### PR TITLE
auto-improve: Rescue prevention: The `_PATH_RE` regex in the plan's `_extract_paths` helper only matches paths starting with `[A-Za-z_]`, making the `/tm

### DIFF
--- a/cai_lib/actions/refine.py
+++ b/cai_lib/actions/refine.py
@@ -82,6 +82,17 @@ _PATH_RE = re.compile(
 # bare `cai_lib/publish.py` reference for the contradiction check.
 _CLONE_PREFIX_RE = re.compile(r"/tmp/cai-[^/\s]+/")
 
+# Matches a leading "./" on a path reference (e.g. "./cai_lib/foo.py")
+# that occurs at the start of a token — at string start or after
+# whitespace / backtick / bracket / comma / etc. The lookbehind excludes
+# word chars and "/" so mid-path occurrences like "foo/./bar" are NOT
+# stripped. Running this after _CLONE_PREFIX_RE (which removes
+# "/tmp/cai-<phase>-<issue>-<hash>/") and before _PATH_RE lets the
+# word-char-anchored _PATH_RE match the bare remainder, since its own
+# lookbehind (?<![\w/.-]) would otherwise block a match immediately
+# after a slash.
+_DOT_SLASH_RE = re.compile(r"(?<![/\w])\./")
+
 _FILES_TO_CHANGE_HEADER = "### Files to change"
 _SCOPE_GUARDRAILS_HEADER = "### Scope guardrails"
 
@@ -108,13 +119,15 @@ def _extract_paths(section_text: str) -> set[str]:
     # Pre-strip clone-prefix paths so the path regex (which is anchored on
     # word chars and cannot start with `/`) matches the relative remainder.
     text = _CLONE_PREFIX_RE.sub("", section_text or "")
+    # Pre-strip a leading "./" so references like "./cai_lib/foo.py" also
+    # match _PATH_RE on the bare remainder "cai_lib/foo.py". Without this,
+    # _PATH_RE's lookbehind (?<![\w/.-]) blocks matching after a slash.
+    text = _DOT_SLASH_RE.sub("", text)
     paths: set[str] = set()
     for m in _PATH_RE.finditer(text):
         raw = m.group(1).strip("`()[],.;: ")
         if not raw or any(ch.isspace() for ch in raw):
             continue
-        if raw.startswith("./"):
-            raw = raw[2:]
         paths.add(raw)
     return paths
 

--- a/tests/test_multistep.py
+++ b/tests/test_multistep.py
@@ -190,8 +190,12 @@ class TestDepthGate(unittest.TestCase):
 
 
 from cai_lib.actions.refine import (
+    _CLONE_PREFIX_RE,
+    _DOT_SLASH_RE,
+    _PATH_RE,
     _detect_guardrail_contradictions,
     _extract_files_to_change,
+    _extract_paths,
     _extract_scope_guardrails_paths,
 )
 
@@ -287,6 +291,70 @@ class TestGuardrailContradictionLint(unittest.TestCase):
     def test_missing_sections_no_contradictions(self):
         body = "## Refined Issue\n\n### Description\n\nSomething.\n"
         self.assertEqual(_detect_guardrail_contradictions(body), [])
+
+
+class TestExtractPathsHelper(unittest.TestCase):
+    """Tests for the _extract_paths pre-strips (clone-prefix + leading ./).
+
+    These lock in that both _CLONE_PREFIX_RE and _DOT_SLASH_RE are
+    load-bearing: without them, _PATH_RE's word-char-anchored lookbehind
+    silently drops the following legitimate path references.
+    """
+
+    def test_clone_prefix_stripped_so_path_is_extracted(self):
+        body = (
+            "### Files to change\n"
+            "- `/tmp/cai-plan-902-abcd1234/cai_lib/publish.py`\n"
+        )
+        self.assertEqual(
+            _extract_paths(body),
+            {"cai_lib/publish.py"},
+        )
+
+    def test_clone_prefix_is_load_bearing(self):
+        # Without _CLONE_PREFIX_RE, _PATH_RE cannot match the bare path
+        # because every candidate start position is preceded by "/" or
+        # "-", both of which are in _PATH_RE's excluded-lookbehind class.
+        raw = "/tmp/cai-plan-902-abcd1234/cai_lib/publish.py"
+        self.assertEqual(_PATH_RE.findall(raw), [])
+        stripped = _CLONE_PREFIX_RE.sub("", raw)
+        self.assertEqual(stripped, "cai_lib/publish.py")
+        self.assertEqual(_PATH_RE.findall(stripped), ["cai_lib/publish.py"])
+
+    def test_clone_prefix_regex_matches_canonical_shape(self):
+        for prefix in (
+            "/tmp/cai-plan-902-abcd1234/",
+            "/tmp/cai-implement-998-94eb0b0b/",
+            "/tmp/cai-refine-7-deadbeef/",
+        ):
+            self.assertIsNotNone(
+                _CLONE_PREFIX_RE.fullmatch(prefix),
+                f"expected _CLONE_PREFIX_RE to fullmatch {prefix!r}",
+            )
+
+    def test_leading_dot_slash_is_normalised(self):
+        body = (
+            "### Files to change\n"
+            "- `./cai_lib/publish.py`\n"
+        )
+        self.assertEqual(
+            _extract_paths(body),
+            {"cai_lib/publish.py"},
+        )
+
+    def test_dot_slash_is_load_bearing(self):
+        # Without _DOT_SLASH_RE, _PATH_RE cannot match "./cai_lib/publish.py"
+        # because the "c" of "cai_lib" is preceded by "/", which is in
+        # _PATH_RE's excluded-lookbehind class [\w/.-].
+        raw = "./cai_lib/publish.py"
+        self.assertEqual(_PATH_RE.findall(raw), [])
+        stripped = _DOT_SLASH_RE.sub("", raw)
+        self.assertEqual(stripped, "cai_lib/publish.py")
+        self.assertEqual(_PATH_RE.findall(stripped), ["cai_lib/publish.py"])
+
+    def test_empty_and_none_input(self):
+        self.assertEqual(_extract_paths(""), set())
+        self.assertEqual(_extract_paths(None), set())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#998

**Issue:** #998 — Rescue prevention: The `_PATH_RE` regex in the plan's `_extract_paths` helper only matches paths starting with `[A-Za-z_]`, making the `/tm

## PR Summary

### What this fixes
`_extract_paths` in `cai_lib/actions/refine.py` silently dropped path references like `` `./cai_lib/publish.py` `` because `_PATH_RE`'s lookbehind (`(?<![\w/.-])`) blocked matching `cai_lib/publish.py` when the preceding character was `/` (from `./`). The `if raw.startswith("./"):` branch was dead code — `_PATH_RE` never captures a group starting with `.`. This caused the guardrail-contradiction checker to miss legitimate contradictions when paths used the `./`-relative form.

### What was changed
- **`cai_lib/actions/refine.py`**: Added `_DOT_SLASH_RE = re.compile(r"(?<![/\w])\./")` after `_CLONE_PREFIX_RE`; applied it as a second pre-strip in `_extract_paths` (after `_CLONE_PREFIX_RE`, before `_PATH_RE` iteration); removed the now-dead `if raw.startswith("./"):` / `raw = raw[2:]` branch.
- **`tests/test_multistep.py`**: Extended the `cai_lib.actions.refine` import block to include `_CLONE_PREFIX_RE`, `_DOT_SLASH_RE`, `_PATH_RE`, and `_extract_paths`; added `TestExtractPathsHelper` class with 6 tests covering clone-prefix normalisation, `./` normalisation, the load-bearing nature of each pre-strip, canonical clone-prefix shape, and empty/`None` input.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
