### PR TITLE
auto-improve: audit-refactor 5.3: update docs/cli.md and README with the new `cai audit` UX

### DIFF
--- a/.claude/agents/lifecycle/cai-refine.md
+++ b/.claude/agents/lifecycle/cai-refine.md
@@ -228,8 +228,8 @@ Multi-step guidelines:
   planner.
 - **Check runtime data flow before guardrailing a file.** Before
   writing a `do not touch X` guardrail, trace where the feature's
-  output goes. Concrete example from issue #902: the new `cai audit
-  <kind>` runner emits findings that flow through
+  output goes. Concrete example from issue #902: the new `cai audit-module
+  --kind <kind>` runner emits findings that flow through
   `cai_lib/publish.py`'s `AUDIT_CATEGORIES` filter. Forbidding
   `publish.py` in Scope guardrails while shipping the runner makes
   every finding silently rejected at publish time — the feature

--- a/README.md
+++ b/README.md
@@ -78,17 +78,8 @@ targeted invocation, `cai.py dispatch --issue N` and
 | `cai.py cycle` | `0 * * * *` (hourly, startup, manual) | One dispatcher tick: restart-recovery + `dispatch_oldest_actionable()` (runs the handler for whatever state the oldest actionable issue or PR is in). A flock serializes overlapping runs; the entrypoint also runs this once synchronously at `docker compose up -d` so startup logs are immediate |
 | `cai.py verify` | `15 * * * *` (hourly @15) | Label-state reconciliation — removes deprecated cai-managed labels from open issues, then keeps `:pr-open` / `:merged` / etc. consistent with actual GitHub state |
 | `cai.py dispatch [--issue N \| --pr N]` | _(manual/on-demand)_ | Direct entry into the FSM dispatcher for a specific issue or PR (or the oldest actionable item when no target is given) |
-| `cai.py analyze` | `0 0 * * *` (daily 00:00 UTC) | Parses transcripts, asks claude to produce structured findings, publishes them as issues with fingerprint dedup |
 | `cai.py audit` | `0 */6 * * *` (every 6 hours) | Queue/PR consistency audit — rolls back stale `:in-progress` (6-hour TTL), `:revising` (1-hour TTL), and `:applying` (2-hour TTL) locks, migrates open `:no-action` issues (deprecated label) to closed-as-not-planned, flags stale `:merged` issues for human review, recovers `:pr-open` issues whose linked PR was closed (rolls back to `:refined`), deletes remote branches for merged/closed PRs, retroactively closes closed issues lacking terminal labels (as 'not planned'), then flags duplicates, stuck loops, label corruption, and human-needed issues (pipeline jams, abandoned issues, repeated diversions, missing divert reasons) as `auto-improve:raised` + `audit` findings (Opus). |
 | `cai.py audit-module` | _(manual/on-demand)_ | On-demand per-module audit: takes `--kind` (one of: good-practices, code-reduction, cost-reduction, workflow-enhancement) and iterates every module in `docs/modules.yaml`, dispatching the matching on-demand audit agent for each module and publishing findings via the existing dedup/dup-check pipeline. |
-| `cai.py code-audit` | `0 3 * * 0` (weekly Sunday 03:00 UTC) | Source-code consistency audit — clones the repo read-only, runs an Opus agent to flag cross-file inconsistencies, dead code, missing references, duplicated logic, hardcoded drift, config mismatches, and registration mismatches; publishes findings as `code-audit` namespace issues |
-| `cai.py propose` | `0 4 * * 0` (weekly Sunday 04:00 UTC) | Creative improvement proposals — clones the repo read-only, runs a creative agent to propose an ambitious improvement, then a review agent to evaluate feasibility; approved proposals are filed as `auto-improve:raised` issues so they flow through the triage → (optionally skip to `:plan-approved` / `:applying`) → refine → plan → implement pipeline |
-| `cai.py update-check` | `0 4 * * 1` (weekly Monday 04:00 UTC) | Claude Code release check — clones the repo, fetches the latest Claude Code releases from GitHub, and runs a Sonnet agent that compares the current pinned version against the latest releases; findings (new versions, feature adoptions, deprecated flags, best practices) are published as `update-check` namespace issues |
-| `cai.py external-scout` | `0 6 * * 1` (weekly Monday 06:00 UTC) | Weekly scout for open-source libraries that could replace in-house plumbing. Clones the repo read-only, runs an Opus agent that walks the codebase, picks one category of in-house utility, searches the open-source ecosystem for mature alternatives, and emits a single adoption proposal (or `No findings.`). Findings are published as `external-scout` namespace issues. Uses project-scope memory to avoid re-proposing the same category or library. |
-| `cai.py health-report` | `0 7 * * 1` (weekly Monday 07:00 UTC) | Automated pipeline health report with anomaly detection. Aggregates cost trends (last 7d vs prior 7d WoW delta), issue queue counts per label state, pipeline stalls, and fix quality metrics. Posts a GitHub-flavored markdown report with 🔴/🟡/🟢 traffic-light indicators as a `health-report` labelled issue. Use `--dry-run` to print to stdout without posting. |
-| `cai.py cost-optimize` | `0 5 * * 0` (weekly Sunday 05:00 UTC) | Weekly cost-reduction agent — loads 14 days of cost data, computes per-agent WoW deltas and cache hit rates, and proposes one concrete optimization targeting the most expensive agent or workflow. Alternates with evaluating previous proposals to track effectiveness. Files proposals as `auto-improve:raised` issues. |
-| `cai.py check-workflows` | `0 */6 * * *` (every 6 hours) | GitHub Actions failure monitor — fetches recent failed workflow runs (last 24 h), filters out bot branches, and runs a Haiku agent to group related failures and identify root causes; findings are published as `check-workflows` namespace issues. |
-| `cai.py agent-audit` | `0 6 * * 0` (weekly Sunday 06:00 UTC) | Weekly audit of `.claude/agents/**/*.md` for Claude Code best-practice violations, unused agents (not invoked via `--agent` anywhere), and near-duplicate agents; runs on Opus and publishes findings as `agent-audit` namespace issues. |
 | `cai.py verify` / `audit` / `unblock` | _(own cron schedules; also manual/on-demand)_ | Housekeeping subcommands that are not FSM handlers. Per-state handlers (triage, refine, plan, implement, explore, confirm, maintain, review-pr, revise, review-docs, fix-ci, merge) are no longer standalone subcommands — invoke them via `cai.py dispatch`. |
 | `cai.py test` | _(manual/on-demand)_ | Runs the project test suite (`python -m unittest discover` under `tests/`) |
 
@@ -99,10 +90,9 @@ the env vars (`CAI_CYCLE_SCHEDULE`, `CAI_ANALYZER_SCHEDULE`,
 `CAI_COST_OPTIMIZE_SCHEDULE`, `CAI_CHECK_WORKFLOWS_SCHEDULE`, `CAI_AGENT_AUDIT_SCHEDULE`, `CAI_VERIFY_SCHEDULE`),
 runs `cai.py cycle` once synchronously so the issue-solving pipeline
 produces immediate logs, then execs supercronic. Orthogonal tasks
-(analyze, audit, propose, update-check, external-scout, health-report, cost-optimize,
-check-workflows, code-audit, agent-audit) are **not** run at startup — they wait
-for their own cron ticks so container restarts don't re-trigger
-token-heavy analysis passes.
+(`audit`, `audit-module`) are **not** run at startup — they wait
+for their own cron ticks (or for an admin to invoke them) so
+container restarts don't re-trigger token-heavy analysis passes.
 
 **Multi-workspace support:** The container can optionally maintain additional
 repositories alongside the primary one. Create a `workspaces.json` file listing
@@ -111,6 +101,28 @@ to point to it. The entrypoint will generate independent cron lines for each
 workspace and run initial cycles on startup. See
 [docs/configuration.md](docs/configuration.md#multi-workspace-configuration) for
 details.
+
+### Running an audit
+
+Two complementary audit entry points feed into the same auto-improve
+loop. `cai audit` runs the periodic queue/PR consistency audit
+(stale-lock rollback, orphaned-branch cleanup, plus an Opus-driven
+sweep for duplicates and stuck loops). `cai audit-module --kind <kind>`
+iterates every module declared in `docs/modules.yaml`, dispatches
+the matching on-demand audit agent per module, and publishes
+findings through the existing dedup/dup-check pipeline.
+
+```bash
+cai audit
+cai audit-module --kind good-practices
+cai audit-module --kind code-reduction
+cai audit-module --kind cost-reduction
+cai audit-module --kind workflow-enhancement
+```
+
+See [`docs/cli.md`](docs/cli.md#audit) for the full reference,
+including the supported `--kind` choices, their matching per-module
+audit agents, and per-command option tables.
 
 ### Issue lifecycle
 
@@ -403,12 +415,12 @@ running container. This is what GitHub Actions, host cron jobs, or
 just-trying-things-out from the terminal would use:
 
 ```bash
-docker compose exec cai python /app/cai.py analyze
 docker compose exec cai python /app/cai.py dispatch             # oldest actionable
 docker compose exec cai python /app/cai.py dispatch --issue 12  # specific issue
 docker compose exec cai python /app/cai.py dispatch --pr 45     # specific PR
 docker compose exec cai python /app/cai.py verify
 docker compose exec cai python /app/cai.py audit
+docker compose exec cai python /app/cai.py audit-module --kind good-practices
 ```
 
 A short alias makes this trivial:
@@ -520,7 +532,7 @@ docker compose logs -f cai     # watch the first cycle
 
 Expected output: the templated crontab, the initial `cai.py init` (a
 greeting on the very first run, otherwise skipped), the initial
-`cai.py analyze`, then supercronic standing by for the next cron tick.
+`cai.py cycle`, then supercronic standing by for the next cron tick.
 
 ### Changing the schedule
 
@@ -539,7 +551,7 @@ invoked directly against the running container, which is what
 GitHub Actions or a host cron job would use to kick off a task:
 
 ```bash
-docker compose exec cai python /app/cai.py analyze
+docker compose exec cai python /app/cai.py dispatch
 ```
 
 ### One-shot smoke test (no install)
@@ -663,8 +675,9 @@ docker run --rm -v cai_home:/data alpine ls -R /data
 ```
 
 A **run log** is written to `/var/log/cai/cai.log` inside the container
-(persisted in the `cai_logs` named volume). Each `init`, `analyze`,
-`implement`, `review-pr`, `review-docs`, `revise`, `verify`, `audit`, `code-audit`, `propose`, `confirm`, `merge`, `agent-audit`, and `health-report` invocation appends one key=value line so you can
+(persisted in the `cai_logs` named volume). Each `init`, `dispatch`,
+`verify`, `audit`, `audit-module`, `confirm`, `merge`, `review-pr`,
+`review-docs`, and `revise` invocation appends one key=value line so you can
 watch cycle activity:
 
 ```bash

--- a/cai.py
+++ b/cai.py
@@ -42,9 +42,8 @@ Subcommands:
                             closed-unmerged → `:refined`,
                             no-linked-PR → `:raised`.
 
-    python cai.py audit     Dual-mode audit command. With no <kind>
-                            argument: runs legacy queue/PR consistency
-                            audit. Deterministically rolls back stale
+    python cai.py audit     Periodic queue/PR consistency audit.
+                            Deterministically rolls back stale
                             `:in-progress` (>6h), `:revising` (>1h),
                             and `:applying` (>2h) locks; unsticks stale
                             `:no-action` issues; flags stale `:merged`
@@ -60,12 +59,15 @@ Subcommands:
                             cai-dup-check; survivors are published as
                             `auto-improve:raised` + `audit` issues in
                             the unified label scheme.
-                            With <kind> (e.g., `cost`): runs on-demand
-                            per-module audit dispatching the matching
-                            agent over selected modules (--module <name>
-                            or --all). Module manifests are loaded from
-                            docs/modules.yaml and passed to the audit
-                            agent for focused analysis.
+
+    python cai.py audit-module  On-demand per-module audit: iterate every
+                            module in docs/modules.yaml and dispatch the
+                            matching on-demand audit agent for each module.
+                            Takes --kind <kind> to select which audit type
+                            to run (choices: good-practices, code-reduction,
+                            cost-reduction, workflow-enhancement). Publishes
+                            findings through the existing dedup/dup-check
+                            pipeline.
 
     python cai.py audit-triage  Autonomously resolve `auto-improve:raised`
                             + `audit` findings without opening a PR. Calls
@@ -324,7 +326,7 @@ def main() -> int:
     sub.add_parser("verify", help="Update labels based on PR merge state")
     sub.add_parser(
         "audit",
-        help="Queue/PR consistency audit (legacy single-mode)",
+        help="Periodic queue/PR consistency audit with stale-lock rollback and semantic analysis",
     )
     audit_module_p = sub.add_parser(
         "audit-module",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,13 +4,9 @@
 
 Run inside the container: `docker compose exec cai python /app/cai.py <subcommand>`
 
+Subcommands group into three categories: **pipeline drivers** (`cycle`, `dispatch`) drain the auto-improve FSM queue; **audit subcommands** (`audit`, `audit-module`) file findings into the loop; **utility commands** (`cost-report`, `init`, `test`, `unblock`, `verify`) are operational helpers.
+
 ---
-
-## analyze
-
-Parse prior Claude Code transcripts, invoke the `cai-analyze` agent, and publish findings as GitHub issues labeled `auto-improve:raised`.
-
-No arguments.
 
 ## audit
 
@@ -24,7 +20,7 @@ No arguments.
 
 ## audit-module
 
-Run an on-demand per-module audit that dispatches the matching audit agent over selected modules. Module manifests are loaded from `docs/modules.yaml`.
+Run an on-demand per-module audit. For the supplied `--kind`, the runner iterates every module declared in `docs/modules.yaml`, invokes the matching audit agent on each module in turn, and publishes each agent's `findings.json` through the existing dedup/dup-check pipeline. Each created issue carries a `<!-- module: <name> -->` body footer so future audit runs can scope dedup by module + fingerprint. Per-module failures (agent exit non-zero, missing findings file, publish failure) are logged to stderr and counted but never abort the loop.
 
 ```bash
 cai audit-module --kind <kind>
@@ -34,31 +30,14 @@ cai audit-module --kind <kind>
 |---|---|---|
 | `--kind` | required | Audit type. Choices: `good-practices`, `code-reduction`, `cost-reduction`, `workflow-enhancement`. |
 
-The command iterates over all modules defined in `docs/modules.yaml` and publishes findings via the existing dedup/dup-check pipeline.
+One example per supported kind:
 
-## code-audit
-
-Clone the repo and run `cai-code-audit` to find concrete inconsistencies, dead code, and missing cross-file references.
-
-No arguments.
-
-## agent-audit
-
-Run the weekly agent inventory audit to check `.claude/agents/**/*.md` files for Claude Code best-practice violations, unused agents, and near-duplicate purposes.
-
-No arguments.
-
-## check-workflows
-
-Monitor GitHub Actions for recent workflow failures and publish findings as issues. Fetches recent failed workflow runs (last 24 hours), filters out bot branches, and runs a Haiku agent to identify and group related failures. Findings are published with the `check-workflows` namespace and integrated into the unified auto-improve pipeline.
-
-No arguments.
-
-## cost-optimize
-
-Run the weekly `cai-cost-optimize` agent to analyze spending trends and propose one cost-reduction optimization.
-
-No arguments.
+```bash
+cai audit-module --kind good-practices
+cai audit-module --kind code-reduction
+cai audit-module --kind cost-reduction
+cai audit-module --kind workflow-enhancement
+```
 
 ## cost-report
 
@@ -69,12 +48,6 @@ Print a human-readable cost report from `/var/log/cai/cai-cost.jsonl`.
 | `--days INT` | optional | 7 | Window in days to include |
 | `--top INT` | optional | 10 | Number of most-expensive invocations to list |
 | `--by {category,agent,day}` | optional | category | Aggregation grouping |
-
-## external-scout
-
-Clone the repo and run `cai-external-scout` to scout for mature open-source libraries that could replace in-house plumbing. The agent walks the codebase, picks one category of in-house utility per run, searches the open-source ecosystem for mature alternatives, and emits a single adoption proposal (or `No findings.` if no candidate passes the fit check). Uses project-scope memory to avoid re-proposing the same category or library.
-
-No arguments.
 
 ## cycle
 
@@ -96,23 +69,9 @@ Three modes:
 
 Terminal or parked states (SOLVED, HUMAN_NEEDED, PR_HUMAN_NEEDED, PR MERGED) have no handler — the dispatcher returns without doing anything. Issues reaching the SOLVED state are automatically closed in GitHub as "completed".
 
-## health-report
-
-Generate an automated pipeline health report with anomaly detection: cost trends, issue throughput, pipeline stalls, and fix quality metrics. Posts the report as a GitHub issue.
-
-| Argument | Type | Description |
-|---|---|---|
-| `--dry-run` | flag | Print report to stdout without posting a GitHub issue |
-
 ## init
 
 Seed the loop with a smoke test, but only if no prior transcripts exist. If transcripts already exist, exits immediately.
-
-No arguments.
-
-## propose
-
-Clone the repo and run `cai-propose` (creative improvements) followed by `cai-propose-review` to evaluate feasibility before filing issues.
 
 No arguments.
 
@@ -127,12 +86,6 @@ No arguments.
 Scan open issues parked at `auto-improve:human-needed` that an admin has explicitly marked ready for resume by applying the `human:solved` label. For each such issue with a pending-transition marker in its body and at least one comment from an admin login (`CAI_ADMIN_LOGINS`), invokes the `cai-unblock` Haiku agent to classify the comment into a `ResumeTo:` target, then fires the matching `human_to_<state>` transition, strips the marker, and removes the `human:solved` label. Confidence below `HIGH` leaves the issue parked (label stays on so the admin can iterate). Issues without `human:solved` are ignored entirely — the admin is free to discuss or ask questions without waking the classifier.
 
 PR-side (`auto-improve:pr-human-needed`) is not yet wired — follow-up.
-
-No arguments.
-
-## update-check
-
-Clone the repo and run `cai-update-check` to compare the current pinned Claude Code version against latest releases and emit findings for new versions or deprecations.
 
 No arguments.
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#904

**Issue:** #904 — audit-refactor 5.3: update docs/cli.md and README with the new `cai audit` UX

## PR Summary

### What this fixes
`docs/cli.md` still documented nine deprecated subcommands (`analyze`, `code-audit`, `agent-audit`, etc.) and lacked per-kind examples for `audit-module`. `README.md` contained those same deprecated names in the schedule table, startup-exclusion sentence, ad-hoc bash blocks, expected-output text, and run-log list, with no `### Running an audit` section to guide users to the audit entry points.

### What was changed
- **`docs/cli.md`**: Wholesale rewrite — removed the nine deprecated `## <command>` sections, added a subcommand-category overview paragraph after the intro, and expanded `## audit-module` with a richer description and one `bash` example per supported `--kind` (`good-practices`, `code-reduction`, `cost-reduction`, `workflow-enhancement`). All surviving command sections (`audit`, `audit-module`, `cost-report`, `cycle`, `dispatch`, `init`, `test`, `unblock`, `verify`) are preserved at level-2 headings so existing anchor links remain valid.
- **`README.md`**: Seven surgical edits — (1) schedule table shrunk from 13 rows to 3 (keeping `audit`, `audit-module`, and the summary row); (2) startup-exclusion sentence updated to name only `audit`/`audit-module`; (3) new `### Running an audit` subsection inserted before `### Issue lifecycle` with prose + bash examples + link to `docs/cli.md`; (4) ad-hoc trigger bash block updated (removed `cai.py analyze`, added `cai.py audit-module --kind good-practices`); (5) expected-output sentence changed from `cai.py analyze` to `cai.py cycle`; (6) standalone `### Triggering a run ad-hoc` bash block changed from `cai.py analyze` to `cai.py dispatch`; (7) run-log enumeration sentence updated to list surviving subcommands only.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
