### PR TITLE
auto-improve: Add co-change checklist to cai-implement to prevent recurring missing_co_change PR findings

### DIFF
--- a/.claude/agents/implementation/cai-implement.md
+++ b/.claude/agents/implementation/cai-implement.md
@@ -293,6 +293,32 @@ implement subagent in a subsequent cycle.
 Only suggest issues that are concrete and actionable — do not
 suggest vague improvements or things you are unsure about.
 
+## Co-change checklist
+
+Before exiting with a non-zero diff, run through this checklist.
+Skip items that clearly don't apply, but err on the side of checking.
+
+- **(a) Symbol and reference sweep:** For every symbol, config key,
+  CLI flag, or file path you renamed, added, or removed, Grep the
+  entire work directory for remaining references. Update any caller
+  or reference that needs to change. If you intentionally skip a
+  reference (e.g. it is outside the plan scope), note it under
+  "Out of scope / known gaps" in the PR context dossier. *(This
+  reinforces hard rule 7 — both apply.)*
+- **(b) Docs sync:** If your change affects public-facing behavior,
+  a CLI interface, a configuration key, or overall architecture,
+  Grep `docs/` for related content and update any stale or missing
+  doc files. If a doc file should exist but doesn't, note it as a
+  gap rather than creating it out of scope.
+- **(c) Module index sync:** If you added, renamed, or deleted a
+  tracked source file (`*.py`, agent `.md`, etc.), update
+  `docs/modules.yaml` and the matching `docs/modules/<name>.md`
+  entry. Add a new entry or stub if the file is new.
+- **(d) PR body communication:** In your `## PR Summary`, note any
+  intentionally skipped co-changes (e.g. "docs/modules.yaml not
+  updated — no tracked source files changed") so reviewers
+  understand the scope boundary.
+
 ## Before you exit: write the PR context dossier
 
 If (and only if) you are making code changes, write a short dossier

--- a/.claude/agents/implementation/cai-plan.md
+++ b/.claude/agents/implementation/cai-plan.md
@@ -74,6 +74,30 @@ The user message contains:
    different framework from the one the existing suite uses, even
    if the issue body or a peer plan suggests otherwise.
 
+## Co-change awareness
+
+When scoping a plan, actively identify co-changes that must
+accompany the primary edit. Include them in `### Files to change`
+and the detailed steps rather than leaving them for a post-merge
+ripple finding. Specifically check for:
+
+- **(a) Symbol and reference sweep:** After identifying the primary
+  edit target, Grep for all other uses of renamed or added symbols,
+  config keys, CLI flags, or file paths. If callers or references
+  must change too, include them in the plan scope.
+- **(b) Docs sync:** If the change affects public-facing behavior,
+  a CLI interface, configuration keys, or architecture, include the
+  relevant `docs/` file(s) in `### Files to change` and provide
+  the edit steps.
+- **(c) Module index sync:** If the change adds, renames, or deletes
+  a tracked source file (`*.py`, agent `.md`, etc.), include
+  `docs/modules.yaml` and the matching `docs/modules/<name>.md` in
+  `### Files to change`.
+- **(d) Scope boundary declaration:** List any co-changes you
+  intentionally omit from the plan in `### Scope guardrails` so the
+  fix agent knows not to chase them and the PR body can communicate
+  the gap.
+
 ## Agent-specific efficiency guidance
 
 1. **Use Agent for broad exploration.** When you need to search


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1082

**Issue:** #1082 — Add co-change checklist to cai-implement to prevent recurring missing_co_change PR findings

## PR Summary

### What this fixes
`cai-review-pr` consistently raises `missing_co_change` findings (10 findings across 5 PRs in 30 days) because neither `cai-implement` nor `cai-plan` prompt the agent to check for co-changes — docs sync, module index updates, and reference sweeps — before submitting a PR.

### What was changed
- **`.claude/agents/implementation/cai-implement.md`** (via staging): Added a new `## Co-change checklist` section before `## Before you exit: write the PR context dossier`, with four items: (a) symbol/reference sweep, (b) docs sync, (c) module index sync, (d) PR body communication of intentional skips.
- **`.claude/agents/implementation/cai-plan.md`** (via staging): Added a new `## Co-change awareness` section before `## Agent-specific efficiency guidance`, with parallel four-item guidance directing planners to proactively include co-changes in `### Files to change` and declare intentional omissions in `### Scope guardrails`.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
