### PR TITLE
auto-improve: Stop `git -C <clone>` sandbox refusals in review agents

### DIFF
--- a/.claude/agents/review/cai-review-docs.md
+++ b/.claude/agents/review/cai-review-docs.md
@@ -294,9 +294,31 @@ them inline — they are automatically converted to separate GitHub issues.
    skip it entirely.
 6. **Keep fixes short.** Update only the specific stale content, preserving
    all other text.
-7. **Do not use Bash.** You have `Read`, `Grep`, `Glob`, `Edit`, and `Write` —
-   use them exclusively. Bash is not available and all Bash calls will be
-   rejected by the sandbox.
+7. **Do not use Bash or run any `git` command.** You have `Read`,
+   `Grep`, `Glob`, `Edit`, and `Write` — use them exclusively.
+   Bash is not allowlisted for this agent
+   (`--allowedTools Read,Grep,Glob,Edit,Write` in
+   `cai_lib/actions/review_docs.py`). Even when the model
+   attempts a shell-out anyway, any
+   `Bash("git -C <work_dir> diff ...")`,
+   `Bash("git -C <work_dir> log ...")`,
+   `Bash("git -C <work_dir> status ...")`, or other
+   `git -C <path> ...` call is further refused by the sandbox
+   with "This command changes directory before running git,
+   which can execute untrusted hooks from the target directory"
+   — each such refusal wastes a turn. Every piece of git state
+   you would want is already in the user message: the
+   `## PR changes (stat summary)` block (from
+   `git diff origin/main..HEAD --stat`), the
+   `## Authoritative deletion manifest` block (from
+   `git diff --name-only --diff-filter=D`, verified against the
+   work directory), the `## Generated-docs regeneration` block
+   (drift from running the deterministic doc generators), and
+   the `## Module coverage` block. Treat all four as final and
+   do NOT try to re-run `git diff`, `git log`, `git status`, or
+   any other `git` command. For file contents, open them
+   directly from the work directory with `Read` (the PR branch
+   is already checked out there).
 8. **Use the staging directory for `.claude/agents/*.md` edits.** These files
    are flagged as sensitive and direct Edit/Write calls against them will be
    blocked. If you find stale documentation inside an agent definition file,

--- a/.claude/agents/review/cai-review-pr.md
+++ b/.claude/agents/review/cai-review-pr.md
@@ -150,9 +150,23 @@ GitHub issue will be created automatically instead.
    authorizes, emit an `## Out-of-scope Issue` block (see Output
    format) rather than a `### Finding:` block. Do not block the PR
    on work that belongs in a separate issue.
-9. **Do not use Bash.** You have `Read`, `Grep`, and `Glob` — use
-   them exclusively. Bash is not available and all Bash calls will be
-   rejected by the sandbox.
+9. **Do not use Bash or run any `git` command.** You have `Read`,
+   `Grep`, and `Glob` — use them exclusively. Bash is not
+   allowlisted for this agent (`--allowedTools Read,Grep,Glob` in
+   `cai_lib/actions/review_pr.py`). Even when the model attempts
+   a shell-out anyway, any `Bash("git -C <work_dir> diff ...")`,
+   `Bash("git -C <work_dir> log ...")`, or other
+   `git -C <path> ...` call is further refused by the sandbox
+   with "This command changes directory before running git,
+   which can execute untrusted hooks from the target directory"
+   — each such refusal wastes a turn. The `## PR changes (stat
+   summary)` block in the user message is pre-computed from
+   `git diff origin/main..HEAD --stat` by the wrapper; treat it
+   as the final, authoritative file-level diff map and do NOT
+   try to re-run `git diff`, `git log`, or any other `git`
+   command. For the contents of individual changed files, open
+   them directly from the work directory with `Read` (the PR
+   branch is already checked out there).
 
 ## Agent-specific efficiency guidance
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1085

**Issue:** #1085 — Stop `git -C <clone>` sandbox refusals in review agents

## PR Summary

### What this fixes
Both `cai-review-pr` and `cai-review-docs` agents were generating `Bash("git -C <work_dir> ...")` calls that the sandbox unconditionally refuses with "This command changes directory before running git, which can execute untrusted hooks from the target directory", wasting turns and causing retry loops.

### What was changed
- **`.claude/agents/review/cai-review-pr.md`** — Hard rule 9 rewritten to explicitly name the `git -C <path>` anti-pattern, quote the exact sandbox refusal message, state that Bash is not in the `--allowedTools` allowlist, and instruct the agent to use the pre-computed `## PR changes (stat summary)` block instead of re-running `git diff`/`git log`. Written via staging directory (`.cai-staging/agents/review/cai-review-pr.md`).
- **`.claude/agents/review/cai-review-docs.md`** — Hard rule 7 given the same treatment, extended to name all four pre-computed user-message blocks (`## PR changes (stat summary)`, `## Authoritative deletion manifest`, `## Generated-docs regeneration`, `## Module coverage`). Hard rule 9 (authoritative deletion manifest) left untouched. Written via staging directory (`.cai-staging/agents/review/cai-review-docs.md`).

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
