### PR TITLE
auto-improve: `tests/test_merge_workflow_review_label.py`: three tests invoke real `git fetch` via unmocked `_git` — 3 errors on main

### DIFF
--- a/tests/test_merge_workflow_review_label.py
+++ b/tests/test_merge_workflow_review_label.py
@@ -153,6 +153,8 @@ class TestHandleMergeWorkflowReviewLabel(unittest.TestCase):
                           MagicMock(return_value=True)), \
              patch.object(merge_mod, "apply_pr_transition",
                           MagicMock(return_value=True)), \
+             patch.object(merge_mod, "_git",
+                          MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))), \
              patch.object(merge_mod, "log_run", log_mock):
             rc = merge_mod.handle_merge(pr)
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1076

**Issue:** #1076 — `tests/test_merge_workflow_review_label.py`: three tests invoke real `git fetch` via unmocked `_git` — 3 errors on main

## PR Summary

### What this fixes
Three tests in `tests/test_merge_workflow_review_label.py` were failing because the `_invoke` helper did not mock `_git`, allowing `handle_merge` to attempt a real `git fetch` that fails since the test work directory has no remote configured.

### What was changed
- `tests/test_merge_workflow_review_label.py`: Added `patch.object(merge_mod, "_git", MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr="")))` to the `_invoke` helper's patch context manager, preventing real git commands from executing during `test_medium_hold_workflow_file_adds_label`, `test_medium_hold_no_workflow_file_no_label`, and `test_low_hold_workflow_file_no_label`.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
