### PR TITLE
auto-improve: Rescue prevention: The merge agent produced a clear, actionable field-name mismatch finding but the FSM parked the PR as human-needed inste

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -152,6 +152,7 @@
 | `tests/test_maintain.py` | Tests for cai_lib.actions.maintain — handle_maintain confidence routing and FSM transitions |
 | `tests/test_merge_agent_deletion_guard.py` | TODO: add description |
 | `tests/test_merge_diff.py` | TODO: add description |
+| `tests/test_merge_low_to_revision.py` | TODO: add description |
 | `tests/test_merge_non_bot_branch.py` | TODO: add description |
 | `tests/test_merge_pipeline_coedits.py` | TODO: add description |
 | `tests/test_merge_requeue_exemption.py` | TODO: add description |

--- a/README.md
+++ b/README.md
@@ -358,7 +358,13 @@ implement their linked issue. For each open `:pr-open` PR on an
 6. If the action is `reject` and confidence meets the threshold,
    closes the PR via `gh pr close --delete-branch` and closes the
    linked issue via `gh issue close --reason "not planned"`
-7. Otherwise, labels the issue `merge-blocked` and
+7. If the action is `hold`, confidence is `low`, and the verdict's
+   reasoning cites a concrete, mechanically-fixable code bug (e.g.,
+   "field-name mismatch", "AttributeError", "NameError", "typo"),
+   routes the PR to `:pr-revision-pending` so `cai-revise` can
+   immediately apply the fix on the next tick, rather than parking
+   at `:pr-human-needed` for human review
+8. Otherwise, labels the issue `merge-blocked` and
    posts the verdict reasoning as a PR comment
 
 **Confidence levels:**

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -6,9 +6,15 @@ agent to obtain a confidence-gated verdict and, on a high-enough
 merge verdict, squash-merges via ``gh pr merge``. On new commits
 arriving since the APPROVED label was set, diverts back to code
 review. On low-confidence / refusal / merge failure on a still-open
-PR, transitions the PR out of APPROVED into ``PR_HUMAN_NEEDED``
-(``approved_to_human``) so the dispatcher parks it instead of
-re-routing back to ``handle_merge`` every drain tick.
+PR:
+
+- If the verdict is LOW+hold citing a concrete, mechanically-fixable
+  code bug (e.g., "field-name mismatch", "AttributeError", "typo"),
+  transitions to ``PR_REVISION_PENDING`` (``approved_to_revision_pending``)
+  so ``cai-revise`` can immediately fix it.
+- Otherwise, transitions the PR out of APPROVED into ``PR_HUMAN_NEEDED``
+  (``approved_to_human``) so the dispatcher parks it instead of
+  re-routing back to ``handle_merge`` every drain tick.
 """
 from __future__ import annotations
 

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -52,6 +52,58 @@ from cai_lib.logging_utils import log_run
 
 _MERGE_COMMENT_HEADING = "## cai merge verdict"
 
+# Heading for the follow-up comment posted when a LOW+hold verdict's
+# reasoning names a concrete, mechanically-fixable code bug (see
+# ``_verdict_cites_concrete_code_bug`` below). The heading is
+# intentionally distinct from ``_MERGE_COMMENT_HEADING`` so
+# ``cai-comment-filter`` does not treat it as a resolved bot
+# self-comment — the heading is NOT listed in the filter's
+# bot-self-comment allowlist in ``cai-comment-filter.md``, so the
+# filter defaults to classifying it as unresolved. cai-revise then
+# picks up the comment on its next tick and addresses the cited bug
+# without waiting for a rescue cycle (issue #1055).
+_MERGE_FIXABLE_COMMENT_HEADING = "## cai merge: fixable code bug"
+
+# Reasoning patterns that indicate a LOW+hold verdict is citing a
+# concrete, mechanically-fixable code bug rather than a design /
+# scope / policy concern. Matched case-insensitively on the verdict's
+# ``reasoning`` string. When ANY of these patterns match AND the
+# verdict is ``low`` + ``hold``, ``handle_merge`` routes the PR to
+# REVISION_PENDING via ``approved_to_revision_pending`` instead of
+# parking at PR_HUMAN_NEEDED via ``approved_to_human``.
+_CONCRETE_CODE_BUG_PATTERNS: tuple[re.Pattern, ...] = (
+    re.compile(r"\bAttributeError\b"),
+    re.compile(r"\bNameError\b"),
+    re.compile(r"\bTypeError\b"),
+    re.compile(r"\bImportError\b"),
+    re.compile(r"\bModuleNotFoundError\b"),
+    re.compile(r"\bKeyError\b"),
+    re.compile(r"\bwrong (?:field|method|attribute|argument|parameter|variable) name\b", re.IGNORECASE),
+    re.compile(r"\bincorrect (?:field|method|attribute|argument|parameter|variable) name\b", re.IGNORECASE),
+    re.compile(r"\b(?:field|method|attribute) name mismatch\b", re.IGNORECASE),
+    re.compile(r"\btypo\b", re.IGNORECASE),
+    re.compile(r"\bundefined (?:name|variable|symbol|reference|function)\b", re.IGNORECASE),
+)
+
+
+def _verdict_cites_concrete_code_bug(reasoning: str) -> bool:
+    """Return True when *reasoning* matches a concrete-bug pattern.
+
+    The detector is deliberately narrow — it fires only when the
+    merge agent's reasoning names a Python exception class or a
+    short, well-known "wrong-name / typo" phrase. Design concerns,
+    scope concerns, and vague correctness worries ("logic looks
+    suspicious", "unsure about edge case") do NOT match, so those
+    parks keep the current ``approved_to_human`` routing.
+    """
+    if not reasoning:
+        return False
+    for pattern in _CONCRETE_CODE_BUG_PATTERNS:
+        if pattern.search(reasoning):
+            return True
+    return False
+
+
 # Confidence threshold: only verdicts at or above this level trigger a merge.
 # "high" = only high merges, "medium" = high + medium merge,
 # "disabled" = never merge.
@@ -1075,6 +1127,52 @@ def handle_merge(pr: dict) -> int:
             f"< threshold={_MERGE_THRESHOLD}; holding",
             flush=True,
         )
+        # Issue #1055: when a LOW+hold verdict's reasoning cites a
+        # concrete, mechanically-fixable code bug, route the PR back
+        # through cai-revise instead of parking at PR_HUMAN_NEEDED.
+        # The verdict comment above already has the "## cai merge
+        # verdict" heading, which cai-comment-filter treats as a
+        # resolved bot self-comment — so we post a SECOND comment
+        # under a heading that is NOT in the filter's allowlist,
+        # containing the reasoning verbatim, so cai-revise sees it
+        # as an unresolved reviewer comment on the next tick.
+        fixable_bug = (
+            action == "hold"
+            and confidence == "low"
+            and _verdict_cites_concrete_code_bug(reasoning)
+        )
+        if fixable_bug:
+            fixable_body = (
+                f"{_MERGE_FIXABLE_COMMENT_HEADING} \u2014 {head_sha}\n\n"
+                f"The merge agent flagged this PR with a **low-"
+                f"confidence hold** citing a concrete, mechanically-"
+                f"fixable code bug. Routing through `cai-revise` "
+                f"instead of parking for human review.\n\n"
+                f"**Verdict reasoning:**\n\n"
+                f"{reasoning}\n\n"
+                f"---\n"
+                f"_Auto-routed by `cai merge` to `pr:revision-"
+                f"pending`. `cai-revise` will address the bug cited "
+                f"above on its next tick; the revised PR returns to "
+                f"code review automatically._"
+            )
+            _run(
+                ["gh", "pr", "comment", str(pr_number),
+                 "--repo", REPO, "--body", fixable_body],
+                capture_output=True,
+            )
+            print(
+                f"[cai merge] PR #{pr_number}: LOW+hold verdict cites "
+                f"concrete code bug; routing to REVISION_PENDING",
+                flush=True,
+            )
+            apply_pr_transition(
+                pr_number, "approved_to_revision_pending",
+                log_prefix="cai merge",
+            )
+            log_run("merge", repo=REPO, pr=pr_number,
+                    duration=dur(), result="held_fixable_bug", exit=0)
+            return 0
         if not _issue_has_label(issue_number, LABEL_MERGED):
             if not _set_labels(
                 issue_number,

--- a/cai_lib/fsm_transitions.py
+++ b/cai_lib/fsm_transitions.py
@@ -373,6 +373,23 @@ PR_TRANSITIONS: list[Transition] = [
                labels_remove=[LABEL_PR_APPROVED],
                labels_add=[LABEL_PR_HUMAN_NEEDED],
                human_label_if_below=LABEL_PR_HUMAN_NEEDED),
+    # Merge handler redirect: when the merge agent's verdict is LOW
+    # confidence + action=hold AND the reasoning cites only a concrete
+    # mechanically-fixable code bug (AttributeError, NameError, wrong
+    # field / method name, typo, etc.), route back through cai-revise
+    # instead of parking at PR_HUMAN_NEEDED. cai-revise can address the
+    # cited bug in one shot, whereas parking would burn a rescue cycle
+    # for a trivially fixable finding (issue #1055). The merge handler
+    # is responsible for (a) posting a follow-up comment with a heading
+    # NOT in cai-comment-filter's bot-self-comment allowlist so the
+    # filter treats it as unresolved, and (b) firing this transition
+    # only on LOW+hold verdicts that match the concrete-bug detector.
+    # All other held verdicts continue to use ``approved_to_human``.
+    Transition("approved_to_revision_pending",
+               PRState.APPROVED, PRState.REVISION_PENDING,
+               labels_remove=[LABEL_PR_APPROVED],
+               labels_add=[LABEL_PR_REVISION_PENDING],
+               human_label_if_below=LABEL_PR_HUMAN_NEEDED),
     Transition("pr_human_to_reviewing_code",
                PRState.PR_HUMAN_NEEDED, PRState.REVIEWING_CODE,
                labels_remove=[LABEL_PR_HUMAN_NEEDED],

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -76,6 +76,7 @@ stateDiagram-v2
     REBASING --> REVIEWING_CODE : rebasing_to_reviewing_code [≥HIGH]
     REVIEWING_CODE --> PR_HUMAN_NEEDED : reviewing_code_to_human [≥HIGH]
     APPROVED --> PR_HUMAN_NEEDED : approved_to_human [≥HIGH]
+    APPROVED --> REVISION_PENDING : approved_to_revision_pending [≥HIGH]
     PR_HUMAN_NEEDED --> REVIEWING_CODE : pr_human_to_reviewing_code [≥HIGH]
     PR_HUMAN_NEEDED --> REVISION_PENDING : pr_human_to_revision_pending [≥HIGH]
     PR_HUMAN_NEEDED --> REVIEWING_DOCS : pr_human_to_reviewing_docs [≥HIGH]

--- a/tests/test_merge_low_to_revision.py
+++ b/tests/test_merge_low_to_revision.py
@@ -1,0 +1,260 @@
+"""Regression tests for issue #1055 — LOW-confidence merge verdicts
+that cite concrete code bugs are routed to REVISION_PENDING via
+``approved_to_revision_pending`` instead of parking at
+PR_HUMAN_NEEDED via ``approved_to_human``.
+
+The companion helper ``_verdict_cites_concrete_code_bug`` must fire
+only on mechanically-fixable reasoning (AttributeError, NameError,
+wrong field/method name, typo, undefined name, ...). Design/scope
+concerns must keep the old ``approved_to_human`` routing.
+"""
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.actions import merge as merge_mod
+from cai_lib.actions.merge import _verdict_cites_concrete_code_bug
+from cai_lib.fsm_transitions import PR_TRANSITIONS
+
+
+class TestVerdictCitesConcreteCodeBug(unittest.TestCase):
+    """The detector fires only on concrete, mechanically-fixable bugs."""
+
+    def test_empty_reasoning_is_false(self):
+        self.assertFalse(_verdict_cites_concrete_code_bug(""))
+        self.assertFalse(_verdict_cites_concrete_code_bug(None))  # type: ignore[arg-type]
+
+    def test_attribute_error_matches(self):
+        self.assertTrue(_verdict_cites_concrete_code_bug(
+            "runner.py:38 accesses entry.file_globs, but ModuleEntry "
+            "defines a `globs` field — any real invocation will crash "
+            "with AttributeError inside _build_module_message."
+        ))
+
+    def test_name_error_matches(self):
+        self.assertTrue(_verdict_cites_concrete_code_bug(
+            "The helper references `results` but the enclosing scope "
+            "only defines `result`; calling this path raises NameError."
+        ))
+
+    def test_type_and_key_errors_match(self):
+        self.assertTrue(_verdict_cites_concrete_code_bug(
+            "calling .split() on None raises TypeError"))
+        self.assertTrue(_verdict_cites_concrete_code_bug(
+            "lookup without .get() raises KeyError on missing label"))
+
+    def test_import_and_module_not_found_match(self):
+        self.assertTrue(_verdict_cites_concrete_code_bug(
+            "new import fails with ImportError under Python 3.12"))
+        self.assertTrue(_verdict_cites_concrete_code_bug(
+            "the helper imports cai_lib.foo which raises "
+            "ModuleNotFoundError at runtime"))
+
+    def test_wrong_field_name_matches(self):
+        self.assertTrue(_verdict_cites_concrete_code_bug(
+            "Minor issue: wrong field name `file_globs` — the dataclass "
+            "calls it `globs`."
+        ))
+
+    def test_incorrect_method_name_matches(self):
+        self.assertTrue(_verdict_cites_concrete_code_bug(
+            "incorrect method name — the call site uses `.set_label()` "
+            "but the class defines `.set_labels()`."
+        ))
+
+    def test_typo_matches(self):
+        self.assertTrue(_verdict_cites_concrete_code_bug(
+            "There is a typo in the variable name that will cause the "
+            "lookup to miss."
+        ))
+
+    def test_undefined_name_matches(self):
+        self.assertTrue(_verdict_cites_concrete_code_bug(
+            "Reference to undefined variable `ctx` in the new branch."
+        ))
+
+    def test_design_concern_does_not_match(self):
+        self.assertFalse(_verdict_cites_concrete_code_bug(
+            "The new helper duplicates logic already present in "
+            "cai_lib/foo.py; consider consolidating before merge."
+        ))
+
+    def test_scope_concern_does_not_match(self):
+        self.assertFalse(_verdict_cites_concrete_code_bug(
+            "PR scope is broader than the issue requested; extra file "
+            "edits under scripts/ are not mentioned in the remediation."
+        ))
+
+    def test_case_insensitive_phrase_matches(self):
+        self.assertTrue(_verdict_cites_concrete_code_bug(
+            "The call site uses a WRONG METHOD NAME — typo-like bug."
+        ))
+
+
+class TestApprovedToRevisionPendingTransition(unittest.TestCase):
+    """The new FSM transition must exist with the expected shape."""
+
+    def test_transition_registered(self):
+        names = {t.name for t in PR_TRANSITIONS}
+        self.assertIn("approved_to_revision_pending", names)
+
+    def test_transition_label_shape(self):
+        from cai_lib.fsm_states import PRState
+        from cai_lib.config import (
+            LABEL_PR_APPROVED, LABEL_PR_REVISION_PENDING,
+        )
+        t = next(
+            t for t in PR_TRANSITIONS
+            if t.name == "approved_to_revision_pending"
+        )
+        self.assertEqual(t.from_state, PRState.APPROVED)
+        self.assertEqual(t.to_state, PRState.REVISION_PENDING)
+        self.assertIn(LABEL_PR_APPROVED, t.labels_remove)
+        self.assertIn(LABEL_PR_REVISION_PENDING, t.labels_add)
+
+
+def _pr_fixture(number: int = 1234) -> dict:
+    return {
+        "number": number,
+        "title": "auto-improve: example",
+        "headRefName": f"auto-improve/{number}-example",
+        "headRefOid": "d7becb043dfd84c2796f35b7deb1353881435930",
+        "labels": [{"name": "pr:approved"}],
+        "state": "OPEN",
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "mergedAt": None,
+        "comments": [],
+        "reviews": [],
+        "createdAt": "2026-04-20T00:00:00Z",
+    }
+
+
+class TestHandleMergeLowHoldRouting(unittest.TestCase):
+    """handle_merge must pick the right transition for a held verdict."""
+
+    def _invoke(self, reasoning: str, confidence: str = "low",
+                action: str = "hold") -> tuple[MagicMock, MagicMock]:
+        pr = _pr_fixture()
+
+        # Mock gh + git subprocess calls used by filters + verdict post.
+        run_mock = MagicMock()
+        run_mock.return_value.returncode = 0
+        run_mock.return_value.stdout = ""
+        run_mock.return_value.stderr = ""
+
+        # Mock the model call: return a JSON verdict matching
+        # _MERGE_JSON_SCHEMA.
+        claude_mock = MagicMock()
+        claude_mock.return_value.returncode = 0
+        claude_mock.return_value.stdout = json.dumps({
+            "confidence": confidence,
+            "action": action,
+            "reasoning": reasoning,
+        })
+        claude_mock.return_value.stderr = ""
+
+        # Mock GitHub JSON: issue carries :pr-open so the pre-gate passes.
+        def gh_json_side_effect(args):
+            if "issue" in args and "view" in args:
+                return {
+                    "number": 1234,
+                    "title": "auto-improve: example",
+                    "labels": [{"name": "auto-improve:pr-open"}],
+                    "state": "OPEN",
+                    "body": "",
+                }
+            if "pr" in args and "view" in args:
+                return {"statusCheckRollup": []}
+            return {}
+
+        gh_json_mock = MagicMock(side_effect=gh_json_side_effect)
+        filter_mock = MagicMock(return_value=[])  # no unaddressed comments
+        fetch_review_mock = MagicMock(return_value=[])
+        has_label_mock = MagicMock(return_value=False)
+        set_labels_mock = MagicMock(return_value=True)
+        transition_mock = MagicMock(return_value=True)
+        log_mock = MagicMock()
+
+        with patch.object(merge_mod, "_run", run_mock), \
+             patch.object(merge_mod, "_run_claude_p", claude_mock), \
+             patch.object(merge_mod, "_gh_json", gh_json_mock), \
+             patch.object(merge_mod, "_filter_comments_with_haiku",
+                          filter_mock), \
+             patch.object(merge_mod, "_fetch_review_comments",
+                          fetch_review_mock), \
+             patch.object(merge_mod, "_issue_has_label", has_label_mock), \
+             patch.object(merge_mod, "_set_labels", set_labels_mock), \
+             patch.object(merge_mod, "apply_pr_transition",
+                          transition_mock), \
+             patch.object(merge_mod, "log_run", log_mock):
+            rc = merge_mod.handle_merge(pr)
+
+        self.assertEqual(rc, 0)
+        return transition_mock, run_mock
+
+    def test_low_hold_with_attribute_error_routes_to_revision(self):
+        reasoning = (
+            "runner.py:38 accesses entry.file_globs, but ModuleEntry "
+            "defines a `globs` field. Any invocation crashes with "
+            "AttributeError inside _build_module_message."
+        )
+        transition_mock, run_mock = self._invoke(reasoning)
+        transition_calls = [
+            c for c in transition_mock.call_args_list
+            if c.args and isinstance(c.args[1], str)
+        ]
+        # Exactly one FSM transition, pointing at REVISION_PENDING.
+        self.assertEqual(len(transition_calls), 1)
+        self.assertEqual(transition_calls[0].args[1],
+                         "approved_to_revision_pending")
+        # A follow-up comment with the new heading must be posted
+        # so cai-comment-filter does NOT silently resolve it.
+        comment_bodies = [
+            call.args[0][call.args[0].index("--body") + 1]
+            for call in run_mock.call_args_list
+            if call.args and call.args[0][:3] == ["gh", "pr", "comment"]
+        ]
+        self.assertTrue(any(
+            b.startswith("## cai merge: fixable code bug")
+            for b in comment_bodies
+        ), f"no fixable-bug comment posted; got: {comment_bodies!r}")
+
+    def test_low_hold_design_concern_still_parks_as_human(self):
+        reasoning = (
+            "PR scope is broader than the issue requested; extra file "
+            "edits under scripts/ are not mentioned in the remediation."
+        )
+        transition_mock, _run_mock = self._invoke(reasoning)
+        transition_calls = [
+            c for c in transition_mock.call_args_list
+            if c.args and isinstance(c.args[1], str)
+        ]
+        self.assertEqual(len(transition_calls), 1)
+        self.assertEqual(transition_calls[0].args[1], "approved_to_human")
+
+    def test_medium_hold_with_attribute_error_still_parks_as_human(self):
+        """The redirect is gated on confidence=='low' only — MEDIUM
+        holds continue to park at human-needed so the narrower fix is
+        conservative (issue #1055)."""
+        reasoning = (
+            "Possible AttributeError on the new helper's return path, "
+            "but unclear whether the branch is reachable."
+        )
+        transition_mock, _run_mock = self._invoke(
+            reasoning, confidence="medium"
+        )
+        transition_calls = [
+            c for c in transition_mock.call_args_list
+            if c.args and isinstance(c.args[1], str)
+        ]
+        self.assertEqual(len(transition_calls), 1)
+        self.assertEqual(transition_calls[0].args[1], "approved_to_human")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1055

**Issue:** #1055 — Rescue prevention: The merge agent produced a clear, actionable field-name mismatch finding but the FSM parked the PR as human-needed inste

## PR Summary

### What this fixes
When `cai-merge` emits a LOW-confidence `hold` verdict whose reasoning cites a concrete, mechanically-fixable code bug (AttributeError, NameError, wrong field/method name, typo, etc.), the FSM was parking the PR at `PR_HUMAN_NEEDED` — burning a rescue cycle for a trivially fixable finding. This PR routes such verdicts directly to `REVISION_PENDING` so `cai-revise` can address the bug on the next tick.

### What was changed
- **`cai_lib/fsm_transitions.py`**: Added `approved_to_revision_pending` transition (`APPROVED` → `REVISION_PENDING`) immediately after `approved_to_human`
- **`cai_lib/actions/merge.py`**: Added `_MERGE_FIXABLE_COMMENT_HEADING` constant, `_CONCRETE_CODE_BUG_PATTERNS` tuple, and `_verdict_cites_concrete_code_bug()` helper; branched the held-verdict `else:` path to post a fixable-bug comment and fire `approved_to_revision_pending` when `confidence=="low"` + `action=="hold"` + concrete-bug pattern matches (all other holds continue to use `approved_to_human`)
- **`tests/test_merge_low_to_revision.py`**: New test module covering the detection helper (12 cases), the new FSM transition shape, and the `handle_merge` routing branch (3 integration-style tests)

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
