### PR TITLE
auto-improve: cai-implement emits repeated unexpected_error across three issues in one hour

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -145,11 +145,11 @@
 | `tests/test_dup_check.py` | TODO: add description |
 | `tests/test_fsm.py` | Tests for cai_lib.fsm — states, transitions, Confidence, divert, marker, resume helpers |
 | `tests/test_fsm_schema.py` | Tests for cai_lib.fsm_schema — validates ISSUE_TRANSITIONS and PR_TRANSITIONS catalogs against transitions.Machine for state reference correctness |
-| `tests/test_implement_consecutive_failures.py` | TODO: add description |
-| `tests/test_implement_helper_extract.py` | TODO: add description |
-| `tests/test_implement_human_needed_reason.py` | TODO: add description |
+| `tests/test_implement_consecutive_failures.py` | Tests for cai_lib.actions.implement._count_consecutive_tests_failed — validates counting of consecutive test failures for early-abort guard |
+| `tests/test_implement_helper_extract.py` | Tests for cai_lib.actions.implement._extract_referenced_helpers and _enclosing_function_source (issue #987) — validates helper function source extraction from test output |
+| `tests/test_implement_human_needed_reason.py` | Regression tests for implement-side human-needed parks (issue #1083) — validates in_progress_to_human_needed transition and _park_in_progress_at_human_needed helper ensure divert-reason comments carry structured fields |
 | `tests/test_implement_scope.py` | Tests for plan-scope enforcement in cai_lib.actions.implement — validates scope parsing, path normalization, and out-of-scope file detection (issue #1074) |
-| `tests/test_implement_test_failure_extract.py` | TODO: add description |
+| `tests/test_implement_test_failure_extract.py` | Tests for cai_lib.actions.implement._extract_test_failures — validates parsing of test failure output from unittest discovery |
 | `tests/test_lint.py` | Lint check: ruff must report zero violations |
 | `tests/test_maintain.py` | Tests for cai_lib.actions.maintain — handle_maintain confidence routing and FSM transitions |
 | `tests/test_merge_agent_deletion_guard.py` | TODO: add description |

--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -22,6 +22,7 @@ import re
 import shutil
 import subprocess
 import sys
+import traceback
 import uuid
 
 from pathlib import Path
@@ -1475,6 +1476,7 @@ def handle_implement(issue: dict) -> int:
 
     except Exception as e:
         print(f"[cai implement] unexpected failure: {e!r}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
         rollback()
         log_run("implement", repo=REPO, issue=issue_number,
                 result="unexpected_error", exit=1)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1087

**Issue:** #1087 — cai-implement emits repeated unexpected_error across three issues in one hour

## PR Summary

### What this fixes
`cai-implement` was catching all unexpected exceptions and returning `result=unexpected_error` with only the exception repr (`{e!r}`) printed to stderr — no traceback, making it impossible to identify the call site or root cause of failures.

### What was changed
- **`cai_lib/actions/implement.py`**: Added `import traceback` to the imports and added `traceback.print_exc(file=sys.stderr)` inside the `except Exception as e` block (immediately after the existing exception repr print), so the next `unexpected_error` occurrence will emit a full stack trace to stderr alongside the existing one-line repr.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
