### PR TITLE
auto-improve: Rescue prevention: When `cai-update-check` raises an issue that requires a Dockerfile or source-file edit (not a declarative gh-CLI operati

### DIFF
--- a/.claude/agents/ops/cai-update-check.md
+++ b/.claude/agents/ops/cai-update-check.md
@@ -60,6 +60,25 @@ The user message contains:
 5. Raise only **actionable, concrete** findings — not speculative ones.
 6. Write findings.json, then output the memory update block on stdout.
 
+## Kind classification is handled structurally — do not classify yourself
+
+Every finding you raise requires a source-controlled file edit (the
+`Dockerfile`, `.claude/settings.json`, `cai.py` / `cai_lib/*.py`,
+or an agent prompt under `.claude/agents/`). None of your findings
+are declarative gh-CLI operations expressible in a `cai-maintain`
+ops block (label add/remove, issue close, `workflow edit`).
+
+The `cai_lib.publish.create_issue` function therefore pre-applies
+the `kind:code` label to every `update-check` issue at creation
+time, and `cai-triage` treats that label as authoritative and
+overrides any contrary haiku-classifier verdict before applying
+FSM transitions (issue #991). You do **not** need to emit any
+kind marker in your remediation — the label is applied for you.
+
+This guarantee exists because a mis-labelled `kind:maintenance`
+finding would divert `cai-maintain` to `:human-needed` with
+"No Ops block found" (see the #980 divert class).
+
 ## Output format
 
 Write all findings to `<work_dir>/findings.json` (where `<work_dir>`
@@ -105,6 +124,9 @@ run knows what you covered:
 
 - Every finding must cite the release tag or file that is evidence.
 - Stick to the four categories above; do not invent new ones.
+- Every finding you raise requires a source-file edit (see
+  **Kind classification** above) — `kind:code` is pre-applied at
+  publish time; do not attempt to classify kind yourself.
 - Do not raise findings about missing tests, docstrings, or type annotations.
 - Do not suggest general code improvements outside of Claude Code version/config
   concerns.

--- a/cai_lib/actions/triage.py
+++ b/cai_lib/actions/triage.py
@@ -117,6 +117,37 @@ def _ops_body_has_valid_maintenance_op(ops_body: str | None) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Pre-applied kind label detection
+# ---------------------------------------------------------------------------
+
+
+def _prelabeled_kind(label_names: list[str]) -> str | None:
+    """Return ``"code"`` / ``"maintenance"`` / ``None`` based on any
+    ``kind:code`` or ``kind:maintenance`` already present on the issue.
+
+    Raising agents with a narrow remit (e.g. cai-update-check whose
+    findings are always source-file edits) pre-apply a ``kind:*``
+    label at issue creation time via ``cai_lib.publish.create_issue``.
+    The triage handler treats that pre-applied label as authoritative
+    and overrides the haiku classifier's own ``kind`` verdict —
+    preventing the #980-class divert where a source-edit finding
+    got classified ``kind:maintenance`` and routed to cai-maintain
+    (issue #991).
+
+    If both labels are somehow present, ``"code"`` wins — it is the
+    safer default because a mis-labelled ``code`` finding walks
+    through the normal implement pipeline (which handles both
+    edit-shaped and ops-shaped remediations), while a mis-labelled
+    ``maintenance`` finding diverts cai-maintain to ``:human-needed``.
+    """
+    if LABEL_KIND_CODE in label_names:
+        return "code"
+    if LABEL_KIND_MAINTENANCE in label_names:
+        return "maintenance"
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Handler
 # ---------------------------------------------------------------------------
 
@@ -240,6 +271,23 @@ def handle_triage(issue: dict) -> int:
     confidence = tool_input.get("routing_confidence", "")
     kind       = tool_input.get("kind", "code")
     reasoning  = tool_input.get("reasoning", "(no reasoning)")
+
+    # A pre-applied kind:code / kind:maintenance label on the issue
+    # at triage entry is authoritative and overrides the haiku
+    # classifier's own ``kind`` judgement. cai-update-check uses
+    # this mechanism (via cai_lib.publish.create_issue for the
+    # ``update-check`` namespace) to guarantee its source-file-edit
+    # findings are never flipped to ``kind:maintenance`` / cai-maintain
+    # (issue #991; prevents the #980 divert class).
+    prelabel_kind = _prelabeled_kind(issue_labels)
+    if prelabel_kind is not None and prelabel_kind != kind:
+        print(
+            f"[cai triage] #{issue_number}: overriding agent kind "
+            f"'{kind}' with pre-applied label kind '{prelabel_kind}' "
+            f"(found on issue labels at triage entry)",
+            flush=True,
+        )
+        kind = prelabel_kind
 
     print(
         f"[cai triage] verdict: decision={decision} confidence={confidence} "

--- a/cai_lib/publish.py
+++ b/cai_lib/publish.py
@@ -234,6 +234,13 @@ CODE_AUDIT_LABELS = [
 UPDATE_CHECK_LABELS = [
     ("auto-improve", "ededed", "Self-improvement finding raised by the analyzer"),
     ("auto-improve:raised", "0e8a16", "Awaiting structured refinement before implement subagent picks it up"),
+    # cai-update-check findings are 100% source-file edits
+    # (Dockerfile/settings.json/cai.py/agent-prompt) — never
+    # declarative gh-CLI ops expressible in a cai-maintain block.
+    # We attach kind:code at create_issue time so triage never
+    # mis-routes an update-check issue to kind:maintenance /
+    # cai-maintain (issue #991; prevents the #980 divert class).
+    ("kind:code", "0075ca", "Triage: issue requires a code change"),
 ]
 
 CHECK_WORKFLOWS_LABELS = [
@@ -596,6 +603,18 @@ def create_issue(
             "auto-improve",
             "auto-improve:raised",
             "check-workflows",
+        ])
+    elif namespace == "update-check":
+        # cai-update-check findings always require a source-file
+        # edit (Dockerfile bump, .claude/settings.json flag,
+        # cai.py/cai_lib invocation change, agent-prompt update).
+        # Pre-apply kind:code at creation time so cai-triage honors
+        # it as authoritative and never flips the issue to
+        # kind:maintenance / cai-maintain (issue #991).
+        labels = ",".join([
+            "auto-improve",
+            "auto-improve:raised",
+            "kind:code",
         ])
     else:
         labels = ",".join([

--- a/cai_lib/publish.py
+++ b/cai_lib/publish.py
@@ -545,7 +545,7 @@ def create_issue(
         source_file = ".claude/agents/cai-code-audit.md"
     elif namespace == "update-check":
         source_note = "cai update-check agent"
-        source_file = ".claude/agents/cai-update-check.md"
+        source_file = ".claude/agents/ops/cai-update-check.md"
     elif namespace == "check-workflows":
         source_note = "cai check-workflows agent"
         source_file = ".claude/agents/cai-check-workflows.md"

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -1057,5 +1057,87 @@ class TestTriagingHandlerOpsValidation(unittest.TestCase):
         self.assertNotIn(LABEL_KIND_CODE, labels_added)
 
 
+class TestTriagingPrelabeledKindOverride(unittest.TestCase):
+    """_prelabeled_kind() + handle_triage() override logic: a
+    kind:code / kind:maintenance label already present on the
+    issue at triage entry is authoritative and overrides the
+    haiku classifier's ``kind`` verdict (issue #991).
+    """
+
+    def test_prelabeled_kind_returns_code_when_kind_code_present(self):
+        from cai_lib.actions.triage import _prelabeled_kind
+        self.assertEqual(
+            _prelabeled_kind([LABEL_TRIAGING, LABEL_KIND_CODE]),
+            "code",
+        )
+
+    def test_prelabeled_kind_returns_maintenance_when_kind_maintenance_present(self):
+        from cai_lib.actions.triage import _prelabeled_kind
+        self.assertEqual(
+            _prelabeled_kind([LABEL_KIND_MAINTENANCE]),
+            "maintenance",
+        )
+
+    def test_prelabeled_kind_returns_none_when_absent(self):
+        from cai_lib.actions.triage import _prelabeled_kind
+        self.assertIsNone(_prelabeled_kind([LABEL_TRIAGING]))
+        self.assertIsNone(_prelabeled_kind([]))
+
+    def test_prelabel_overrides_agent_maintenance_verdict(self):
+        """A pre-applied kind:code label must force handle_triage to
+        re-route an APPLY+maintenance+HIGH verdict through REFINE as
+        kind:code (the pair_ok check fails once kind is overridden)."""
+        import json
+        import subprocess
+        from unittest import mock
+        import cai_lib.actions.triage as T
+
+        issue = {
+            "number": 991,
+            "title": "Bump claude-code version",
+            "body": "Release notes mention a relevant fix.",
+            "labels": [
+                {"name": LABEL_TRIAGING},
+                {"name": LABEL_KIND_CODE},
+            ],
+        }
+        verdict = {
+            "routing_decision": "APPLY",
+            "routing_confidence": "HIGH",
+            "kind": "maintenance",
+            "skip_confidence": "HIGH",
+            "reasoning": "looks ops-shaped to the classifier",
+            "ops": "1. label add 991 kind:maintenance\n2. close 991\n",
+        }
+        fake_result = subprocess.CompletedProcess(
+            args=["claude"], returncode=0,
+            stdout=json.dumps(verdict), stderr="",
+        )
+        transitions_called = []
+
+        def fake_apply_transition(issue_number, transition_name, **kwargs):
+            transitions_called.append(transition_name)
+            return True
+
+        labels_added = []
+
+        def fake_set_labels(issue_number, *, add=(), remove=(), log_prefix="cai"):
+            labels_added.extend(add)
+            return True
+
+        with mock.patch.object(T, "_run_claude_p", return_value=fake_result), \
+             mock.patch.object(T, "apply_transition", side_effect=fake_apply_transition), \
+             mock.patch.object(T, "_set_labels", side_effect=fake_set_labels), \
+             mock.patch.object(T, "check_duplicate_or_resolved", return_value=None), \
+             mock.patch.object(T, "log_run"):
+            rc = T.handle_triage(issue)
+
+        self.assertEqual(rc, 0)
+        self.assertIn("triaging_to_refining", transitions_called)
+        self.assertNotIn("triaging_to_applying", transitions_called)
+        self.assertIn(LABEL_KIND_CODE, labels_added)
+        self.assertNotIn(LABEL_KIND_MAINTENANCE, labels_added)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -42,6 +42,81 @@ class TestCheckWorkflowsLabels(unittest.TestCase):
         self.assertIn("check-workflows:raised", LABELS_TO_DELETE)
 
 
+class TestUpdateCheckKindCodePrelabel(unittest.TestCase):
+    """cai-update-check findings always require source-file edits,
+    so kind:code is pre-applied at create_issue time and guaranteed
+    to exist via UPDATE_CHECK_LABELS. Prevents the #980 divert
+    class where an update-check finding got mis-classified as
+    kind:maintenance and routed to cai-maintain (issue #991).
+    """
+
+    def test_kind_code_in_update_check_labels(self):
+        from cai_lib.publish import UPDATE_CHECK_LABELS
+        names = [name for name, _, _ in UPDATE_CHECK_LABELS]
+        self.assertIn("kind:code", names)
+
+    def test_create_issue_passes_kind_code_for_update_check(self):
+        from cai_lib import publish as pub
+        captured = {}
+
+        class FakeResult:
+            returncode = 0
+
+        def fake_run(argv, check=False, capture_output=False):
+            captured["argv"] = list(argv)
+            return FakeResult()
+
+        f = pub.Finding(
+            title="Bump CLAUDE_CODE_VERSION to 2.1.114",
+            category="version_update",
+            key="update-check-2.1.114",
+            confidence="high",
+            evidence="Release notes mention a relevant fix.",
+            remediation="Edit Dockerfile line 12.",
+        )
+        with mock.patch.object(pub.subprocess, "run", side_effect=fake_run):
+            rc = pub.create_issue(f, namespace="update-check")
+        self.assertEqual(rc, 0)
+        # Extract the --label argument value from the captured argv.
+        argv = captured["argv"]
+        idx = argv.index("--label")
+        label_arg = argv[idx + 1]
+        labels = label_arg.split(",")
+        self.assertIn("kind:code", labels)
+        self.assertIn("auto-improve", labels)
+        self.assertIn("auto-improve:raised", labels)
+
+    def test_create_issue_does_not_pass_kind_code_for_other_namespaces(self):
+        """Only update-check should pre-apply kind:code; other namespaces
+        still rely on cai-triage's haiku classifier to set kind."""
+        from cai_lib import publish as pub
+        captured = {}
+
+        class FakeResult:
+            returncode = 0
+
+        def fake_run(argv, check=False, capture_output=False):
+            captured["argv"] = list(argv)
+            return FakeResult()
+
+        f = pub.Finding(
+            title="Some finding",
+            category="reliability",
+            key="analyzer-1",
+            confidence="high",
+            evidence="ev",
+            remediation="rm",
+        )
+        with mock.patch.object(pub.subprocess, "run", side_effect=fake_run):
+            rc = pub.create_issue(f, namespace="auto-improve")
+        self.assertEqual(rc, 0)
+        argv = captured["argv"]
+        idx = argv.index("--label")
+        label_arg = argv[idx + 1]
+        labels = label_arg.split(",")
+        self.assertNotIn("kind:code", labels)
+
+
 class TestFindingBodyForDupCheck(unittest.TestCase):
 
     def test_body_contains_evidence_and_remediation(self):


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#991

**Issue:** #991 — Rescue prevention: When `cai-update-check` raises an issue that requires a Dockerfile or source-file edit (not a declarative gh-CLI operati

## PR Summary

### What this fixes
When `cai-update-check` raises an issue requiring a source-file edit (Dockerfile bump, settings.json change, agent prompt update), `cai-triage`'s haiku classifier could mis-classify it as `kind:maintenance` and route it to `cai-maintain`, which immediately diverts to `:human-needed` with "No Ops block found". This is the #980 divert class.

### What was changed
- **`cai_lib/publish.py`**: Added `("kind:code", "0075ca", …)` to `UPDATE_CHECK_LABELS` so `ensure_labels("update-check")` creates the label. Added `elif namespace == "update-check":` branch in `create_issue` that pre-applies `kind:code` at issue creation time.
- **`cai_lib/actions/triage.py`**: Added `_prelabeled_kind(label_names)` helper that detects a pre-applied `kind:code` or `kind:maintenance` label. Added an override block in `handle_triage` (after verdict parsing, before `pair_ok` derivation) that replaces the agent's `kind` with the authoritative pre-applied label and logs the override.
- **`.cai-staging/agents/ops/cai-update-check.md`**: Added "Kind classification is handled structurally" section explaining that `kind:code` is pre-applied at publish time and the agent should not attempt to classify kind itself.
- **`tests/test_publish.py`**: Added `TestUpdateCheckKindCodePrelabel` with 3 tests verifying `kind:code` is in `UPDATE_CHECK_LABELS` and that `create_issue(namespace="update-check")` passes it in the `--label` argument (and other namespaces do not).
- **`tests/test_fsm.py`**: Added `TestTriagingPrelabeledKindOverride` with 4 tests verifying `_prelabeled_kind` behavior and that a pre-applied `kind:code` label overrides an `APPLY+maintenance+HIGH` agent verdict, routing the issue to REFINE with `kind:code`.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
