### PR TITLE
auto-improve: Rescue prevention: The merge agent's `.github/workflows/` hard-block is working as intended, but the pipeline has no way to route "workflow

### DIFF
--- a/.github/workflows/admin-only-label.yml
+++ b/.github/workflows/admin-only-label.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   enforce:
     if: >-
-      contains(fromJSON('["auto-improve:raised","auto-improve:in-progress","auto-improve:pr-open","auto-improve:merged","auto-improve:solved","auto-improve:needs-exploration","auto-improve:refined","auto-improve:revising","auto-improve:parent","merge-blocked","auto-improve:planned","auto-improve:plan-approved","auto-improve:refining","auto-improve:planning","auto-improve:applying","auto-improve:applied","auto-improve:human-needed","auto-improve:pr-human-needed","human:solved","auto-improve:triaging","kind:code","kind:maintenance","pr:reviewing-code","pr:revision-pending","pr:reviewing-docs","pr:approved","pr:rebasing","pr:ci-failing","needs-human-review"]'), github.event.label.name)
+      contains(fromJSON('["auto-improve:raised","auto-improve:in-progress","auto-improve:pr-open","auto-improve:merged","auto-improve:solved","auto-improve:needs-exploration","auto-improve:refined","auto-improve:revising","auto-improve:parent","merge-blocked","auto-improve:planned","auto-improve:plan-approved","auto-improve:refining","auto-improve:planning","auto-improve:applying","auto-improve:applied","auto-improve:human-needed","auto-improve:pr-human-needed","human:solved","auto-improve:triaging","kind:code","kind:maintenance","pr:reviewing-code","pr:revision-pending","pr:reviewing-docs","pr:approved","pr:rebasing","pr:ci-failing","needs-human-review","needs-workflow-review"]'), github.event.label.name)
     runs-on: ubuntu-latest
     steps:
       - name: Check sender's permission

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -158,6 +158,7 @@
 | `tests/test_merge_non_bot_branch.py` | TODO: add description |
 | `tests/test_merge_pipeline_coedits.py` | TODO: add description |
 | `tests/test_merge_requeue_exemption.py` | TODO: add description |
+| `tests/test_merge_workflow_review_label.py` | TODO: add description |
 | `tests/test_multistep.py` | Tests for multi-step plan support |
 | `tests/test_orphaned_prs.py` | TODO: add description |
 | `tests/test_parse.py` | Tests for parse.py signal extraction |

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -33,6 +33,7 @@ from cai_lib.config import (
     LABEL_REVISING,
     LABEL_PLAN_APPROVED,
     LABEL_PR_NEEDS_HUMAN,
+    LABEL_PR_NEEDS_WORKFLOW_REVIEW,
 )
 from cai_lib.fsm import apply_pr_transition, get_pr_state, PRState
 from cai_lib.github import _gh_json, _set_labels, _issue_has_label, close_issue_not_planned
@@ -570,6 +571,50 @@ def _assemble_diff(raw_diff: str, max_len: int) -> str:
         assembled += f"\n... ({len(omitted)} file(s) omitted: {', '.join(omitted)})"
 
     return assembled
+
+
+# ---------------------------------------------------------------------------
+# Workflow-file review routing (issue #1064).
+#
+# The ``cai-merge`` agent's "never high" rule disqualifies PRs that
+# touch ``.github/workflows/`` from a high verdict; ``medium + hold``
+# is the best possible outcome, which then parks at
+# ``pr:human-needed`` alongside any other medium-held PR. Admins have
+# no cheap way to distinguish "this PR needs someone with
+# workflow-review authority" from the generic human-needed queue
+# (observed on PR #1057: a CI-fix commit touched
+# ``.github/workflows/regenerate-docs.yml`` and the merge agent
+# correctly held at medium, but the admin had to dig through the
+# verdict comment to understand why).
+#
+# We detect ``.github/workflows/**`` file changes **structurally, in
+# Python**, on the untruncated ``gh pr diff`` output and add a
+# PR-level ``needs-workflow-review`` label whenever a ``medium + hold``
+# verdict lands on a workflow-touching PR. The label supplements (does
+# not replace) ``pr:human-needed`` — the FSM park behaviour via
+# ``approved_to_human`` is unchanged. Gating on ``medium`` specifically
+# avoids labelling ``low + hold`` verdicts, which are caused by actual
+# bugs (the fixable-bug path above already routes those cases).
+# ---------------------------------------------------------------------------
+_WORKFLOW_DIFF_HEADER_RE = re.compile(
+    r"^diff --git a/(\.github/workflows/\S+)",
+    re.MULTILINE,
+)
+
+
+def _pr_touches_workflow_files(raw_diff: str) -> bool:
+    """Return ``True`` when *raw_diff* modifies any
+    ``.github/workflows/`` file.
+
+    Matches ``diff --git a/.github/workflows/<name>`` headers at the
+    start of any diff chunk. Returns ``False`` for empty / ``None``
+    input or diffs that touch only other paths. Paired with
+    :func:`handle_merge`'s held-else branch to decide whether to apply
+    the ``needs-workflow-review`` PR label.
+    """
+    if not raw_diff:
+        return False
+    return bool(_WORKFLOW_DIFF_HEADER_RE.search(raw_diff))
 
 
 def handle_merge(pr: dict) -> int:
@@ -1200,10 +1245,43 @@ def handle_merge(pr: dict) -> int:
                     f"label to #{issue_number} for held PR #{pr_number}",
                     file=sys.stderr, flush=True,
                 )
+        # Issue #1064: when a `medium + hold` verdict lands on a PR
+        # whose diff touches any `.github/workflows/` file, add the
+        # PR-level `needs-workflow-review` label so admins can filter
+        # workflow-review-required holds out of the generic
+        # `pr:human-needed` queue. Purely informational — the FSM park
+        # via `approved_to_human` below is unchanged.
+        held_result_tag = "held"
+        if (
+            action == "hold"
+            and confidence == "medium"
+            and _pr_touches_workflow_files(diff_result.stdout)
+        ):
+            label_add = _run(
+                ["gh", "pr", "edit", str(pr_number),
+                 "--repo", REPO,
+                 "--add-label", LABEL_PR_NEEDS_WORKFLOW_REVIEW],
+                capture_output=True,
+            )
+            if label_add.returncode != 0:
+                print(
+                    f"[cai merge] PR #{pr_number}: could not add "
+                    f"`{LABEL_PR_NEEDS_WORKFLOW_REVIEW}` label:\n"
+                    f"{label_add.stderr}",
+                    file=sys.stderr, flush=True,
+                )
+            else:
+                print(
+                    f"[cai merge] PR #{pr_number}: added "
+                    f"`{LABEL_PR_NEEDS_WORKFLOW_REVIEW}` (medium+hold "
+                    f"on workflow-touching PR)",
+                    flush=True,
+                )
+                held_result_tag = "held_workflow_review"
         apply_pr_transition(
             pr_number, "approved_to_human",
             log_prefix="cai merge",
         )
         log_run("merge", repo=REPO, pr=pr_number,
-                duration=dur(), result="held", exit=0)
+                duration=dur(), result=held_result_tag, exit=0)
         return 0

--- a/cai_lib/cmd_misc.py
+++ b/cai_lib/cmd_misc.py
@@ -55,6 +55,7 @@ _MANAGED_ISSUE_PREFIXES: tuple[str, ...] = (
     "kind",           # matches kind:code, kind:maintenance
     "pr",             # pr:* labels are PR-only; stale if found on an issue
     "needs-human-review",
+    "needs-workflow-review",  # PR-only; stale if found on an issue
 )
 
 

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -191,6 +191,16 @@ LABEL_PR_CI_FAILING       = "pr:ci-failing"        # PRState.CI_FAILING
 # on their decision (`label:needs-human-review`). Issue #216.
 LABEL_PR_NEEDS_HUMAN = "needs-human-review"
 
+# PR-level label applied by `cai merge` when a `medium + hold` verdict
+# lands on a PR whose diff touches any `.github/workflows/` file. The
+# cai-merge "never high" rule structurally caps workflow-touching PRs
+# at medium confidence, so the merge wrapper surfaces a dedicated
+# `needs-workflow-review` label that admins can filter on
+# (`label:needs-workflow-review`) instead of scanning the generic
+# `pr:human-needed` queue. Supplements — does not replace —
+# `pr:human-needed`. Issue #1064.
+LABEL_PR_NEEDS_WORKFLOW_REVIEW = "needs-workflow-review"
+
 # Cross-instance ownership lock. Orthogonal to the FSM state labels
 # (:in-progress, :applying, :revising, …) — :locked marks which cai
 # instance currently owns the issue/PR and serializes work across

--- a/cai_lib/publish.py
+++ b/cai_lib/publish.py
@@ -160,6 +160,7 @@ LABELS = [
     ("auto-improve:pr-human-needed", "e11d48", "PR parked awaiting admin comment (cai-unblock resume)"),
     ("merge-blocked", "e11d48", "Merge subcommand reviewed and decided not to auto-merge; awaiting human"),
     ("needs-human-review", "e11d48", "PR needs a human decision before merge"),
+    ("needs-workflow-review", "e11d48", "PR touches `.github/workflows/` and was held at medium confidence; awaiting admin workflow review"),
     ("pr:reviewing-code",   "e4e669", "PR is in code review (cai-review-pr)"),
     ("pr:revision-pending", "d93f0b", "Code review posted findings; revise needed"),
     ("pr:reviewing-docs",   "0075ca", "Code clean; in docs review (cai-review-docs)"),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,6 +59,7 @@ Issues still enter the pipeline the same way: `cai analyze`, `cai propose`, `cai
 | `audit` | Source tag indicating an audit-originated finding (combined with `auto-improve:raised` in unified FSM) |
 | `merge-blocked` | PR has a blocking review finding; will not auto-merge |
 | `needs-human-review` | Issue or PR requires human attention |
+| `needs-workflow-review` | PR held on a workflow-file concern (supplement to `pr:human-needed`, set alongside it); allows admins to filter workflow-review-required holds separately. Set when a `medium + hold` verdict lands on a PR that modifies `.github/workflows/` files (issue #1064) |
 | `human:solved` | Admin-applied signal to resume FSM for parked issues/PRs (unblocking) |
 | `blocked-on:<N>` | Suppresses dispatch and rescue on this issue/PR while issue `#<N>` is open. Multiple blockers may be declared by applying the label once per blocker. The label is a hint, not a state change — it never clears itself. (Self-blocking cycles result in both issues staying skipped; no cycle detection is performed.) |
 | `kind:code` | Issue is a code fix (vs. kind:maintenance) |

--- a/tests/test_merge_workflow_review_label.py
+++ b/tests/test_merge_workflow_review_label.py
@@ -1,0 +1,219 @@
+"""Regression tests for issue #1064 — PRs held on a workflow-file
+concern get the `needs-workflow-review` PR label added by the merge
+wrapper so admins can filter workflow-review-required holds out of
+the generic `pr:human-needed` queue.
+
+The detector `_pr_touches_workflow_files` must fire only on diffs
+that modify `.github/workflows/` files. The integrated handler
+path must gate the label on `medium + hold` (workflow-file rule
+caps at medium) AND a workflow-touching diff.
+"""
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.actions import merge as merge_mod
+from cai_lib.actions.merge import _pr_touches_workflow_files
+from cai_lib.config import LABEL_PR_NEEDS_WORKFLOW_REVIEW
+
+
+class TestPrTouchesWorkflowFiles(unittest.TestCase):
+    """The detector matches only `.github/workflows/` diff headers."""
+
+    def test_empty_diff_is_false(self):
+        self.assertFalse(_pr_touches_workflow_files(""))
+        self.assertFalse(_pr_touches_workflow_files(None))  # type: ignore[arg-type]
+
+    def test_workflow_file_modified_matches(self):
+        diff = (
+            "diff --git a/.github/workflows/regenerate-docs.yml "
+            "b/.github/workflows/regenerate-docs.yml\n"
+            "index 1111111..2222222 100644\n"
+            "--- a/.github/workflows/regenerate-docs.yml\n"
+            "+++ b/.github/workflows/regenerate-docs.yml\n"
+            "@@ -1,3 +1,4 @@\n"
+            " name: regenerate-docs\n"
+            "+# new comment\n"
+        )
+        self.assertTrue(_pr_touches_workflow_files(diff))
+
+    def test_workflow_file_added_matches(self):
+        diff = (
+            "diff --git a/.github/workflows/new.yml b/.github/workflows/new.yml\n"
+            "new file mode 100644\n"
+            "index 0000000..abcdef0\n"
+            "--- /dev/null\n"
+            "+++ b/.github/workflows/new.yml\n"
+        )
+        self.assertTrue(_pr_touches_workflow_files(diff))
+
+    def test_non_workflow_file_does_not_match(self):
+        diff = (
+            "diff --git a/cai_lib/actions/merge.py b/cai_lib/actions/merge.py\n"
+            "index 1111111..2222222 100644\n"
+        )
+        self.assertFalse(_pr_touches_workflow_files(diff))
+
+    def test_near_miss_path_does_not_match(self):
+        # `.github/NOT-workflows/` must not be treated as workflow.
+        diff = (
+            "diff --git a/.github/NOT-workflows/foo.yml "
+            "b/.github/NOT-workflows/foo.yml\n"
+        )
+        self.assertFalse(_pr_touches_workflow_files(diff))
+
+    def test_mixed_diff_with_workflow_matches(self):
+        diff = (
+            "diff --git a/cai_lib/actions/merge.py b/cai_lib/actions/merge.py\n"
+            "index 1111111..2222222 100644\n"
+            "diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml\n"
+            "index 3333333..4444444 100644\n"
+        )
+        self.assertTrue(_pr_touches_workflow_files(diff))
+
+
+def _pr_fixture(number: int = 2000) -> dict:
+    return {
+        "number": number,
+        "title": "auto-improve: example",
+        "headRefName": f"auto-improve/{number}-example",
+        "headRefOid": "d7becb043dfd84c2796f35b7deb1353881435930",
+        "labels": [{"name": "pr:approved"}],
+        "state": "OPEN",
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "mergedAt": None,
+        "comments": [],
+        "reviews": [],
+        "createdAt": "2026-04-20T00:00:00Z",
+    }
+
+
+class TestHandleMergeWorkflowReviewLabel(unittest.TestCase):
+    """handle_merge must attach `needs-workflow-review` only on
+    `medium + hold` verdicts for workflow-touching PRs."""
+
+    def _invoke(self, confidence: str, action: str, reasoning: str,
+                diff_stdout: str) -> tuple[MagicMock, MagicMock]:
+        pr = _pr_fixture()
+
+        def run_side_effect(cmd, *args, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ""
+            if (isinstance(cmd, list) and len(cmd) >= 3
+                    and cmd[0] == "gh" and cmd[1] == "pr"
+                    and cmd[2] == "diff"):
+                result.stdout = diff_stdout
+            else:
+                result.stdout = ""
+            return result
+
+        run_mock = MagicMock(side_effect=run_side_effect)
+
+        claude_mock = MagicMock()
+        claude_mock.return_value.returncode = 0
+        claude_mock.return_value.stdout = json.dumps({
+            "confidence": confidence,
+            "action": action,
+            "reasoning": reasoning,
+        })
+        claude_mock.return_value.stderr = ""
+
+        def gh_json_side_effect(args):
+            if "issue" in args and "view" in args:
+                return {
+                    "number": 2000,
+                    "title": "auto-improve: example",
+                    "labels": [{"name": "auto-improve:pr-open"}],
+                    "state": "OPEN",
+                    "body": "",
+                }
+            if "pr" in args and "view" in args:
+                return {"statusCheckRollup": []}
+            return {}
+
+        log_mock = MagicMock()
+
+        with patch.object(merge_mod, "_run", run_mock), \
+             patch.object(merge_mod, "_run_claude_p", claude_mock), \
+             patch.object(merge_mod, "_gh_json",
+                          MagicMock(side_effect=gh_json_side_effect)), \
+             patch.object(merge_mod, "_filter_comments_with_haiku",
+                          MagicMock(return_value=[])), \
+             patch.object(merge_mod, "_fetch_review_comments",
+                          MagicMock(return_value=[])), \
+             patch.object(merge_mod, "_issue_has_label",
+                          MagicMock(return_value=False)), \
+             patch.object(merge_mod, "_set_labels",
+                          MagicMock(return_value=True)), \
+             patch.object(merge_mod, "apply_pr_transition",
+                          MagicMock(return_value=True)), \
+             patch.object(merge_mod, "log_run", log_mock):
+            rc = merge_mod.handle_merge(pr)
+
+        self.assertEqual(rc, 0)
+        return run_mock, log_mock
+
+    def _label_add_calls(self, run_mock: MagicMock) -> list:
+        return [
+            call for call in run_mock.call_args_list
+            if call.args
+            and isinstance(call.args[0], list)
+            and call.args[0][:3] == ["gh", "pr", "edit"]
+            and "--add-label" in call.args[0]
+            and LABEL_PR_NEEDS_WORKFLOW_REVIEW in call.args[0]
+        ]
+
+    def test_medium_hold_workflow_file_adds_label(self):
+        diff = (
+            "diff --git a/.github/workflows/regenerate-docs.yml "
+            "b/.github/workflows/regenerate-docs.yml\n"
+            "index 1111111..2222222 100644\n"
+        )
+        run_mock, log_mock = self._invoke(
+            "medium", "hold",
+            "Workflow-file rule caps at medium.",
+            diff,
+        )
+        self.assertEqual(len(self._label_add_calls(run_mock)), 1)
+        log_kwargs = log_mock.call_args.kwargs
+        self.assertEqual(log_kwargs.get("result"), "held_workflow_review")
+
+    def test_medium_hold_no_workflow_file_no_label(self):
+        diff = (
+            "diff --git a/cai_lib/actions/merge.py "
+            "b/cai_lib/actions/merge.py\n"
+            "index 1111111..2222222 100644\n"
+        )
+        run_mock, log_mock = self._invoke(
+            "medium", "hold",
+            "Unrelated scope concern.",
+            diff,
+        )
+        self.assertEqual(len(self._label_add_calls(run_mock)), 0)
+        log_kwargs = log_mock.call_args.kwargs
+        self.assertEqual(log_kwargs.get("result"), "held")
+
+    def test_low_hold_workflow_file_no_label(self):
+        """LOW + hold is not caused by the workflow rule (which caps at
+        MEDIUM) — leave it to the fixable-bug path or the default park.
+        """
+        diff = (
+            "diff --git a/.github/workflows/regenerate-docs.yml "
+            "b/.github/workflows/regenerate-docs.yml\n"
+        )
+        run_mock, _log_mock = self._invoke(
+            "low", "hold",
+            "Some unrelated concern.",
+            diff,
+        )
+        self.assertEqual(len(self._label_add_calls(run_mock)), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1064

**Issue:** #1064 — Rescue prevention: The merge agent's `.github/workflows/` hard-block is working as intended, but the pipeline has no way to route "workflow

## PR Summary

### What this fixes
The `cai-merge` agent's `.github/workflows/` hard-block correctly caps PRs touching workflow files at `medium` confidence, but the resulting `medium + hold` verdict parks them in the generic `pr:human-needed` queue alongside all other held PRs — admins had no cheap way to identify workflow-review-specific holds (observed on PR #1057).

### What was changed
- **`cai_lib/config.py`**: Added `LABEL_PR_NEEDS_WORKFLOW_REVIEW = "needs-workflow-review"` constant with a comment explaining purpose and issue reference.
- **`cai_lib/actions/merge.py`**: Imported the new label; added `_WORKFLOW_DIFF_HEADER_RE` regex and `_pr_touches_workflow_files(raw_diff)` helper; in the held-else branch, added wrapper-driven logic to apply `needs-workflow-review` via `gh pr edit --add-label` when the verdict is `medium + hold` and the diff touches any `.github/workflows/` file; telemetry tag switches to `held_workflow_review` on that path.
- **`cai_lib/publish.py`**: Added `("needs-workflow-review", ...)` entry to `LABELS` list so the label is created idempotently on `cai publish`.
- **`tests/test_merge_workflow_review_label.py`**: New unittest file covering the `_pr_touches_workflow_files` detector (5 cases) and the integrated `handle_merge` routing (3 cases: medium+hold+workflow adds label, medium+hold without workflow does not, low+hold+workflow does not).

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
