### PR TITLE
auto-improve: [#1014 Step 2/3] Replace hand-rolled `render_fsm_mermaid` with library-backed Mermaid rendering

### DIFF
--- a/cai_lib/fsm_transitions.py
+++ b/cai_lib/fsm_transitions.py
@@ -7,9 +7,12 @@ confidence parsing lives in :mod:`cai_lib.fsm_confidence`.
 """
 from __future__ import annotations
 
+import re
 import sys
 from dataclasses import dataclass, field
 from typing import Optional, Sequence
+
+from transitions.extensions import GraphMachine
 
 from cai_lib.config import (
     LABEL_RAISED, LABEL_REFINING, LABEL_REFINED, LABEL_PLANNING,
@@ -797,13 +800,81 @@ def resume_pr_transition_for(target_state_name: str) -> Optional[Transition]:
     return None
 
 
+class _SentinelModel:
+    """Empty model passed to :class:`GraphMachine` for diagram-only use.
+
+    ``transitions`` requires a model object to bind triggers to, but
+    ``render_fsm_mermaid`` never fires them — the machine exists solely
+    to emit a Mermaid source string. The sanitised condition names
+    (``ge_HIGH`` / ``ge_MEDIUM`` / ``ge_LOW`` / ``caller_gated``) are
+    display-only labels; they are never resolved at runtime because
+    nothing ever calls ``.trigger(...)`` on this model.
+    """
+    pass
+
+
+def _build_mermaid_machine(transitions_list: list[Transition]) -> GraphMachine:
+    """Construct a :class:`GraphMachine` for Mermaid rendering.
+
+    Condition labels are sanitised to valid Python identifiers
+    (``ge_HIGH`` / ``ge_MEDIUM`` / ``ge_LOW`` / ``caller_gated``) so
+    ``transitions`` accepts them as ``conditions``; :func:`render_fsm_mermaid`
+    restores the display form (``≥HIGH`` / ``caller-gated``) via regex
+    after rendering. No runtime FSM semantics are wired — the machine
+    is a diagram-only construct.
+    """
+    states: list[str] = []
+    for t in transitions_list:
+        for name in (t.from_state.name, t.to_state.name):
+            if name not in states:
+                states.append(name)
+    trans_defs = [
+        {
+            "trigger": t.name,
+            "source": t.from_state.name,
+            "dest":   t.to_state.name,
+            "conditions": (
+                f"ge_{t.min_confidence.name}"
+                if t.min_confidence is not None
+                else "caller_gated"
+            ),
+        }
+        for t in transitions_list
+    ]
+    return GraphMachine(
+        model=_SentinelModel(),
+        states=states,
+        initial=states[0],
+        transitions=trans_defs,
+        graph_engine="mermaid",
+        show_conditions=True,
+        show_auto_transitions=False,
+    )
+
+
 def render_fsm_mermaid(transitions: list[Transition], title: str = "FSM") -> str:
-    """Render *transitions* as a Mermaid stateDiagram-v2 block."""
-    lines = ["stateDiagram-v2"]
-    for t in transitions:
-        from_name = t.from_state.name if hasattr(t.from_state, "name") else str(t.from_state)
-        to_name   = t.to_state.name   if hasattr(t.to_state,   "name") else str(t.to_state)
-        gate = f"≥{t.min_confidence.name}" if t.min_confidence is not None else "caller-gated"
-        label = f"{t.name} [{gate}]"
-        lines.append(f"    {from_name} --> {to_name} : {label}")
-    return "\n".join(lines)
+    """Render *transitions* as a Mermaid stateDiagram-v2 block.
+
+    Backed by :class:`transitions.extensions.GraphMachine` (the
+    ``pytransitions/transitions`` library). The raw
+    ``get_combined_graph().source`` string is post-processed to:
+
+    * strip the library's ``---\\nState Machine\\n---`` YAML front
+      matter (the wrapper page in ``docs/fsm.md`` supplies its own
+      title);
+    * restore the display form of the confidence-gate labels
+      (``[ge_HIGH]`` → ``[≥HIGH]``, ``[caller_gated]`` → ``[caller-gated]``)
+      that had to be sanitised to valid Python identifiers for the
+      machine's ``conditions`` field.
+
+    The ``title`` parameter is retained for backward compatibility
+    with the pre-library signature but is not interpolated — the
+    library's default header is stripped and the caller supplies its
+    own heading in the surrounding Markdown page.
+    """
+    machine = _build_mermaid_machine(transitions)
+    source = machine.get_combined_graph().source
+    source = re.sub(r"^---.*?---\n", "", source, flags=re.DOTALL)
+    source = re.sub(r"\[ge_(\w+)\]", lambda m: f"[≥{m.group(1)}]", source)
+    source = source.replace("[caller_gated]", "[caller-gated]")
+    return source.strip()

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -14,71 +14,133 @@ nav_order: 5
 
 ```mermaid
 stateDiagram-v2
-    RAISED --> REFINING : raise_to_refining [≥HIGH]
-    RAISED --> HUMAN_NEEDED : raise_to_human [≥HIGH]
-    RAISED --> TRIAGING : raise_to_triaging [≥HIGH]
-    TRIAGING --> REFINING : triaging_to_refining [≥HIGH]
-    TRIAGING --> HUMAN_NEEDED : triaging_to_human [≥HIGH]
-    TRIAGING --> PLAN_APPROVED : triaging_to_plan_approved [caller-gated]
-    TRIAGING --> APPLYING : triaging_to_applying [caller-gated]
-    APPLYING --> APPLIED : applying_to_applied [≥HIGH]
-    APPLYING --> APPLIED : applying_to_applied_inferred_ops [≥MEDIUM]
-    APPLYING --> HUMAN_NEEDED : applying_to_human [≥HIGH]
-    APPLIED --> SOLVED : applied_to_solved [≥HIGH]
-    REFINING --> REFINED : refining_to_refined [≥HIGH]
-    REFINING --> NEEDS_EXPLORATION : refining_to_exploration [≥HIGH]
-    REFINING --> HUMAN_NEEDED : refining_to_human [≥HIGH]
-    NEEDS_EXPLORATION --> REFINING : exploration_to_refining [≥HIGH]
-    REFINED --> PLANNING : refined_to_planning [≥HIGH]
-    PLANNING --> PLANNED : planning_to_planned [≥HIGH]
-    PLANNING --> HUMAN_NEEDED : planning_to_human [≥HIGH]
-    PLANNED --> PLAN_APPROVED : planned_to_plan_approved [≥HIGH]
-    PLANNED --> PLAN_APPROVED : planned_to_plan_approved_mitigated [≥MEDIUM]
-    PLANNED --> PLAN_APPROVED : planned_to_plan_approved_docs_only [≥MEDIUM]
-    PLANNED --> PLAN_APPROVED : planned_to_plan_approved_approvable [≥MEDIUM]
-    PLANNED --> HUMAN_NEEDED : planned_to_human [≥HIGH]
-    PLAN_APPROVED --> IN_PROGRESS : approved_to_in_progress [≥HIGH]
-    IN_PROGRESS --> PR : in_progress_to_pr [≥HIGH]
-    IN_PROGRESS --> REFINING : in_progress_to_refining [caller-gated]
-    PR --> MERGED : pr_to_merged [≥HIGH]
-    PR --> REFINED : pr_to_refined [≥HIGH]
-    PR --> HUMAN_NEEDED : pr_to_human_needed [≥HIGH]
-    MERGED --> SOLVED : merged_to_solved [≥HIGH]
-    HUMAN_NEEDED --> RAISED : human_to_raised [≥HIGH]
-    HUMAN_NEEDED --> REFINING : human_to_refining [≥HIGH]
-    HUMAN_NEEDED --> PLAN_APPROVED : human_to_plan_approved [≥HIGH]
-    HUMAN_NEEDED --> NEEDS_EXPLORATION : human_to_exploration [≥HIGH]
-    HUMAN_NEEDED --> SOLVED : human_to_solved [≥HIGH]
+  direction LR
+  classDef s_default fill:white,color:black
+  classDef s_inactive fill:white,color:black
+  classDef s_parallel color:black,fill:white
+  classDef s_active color:red,fill:darksalmon
+  classDef s_previous color:blue,fill:azure
+  
+  state "RAISED" as RAISED
+  Class RAISED s_active
+  state "REFINING" as REFINING
+  Class REFINING s_default
+  state "HUMAN_NEEDED" as HUMAN_NEEDED
+  Class HUMAN_NEEDED s_default
+  state "TRIAGING" as TRIAGING
+  Class TRIAGING s_default
+  state "PLAN_APPROVED" as PLAN_APPROVED
+  Class PLAN_APPROVED s_default
+  state "APPLYING" as APPLYING
+  Class APPLYING s_default
+  state "APPLIED" as APPLIED
+  Class APPLIED s_default
+  state "SOLVED" as SOLVED
+  Class SOLVED s_default
+  state "REFINED" as REFINED
+  Class REFINED s_default
+  state "NEEDS_EXPLORATION" as NEEDS_EXPLORATION
+  Class NEEDS_EXPLORATION s_default
+  state "PLANNING" as PLANNING
+  Class PLANNING s_default
+  state "PLANNED" as PLANNED
+  Class PLANNED s_default
+  state "IN_PROGRESS" as IN_PROGRESS
+  Class IN_PROGRESS s_default
+  state "PR" as PR
+  Class PR s_default
+  state "MERGED" as MERGED
+  Class MERGED s_default
+  
+  RAISED --> REFINING: raise_to_refining [≥HIGH]
+  RAISED --> HUMAN_NEEDED: raise_to_human [≥HIGH]
+  RAISED --> TRIAGING: raise_to_triaging [≥HIGH]
+  TRIAGING --> REFINING: triaging_to_refining [≥HIGH]
+  TRIAGING --> HUMAN_NEEDED: triaging_to_human [≥HIGH]
+  TRIAGING --> PLAN_APPROVED: triaging_to_plan_approved [caller-gated]
+  TRIAGING --> APPLYING: triaging_to_applying [caller-gated]
+  APPLYING --> APPLIED: applying_to_applied [≥HIGH] | applying_to_applied_inferred_ops [≥MEDIUM]
+  APPLYING --> HUMAN_NEEDED: applying_to_human [≥HIGH]
+  APPLIED --> SOLVED: applied_to_solved [≥HIGH]
+  REFINING --> REFINED: refining_to_refined [≥HIGH]
+  REFINING --> NEEDS_EXPLORATION: refining_to_exploration [≥HIGH]
+  REFINING --> HUMAN_NEEDED: refining_to_human [≥HIGH]
+  NEEDS_EXPLORATION --> REFINING: exploration_to_refining [≥HIGH]
+  REFINED --> PLANNING: refined_to_planning [≥HIGH]
+  PLANNING --> PLANNED: planning_to_planned [≥HIGH]
+  PLANNING --> HUMAN_NEEDED: planning_to_human [≥HIGH]
+  PLANNED --> PLAN_APPROVED: planned_to_plan_approved [≥HIGH] | planned_to_plan_approved_mitigated [≥MEDIUM] | planned_to_plan_approved_docs_only [≥MEDIUM] | planned_to_plan_approved_approvable [≥MEDIUM]
+  PLANNED --> HUMAN_NEEDED: planned_to_human [≥HIGH]
+  PLAN_APPROVED --> IN_PROGRESS: approved_to_in_progress [≥HIGH]
+  IN_PROGRESS --> PR: in_progress_to_pr [≥HIGH]
+  IN_PROGRESS --> REFINING: in_progress_to_refining [caller-gated]
+  PR --> MERGED: pr_to_merged [≥HIGH]
+  PR --> REFINED: pr_to_refined [≥HIGH]
+  PR --> HUMAN_NEEDED: pr_to_human_needed [≥HIGH]
+  MERGED --> SOLVED: merged_to_solved [≥HIGH]
+  HUMAN_NEEDED --> RAISED: human_to_raised [≥HIGH]
+  HUMAN_NEEDED --> REFINING: human_to_refining [≥HIGH]
+  HUMAN_NEEDED --> PLAN_APPROVED: human_to_plan_approved [≥HIGH]
+  HUMAN_NEEDED --> NEEDS_EXPLORATION: human_to_exploration [≥HIGH]
+  HUMAN_NEEDED --> SOLVED: human_to_solved [≥HIGH]
+  [*] --> RAISED
 ```
 
 ## PR state machine
 
 ```mermaid
 stateDiagram-v2
-    OPEN --> REVIEWING_CODE : open_to_reviewing_code [≥HIGH]
-    REVIEWING_CODE --> REVISION_PENDING : reviewing_code_to_revision_pending [≥HIGH]
-    REVIEWING_CODE --> REVIEWING_DOCS : reviewing_code_to_reviewing_docs [≥HIGH]
-    REVISION_PENDING --> REVIEWING_CODE : revision_pending_to_reviewing_code [≥HIGH]
-    REVIEWING_DOCS --> REVIEWING_CODE : reviewing_docs_to_reviewing_code [≥HIGH]
-    REVIEWING_DOCS --> APPROVED : reviewing_docs_to_approved [≥HIGH]
-    APPROVED --> MERGED : approved_to_merged [≥HIGH]
-    APPROVED --> REVIEWING_CODE : approved_to_reviewing_code [≥HIGH]
-    REVIEWING_CODE --> CI_FAILING : reviewing_code_to_ci_failing [≥HIGH]
-    REVISION_PENDING --> CI_FAILING : revision_pending_to_ci_failing [≥HIGH]
-    REVIEWING_DOCS --> CI_FAILING : reviewing_docs_to_ci_failing [≥HIGH]
-    APPROVED --> CI_FAILING : approved_to_ci_failing [≥HIGH]
-    CI_FAILING --> REVIEWING_CODE : ci_failing_to_reviewing_code [≥HIGH]
-    REVIEWING_CODE --> REBASING : reviewing_code_to_rebasing [≥HIGH]
-    REVISION_PENDING --> REBASING : revision_pending_to_rebasing [≥HIGH]
-    REVIEWING_DOCS --> REBASING : reviewing_docs_to_rebasing [≥HIGH]
-    APPROVED --> REBASING : approved_to_rebasing [≥HIGH]
-    CI_FAILING --> REBASING : ci_failing_to_rebasing [≥HIGH]
-    REBASING --> REVIEWING_CODE : rebasing_to_reviewing_code [≥HIGH]
-    REVIEWING_CODE --> PR_HUMAN_NEEDED : reviewing_code_to_human [≥HIGH]
-    APPROVED --> PR_HUMAN_NEEDED : approved_to_human [≥HIGH]
-    APPROVED --> REVISION_PENDING : approved_to_revision_pending [≥HIGH]
-    PR_HUMAN_NEEDED --> REVIEWING_CODE : pr_human_to_reviewing_code [≥HIGH]
-    PR_HUMAN_NEEDED --> REVISION_PENDING : pr_human_to_revision_pending [≥HIGH]
-    PR_HUMAN_NEEDED --> REVIEWING_DOCS : pr_human_to_reviewing_docs [≥HIGH]
-    PR_HUMAN_NEEDED --> APPROVED : pr_human_to_approved [≥HIGH]
+  direction LR
+  classDef s_default fill:white,color:black
+  classDef s_inactive fill:white,color:black
+  classDef s_parallel color:black,fill:white
+  classDef s_active color:red,fill:darksalmon
+  classDef s_previous color:blue,fill:azure
+  
+  state "OPEN" as OPEN
+  Class OPEN s_active
+  state "REVIEWING_CODE" as REVIEWING_CODE
+  Class REVIEWING_CODE s_default
+  state "REVISION_PENDING" as REVISION_PENDING
+  Class REVISION_PENDING s_default
+  state "REVIEWING_DOCS" as REVIEWING_DOCS
+  Class REVIEWING_DOCS s_default
+  state "APPROVED" as APPROVED
+  Class APPROVED s_default
+  state "MERGED" as MERGED
+  Class MERGED s_default
+  state "CI_FAILING" as CI_FAILING
+  Class CI_FAILING s_default
+  state "REBASING" as REBASING
+  Class REBASING s_default
+  state "PR_HUMAN_NEEDED" as PR_HUMAN_NEEDED
+  Class PR_HUMAN_NEEDED s_default
+  
+  OPEN --> REVIEWING_CODE: open_to_reviewing_code [≥HIGH]
+  REVIEWING_CODE --> REVISION_PENDING: reviewing_code_to_revision_pending [≥HIGH]
+  REVIEWING_CODE --> REVIEWING_DOCS: reviewing_code_to_reviewing_docs [≥HIGH]
+  REVIEWING_CODE --> CI_FAILING: reviewing_code_to_ci_failing [≥HIGH]
+  REVIEWING_CODE --> REBASING: reviewing_code_to_rebasing [≥HIGH]
+  REVIEWING_CODE --> PR_HUMAN_NEEDED: reviewing_code_to_human [≥HIGH]
+  REVISION_PENDING --> REVIEWING_CODE: revision_pending_to_reviewing_code [≥HIGH]
+  REVISION_PENDING --> CI_FAILING: revision_pending_to_ci_failing [≥HIGH]
+  REVISION_PENDING --> REBASING: revision_pending_to_rebasing [≥HIGH]
+  REVIEWING_DOCS --> REVIEWING_CODE: reviewing_docs_to_reviewing_code [≥HIGH]
+  REVIEWING_DOCS --> APPROVED: reviewing_docs_to_approved [≥HIGH]
+  REVIEWING_DOCS --> CI_FAILING: reviewing_docs_to_ci_failing [≥HIGH]
+  REVIEWING_DOCS --> REBASING: reviewing_docs_to_rebasing [≥HIGH]
+  APPROVED --> MERGED: approved_to_merged [≥HIGH]
+  APPROVED --> REVIEWING_CODE: approved_to_reviewing_code [≥HIGH]
+  APPROVED --> CI_FAILING: approved_to_ci_failing [≥HIGH]
+  APPROVED --> REBASING: approved_to_rebasing [≥HIGH]
+  APPROVED --> PR_HUMAN_NEEDED: approved_to_human [≥HIGH]
+  APPROVED --> REVISION_PENDING: approved_to_revision_pending [≥HIGH]
+  CI_FAILING --> REVIEWING_CODE: ci_failing_to_reviewing_code [≥HIGH]
+  CI_FAILING --> REBASING: ci_failing_to_rebasing [≥HIGH]
+  REBASING --> REVIEWING_CODE: rebasing_to_reviewing_code [≥HIGH]
+  PR_HUMAN_NEEDED --> REVIEWING_CODE: pr_human_to_reviewing_code [≥HIGH]
+  PR_HUMAN_NEEDED --> REVISION_PENDING: pr_human_to_revision_pending [≥HIGH]
+  PR_HUMAN_NEEDED --> REVIEWING_DOCS: pr_human_to_reviewing_docs [≥HIGH]
+  PR_HUMAN_NEEDED --> APPROVED: pr_human_to_approved [≥HIGH]
+  [*] --> OPEN
 ```

--- a/docs/modules/fsm.md
+++ b/docs/modules/fsm.md
@@ -20,7 +20,10 @@ import from `cai_lib.fsm` rather than the split modules directly.
   `apply_transition`, `apply_transition_with_confidence`,
   `resume_transition_for`, `apply_pr_transition`,
   `apply_pr_transition_with_confidence`, `resume_pr_transition_for`,
-  `render_fsm_mermaid`.
+  `render_fsm_mermaid` (library-backed via
+  `transitions.extensions.GraphMachine`; the Mermaid source is
+  post-processed to strip the library's YAML front matter and restore
+  the `≥HIGH` / `caller-gated` display labels).
 - [`cai_lib/fsm_confidence.py`](../../cai_lib/fsm_confidence.py) —
   `Confidence` enum (HIGH, MEDIUM, LOW, STOP);
   `parse_confidence`, `parse_confidence_reason`,


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1043

**Issue:** #1043 — [#1014 Step 2/3] Replace hand-rolled `render_fsm_mermaid` with library-backed Mermaid rendering

## PR Summary

### What this fixes
`render_fsm_mermaid` in `cai_lib/fsm_transitions.py` contained a 10-line hand-rolled Mermaid renderer that iterated `Transition` objects manually. The `transitions` library (already a declared dependency at ≥0.9.3) provides built-in Mermaid diagram generation via `GraphMachine(graph_engine='mermaid')` which should be used instead.

### What was changed
- **`cai_lib/fsm_transitions.py`**: Added `import re` and `from transitions.extensions import GraphMachine`; added `_SentinelModel` empty class (required model object for GraphMachine) and `_build_mermaid_machine()` helper (builds GraphMachine with sanitised condition names `ge_HIGH`/`caller_gated`); replaced the 10-line hand-rolled `render_fsm_mermaid` body with a library-backed implementation that calls `_build_mermaid_machine`, strips the library's YAML front matter via `re.sub`, and restores display labels (`[ge_HIGH]` → `[≥HIGH]`, `[caller_gated]` → `[caller-gated]`). Public signature preserved.
- **`docs/modules/fsm.md`**: Updated the `render_fsm_mermaid` description to note it is now library-backed via `transitions.extensions.GraphMachine` with post-processing.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
