### PR TITLE
fix(merge): divert APPROVED PRs with red CI into CI_FAILING

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -150,6 +150,7 @@
 | `tests/test_lint.py` | Lint check: ruff must report zero violations |
 | `tests/test_maintain.py` | Tests for cai_lib.actions.maintain — handle_maintain confidence routing and FSM transitions |
 | `tests/test_merge_agent_deletion_guard.py` | TODO: add description |
+| `tests/test_merge_ci_failing_divert.py` | TODO: add description |
 | `tests/test_merge_diff.py` | TODO: add description |
 | `tests/test_merge_requeue_exemption.py` | TODO: add description |
 | `tests/test_multistep.py` | Tests for multi-step plan support |

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -516,7 +516,13 @@ def handle_merge(pr: dict) -> int:
                 result="unaddressed_comments", exit=0)
         return 0
 
-    # Safety filter 5: failed CI checks.
+    # Safety filter 5: failed CI checks. Divert to CI_FAILING so
+    # handle_fix_ci picks the PR up on the next drive step. Returning
+    # 0 here without a state change would leave the PR stuck at
+    # APPROVED (the dispatcher sees no state change and no CI pending
+    # → "blocked, moving on") because no other code path transitions
+    # into CI_FAILING — handle_fix_ci only applies the transition
+    # from the pre-approved states.
     try:
         pr_detail = _gh_json([
             "pr", "view", str(pr_number),
@@ -529,8 +535,12 @@ def handle_merge(pr: dict) -> int:
             if conclusion == "FAILURE" or status == "FAILURE":
                 print(
                     f"[cai merge] PR #{pr_number}: has failed CI "
-                    f"checks; skipping",
+                    f"checks; diverting to CI_FAILING",
                     flush=True,
+                )
+                apply_pr_transition(
+                    pr_number, "approved_to_ci_failing",
+                    log_prefix="cai merge",
                 )
                 log_run("merge", repo=REPO, pr=pr_number,
                         result="ci_failing", exit=0)

--- a/tests/test_merge_ci_failing_divert.py
+++ b/tests/test_merge_ci_failing_divert.py
@@ -1,0 +1,80 @@
+"""Tests that handle_merge diverts APPROVED → CI_FAILING on red checks.
+
+Regression guard for the gap where the merge handler used to log "has
+failed CI checks; skipping" and return 0 with no state change, leaving
+the PR stuck at ``pr:approved`` (dispatcher then treated it as
+"blocked, moving on"). The handler must apply
+``approved_to_ci_failing`` so ``handle_fix_ci`` picks the PR up.
+"""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.actions import merge as merge_mod
+from cai_lib.fsm import PRState
+
+
+def _pr(number: int) -> dict:
+    return {
+        "number": number,
+        "title": "test",
+        "headRefOid": "b9866ebbbe1884a6fc8b0bcf41c426b20c70dc58",
+        "headRefName": f"auto-improve/{number}-something",
+        "labels": [{"name": "pr:approved"}],
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "comments": [],
+        "state": "OPEN",
+        "mergedAt": None,
+    }
+
+
+class TestHandleMergeDivertsOnFailedCI(unittest.TestCase):
+
+    def test_failed_check_triggers_approved_to_ci_failing(self):
+        pr = _pr(1057)
+        applied: list[tuple[int, str]] = []
+
+        def fake_apply(pr_number, transition_name, **kw):
+            applied.append((pr_number, transition_name))
+            return True
+
+        issue_payload = {
+            "labels": [{"name": "auto-improve:pr-open"}],
+            "state": "OPEN",
+        }
+        pr_detail_payload = {
+            "statusCheckRollup": [
+                {"name": "regenerate-docs", "conclusion": "FAILURE",
+                 "status": "COMPLETED"},
+            ],
+        }
+
+        def fake_gh_json(args):
+            if "issue" in args and "view" in args:
+                return issue_payload
+            if "pr" in args and "view" in args:
+                return pr_detail_payload
+            return {}
+
+        with patch.object(merge_mod, "_gh_json", side_effect=fake_gh_json), \
+             patch.object(merge_mod, "apply_pr_transition",
+                          side_effect=fake_apply), \
+             patch.object(merge_mod, "get_pr_state",
+                          return_value=PRState.APPROVED), \
+             patch.object(merge_mod, "_filter_comments_with_haiku",
+                          return_value=[]), \
+             patch.object(merge_mod, "_fetch_review_comments",
+                          return_value=[]), \
+             patch.object(merge_mod, "log_run"):
+            rc = merge_mod.handle_merge(pr)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(applied, [(1057, "approved_to_ci_failing")])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `handle_merge` at `cai_lib/actions/merge.py:519` used to log `has failed CI checks; skipping` and return 0 with no FSM transition, leaving the PR stuck at `pr:approved`.
- `handle_fix_ci` is only dispatched when the PR is already at `PRState.CI_FAILING`, and the `*_to_ci_failing` transitions live *inside* `handle_fix_ci` — so nothing was ever flipping APPROVED → CI_FAILING. Every drain tick the dispatcher would route the PR back to `handle_merge`, see the same skip, observe no state change, and log `blocked, moving on` (observed today on PR #1057).
- Now: when a FAILURE check is seen, apply `approved_to_ci_failing` and return 0. The dispatcher's next step lands on `handle_fix_ci`.

## Test plan

- [x] `python -m unittest tests.test_merge_ci_failing_divert` — new regression test verifies the transition is applied.
- [x] `python -m unittest tests.test_merge_diff tests.test_merge_requeue_exemption tests.test_merge_agent_deletion_guard tests.test_dispatcher` — 65 existing tests still pass.
- [ ] Watch an APPROVED PR with red CI in the next drain cycle — expect `[cai merge] PR #N: has failed CI checks; diverting to CI_FAILING` followed by `handle_fix_ci` picking it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)