### PR TITLE
auto-improve: Issue #1044 parked at human-needed with no parseable divert-reason comment despite #1072 fix

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -147,6 +147,7 @@
 | `tests/test_fsm_schema.py` | Tests for cai_lib.fsm_schema — validates ISSUE_TRANSITIONS and PR_TRANSITIONS catalogs against transitions.Machine for state reference correctness |
 | `tests/test_implement_consecutive_failures.py` | TODO: add description |
 | `tests/test_implement_helper_extract.py` | TODO: add description |
+| `tests/test_implement_human_needed_reason.py` | TODO: add description |
 | `tests/test_implement_scope.py` | Tests for plan-scope enforcement in cai_lib.actions.implement — validates scope parsing, path normalization, and out-of-scope file detection (issue #1074) |
 | `tests/test_implement_test_failure_extract.py` | TODO: add description |
 | `tests/test_lint.py` | Lint check: ruff must report zero violations |

--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -86,15 +86,49 @@ _SLUG_RE = re.compile(r"[^a-z0-9]+")
 # (see issues #748 / #695).
 _MAX_TESTS_FAILED_RETRIES = 2
 
-# Divert-reason marker prepended to every comment this module posts
-# alongside a direct `_set_labels(add=[LABEL_HUMAN_NEEDED])` call.
-# `cmd_agents.py` (see `MARKER` at line 126) scans for this literal
-# substring when compiling the `human_needed_reason_missing` audit
-# finding — comments that omit it are treated as missing a reason.
-# Format matches the `**🙋 Human attention needed**\n\n` convention
-# used by `cai_lib/fsm_transitions.py`, `actions/plan.py`, and
-# `actions/refine.py`.
-_HUMAN_NEEDED_MARKER = "**🙋 Human attention needed**\n\n"
+def _park_in_progress_at_human_needed(
+    issue_number: int,
+    *,
+    reason: str,
+    extra_remove: tuple[str, ...] = (),
+    log_prefix: str = "cai implement",
+) -> bool:
+    """Park an :in-progress issue at :human-needed with a parseable divert-reason comment.
+
+    Wraps :func:`apply_transition` for ``in_progress_to_human_needed``
+    so every implement-side escalation path goes through the PR #1072
+    invariant (issue #1009) — which refuses silent HUMAN_NEEDED diverts
+    and auto-posts a :func:`_render_human_divert_reason`-rendered
+    comment carrying the ``Automation paused ``<transition>```,
+    ``Required confidence: ``<val>``` and ``Reported confidence:
+    ``<val>``` lines that ``_fetch_human_needed_issues`` in
+    :mod:`cai_lib.cmd_agents` regex-matches for the audit agent's
+    ``human_needed_reason_missing`` finder.
+
+    Prior to issue #1083 this handler called
+    ``_set_labels(add=[LABEL_HUMAN_NEEDED])`` directly in four places
+    with a hand-rolled comment that only carried the marker header
+    and skipped the structured fields — leaving #1044 (and any future
+    opus-retry park) invisible to the audit parser.
+
+    Returns True iff the park succeeded (labels changed + MARKER
+    comment posted). Retries once on transient ``_set_labels`` failure
+    — the same double-retry pattern the direct-label path had before
+    the refactor. The retry re-invokes ``apply_transition``; because
+    its comment post is gated on ``ok`` from ``_set_labels``, a failed
+    first attempt does not double-post the comment on the second
+    attempt.
+    """
+    for _attempt in range(2):
+        if apply_transition(
+            issue_number,
+            "in_progress_to_human_needed",
+            extra_remove=list(extra_remove),
+            log_prefix=log_prefix,
+            divert_reason=reason,
+        ):
+            return True
+    return False
 
 
 def _slugify(text: str, max_len: int = 50) -> str:
@@ -869,8 +903,7 @@ def handle_implement(issue: dict) -> int:
                 f"and escalating to auto-improve:human-needed",
                 flush=True,
             )
-            comment_body = (
-                f"{_HUMAN_NEEDED_MARKER}"
+            reason = (
                 "## Implement subagent: pre-empted after repeated "
                 "test failures\n\n"
                 f"This issue already has {prior_fails} consecutive "
@@ -884,33 +917,19 @@ def handle_implement(issue: dict) -> int:
                 f"Re-label to `{LABEL_PLAN_APPROVED}` once the "
                 "underlying problem is resolved to retry._"
             )
-            _run(
-                ["gh", "issue", "comment", str(issue_number),
-                 "--repo", REPO,
-                 "--body", comment_body],
-                capture_output=True,
-            )
-            terminal_remove = [LABEL_IN_PROGRESS]
-            if not _set_labels(
-                issue_number,
-                add=[LABEL_HUMAN_NEEDED],
-                remove=terminal_remove,
+            if not _park_in_progress_at_human_needed(
+                issue_number, reason=reason,
             ):
-                if not _set_labels(
-                    issue_number,
-                    add=[LABEL_HUMAN_NEEDED],
-                    remove=terminal_remove,
-                ):
-                    print(
-                        f"[cai implement] WARNING: label transition "
-                        f"to auto-improve:human-needed failed twice "
-                        f"for #{issue_number} — issue may be stuck",
-                        file=sys.stderr, flush=True,
-                    )
-                    log_run("implement", repo=REPO,
-                            issue=issue_number,
-                            result="label_transition_failed", exit=1)
-                    return 1
+                print(
+                    f"[cai implement] WARNING: label transition "
+                    f"to auto-improve:human-needed failed twice "
+                    f"for #{issue_number} — issue may be stuck",
+                    file=sys.stderr, flush=True,
+                )
+                log_run("implement", repo=REPO,
+                        issue=issue_number,
+                        result="label_transition_failed", exit=1)
+                return 1
             log_run("implement", repo=REPO, issue=issue_number,
                     result="tests_failed_escalated_early", exit=0)
             return 0
@@ -921,24 +940,15 @@ def handle_implement(issue: dict) -> int:
     print(f"[cai implement] pre-screen: verdict={ps_verdict} reason={ps_reason}", flush=True)
 
     if ps_verdict == "spike":
-        _set_labels(
-            issue_number,
-            add=[LABEL_HUMAN_NEEDED],
-            remove=[LABEL_IN_PROGRESS],
+        reason = (
+            f"## Pre-screen: spike-shaped\n\n"
+            f"{ps_reason}\n\n---\n"
+            f"_Flagged by `cai implement` pre-screen (Haiku) as "
+            f"spike-shaped (needs research, not code). No spike agent "
+            f"exists — routed to human review. Re-label to "
+            f"`{LABEL_PLAN_APPROVED}` to retry._"
         )
-        _run(
-            ["gh", "issue", "comment", str(issue_number),
-             "--repo", REPO,
-             "--body",
-             f"{_HUMAN_NEEDED_MARKER}"
-             f"## Pre-screen: spike-shaped\n\n"
-             f"{ps_reason}\n\n---\n"
-             f"_Flagged by `cai implement` pre-screen (Haiku) as "
-             f"spike-shaped (needs research, not code). No spike agent "
-             f"exists — routed to human review. Re-label to "
-             f"`{LABEL_PLAN_APPROVED}` to retry._"],
-            capture_output=True,
-        )
+        _park_in_progress_at_human_needed(issue_number, reason=reason)
         log_run("implement", repo=REPO, issue=issue_number, result="pre_screen_human", exit=0)
         return 0
 
@@ -1161,8 +1171,7 @@ def handle_implement(issue: dict) -> int:
             ) is not None
 
             if is_spike:
-                comment_body = (
-                    f"{_HUMAN_NEEDED_MARKER}"
+                reason = (
                     "## Implement subagent: needs human review\n\n"
                     f"{reasoning}\n\n"
                     "---\n"
@@ -1178,34 +1187,22 @@ def handle_implement(issue: dict) -> int:
                     f"#{issue_number}; marking auto-improve:human-needed",
                     flush=True,
                 )
-                _run(
-                    ["gh", "issue", "comment", str(issue_number),
-                     "--repo", REPO,
-                     "--body", comment_body],
-                    capture_output=True,
-                )
-                terminal_remove = [LABEL_IN_PROGRESS, LABEL_PLAN_APPROVED]
-                if not _set_labels(
+                if not _park_in_progress_at_human_needed(
                     issue_number,
-                    add=[LABEL_HUMAN_NEEDED],
-                    remove=terminal_remove,
+                    reason=reason,
+                    extra_remove=(LABEL_PLAN_APPROVED,),
                 ):
-                    if not _set_labels(
-                        issue_number,
-                        add=[LABEL_HUMAN_NEEDED],
-                        remove=terminal_remove,
-                    ):
-                        print(
-                            f"[cai implement] WARNING: label transition to "
-                            f"auto-improve:human-needed failed twice for "
-                            f"#{issue_number} — issue may be stuck without "
-                            "a lifecycle label",
-                            file=sys.stderr, flush=True,
-                        )
-                        rollback()
-                        log_run("implement", repo=REPO, issue=issue_number,
-                                result="label_transition_failed", exit=1)
-                        return 1
+                    print(
+                        f"[cai implement] WARNING: label transition to "
+                        f"auto-improve:human-needed failed twice for "
+                        f"#{issue_number} — issue may be stuck without "
+                        "a lifecycle label",
+                        file=sys.stderr, flush=True,
+                    )
+                    rollback()
+                    log_run("implement", repo=REPO, issue=issue_number,
+                            result="label_transition_failed", exit=1)
+                    return 1
                 locked = False
                 log_run("implement", repo=REPO, issue=issue_number,
                         result="human_needed", exit=0)
@@ -1350,8 +1347,7 @@ def handle_implement(issue: dict) -> int:
                                 result="tests_failed_auto_refine", exit=0)
                         return 0
 
-                comment_body = (
-                    f"{_HUMAN_NEEDED_MARKER}"
+                reason = (
                     "## Implement subagent: repeated test failures\n\n"
                     f"Regression tests failed {consecutive} consecutive times "
                     f"for this issue. Escalating to human review to avoid "
@@ -1371,34 +1367,20 @@ def handle_implement(issue: dict) -> int:
                     f"for #{issue_number}; marking auto-improve:human-needed",
                     flush=True,
                 )
-                _run(
-                    ["gh", "issue", "comment", str(issue_number),
-                     "--repo", REPO,
-                     "--body", comment_body],
-                    capture_output=True,
-                )
-                terminal_remove = [LABEL_IN_PROGRESS]
-                if not _set_labels(
-                    issue_number,
-                    add=[LABEL_HUMAN_NEEDED],
-                    remove=terminal_remove,
+                if not _park_in_progress_at_human_needed(
+                    issue_number, reason=reason,
                 ):
-                    if not _set_labels(
-                        issue_number,
-                        add=[LABEL_HUMAN_NEEDED],
-                        remove=terminal_remove,
-                    ):
-                        print(
-                            f"[cai implement] WARNING: label transition to "
-                            f"auto-improve:human-needed failed twice for "
-                            f"#{issue_number} — issue may be stuck without "
-                            "a lifecycle label",
-                            file=sys.stderr, flush=True,
-                        )
-                        rollback()
-                        log_run("implement", repo=REPO, issue=issue_number,
-                                result="label_transition_failed", exit=1)
-                        return 1
+                    print(
+                        f"[cai implement] WARNING: label transition to "
+                        f"auto-improve:human-needed failed twice for "
+                        f"#{issue_number} — issue may be stuck without "
+                        "a lifecycle label",
+                        file=sys.stderr, flush=True,
+                    )
+                    rollback()
+                    log_run("implement", repo=REPO, issue=issue_number,
+                            result="label_transition_failed", exit=1)
+                    return 1
                 locked = False
                 log_run("implement", repo=REPO, issue=issue_number,
                         result="tests_failed_escalated", exit=0)

--- a/cai_lib/fsm_transitions.py
+++ b/cai_lib/fsm_transitions.py
@@ -205,6 +205,22 @@ ISSUE_TRANSITIONS: list[Transition] = [
     Transition("in_progress_to_refining",    IssueState.IN_PROGRESS,       IssueState.REFINING,
                labels_remove=[LABEL_IN_PROGRESS],       labels_add=[LABEL_REFINING],
                min_confidence=None),
+    # Explicit IN_PROGRESS → HUMAN_NEEDED park used by the four
+    # implement-side escalation paths (early-abort guard, pre-screen
+    # spike verdict, subagent-no-change spike marker, repeated
+    # test-failures on a non-MEDIUM plan). Caller-gated (no FSM-level
+    # confidence threshold) — the handler decides when to park and
+    # supplies the divert_reason text that apply_transition renders
+    # into the MARKER-bearing comment the audit parser picks up. Added
+    # in response to issue #1083: before this transition existed the
+    # four code paths called ``_set_labels(add=[LABEL_HUMAN_NEEDED])``
+    # directly with a hand-rolled comment that was missing the
+    # ``Automation paused`` / ``Required confidence:`` /
+    # ``Reported confidence:`` lines, silently breaking
+    # ``_fetch_human_needed_issues`` in cmd_agents.py.
+    Transition("in_progress_to_human_needed", IssueState.IN_PROGRESS,      IssueState.HUMAN_NEEDED,
+               labels_remove=[LABEL_IN_PROGRESS],       labels_add=[LABEL_HUMAN_NEEDED],
+               min_confidence=None),
     Transition("pr_to_merged",               IssueState.PR,                IssueState.MERGED,
                labels_remove=[LABEL_PR_OPEN],             labels_add=[LABEL_MERGED]),
     # Recovery paths out of PR when the linked PR was closed unmerged
@@ -597,7 +613,11 @@ def _render_human_divert_reason(
     semantics only needs to touch one formatter.
     """
     conf_name = confidence.name if confidence is not None else "MISSING"
-    required = transition.min_confidence.name
+    required = (
+        transition.min_confidence.name
+        if transition.min_confidence is not None
+        else "caller-gated"
+    )
     lines = [
         "**🙋 Human attention needed**",
         "",

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -74,6 +74,7 @@ stateDiagram-v2
   PLAN_APPROVED --> IN_PROGRESS: approved_to_in_progress [≥HIGH]
   IN_PROGRESS --> PR: in_progress_to_pr [≥HIGH]
   IN_PROGRESS --> REFINING: in_progress_to_refining [caller-gated]
+  IN_PROGRESS --> HUMAN_NEEDED: in_progress_to_human_needed [caller-gated]
   PR --> MERGED: pr_to_merged [≥HIGH]
   PR --> REFINED: pr_to_refined [≥HIGH]
   PR --> PLAN_APPROVED: pr_to_plan_approved [caller-gated]

--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -156,6 +156,10 @@ declare -A DESCRIPTIONS=(
   ["tests/test_rollback.py"]="Tests for rollback functionality"
   ["tests/test_transcript_sync.py"]="Tests for cai_lib.transcript_sync — no-op path, parse_source fallback, repo slug"
   ["tests/test_open_pr_non_bot_branch.py"]="Regression tests for PR-open-time non-bot-branch detection (issue #1065)"
+  ["tests/test_implement_consecutive_failures.py"]="Tests for cai_lib.actions.implement._count_consecutive_tests_failed — validates counting of consecutive test failures for early-abort guard"
+  ["tests/test_implement_helper_extract.py"]="Tests for cai_lib.actions.implement._extract_referenced_helpers and _enclosing_function_source (issue #987) — validates helper function source extraction from test output"
+  ["tests/test_implement_human_needed_reason.py"]="Regression tests for implement-side human-needed parks (issue #1083) — validates in_progress_to_human_needed transition and _park_in_progress_at_human_needed helper ensure divert-reason comments carry structured fields"
+  ["tests/test_implement_test_failure_extract.py"]="Tests for cai_lib.actions.implement._extract_test_failures — validates parsing of test failure output from unittest discovery"
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/test_implement_human_needed_reason.py
+++ b/tests/test_implement_human_needed_reason.py
@@ -1,0 +1,195 @@
+"""Regression tests for the :human-needed parking path in cai_lib.actions.implement.
+
+Issue #1083: four implement-side escalation paths (early-abort guard,
+pre-screen spike verdict, subagent-no-change spike marker, repeated
+test failures on a non-MEDIUM plan) called ``_set_labels(add=[LABEL_HUMAN_NEEDED])``
+directly with a hand-rolled comment that carried only the marker
+header and skipped the structured ``Automation paused``, ``Required
+confidence:``, and ``Reported confidence:`` lines that
+``_fetch_human_needed_issues`` in ``cmd_agents.py`` regex-matches.
+That left #1044 (opus-retry post-rollback park) invisible to the
+audit parser's ``human_needed_reason_missing`` finder.
+
+These tests pin the refactored behaviour:
+
+- ``in_progress_to_human_needed`` transition exists and is caller-gated.
+- ``_park_in_progress_at_human_needed`` funnels through
+  ``apply_transition`` so the PR #1072 invariant fires and the MARKER
+  comment is auto-posted with the structured fields.
+- ``_render_human_divert_reason`` is safe when ``transition.min_confidence``
+  is ``None`` (previously crashed with ``AttributeError``).
+"""
+import os
+import re
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.actions import implement as impl_mod  # noqa: E402
+from cai_lib.config import (  # noqa: E402
+    LABEL_HUMAN_NEEDED, LABEL_IN_PROGRESS, LABEL_PLAN_APPROVED,
+)
+from cai_lib.fsm import (  # noqa: E402
+    Confidence, ISSUE_TRANSITIONS, IssueState, Transition, find_transition,
+)
+from cai_lib.fsm_transitions import _render_human_divert_reason  # noqa: E402
+
+
+class TestInProgressToHumanNeededTransition(unittest.TestCase):
+    """The new FSM transition for implement-side parks (#1083)."""
+
+    def test_transition_registered(self):
+        t = find_transition("in_progress_to_human_needed")
+        self.assertEqual(t.from_state, IssueState.IN_PROGRESS)
+        self.assertEqual(t.to_state, IssueState.HUMAN_NEEDED)
+        self.assertIn(t, ISSUE_TRANSITIONS)
+
+    def test_transition_is_caller_gated(self):
+        """No FSM-level confidence threshold — the handler decides."""
+        t = find_transition("in_progress_to_human_needed")
+        self.assertIsNone(t.min_confidence)
+
+    def test_transition_label_deltas(self):
+        t = find_transition("in_progress_to_human_needed")
+        self.assertIn(LABEL_IN_PROGRESS, t.labels_remove)
+        self.assertIn(LABEL_HUMAN_NEEDED, t.labels_add)
+
+
+class TestRenderHumanDivertReasonNoneThreshold(unittest.TestCase):
+    """``_render_human_divert_reason`` must not crash when min_confidence is None."""
+
+    def test_caller_gated_transition_renders_placeholder(self):
+        t = Transition(
+            "fake_caller_gated",
+            IssueState.IN_PROGRESS, IssueState.HUMAN_NEEDED,
+            labels_remove=[LABEL_IN_PROGRESS],
+            labels_add=[LABEL_HUMAN_NEEDED],
+            min_confidence=None,
+        )
+        body = _render_human_divert_reason(
+            transition_name="fake_caller_gated",
+            transition=t,
+            confidence=None,
+            extra="reason text",
+        )
+        self.assertIn("Required confidence: `caller-gated`", body)
+        self.assertIn("Reported confidence: `MISSING`", body)
+        self.assertIn("reason text", body)
+
+
+class TestParkInProgressAtHumanNeeded(unittest.TestCase):
+    """``_park_in_progress_at_human_needed`` funnels through apply_transition."""
+
+    # Regex mirrors ``_fetch_human_needed_issues`` in cai_lib/cmd_agents.py:
+    # those three patterns are what the audit agent uses to report
+    # ``human_needed_reason_missing``; if any stops matching, the audit
+    # agent will flag the divert as silent again.
+    _TRANSITION_RE = re.compile(r"Automation paused `([^`]+)`")
+    _REQUIRED_RE = re.compile(r"Required confidence:\s*`([^`]+)`")
+    _REPORTED_RE = re.compile(r"Reported confidence:\s*`([^`]+)`")
+
+    def _install_fakes(self, *, first_set_labels_ok=True, second_set_labels_ok=True):
+        calls = {"set_labels": [], "post_comment": []}
+
+        def _fake_set_labels(issue_number, *, add=(), remove=(), log_prefix="cai"):
+            calls["set_labels"].append({
+                "issue": issue_number,
+                "add": list(add),
+                "remove": list(remove),
+            })
+            if len(calls["set_labels"]) == 1:
+                return first_set_labels_ok
+            return second_set_labels_ok
+
+        def _fake_post_comment(issue_number, body, *, log_prefix="cai"):
+            calls["post_comment"].append({"issue": issue_number, "body": body})
+            return True
+
+        p1 = mock.patch("cai_lib.github._set_labels", _fake_set_labels)
+        p2 = mock.patch("cai_lib.github._post_issue_comment", _fake_post_comment)
+        p1.start()
+        p2.start()
+        self.addCleanup(p1.stop)
+        self.addCleanup(p2.stop)
+        return calls
+
+    def test_first_attempt_success_posts_structured_comment(self):
+        calls = self._install_fakes()
+        ok = impl_mod._park_in_progress_at_human_needed(
+            1044, reason="## Test escalation\n\nBody text.",
+        )
+        self.assertTrue(ok)
+        # Only one _set_labels call on the success path.
+        self.assertEqual(len(calls["set_labels"]), 1)
+        first = calls["set_labels"][0]
+        self.assertEqual(first["issue"], 1044)
+        self.assertIn(LABEL_HUMAN_NEEDED, first["add"])
+        self.assertIn(LABEL_IN_PROGRESS, first["remove"])
+        # Exactly one MARKER comment, carrying the three structured fields.
+        self.assertEqual(len(calls["post_comment"]), 1)
+        body = calls["post_comment"][0]["body"]
+        self.assertIn("🙋 Human attention needed", body)
+        m = self._TRANSITION_RE.search(body)
+        self.assertIsNotNone(m, "missing `Automation paused \\`...\\`` line")
+        self.assertEqual(m.group(1), "in_progress_to_human_needed")
+        m = self._REQUIRED_RE.search(body)
+        self.assertIsNotNone(m, "missing `Required confidence` line")
+        self.assertEqual(m.group(1), "caller-gated")
+        m = self._REPORTED_RE.search(body)
+        self.assertIsNotNone(m, "missing `Reported confidence` line")
+        self.assertEqual(m.group(1), "MISSING")
+        # The reason text is appended verbatim after the structured fields.
+        self.assertIn("## Test escalation", body)
+        self.assertIn("Body text.", body)
+
+    def test_extra_remove_is_appended_to_labels_remove(self):
+        """The subagent-no-change spike path must also strip LABEL_PLAN_APPROVED."""
+        calls = self._install_fakes()
+        ok = impl_mod._park_in_progress_at_human_needed(
+            1044,
+            reason="## Needs spike\n\nresearch required",
+            extra_remove=(LABEL_PLAN_APPROVED,),
+        )
+        self.assertTrue(ok)
+        first = calls["set_labels"][0]
+        self.assertIn(LABEL_IN_PROGRESS, first["remove"])
+        self.assertIn(LABEL_PLAN_APPROVED, first["remove"])
+
+    def test_double_retry_on_transient_label_failure(self):
+        calls = self._install_fakes(
+            first_set_labels_ok=False, second_set_labels_ok=True,
+        )
+        ok = impl_mod._park_in_progress_at_human_needed(
+            1044, reason="## Retry\n\nretry body",
+        )
+        self.assertTrue(ok)
+        self.assertEqual(len(calls["set_labels"]), 2)
+        # First attempt's _set_labels failed, so apply_transition never
+        # posted on that attempt. The second attempt succeeded and
+        # posted exactly one comment.
+        self.assertEqual(len(calls["post_comment"]), 1)
+
+    def test_returns_false_when_both_attempts_fail(self):
+        calls = self._install_fakes(
+            first_set_labels_ok=False, second_set_labels_ok=False,
+        )
+        ok = impl_mod._park_in_progress_at_human_needed(
+            1044, reason="## Always fails\n\nbody",
+        )
+        self.assertFalse(ok)
+        self.assertEqual(len(calls["set_labels"]), 2)
+        self.assertEqual(calls["post_comment"], [])
+
+    def test_empty_reason_refused_by_apply_transition_invariant(self):
+        """Empty divert_reason must be refused (PR #1072 invariant)."""
+        calls = self._install_fakes()
+        ok = impl_mod._park_in_progress_at_human_needed(1044, reason="")
+        self.assertFalse(ok)
+        self.assertEqual(calls["set_labels"], [])
+        self.assertEqual(calls["post_comment"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1083

**Issue:** #1083 — Issue #1044 parked at human-needed with no parseable divert-reason comment despite #1072 fix

## PR Summary

### What this fixes
Issue #1083: Four escalation paths in `cai_lib/actions/implement.py` called `_set_labels(add=[LABEL_HUMAN_NEEDED])` directly with hand-rolled comments that omitted the structured `Automation paused`, `Required confidence:`, and `Reported confidence:` fields that `_fetch_human_needed_issues` in `cmd_agents.py` regex-matches — leaving diverts like #1044 invisible to the audit parser despite the PR #1072 fix.

### What was changed
- **`cai_lib/fsm_transitions.py`**: Hardened `_render_human_divert_reason` to emit `"caller-gated"` when `transition.min_confidence is None` (latent crash fix); added new `in_progress_to_human_needed` caller-gated FSM transition (`IN_PROGRESS → HUMAN_NEEDED`, `min_confidence=None`) after `in_progress_to_refining`
- **`cai_lib/actions/implement.py`**: Replaced the `_HUMAN_NEEDED_MARKER` constant with a new `_park_in_progress_at_human_needed` helper that routes all parks through `apply_transition("in_progress_to_human_needed", divert_reason=...)`, enforcing the PR #1072 invariant; rewrote all four call sites (early-abort guard, pre-screen spike, subagent-no-change spike, tests-failed escalation) to use the helper
- **`tests/test_implement_human_needed_reason.py`**: New regression test file covering transition registration, `_render_human_divert_reason` with `None` threshold, helper success/retry/failure paths, and structured MARKER comment content

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
