### PR TITLE
auto-improve: Two stale_lock_rollback events with stale_hours=inf — claim comment never posted

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -145,11 +145,11 @@
 | `tests/test_dup_check.py` | TODO: add description |
 | `tests/test_fsm.py` | Tests for cai_lib.fsm — states, transitions, Confidence, divert, marker, resume helpers |
 | `tests/test_fsm_schema.py` | Tests for cai_lib.fsm_schema — validates ISSUE_TRANSITIONS and PR_TRANSITIONS catalogs against transitions.Machine for state reference correctness |
-| `tests/test_implement_consecutive_failures.py` | TODO: add description |
-| `tests/test_implement_helper_extract.py` | TODO: add description |
-| `tests/test_implement_human_needed_reason.py` | TODO: add description |
+| `tests/test_implement_consecutive_failures.py` | Tests for cai_lib.actions.implement._count_consecutive_tests_failed — validates counting of consecutive test failures for early-abort guard |
+| `tests/test_implement_helper_extract.py` | Tests for cai_lib.actions.implement._extract_referenced_helpers and _enclosing_function_source (issue #987) — validates helper function source extraction from test output |
+| `tests/test_implement_human_needed_reason.py` | Regression tests for implement-side human-needed parks (issue #1083) — validates in_progress_to_human_needed transition and _park_in_progress_at_human_needed helper ensure divert-reason comments carry structured fields |
 | `tests/test_implement_scope.py` | Tests for plan-scope enforcement in cai_lib.actions.implement — validates scope parsing, path normalization, and out-of-scope file detection (issue #1074) |
-| `tests/test_implement_test_failure_extract.py` | TODO: add description |
+| `tests/test_implement_test_failure_extract.py` | Tests for cai_lib.actions.implement._extract_test_failures — validates parsing of test failure output from unittest discovery |
 | `tests/test_lint.py` | Lint check: ruff must report zero violations |
 | `tests/test_maintain.py` | Tests for cai_lib.actions.maintain — handle_maintain confidence routing and FSM transitions |
 | `tests/test_merge_agent_deletion_guard.py` | TODO: add description |

--- a/cai_lib/github.py
+++ b/cai_lib/github.py
@@ -553,9 +553,14 @@ def _acquire_remote_lock(kind: str, number: int) -> bool:
     refcount and returns True without any GitHub round-trip.
 
     Protocol:
-      1. Add LABEL_LOCKED via the appropriate label helper.
-      2. Post a ``<!-- cai-lock owner=INSTANCE_ID acquired=... -->``
-         claim comment.
+      1. Post a ``<!-- cai-lock owner=INSTANCE_ID acquired=... -->``
+         claim comment. If this fails, no label is ever applied, so
+         a comment-post failure cannot strand an orphan ``:locked``
+         label behind a missing claim (the ``stale_hours=inf``
+         signature seen in the watchdog audit).
+      2. Add LABEL_LOCKED via the appropriate label helper. If this
+         fails, delete the just-posted claim comment and abort so
+         neither artifact is left on the target.
       3. Poll the lock-comment list until two consecutive snapshots
          agree (or the timeout elapses), to dampen GitHub
          read-after-write replica lag.
@@ -567,25 +572,29 @@ def _acquire_remote_lock(kind: str, number: int) -> bool:
         _HELD_LOCKS[key] += 1
         return True
 
-    if kind == "issue":
-        labelled = _set_labels(number, add=[LABEL_LOCKED], log_prefix="cai lock")
-    else:
-        labelled = _set_pr_labels(number, add=[LABEL_LOCKED], log_prefix="cai lock")
-    if not labelled:
-        return False
-
+    # Post the claim comment BEFORE applying the label so a comment
+    # failure cannot leave an orphan ``:locked`` label behind — an
+    # orphan label presents as ``stale_hours=inf`` in the watchdog
+    # (see _lock_claim_age_seconds) and wastes a TTL cycle before
+    # being cleaned up.
     acquired = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     body = f"<!-- cai-lock owner={INSTANCE_ID} acquired={acquired} -->"
     posted = (_post_issue_comment if kind == "issue" else _post_pr_comment)(
         number, body, log_prefix="cai lock"
     )
     if not posted:
-        # Couldn't post — strip the label so we don't strand the target
-        # behind a label nobody can release without watchdog help.
-        if kind == "issue":
-            _set_labels(number, remove=[LABEL_LOCKED], log_prefix="cai lock")
-        else:
-            _set_pr_labels(number, remove=[LABEL_LOCKED], log_prefix="cai lock")
+        return False
+
+    if kind == "issue":
+        labelled = _set_labels(number, add=[LABEL_LOCKED], log_prefix="cai lock")
+    else:
+        labelled = _set_pr_labels(number, add=[LABEL_LOCKED], log_prefix="cai lock")
+    if not labelled:
+        # Couldn't label — delete the claim comment we just posted so
+        # we don't leave a stranded comment with no label either.
+        for entry in _list_lock_comments(number):
+            if entry.get("owner") == INSTANCE_ID and entry.get("id") is not None:
+                _delete_issue_comment(int(entry["id"]))
         return False
 
     locks = _stabilize_lock_comments(number)

--- a/cai_lib/watchdog.py
+++ b/cai_lib/watchdog.py
@@ -57,6 +57,17 @@ def _lock_claim_age_seconds(number: int, now: float) -> float | None:
     """
     locks = _list_lock_comments(number)
     if not locks:
+        # :locked label with no cai-lock claim comment is an anomaly —
+        # either _acquire_remote_lock partially failed (crashed between
+        # the post and the label-add) or the claim comment was manually
+        # deleted. Emit a warn so the orphan is visible every watchdog
+        # tick, not only after _STALE_LOCKED_HOURS strips it.
+        print(
+            f"[cai lock] WARN: #{number} has :locked label but no "
+            "cai-lock claim comment — orphan lock detected",
+            file=sys.stderr,
+            flush=True,
+        )
         return None
     oldest = locks[0].get("created_at") or ""
     try:

--- a/tests/test_remote_lock.py
+++ b/tests/test_remote_lock.py
@@ -221,6 +221,51 @@ class TestAcquireRelease(unittest.TestCase):
         ok = github._release_remote_lock("issue", 1234)
         self.assertTrue(ok)
 
+    def test_acquire_post_comment_failure_leaves_no_label(self):
+        """If posting the claim comment fails, LABEL_LOCKED is never applied.
+
+        Regression for the ``stale_hours=inf`` orphan-label bug (#1086):
+        the prior ordering set the label FIRST and relied on a
+        best-effort strip-label cleanup when the subsequent post
+        failed, which could leave a label without a claim if either
+        step crashed. Inverting the ordering eliminates the class.
+        """
+        fake = _FakeGitHub()
+        with self._with_fake(fake):
+            # _install_fake already wires _post_issue_comment to the
+            # fake; override it inside the ExitStack so this patch wins.
+            with patch.object(github, "_post_issue_comment",
+                              return_value=False):
+                with patch.object(github, "INSTANCE_ID", "instance-A"):
+                    ok = github._acquire_remote_lock("issue", 55)
+        self.assertFalse(ok)
+        self.assertNotIn(("issue", 55), github._HELD_LOCKS)
+        target = fake.targets.get(55, {"labels": set(), "comments": []})
+        self.assertNotIn(
+            LABEL_LOCKED, target.get("labels", set()),
+            "post-failure must not leave an orphan :locked label",
+        )
+
+    def test_acquire_label_failure_deletes_claim_comment(self):
+        """If label-add fails after a successful claim post, the comment is deleted."""
+        fake = _FakeGitHub()
+        with self._with_fake(fake):
+            with patch.object(github, "_set_labels",
+                              return_value=False):
+                with patch.object(github, "INSTANCE_ID", "instance-A"):
+                    ok = github._acquire_remote_lock("issue", 56)
+        self.assertFalse(ok)
+        target = fake.targets.get(56, {"labels": set(), "comments": []})
+        lock_comments = [
+            c for c in target.get("comments", [])
+            if "cai-lock" in c.get("body", "")
+        ]
+        self.assertEqual(
+            lock_comments, [],
+            "label-add failure after claim-post must delete the claim",
+        )
+        self.assertNotIn(LABEL_LOCKED, target.get("labels", set()))
+
 
 class TestDispatcherLockIntegration(unittest.TestCase):
     """The drain driver must release the lock on every exit path —


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1086

**Issue:** #1086 — Two stale_lock_rollback events with stale_hours=inf — claim comment never posted

## PR Summary

### What this fixes
Two `:locked` issues appeared in the watchdog log with `stale_hours=inf`, meaning they had the `auto-improve:locked` label but no corresponding claim comment. This happened because `_acquire_remote_lock` applied the label first and then tried to post the claim comment — a comment-post failure left an orphan label that the watchdog couldn't age-check, forcing a conservative rollback after the full TTL expired.

### What was changed
- **`cai_lib/github.py`**: Inverted the step order in `_acquire_remote_lock` — the claim comment is now posted *before* `LABEL_LOCKED` is applied. A comment-post failure now aborts cleanly with no label set. The `if not labelled:` cleanup branch now deletes the just-posted claim comment (via `_list_lock_comments` + `_delete_issue_comment`) instead of stripping a label that was never added. Updated the `Protocol:` docstring accordingly.
- **`cai_lib/watchdog.py`**: Added a `sys.stderr` warn in `_lock_claim_age_seconds` when `_list_lock_comments` returns empty — the orphan lock is now logged at every watchdog tick rather than only being detectable after the TTL fires.
- **`tests/test_remote_lock.py`**: Added two new `TestAcquireRelease` test methods: `test_acquire_post_comment_failure_leaves_no_label` (asserts no `LABEL_LOCKED` when comment post fails) and `test_acquire_label_failure_deletes_claim_comment` (asserts the claim comment is deleted when label-add fails after a successful post).

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
