### PR TITLE
auto-improve: Issue #932 parked at human-needed with no parseable divert-reason comment

### DIFF
--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -614,6 +614,13 @@ def handle_merge(pr: dict) -> int:
         apply_pr_transition(
             pr["number"], "approved_to_human",
             log_prefix="cai merge",
+            divert_reason=(
+                f"PR still carries the legacy "
+                f"`{LABEL_PR_NEEDS_HUMAN}` flag while at "
+                f"`:pr-approved`. Migrating the park to the canonical "
+                f"`pr:human-needed` state so the dispatcher stops "
+                f"re-routing to handle_merge."
+            ),
         )
         log_run("merge", repo=REPO, pr=pr["number"],
                 result="legacy_park_migration", exit=0)
@@ -671,6 +678,12 @@ def handle_merge(pr: dict) -> int:
         apply_pr_transition(
             pr_number, "approved_to_human",
             log_prefix="cai merge",
+            divert_reason=(
+                f"PR is on branch `{branch}`, which is not an "
+                f"`auto-improve/<issue>-…` bot branch. The cai merge "
+                f"worker cannot auto-merge non-bot branches; a human "
+                f"admin must merge this PR manually."
+            ),
         )
         log_run("merge", repo=REPO, pr=pr_number,
                 result="not_bot_branch", exit=0)
@@ -902,6 +915,13 @@ def handle_merge(pr: dict) -> int:
         apply_pr_transition(
             pr_number, "approved_to_human",
             log_prefix="cai merge",
+            divert_reason=(
+                f"PR contains {len(unauthorized_deletions)} unauthorized "
+                f"agent-file deletion(s). Bot PRs must not delete "
+                f"`.claude/agents/` files without an explicit tombstone "
+                f"in `.cai-staging/agents-delete/`. A human must review "
+                f"the deletions and decide next steps."
+            ),
         )
         dur_tag = f"{int(time.monotonic() - t0)}s"
         log_run("merge", repo=REPO, pr=pr_number,
@@ -1066,6 +1086,12 @@ def handle_merge(pr: dict) -> int:
                 apply_pr_transition(
                     pr_number, "approved_to_human",
                     log_prefix="cai merge",
+                    divert_reason=(
+                        "cai-merge closed this PR as a high-confidence "
+                        "reject, but relabelling the linked issue as "
+                        "`not planned` failed. Parking the PR so a "
+                        "human can clean up the issue label state."
+                    ),
                 )
                 log_run("merge", repo=REPO, pr=pr_number,
                         duration=dur(), result="close_label_failed",
@@ -1095,6 +1121,12 @@ def handle_merge(pr: dict) -> int:
             apply_pr_transition(
                 pr_number, "approved_to_human",
                 log_prefix="cai merge",
+                divert_reason=(
+                    "cai-merge tried to close this PR as a high-"
+                    "confidence reject, but `gh pr close` failed. The "
+                    "linked issue has been flagged `:merge-blocked`. "
+                    "A human must close the PR manually."
+                ),
             )
             log_run("merge", repo=REPO, pr=pr_number,
                     duration=dur(), result="close_failed", exit=0)
@@ -1166,6 +1198,12 @@ def handle_merge(pr: dict) -> int:
             apply_pr_transition(
                 pr_number, "approved_to_human",
                 log_prefix="cai merge",
+                divert_reason=(
+                    "cai-merge verdict was to merge, but `gh pr merge` "
+                    "failed. The PR is still open; a human must "
+                    "diagnose the merge refusal and either merge "
+                    "manually or revise the PR."
+                ),
             )
             log_run("merge", repo=REPO, pr=pr_number,
                     duration=dur(), result="merge_failed", exit=0)
@@ -1236,6 +1274,12 @@ def handle_merge(pr: dict) -> int:
         apply_pr_transition(
             pr_number, "approved_to_human",
             log_prefix="cai merge",
+            divert_reason=(
+                f"cai-merge verdict was `{confidence}` (below the "
+                f"configured threshold `{_MERGE_THRESHOLD}`). Holding "
+                f"the PR at `:pr-human-needed` so a human reviews the "
+                f"merge verdict comment and decides next steps."
+            ),
         )
         log_run("merge", repo=REPO, pr=pr_number,
                 duration=dur(), result="held", exit=0)

--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -564,6 +564,12 @@ def handle_plan(issue: dict) -> int:
                 issue_number, "planning_to_human",
                 current_labels=[LABEL_PLANNING],
                 log_prefix="cai plan",
+                divert_reason=(
+                    "`cai plan` could not clone the repository to run "
+                    "the plan-select pipeline. Inspect the container's "
+                    "network or gh auth state and resume once the clone "
+                    "can succeed."
+                ),
             )
             log_run("plan", repo=REPO, issue=issue_number,
                     result="clone_failed", exit=1)
@@ -590,6 +596,12 @@ def handle_plan(issue: dict) -> int:
                 issue_number, "planning_to_human",
                 current_labels=[LABEL_PLANNING],
                 log_prefix="cai plan",
+                divert_reason=(
+                    "The plan → select pipeline produced no usable "
+                    "output (one of the plan agents or cai-select "
+                    "failed). No plan was stored; re-run the planning "
+                    "step after resolving the underlying failure."
+                ),
             )
             dur = f"{int(time.monotonic() - t0)}s"
             log_run("plan", repo=REPO, issue=issue_number,
@@ -632,6 +644,12 @@ def handle_plan(issue: dict) -> int:
                 issue_number, "planning_to_human",
                 current_labels=[LABEL_PLANNING],
                 log_prefix="cai plan",
+                divert_reason=(
+                    "`gh issue edit` refused to persist the newly-"
+                    "generated plan block into this issue body. "
+                    "Inspect gh auth / rate limits and resume planning "
+                    "once writes succeed."
+                ),
             )
             dur = f"{int(time.monotonic() - t0)}s"
             log_run("plan", repo=REPO, issue=issue_number,
@@ -781,30 +799,18 @@ def handle_plan_gate(issue: dict) -> int:
             f"diverting to :human-needed via planned_to_human (#982)",
             flush=True,
         )
+        reason_lines = [
+            "Plan diverges from refined-issue preference — admin "
+            "approval required before the fix agent proceeds.",
+        ]
+        if plan_confidence_reason:
+            reason_lines.extend(["", plan_confidence_reason.rstrip()])
         ok = apply_transition(
             issue_number, "planned_to_human",
             current_labels=[LABEL_PLANNED],
             log_prefix="cai plan",
+            divert_reason="\n".join(reason_lines),
         )
-        if ok:
-            lines = [
-                "**🙋 Human attention needed**",
-                "",
-                "Plan diverges from refined-issue preference — admin "
-                "approval required before the fix agent proceeds.",
-            ]
-            if plan_confidence_reason:
-                lines.extend(["", plan_confidence_reason.rstrip()])
-            lines.extend([
-                "",
-                "Apply the `human:solved` label after leaving a comment "
-                "to signal the divert is resolved and have the FSM resume.",
-            ])
-            _post_issue_comment(
-                issue_number,
-                "\n".join(lines),
-                log_prefix="cai plan",
-            )
         dur = f"{int(time.monotonic() - t0)}s"
         conf_name = plan_confidence.name if plan_confidence else "MISSING"
         if not ok:

--- a/cai_lib/actions/pr_bounce.py
+++ b/cai_lib/actions/pr_bounce.py
@@ -215,6 +215,14 @@ def handle_pr_bounce(issue: dict) -> int:
                 issue_number, "pr_to_human_needed",
                 current_labels=label_names,
                 log_prefix="cai dispatch",
+                divert_reason=(
+                    f"Linked PR #{closed_pr['number']} was closed "
+                    f"unmerged by `{actor_str}` (our login: "
+                    f"`{our_login or 'unknown'}`). Because the closer "
+                    f"is not this container, the close was a deliberate "
+                    f"human decision — a human must decide the next "
+                    f"move for this issue."
+                ),
             )
         return 0 if ok else 1
 
@@ -229,5 +237,12 @@ def handle_pr_bounce(issue: dict) -> int:
         issue_number, "pr_to_human_needed",
         current_labels=label_names,
         log_prefix="cai dispatch",
+        divert_reason=(
+            f"Issue was at `:pr-open` but no PR (open or recently "
+            f"closed) could be found for branch "
+            f"`auto-improve/{issue_number}-*`. The label was applied "
+            f"without provenance — a human must decide whether to "
+            f"reopen a PR or revert the issue to a pre-PR state."
+        ),
     )
     return 0 if ok else 1

--- a/cai_lib/actions/refine.py
+++ b/cai_lib/actions/refine.py
@@ -365,26 +365,20 @@ def handle_refine(issue: dict) -> int:
     contradictions = _detect_guardrail_contradictions(refined_body)
     if contradictions:
         bullet_list = "\n".join(f"- `{p}`" for p in contradictions)
-        comment_body = (
-            "**🙋 Human attention needed**\n\n"
-            "Automation paused refinement because the proposed scope "
+        divert_reason = (
+            "Refinement was paused because the proposed scope "
             "contradicts itself: the following file(s) are listed under "
             "**Files to change** *and* under **Scope guardrails**.\n\n"
             f"{bullet_list}\n\n"
-            "Either drop the guardrail (the file genuinely needs editing) "
-            "or split the forbidden work into a predecessor issue and "
-            "drop it from **Files to change** here.\n\n"
-            "Apply the `human:solved` label after leaving a comment to "
-            "signal the contradiction is resolved and have the FSM "
-            "resume (the refine agent will re-run with your input)."
-        )
-        _post_issue_comment(
-            issue_number, comment_body, log_prefix="cai refine"
+            "Either drop the guardrail (the file genuinely needs "
+            "editing) or split the forbidden work into a predecessor "
+            "issue and drop it from **Files to change** here."
         )
         apply_transition(
             issue_number, "refining_to_human",
             current_labels=[LABEL_REFINING],
             log_prefix="cai refine",
+            divert_reason=divert_reason,
         )
         dur = f"{int(time.monotonic() - t0)}s"
         print(

--- a/cai_lib/actions/triage.py
+++ b/cai_lib/actions/triage.py
@@ -299,17 +299,15 @@ def handle_triage(issue: dict) -> int:
 
     # 6. Execute verdict.
     if decision == "HUMAN":
-        _post_issue_comment(
-            issue_number,
-            f"cai-triage routed this issue to `:human-needed` "
-            f"(confidence={confidence or 'MISSING'}).\n\n"
-            f"**Reasoning:** {reasoning}",
-            log_prefix="cai triage",
-        )
         apply_transition(
             issue_number, "triaging_to_human",
             current_labels=[LABEL_TRIAGING],
             log_prefix="cai triage",
+            divert_reason=(
+                f"cai-triage routed this issue to `:human-needed` "
+                f"(routing_confidence={confidence or 'MISSING'}).\n\n"
+                f"**Reasoning:** {reasoning}"
+            ),
         )
         action_taken = "human"
     elif decision in ("PLAN_APPROVE", "APPLY"):

--- a/cai_lib/cmd_cycle.py
+++ b/cai_lib/cmd_cycle.py
@@ -92,6 +92,29 @@ def cmd_cycle(args) -> int:
             flush=True,
         )
 
+    # Phase 0.6: self-heal silent HUMAN_NEEDED diverts (issue #1009).
+    # Any issue/PR parked at :human-needed / :pr-human-needed without a
+    # MARKER-bearing divert-reason comment is invisible to the audit
+    # agent's human_needed_reason_missing parser and cannot be resumed
+    # by `cai unblock` (the classifier needs the divert context).
+    # Post a retroactive backfill comment so the pipeline recovers
+    # without an admin hand-crafting a comment.
+    try:
+        from cai_lib.fsm import backfill_silent_human_needed_comments
+        backfilled = backfill_silent_human_needed_comments()
+        if backfilled:
+            nums = ", ".join(f"{k} #{n}" for k, n in backfilled)
+            print(
+                f"[cai cycle] backfilled silent HUMAN_NEEDED divert "
+                f"comments on {len(backfilled)} target(s): {nums}",
+                flush=True,
+            )
+    except Exception as exc:
+        print(
+            f"[cai cycle] Phase 0.6 backfill raised {exc!r} — continuing",
+            file=sys.stderr, flush=True,
+        )
+
     # Phase 1: TTL-based stale-lock sweep — rolls back only locks that
     # have exceeded their configured TTL (_STALE_LOCKED_HOURS etc.).
     # NOTE: immediate=True is NOT used here; that path bypasses TTLs and

--- a/cai_lib/fsm_transitions.py
+++ b/cai_lib/fsm_transitions.py
@@ -486,6 +486,8 @@ def apply_transition(
     extra_remove: Sequence[str] = (),
     log_prefix: str = "cai",
     set_labels=None,
+    divert_reason: Optional[str] = None,
+    post_comment=None,
 ) -> bool:
     """Apply a named issue FSM transition via ``_set_labels``.
 
@@ -499,8 +501,31 @@ def apply_transition(
 
     *set_labels* is injectable for tests; defaults to
     ``cai_lib.github._set_labels``.
+
+    **HUMAN_NEEDED invariant (#1009).** When ``transition.to_state`` is
+    :attr:`IssueState.HUMAN_NEEDED`, the caller MUST pass a non-empty
+    *divert_reason*. The helper then both applies the label AND posts a
+    ``_render_human_divert_reason``-rendered MARKER comment on the issue
+    — guaranteeing every park at ``:human-needed`` has a parseable audit
+    trail for ``_fetch_human_needed_issues`` and ``cai unblock``. Silent
+    diverts (reason missing) are refused with a log and ``return False``
+    so the gap is load-bearing rather than hidden. *post_comment* is
+    injectable for tests; defaults to
+    ``cai_lib.github._post_issue_comment``.
     """
     transition = find_transition(transition_name, ISSUE_TRANSITIONS)
+
+    if transition.to_state == IssueState.HUMAN_NEEDED and not (
+        divert_reason and divert_reason.strip()
+    ):
+        print(
+            f"[{log_prefix}] refusing silent HUMAN_NEEDED divert "
+            f"{transition_name!r} on #{issue_number}: caller must pass "
+            f"a non-empty divert_reason so the divert-reason comment "
+            f"can be posted (see cai_lib.fsm_transitions invariant)",
+            file=sys.stderr,
+        )
+        return False
 
     if current_labels is not None:
         current = get_issue_state(current_labels)
@@ -516,12 +541,26 @@ def apply_transition(
     if set_labels is None:
         from cai_lib.github import _set_labels as set_labels  # local import — avoids cycle at module load
 
-    return set_labels(
+    ok = set_labels(
         issue_number,
         add=list(transition.labels_add),
         remove=list(transition.labels_remove) + list(extra_remove),
         log_prefix=log_prefix,
     )
+    if ok and transition.to_state == IssueState.HUMAN_NEEDED:
+        if post_comment is None:
+            from cai_lib.github import _post_issue_comment as post_comment  # local import — avoids cycle
+        post_comment(
+            issue_number,
+            _render_human_divert_reason(
+                transition_name=transition_name,
+                transition=transition,
+                confidence=None,
+                extra=divert_reason or "",
+            ),
+            log_prefix=log_prefix,
+        )
+    return ok
 
 
 def _render_human_divert_reason(
@@ -669,6 +708,8 @@ def apply_pr_transition(
     current_pr: Optional[dict] = None,
     log_prefix: str = "cai",
     set_pr_labels=None,
+    divert_reason: Optional[str] = None,
+    post_comment=None,
 ) -> bool:
     """Apply a named PR FSM transition via ``_set_pr_labels``.
 
@@ -678,8 +719,29 @@ def apply_pr_transition(
 
     *set_pr_labels* is injectable for tests; defaults to
     ``cai_lib.github._set_pr_labels``.
+
+    **PR_HUMAN_NEEDED invariant (#1009).** Mirrors the issue-side
+    ``apply_transition``: when ``transition.to_state`` is
+    :attr:`PRState.PR_HUMAN_NEEDED`, the caller MUST pass a non-empty
+    *divert_reason*, and on success a MARKER-bearing comment rendered
+    by :func:`_render_human_divert_reason` is posted on the PR so
+    ``_fetch_human_needed_issues`` can parse the reason and
+    ``cai unblock`` has context. *post_comment* is injectable for
+    tests; defaults to ``cai_lib.github._post_pr_comment``.
     """
     transition = find_transition(transition_name, PR_TRANSITIONS)
+
+    if transition.to_state == PRState.PR_HUMAN_NEEDED and not (
+        divert_reason and divert_reason.strip()
+    ):
+        print(
+            f"[{log_prefix}] refusing silent PR_HUMAN_NEEDED divert "
+            f"{transition_name!r} on #{pr_number}: caller must pass "
+            f"a non-empty divert_reason so the divert-reason comment "
+            f"can be posted (see cai_lib.fsm_transitions invariant)",
+            file=sys.stderr,
+        )
+        return False
 
     if current_pr is not None:
         current = get_pr_state(current_pr)
@@ -695,12 +757,26 @@ def apply_pr_transition(
     if set_pr_labels is None:
         from cai_lib.github import _set_pr_labels as set_pr_labels  # local import — avoids cycle at module load
 
-    return set_pr_labels(
+    ok = set_pr_labels(
         pr_number,
         add=list(transition.labels_add),
         remove=list(transition.labels_remove),
         log_prefix=log_prefix,
     )
+    if ok and transition.to_state == PRState.PR_HUMAN_NEEDED:
+        if post_comment is None:
+            from cai_lib.github import _post_pr_comment as post_comment  # local import — avoids cycle
+        post_comment(
+            pr_number,
+            _render_human_divert_reason(
+                transition_name=transition_name,
+                transition=transition,
+                confidence=None,
+                extra=divert_reason or "",
+            ),
+            log_prefix=log_prefix,
+        )
+    return ok
 
 
 def apply_pr_transition_with_confidence(
@@ -850,6 +926,102 @@ def _build_mermaid_machine(transitions_list: list[Transition]) -> GraphMachine:
         show_conditions=True,
         show_auto_transitions=False,
     )
+
+
+def backfill_silent_human_needed_comments(
+    *,
+    gh_json=None,
+    post_issue_comment=None,
+    post_pr_comment=None,
+    log_prefix: str = "cai cycle",
+) -> list[tuple[str, int]]:
+    """Scan open issues/PRs parked at HUMAN_NEEDED / PR_HUMAN_NEEDED and
+    post a retroactive MARKER-bearing backfill comment on any entry that
+    has no MARKER comment in its history.
+
+    This is the self-healing counterpart to the ``apply_transition``
+    invariant added for issue #1009. The invariant guarantees *future*
+    diverts carry a MARKER comment; the backfill sweep closes the gap
+    for issues parked before the fix (e.g. #932) so the audit agent's
+    ``human_needed_reason_missing`` finder and ``cai unblock`` have
+    context on pre-existing silent diverts. Returns the list of
+    ``(kind, number)`` tuples that were backfilled (empty when nothing
+    was missing). The caller is responsible for logging the result.
+
+    All dependencies (``gh_json``, the two comment posters) are
+    injectable for tests; defaults read from ``cai_lib.github``.
+    """
+    MARKER = "🙋 Human attention needed"
+    from cai_lib.config import LABEL_HUMAN_NEEDED, LABEL_PR_HUMAN_NEEDED, REPO
+
+    if gh_json is None:
+        from cai_lib.github import _gh_json as gh_json
+    if post_issue_comment is None:
+        from cai_lib.github import _post_issue_comment as post_issue_comment
+    if post_pr_comment is None:
+        from cai_lib.github import _post_pr_comment as post_pr_comment
+
+    backfilled: list[tuple[str, int]] = []
+    checks = [
+        ("issue", LABEL_HUMAN_NEEDED, post_issue_comment),
+        ("pr", LABEL_PR_HUMAN_NEEDED, post_pr_comment),
+    ]
+    for kind, label, poster in checks:
+        try:
+            items = gh_json([
+                "issue", "list",
+                "--repo", REPO,
+                "--label", label,
+                "--state", "open",
+                "--json", "number,labels,comments",
+                "--limit", "100",
+            ]) or []
+        except Exception as exc:
+            print(
+                f"[{log_prefix}] backfill: gh issue list --label {label} failed: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        for it in items:
+            number = it.get("number")
+            if number is None:
+                continue
+            comments = it.get("comments") or []
+            if any(MARKER in (c.get("body") or "") for c in comments):
+                continue
+            body = (
+                f"**{MARKER}**\n\n"
+                f"Automation paused `(unknown)` — this {kind} was parked "
+                f"at `{label}` without a divert-reason comment. The "
+                f"original divert pre-dates the #1009 invariant, so the "
+                f"failing transition and confidence values cannot be "
+                f"recovered from the code path.\n\n"
+                f"- Required confidence: `(unknown)`\n"
+                f"- Reported confidence: `(unknown)`\n"
+                f"\n"
+                f"Review the issue/PR body and recent logs to decide "
+                f"next steps. Apply the `human:solved` label after "
+                f"leaving a comment to signal the divert is resolved "
+                f"and have the FSM resume.\n"
+                f"\n"
+                f"_Retroactively posted by `cai cycle` self-heal "
+                f"(issue #1009)._"
+            )
+            try:
+                poster(number, body, log_prefix=log_prefix)
+                backfilled.append((kind, number))
+                print(
+                    f"[{log_prefix}] backfilled silent divert on "
+                    f"{kind} #{number}",
+                    flush=True,
+                )
+            except Exception as exc:
+                print(
+                    f"[{log_prefix}] backfill failed for {kind} "
+                    f"#{number}: {exc}",
+                    file=sys.stderr,
+                )
+    return backfilled
 
 
 def render_fsm_mermaid(transitions: list[Transition], title: str = "FSM") -> str:

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -358,6 +358,123 @@ class TestApplyTransition(unittest.TestCase):
         self.assertEqual(t.from_state, IssueState.RAISED)
         self.assertEqual(t.to_state, IssueState.REFINING)
 
+    def test_human_needed_requires_divert_reason(self):
+        """apply_transition refuses a HUMAN_NEEDED divert without a reason (#1009)."""
+        calls, fake = self._recording_set_labels()
+        posted = []
+
+        def _fake_post(n, body, *, log_prefix="cai"):
+            posted.append({"n": n, "body": body})
+            return True
+
+        ok = apply_transition(
+            55, "triaging_to_human",
+            current_labels=[LABEL_TRIAGING],
+            set_labels=fake,
+            post_comment=_fake_post,
+        )
+        self.assertFalse(ok)
+        self.assertEqual(calls, [])
+        self.assertEqual(posted, [])
+
+    def test_human_needed_with_reason_posts_marker_comment(self):
+        """Successful HUMAN_NEEDED divert posts the MARKER-bearing comment (#1009)."""
+        calls, fake = self._recording_set_labels()
+        posted = []
+
+        def _fake_post(n, body, *, log_prefix="cai"):
+            posted.append({"n": n, "body": body})
+            return True
+
+        ok = apply_transition(
+            77, "triaging_to_human",
+            current_labels=[LABEL_TRIAGING],
+            set_labels=fake,
+            post_comment=_fake_post,
+            divert_reason="Triage verdict: HUMAN.",
+        )
+        self.assertTrue(ok)
+        self.assertEqual(len(calls), 1)
+        self.assertIn(LABEL_HUMAN_NEEDED, calls[0]["add"])
+        self.assertEqual(len(posted), 1)
+        body = posted[0]["body"]
+        self.assertIn("🙋 Human attention needed", body)
+        self.assertIn("Automation paused `triaging_to_human`", body)
+        self.assertIn("Required confidence:", body)
+        self.assertIn("Reported confidence:", body)
+        self.assertIn("Triage verdict: HUMAN.", body)
+
+    def test_non_human_transition_ignores_reason_kwarg(self):
+        """Non-HUMAN transitions don't require or post a reason."""
+        calls, fake = self._recording_set_labels()
+        posted = []
+
+        def _fake_post(n, body, *, log_prefix="cai"):
+            posted.append({"n": n, "body": body})
+            return True
+
+        ok = apply_transition(
+            11, "raise_to_refining",
+            current_labels=[LABEL_RAISED],
+            set_labels=fake,
+            post_comment=_fake_post,
+        )
+        self.assertTrue(ok)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(posted, [])
+
+
+class TestBackfillSilentHumanNeeded(unittest.TestCase):
+    """Pins the self-healing backfill sweep (#1009, #932)."""
+
+    def test_backfills_issues_without_marker_comment(self):
+        from cai_lib.fsm import backfill_silent_human_needed_comments
+
+        # Simulate two parked issues: one silent (no MARKER comment),
+        # one already has a MARKER comment and must be skipped.
+        issue_lists = {
+            LABEL_HUMAN_NEEDED: [
+                {
+                    "number": 932,
+                    "labels": [{"name": LABEL_HUMAN_NEEDED}],
+                    "comments": [{"body": "some unrelated comment"}],
+                },
+                {
+                    "number": 980,
+                    "labels": [{"name": LABEL_HUMAN_NEEDED}],
+                    "comments": [
+                        {"body": "**🙋 Human attention needed**\n\n..."}
+                    ],
+                },
+            ],
+        }
+
+        def _fake_gh_json(argv):
+            # argv like: ["issue","list","--repo",REPO,"--label",LBL,...]
+            for i, tok in enumerate(argv):
+                if tok == "--label" and i + 1 < len(argv):
+                    return issue_lists.get(argv[i + 1], [])
+            return []
+
+        posted = []
+
+        def _fake_post_issue(n, body, *, log_prefix="cai"):
+            posted.append({"n": n, "body": body})
+
+        def _fake_post_pr(n, body, *, log_prefix="cai"):
+            posted.append({"n": n, "body": body})
+
+        backfilled = backfill_silent_human_needed_comments(
+            gh_json=_fake_gh_json,
+            post_issue_comment=_fake_post_issue,
+            post_pr_comment=_fake_post_pr,
+        )
+
+        self.assertEqual(backfilled, [("issue", 932)])
+        self.assertEqual(len(posted), 1)
+        self.assertEqual(posted[0]["n"], 932)
+        self.assertIn("🙋 Human attention needed", posted[0]["body"])
+
 
 class TestApplyTransitionWithConfidence(unittest.TestCase):
 

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -410,17 +410,18 @@ class TestHandlePlanGateRequiresHumanReview(unittest.TestCase):
         # The confidence-gated transition must NOT have been called.
         mock_gated.assert_not_called()
         # Instead, the direct planned_to_human transition must fire.
-        args, _ = mock_apply.call_args
+        args, kwargs = mock_apply.call_args
         self.assertEqual(args[0], 982)
         self.assertEqual(args[1], "planned_to_human")
-        # And a bespoke divert comment must be posted.
-        post_args, _ = mock_post.call_args
-        self.assertEqual(post_args[0], 982)
+        # The divert reason must be passed as a kwarg to apply_transition
+        # (which now posts the MARKER comment itself — no direct _post_issue_comment).
+        divert_reason = kwargs.get("divert_reason", "")
         self.assertIn(
             "Plan diverges from refined-issue preference",
-            post_args[1],
+            divert_reason,
         )
-        self.assertIn("admin approval required", post_args[1])
+        self.assertIn("admin approval required", divert_reason)
+        mock_post.assert_not_called()
 
     @patch("cai_lib.actions.plan._post_issue_comment")
     @patch("cai_lib.actions.plan.apply_transition")
@@ -494,10 +495,12 @@ class TestHandlePlanGateRequiresHumanReview(unittest.TestCase):
 
         self.assertEqual(rc, 0)
         mock_gated.assert_not_called()
-        args, _ = mock_apply.call_args
+        args, kwargs = mock_apply.call_args
         self.assertEqual(args[1], "planned_to_human")
-        post_args, _ = mock_post.call_args
-        self.assertIn("admin approval required", post_args[1])
+        # divert_reason kwarg must carry the admin-approval message
+        divert_reason = kwargs.get("divert_reason", "")
+        self.assertIn("admin approval required", divert_reason)
+        mock_post.assert_not_called()
 
 
 class TestParseRequiresHumanReview(unittest.TestCase):


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1009

**Issue:** #1009 — Issue #932 parked at human-needed with no parseable divert-reason comment

## PR Summary

### What this fixes
Issue #932 was parked at `:human-needed` with no parseable divert-reason comment because `apply_transition` called the label-setting helper without also calling `_render_human_divert_reason`. This made the parked issue invisible to the audit agent's `human_needed_reason_missing` parser and unusable by `cai unblock` (the classifier needs the divert context).

### What was changed
- **`cai_lib/fsm_transitions.py`**: `apply_transition` and `apply_pr_transition` now accept `divert_reason` and `post_comment` kwargs; when the target state is `HUMAN_NEEDED` / `PR_HUMAN_NEEDED`, a non-empty `divert_reason` is required — silent diverts return `False`. On success, a `_render_human_divert_reason`-formatted MARKER comment is automatically posted. Added `backfill_silent_human_needed_comments()` self-healing sweep function.
- **`cai_lib/actions/triage.py`**: Folded `_post_issue_comment` into `divert_reason=` kwarg on `triaging_to_human` call.
- **`cai_lib/actions/plan.py`**: Added `divert_reason=` to 3 `planning_to_human` calls and the `planned_to_human` requires-human-review path; removed now-redundant `_post_issue_comment` in the latter.
- **`cai_lib/actions/pr_bounce.py`**: Added `divert_reason=` to 2 `pr_to_human_needed` calls.
- **`cai_lib/actions/refine.py`**: Removed `_post_issue_comment` call; folded into `divert_reason=` on `refining_to_human`.
- **`cai_lib/actions/merge.py`**: Added `divert_reason=` to all 7 `approved_to_human` calls (legacy park, non-bot branch, unauthorized deletions, close-label failed, close failed, merge failed, verdict held).
- **`cai_lib/cmd_cycle.py`**: Inserted Phase 0.6 self-heal sweep that calls `backfill_silent_human_needed_comments()` on each cron tick to retroactively fix issues parked before this change (including #932).
- **`tests/test_fsm.py`**: Added 3 tests for the new `divert_reason` invariant and a `TestBackfillSilentHumanNeeded` class.
- **`tests/test_plan.py`**: Updated `TestHandlePlanGateRequiresHumanReview` tests to check `divert_reason` kwarg instead of direct `_post_issue_comment` calls (which are no longer made).

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
