### PR TITLE
auto-improve: Rescue prevention: When a merge review issues a `hold` verdict citing implementation-approach mismatch (not just style/nit comments), the F

### DIFF
--- a/.claude/agents/review/cai-merge.md
+++ b/.claude/agents/review/cai-merge.md
@@ -54,6 +54,28 @@ You must emit exactly one of three confidence levels:
 | **medium** | The PR mostly implements the issue but has minor concerns: slightly broader scope, a small ambiguous choice, or one element you're not fully sure about. Probably fine, but better with human review. |
 | **low** | The PR has significant issues: wrong approach, missing core functionality, potential bugs, or substantial scope creep. Should not be merged automatically. |
 
+## Issue type classification (optional, only for `hold` verdicts)
+
+When your action is `hold`, you may optionally set the `issue_type`
+field to classify *why* the PR is being held. Setting `issue_type`
+lets the wrapper fast-path specific failure modes instead of parking
+at `pr:human-needed` and burning a rescue cycle.
+
+| `issue_type` | Set when... |
+|---|---|
+| `approach_mismatch` | The implementation took the **wrong fundamental approach** — wrong API used entirely, wrong algorithm (e.g. polling instead of events, linear scan instead of hash lookup), wrong data model, wrong architectural layer. `cai-revise` cannot salvage this with incremental edits; a fresh `cai-implement` attempt is needed. |
+| `missing_steps` | The PR implements the approach correctly but omits one or more required remediation steps from the issue. `cai-revise` can likely add the missing steps. |
+| `implementation_bug` | The approach is correct but there is a concrete code defect (wrong variable, off-by-one, missing edge case). `cai-revise` can fix it. |
+| `scope_creep` | The PR's approach is correct but its scope is too broad. A human must decide whether to narrow, split, or accept the extra edits. |
+| `other` | None of the above — or you are uncertain. Treated the same as omitting the field. |
+
+**Do NOT set `approach_mismatch` for:**
+- stylistic nits, typos, rename suggestions (those are `implementation_bug` at most);
+- bugs that `cai-revise` can fix in a follow-up commit (AttributeError, wrong field name — already routed via the `low+hold` fixable-bug detector);
+- missing remediation steps that the original approach supports (use `missing_steps`).
+
+Only set `approach_mismatch` when you are confident the PR would need to be re-written from scratch on the correct approach. The field is omitted by default and has no effect on `merge` or `reject` verdicts.
+
 ## Things that must NEVER produce a high verdict
 
 - PR scope is broader than the issue asks for
@@ -357,6 +379,7 @@ Emit exactly this structured block — nothing else:
 - **Confidence:** high | medium | low
 - **Action:** merge | hold | reject
 - **Reasoning:** <2-3 sentences explaining your assessment. Be specific about what you checked and why you're confident or not.>
+- **Issue type (optional, only with `hold`):** approach_mismatch | missing_steps | implementation_bug | scope_creep | other
 ```
 
 The action mapping:

--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -152,6 +152,7 @@
 | `tests/test_lint.py` | Lint check: ruff must report zero violations |
 | `tests/test_maintain.py` | Tests for cai_lib.actions.maintain — handle_maintain confidence routing and FSM transitions |
 | `tests/test_merge_agent_deletion_guard.py` | TODO: add description |
+| `tests/test_merge_approach_mismatch.py` | TODO: add description |
 | `tests/test_merge_ci_failing_divert.py` | TODO: add description |
 | `tests/test_merge_diff.py` | TODO: add description |
 | `tests/test_merge_low_to_revision.py` | TODO: add description |

--- a/README.md
+++ b/README.md
@@ -371,13 +371,20 @@ implement their linked issue. For each open `:pr-open` PR on an
 6. If the action is `reject` and confidence meets the threshold,
    closes the PR via `gh pr close --delete-branch` and closes the
    linked issue via `gh issue close --reason "not planned"`
-7. If the action is `hold`, confidence is `low`, and the verdict's
+7. If the action is `hold` with `issue_type == "approach_mismatch"`,
+   the implementation took the wrong fundamental approach (wrong API,
+   wrong algorithm, wrong architecture) — closes the PR, stamps the
+   linked issue with `LABEL_OPUS_ATTEMPTED`, transitions it back to
+   `:plan-approved`, and schedules an Opus re-implement on the next
+   cycle. This bypasses the rescue loop to avoid repeated Sonnet
+   failures on fundamentally-misguided implementations.
+8. If the action is `hold`, confidence is `low`, and the verdict's
    reasoning cites a concrete, mechanically-fixable code bug (e.g.,
    "field-name mismatch", "AttributeError", "NameError", "typo"),
    routes the PR to `:pr-revision-pending` so `cai-revise` can
    immediately apply the fix on the next tick, rather than parking
    at `:pr-human-needed` for human review
-8. Otherwise, labels the issue `merge-blocked` and
+9. Otherwise, labels the issue `merge-blocked` and
    posts the verdict reasoning as a PR comment
 
 **Confidence levels:**

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -37,8 +37,9 @@ from cai_lib.config import (
     LABEL_PLAN_APPROVED,
     LABEL_PR_NEEDS_HUMAN,
     LABEL_PR_NEEDS_WORKFLOW_REVIEW,
+    LABEL_OPUS_ATTEMPTED,
 )
-from cai_lib.fsm import apply_pr_transition, get_pr_state, PRState
+from cai_lib.fsm import apply_pr_transition, apply_transition, get_pr_state, PRState
 from cai_lib.github import _gh_json, _set_labels, _issue_has_label, close_issue_not_planned
 from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.cmd_helpers import (
@@ -132,6 +133,13 @@ _BOT_BRANCH_RE = re.compile(r"^auto-improve/(\d+)-")
 _MERGE_MAX_DIFF_LEN = int(os.environ.get("CAI_MERGE_MAX_DIFF_LEN", "200000"))
 
 # JSON schema for structured merge verdict (forced tool-use via --json-schema).
+# ``issue_type`` is an optional classifier the agent may set on ``hold``
+# verdicts so the handler can fast-path specific failure modes. Today
+# the only value that triggers wrapper-side routing is
+# ``approach_mismatch``, which causes handle_merge to close the PR and
+# schedule an Opus re-implement on the linked issue without burning a
+# rescue cycle (issue #1075). Any other value — or the field being
+# absent — leaves existing held-verdict behaviour unchanged.
 _MERGE_JSON_SCHEMA = {
     "type": "object",
     "properties": {
@@ -145,6 +153,16 @@ _MERGE_JSON_SCHEMA = {
         },
         "reasoning": {
             "type": "string",
+        },
+        "issue_type": {
+            "type": "string",
+            "enum": [
+                "approach_mismatch",
+                "missing_steps",
+                "implementation_bug",
+                "scope_creep",
+                "other",
+            ],
         },
     },
     "required": ["confidence", "action", "reasoning"],
@@ -1304,6 +1322,104 @@ def handle_merge(pr: dict) -> int:
             )
             log_run("merge", repo=REPO, pr=pr_number,
                     duration=dur(), result="held_fixable_bug", exit=0)
+            return 0
+        # Issue #1075: when a held verdict is tagged
+        # ``issue_type == "approach_mismatch"``, the implementation took
+        # the wrong fundamental approach (wrong API / wrong algorithm /
+        # wrong data model) — ``cai-revise`` cannot salvage it.
+        # Short-circuit the rescue loop: close the PR, stamp
+        # ``LABEL_OPUS_ATTEMPTED`` on the linked issue, and transition
+        # the issue back to PLAN_APPROVED via ``pr_to_plan_approved`` so
+        # ``cai-implement`` re-runs under Opus on the next tick.
+        approach_mismatch = (
+            action == "hold"
+            and tool_input.get("issue_type") == "approach_mismatch"
+        )
+        if approach_mismatch:
+            mismatch_body = (
+                f"## cai merge: approach mismatch \u2014 {head_sha}\n\n"
+                f"The merge agent flagged this PR with a **hold** verdict "
+                f"citing an implementation-approach mismatch (wrong API, "
+                f"algorithm, or data model). `cai-revise` cannot address "
+                f"this kind of issue with incremental edits, so the PR "
+                f"will be closed automatically and the linked issue "
+                f"#{issue_number} re-queued for a fresh `cai-implement` "
+                f"run under Opus.\n\n"
+                f"**Verdict reasoning:**\n\n"
+                f"{reasoning}\n\n"
+                f"---\n"
+                f"_Auto-routed by `cai merge`: closing PR, adding "
+                f"`{LABEL_OPUS_ATTEMPTED}` to issue #{issue_number}, "
+                f"and returning the issue to `:plan-approved`._"
+            )
+            _run(
+                ["gh", "pr", "comment", str(pr_number),
+                 "--repo", REPO, "--body", mismatch_body],
+                capture_output=True,
+            )
+            close_result = _run(
+                ["gh", "pr", "close", str(pr_number),
+                 "--repo", REPO, "--delete-branch"],
+                capture_output=True,
+            )
+            if close_result.returncode != 0:
+                print(
+                    f"[cai merge] PR #{pr_number}: approach_mismatch "
+                    f"close failed:\n{close_result.stderr}",
+                    file=sys.stderr,
+                )
+                apply_pr_transition(
+                    pr_number, "approved_to_human",
+                    log_prefix="cai merge",
+                    divert_reason=(
+                        "cai-merge returned a hold verdict with "
+                        "`issue_type=approach_mismatch` but `gh pr "
+                        "close` failed. The PR is still open; a human "
+                        "must close it and decide next steps on the "
+                        "linked issue."
+                    ),
+                )
+                log_run("merge", repo=REPO, pr=pr_number,
+                        duration=dur(),
+                        result="approach_mismatch_close_failed", exit=0)
+                return 0
+            if not _set_labels(
+                issue_number,
+                add=[LABEL_OPUS_ATTEMPTED],
+                log_prefix="cai merge",
+            ):
+                print(
+                    f"[cai merge] WARNING: failed to add "
+                    f"{LABEL_OPUS_ATTEMPTED} to #{issue_number} after "
+                    f"approach_mismatch close of PR #{pr_number}",
+                    file=sys.stderr, flush=True,
+                )
+            issue_labels_now = [
+                (lb.get("name") if isinstance(lb, dict) else lb)
+                for lb in (issue.get("labels") or [])
+            ]
+            transition_ok = apply_transition(
+                issue_number, "pr_to_plan_approved",
+                current_labels=issue_labels_now,
+                log_prefix="cai merge",
+            )
+            if not transition_ok:
+                print(
+                    f"[cai merge] WARNING: pr_to_plan_approved failed "
+                    f"for issue #{issue_number} after closing PR "
+                    f"#{pr_number}",
+                    file=sys.stderr, flush=True,
+                )
+            print(
+                f"[cai merge] PR #{pr_number}: approach_mismatch — "
+                f"closed PR and scheduled Opus re-implement on "
+                f"issue #{issue_number}",
+                flush=True,
+            )
+            log_run("merge", repo=REPO, pr=pr_number,
+                    duration=dur(),
+                    result="held_approach_mismatch_opus_triggered",
+                    exit=0)
             return 0
         if not _issue_has_label(issue_number, LABEL_MERGED):
             if not _set_labels(

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -646,10 +646,17 @@ def handle_merge(pr: dict) -> int:
     ``PRState.APPROVED``. This handler either:
 
     * merges the PR (``approved_to_merged``), or
+    * applies ``pr_to_plan_approved`` (closes the PR, stamps the linked
+      issue with ``LABEL_OPUS_ATTEMPTED``, and re-queues for Opus
+      re-implement) when the merge agent flags a ``hold`` verdict with
+      ``issue_type == "approach_mismatch"`` — the implementation took
+      the wrong fundamental approach and needs a fresh attempt, or
+    * applies ``approved_to_revision_pending`` (routes to ``cai-revise``)
+      when the merge agent flags a ``hold`` verdict whose reasoning cites
+      a concrete, mechanically-fixable code bug, or
     * applies ``approved_to_human`` (clears ``pr:approved``, sets
-      ``pr:human-needed``) when the merge agent refuses / yields low
-      confidence / merge itself fails on a still-open PR. Parking is
-      done via FSM transition so the PR has exactly one state — the
+      ``pr:human-needed``) for all other held/refused verdicts. Parking
+      is done via FSM transition so the PR has exactly one state — the
       old behavior of layering a ``needs-human-review`` flag on top of
       ``pr:approved`` made the dispatcher loop on the same PR every
       drain tick.

--- a/cai_lib/fsm_transitions.py
+++ b/cai_lib/fsm_transitions.py
@@ -213,6 +213,13 @@ ISSUE_TRANSITIONS: list[Transition] = [
     # the issue's branch.
     Transition("pr_to_refined",              IssueState.PR,                IssueState.REFINED,
                labels_remove=[LABEL_PR_OPEN],             labels_add=[LABEL_REFINED]),
+    # Merge-side approach-mismatch escalation (#1075): cai-merge closes
+    # the PR and fires this transition so cai-implement re-runs under
+    # Opus on the next tick. Caller-gated (handler decides when to
+    # fire); no FSM-level confidence threshold.
+    Transition("pr_to_plan_approved",        IssueState.PR,                IssueState.PLAN_APPROVED,
+               labels_remove=[LABEL_PR_OPEN],             labels_add=[LABEL_PLAN_APPROVED],
+               min_confidence=None),
     Transition("pr_to_human_needed",         IssueState.PR,                IssueState.HUMAN_NEEDED,
                labels_remove=[LABEL_PR_OPEN],             labels_add=[LABEL_HUMAN_NEEDED]),
     Transition("merged_to_solved",           IssueState.MERGED,            IssueState.SOLVED,

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -76,6 +76,7 @@ stateDiagram-v2
   IN_PROGRESS --> REFINING: in_progress_to_refining [caller-gated]
   PR --> MERGED: pr_to_merged [≥HIGH]
   PR --> REFINED: pr_to_refined [≥HIGH]
+  PR --> PLAN_APPROVED: pr_to_plan_approved [caller-gated]
   PR --> HUMAN_NEEDED: pr_to_human_needed [≥HIGH]
   MERGED --> SOLVED: merged_to_solved [≥HIGH]
   HUMAN_NEEDED --> RAISED: human_to_raised [≥HIGH]

--- a/tests/test_merge_approach_mismatch.py
+++ b/tests/test_merge_approach_mismatch.py
@@ -1,0 +1,243 @@
+"""Regression tests for issue #1075 — cai-merge `hold` verdicts
+tagged ``issue_type == "approach_mismatch"`` close the PR,
+stamp ``LABEL_OPUS_ATTEMPTED`` on the linked issue, and fire the
+new ``pr_to_plan_approved`` issue FSM transition. Verdicts without
+that tag (or with any other ``issue_type`` value) keep the prior
+``approved_to_human`` parking behaviour.
+"""
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.actions import merge as merge_mod
+from cai_lib.config import (
+    LABEL_OPUS_ATTEMPTED,
+    LABEL_PLAN_APPROVED,
+    LABEL_PR_OPEN,
+)
+from cai_lib.fsm_states import IssueState
+from cai_lib.fsm_transitions import ISSUE_TRANSITIONS
+
+
+class TestPrToPlanApprovedTransition(unittest.TestCase):
+    """The new issue FSM transition must be registered with the right shape."""
+
+    def test_transition_registered(self):
+        names = {t.name for t in ISSUE_TRANSITIONS}
+        self.assertIn("pr_to_plan_approved", names)
+
+    def test_transition_label_shape(self):
+        t = next(
+            t for t in ISSUE_TRANSITIONS
+            if t.name == "pr_to_plan_approved"
+        )
+        self.assertEqual(t.from_state, IssueState.PR)
+        self.assertEqual(t.to_state, IssueState.PLAN_APPROVED)
+        self.assertIn(LABEL_PR_OPEN, t.labels_remove)
+        self.assertIn(LABEL_PLAN_APPROVED, t.labels_add)
+
+
+def _pr_fixture(number: int = 1234) -> dict:
+    return {
+        "number": number,
+        "title": "auto-improve: example",
+        "headRefName": f"auto-improve/{number}-example",
+        "headRefOid": "d7becb043dfd84c2796f35b7deb1353881435930",
+        "labels": [{"name": "pr:approved"}],
+        "state": "OPEN",
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "mergedAt": None,
+        "comments": [],
+        "reviews": [],
+        "createdAt": "2026-04-20T00:00:00Z",
+    }
+
+
+class TestHandleMergeApproachMismatchRouting(unittest.TestCase):
+    """``handle_merge`` fast-paths only ``hold`` + ``approach_mismatch``."""
+
+    def _invoke(self, *, confidence: str, action: str,
+                issue_type):
+        """Drive handle_merge with a model verdict built from kwargs.
+
+        *issue_type* may be a string, ``None`` (field absent), or the
+        sentinel ``"<omit>"`` — the latter drops the key entirely from
+        the emitted JSON so the handler sees no field.
+        """
+        pr = _pr_fixture()
+
+        verdict: dict = {
+            "confidence": confidence,
+            "action": action,
+            "reasoning": "wrong API entirely; needs fresh implement",
+        }
+        if issue_type != "<omit>":
+            verdict["issue_type"] = issue_type
+
+        run_mock = MagicMock()
+        run_mock.return_value.returncode = 0
+        run_mock.return_value.stdout = ""
+        run_mock.return_value.stderr = ""
+
+        claude_mock = MagicMock()
+        claude_mock.return_value.returncode = 0
+        claude_mock.return_value.stdout = json.dumps(verdict)
+        claude_mock.return_value.stderr = ""
+
+        def gh_json_side_effect(args):
+            if "issue" in args and "view" in args:
+                return {
+                    "number": 1234,
+                    "title": "auto-improve: example",
+                    "labels": [{"name": "auto-improve:pr-open"}],
+                    "state": "OPEN",
+                    "body": "",
+                }
+            if "pr" in args and "view" in args:
+                return {"statusCheckRollup": []}
+            return {}
+
+        gh_json_mock = MagicMock(side_effect=gh_json_side_effect)
+        filter_mock = MagicMock(return_value=[])
+        fetch_review_mock = MagicMock(return_value=[])
+        has_label_mock = MagicMock(return_value=False)
+        set_labels_mock = MagicMock(return_value=True)
+        pr_transition_mock = MagicMock(return_value=True)
+        issue_transition_mock = MagicMock(return_value=True)
+        log_mock = MagicMock()
+        git_mock = MagicMock()
+
+        with patch.object(merge_mod, "_run", run_mock), \
+             patch.object(merge_mod, "_run_claude_p", claude_mock), \
+             patch.object(merge_mod, "_gh_json", gh_json_mock), \
+             patch.object(merge_mod, "_git", git_mock), \
+             patch.object(merge_mod, "_filter_comments_with_haiku",
+                          filter_mock), \
+             patch.object(merge_mod, "_fetch_review_comments",
+                          fetch_review_mock), \
+             patch.object(merge_mod, "_issue_has_label",
+                          has_label_mock), \
+             patch.object(merge_mod, "_set_labels", set_labels_mock), \
+             patch.object(merge_mod, "apply_pr_transition",
+                          pr_transition_mock), \
+             patch.object(merge_mod, "apply_transition",
+                          issue_transition_mock), \
+             patch.object(merge_mod, "log_run", log_mock):
+            rc = merge_mod.handle_merge(pr)
+
+        self.assertEqual(rc, 0)
+        return {
+            "pr_transition": pr_transition_mock,
+            "issue_transition": issue_transition_mock,
+            "set_labels": set_labels_mock,
+            "run": run_mock,
+        }
+
+    def _pr_transition_names(self, pr_transition_mock) -> list:
+        return [
+            c.args[1] for c in pr_transition_mock.call_args_list
+            if len(c.args) >= 2 and isinstance(c.args[1], str)
+        ]
+
+    def _issue_transition_names(self, issue_transition_mock) -> list:
+        return [
+            c.args[1] for c in issue_transition_mock.call_args_list
+            if len(c.args) >= 2 and isinstance(c.args[1], str)
+        ]
+
+    def test_hold_with_approach_mismatch_closes_and_transitions(self):
+        mocks = self._invoke(
+            confidence="medium", action="hold",
+            issue_type="approach_mismatch",
+        )
+        # No PR FSM transition fires on the success path (close + issue
+        # transition is the entire recovery).
+        self.assertEqual(self._pr_transition_names(mocks["pr_transition"]), [])
+        # Exactly one issue FSM transition, pointing at PLAN_APPROVED.
+        self.assertEqual(
+            self._issue_transition_names(mocks["issue_transition"]),
+            ["pr_to_plan_approved"],
+        )
+        # LABEL_OPUS_ATTEMPTED was stamped on the issue.
+        set_labels_calls = mocks["set_labels"].call_args_list
+        self.assertTrue(
+            any(
+                LABEL_OPUS_ATTEMPTED in (c.kwargs.get("add") or [])
+                for c in set_labels_calls
+            ),
+            f"LABEL_OPUS_ATTEMPTED was not added; got: {set_labels_calls!r}",
+        )
+        # gh pr close --delete-branch was invoked exactly once.
+        close_calls = [
+            c for c in mocks["run"].call_args_list
+            if c.args and c.args[0][:3] == ["gh", "pr", "close"]
+        ]
+        self.assertEqual(len(close_calls), 1)
+        self.assertIn("--delete-branch", close_calls[0].args[0])
+
+    def test_hold_without_issue_type_still_parks_as_human(self):
+        mocks = self._invoke(
+            confidence="medium", action="hold",
+            issue_type="<omit>",
+        )
+        self.assertEqual(
+            self._pr_transition_names(mocks["pr_transition"]),
+            ["approved_to_human"],
+        )
+        self.assertEqual(
+            self._issue_transition_names(mocks["issue_transition"]),
+            [],
+        )
+
+    def test_hold_with_issue_type_none_still_parks_as_human(self):
+        mocks = self._invoke(
+            confidence="medium", action="hold",
+            issue_type=None,
+        )
+        self.assertEqual(
+            self._pr_transition_names(mocks["pr_transition"]),
+            ["approved_to_human"],
+        )
+        self.assertEqual(
+            self._issue_transition_names(mocks["issue_transition"]),
+            [],
+        )
+
+    def test_hold_with_issue_type_other_still_parks_as_human(self):
+        mocks = self._invoke(
+            confidence="medium", action="hold",
+            issue_type="other",
+        )
+        self.assertEqual(
+            self._pr_transition_names(mocks["pr_transition"]),
+            ["approved_to_human"],
+        )
+        self.assertEqual(
+            self._issue_transition_names(mocks["issue_transition"]),
+            [],
+        )
+
+    def test_hold_with_scope_creep_does_not_trigger_approach_path(self):
+        """Only ``approach_mismatch`` triggers the close+opus path;
+        other enum values are pass-through for this handler."""
+        mocks = self._invoke(
+            confidence="medium", action="hold",
+            issue_type="scope_creep",
+        )
+        self.assertEqual(
+            self._pr_transition_names(mocks["pr_transition"]),
+            ["approved_to_human"],
+        )
+        self.assertEqual(
+            self._issue_transition_names(mocks["issue_transition"]),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1075

**Issue:** #1075 — Rescue prevention: When a merge review issues a `hold` verdict citing implementation-approach mismatch (not just style/nit comments), the F

## PR Summary

### What this fixes
When `cai-merge` returns a `hold` verdict because the PR took the wrong fundamental approach (wrong API, wrong algorithm, wrong data model), the issue used to park at `pr:human-needed`, wasting a rescue cycle on an Opus re-evaluation. This PR adds a fast-path: when the merge agent sets `issue_type = "approach_mismatch"`, the handler automatically closes the PR, stamps `LABEL_OPUS_ATTEMPTED` on the linked issue, and fires the new `pr_to_plan_approved` FSM transition so `cai-implement` re-runs under Opus on the next tick.

### What was changed
- **`cai_lib/actions/merge.py`**: imported `LABEL_OPUS_ATTEMPTED` and `apply_transition`; extended `_MERGE_JSON_SCHEMA` with optional `issue_type` enum field; inserted the approach-mismatch branch (close PR, stamp label, fire `pr_to_plan_approved`) between the existing fixable-bug handler and `LABEL_MERGE_BLOCKED` bookkeeping
- **`cai_lib/fsm_transitions.py`**: added `Transition("pr_to_plan_approved", IssueState.PR, IssueState.PLAN_APPROVED, ...)` between `pr_to_refined` and `pr_to_human_needed`
- **`.claude/agents/review/cai-merge.md`** (via staging): added `## Issue type classification` section documenting when to set each `issue_type` value; extended Output format block to show the optional `issue_type` field
- **`tests/test_merge_approach_mismatch.py`** (new): unit tests covering FSM transition registration and `handle_merge` routing for `approach_mismatch`, absent `issue_type`, `null`, `"other"`, and `"scope_creep"` cases

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
