### PR TITLE
auto-improve: Fix _primary_model: wrong key 'output_tokens' mislabels every cost row as Haiku

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -137,6 +137,7 @@
 | `scripts/server-cleanup.sh` | Server-side age/size cleanup for the transcript-sync store (runs on the OVH box, not in the container) |
 | `tests/__init__.py` | Test package init |
 | `tests/test_agent_staging.py` | TODO: add description |
+| `tests/test_audit_cost.py` | TODO: add description |
 | `tests/test_audit_modules.py` | Tests for cai_lib.audit.modules — load_modules + coverage_check |
 | `tests/test_blocked_on.py` | TODO: add description |
 | `tests/test_close_completed_parents.py` | TODO: add description |

--- a/cai_lib/audit/cost.py
+++ b/cai_lib/audit/cost.py
@@ -102,7 +102,7 @@ def _primary_model(row: dict) -> str:
     models = row.get("models")
     if not models or not isinstance(models, dict):
         return ""
-    best = max(models.items(), key=lambda kv: kv[1].get("output_tokens", 0))
+    best = max(models.items(), key=lambda kv: kv[1].get("outputTokens", 0))
     return best[0] if best else ""
 
 

--- a/tests/test_audit_cost.py
+++ b/tests/test_audit_cost.py
@@ -1,0 +1,53 @@
+"""Tests for cai_lib/audit/cost.py — _primary_model function."""
+import unittest
+
+from cai_lib.audit.cost import _primary_model
+
+
+class TestPrimaryModel(unittest.TestCase):
+    def test_empty_row(self):
+        self.assertEqual(_primary_model({}), "")
+
+    def test_no_models_key(self):
+        self.assertEqual(_primary_model({"cost": 1.0}), "")
+
+    def test_models_not_dict(self):
+        self.assertEqual(_primary_model({"models": []}), "")
+
+    def test_single_model(self):
+        row = {"models": {"claude-sonnet-4-6": {"outputTokens": 500, "inputTokens": 100}}}
+        self.assertEqual(_primary_model(row), "claude-sonnet-4-6")
+
+    def test_picks_highest_output_tokens(self):
+        """Haiku has small outputTokens (SDK overhead); Sonnet has large (agent work)."""
+        row = {
+            "models": {
+                "claude-haiku-4-5-20251001": {"inputTokens": 39463, "outputTokens": 20},
+                "claude-sonnet-4-6": {"inputTokens": 60, "outputTokens": 33600},
+            }
+        }
+        self.assertEqual(_primary_model(row), "claude-sonnet-4-6")
+
+    def test_haiku_wins_when_it_has_more_tokens(self):
+        """If Haiku genuinely produced more output tokens, return it."""
+        row = {
+            "models": {
+                "claude-haiku-4-5-20251001": {"inputTokens": 1000, "outputTokens": 5000},
+                "claude-sonnet-4-6": {"inputTokens": 60, "outputTokens": 100},
+            }
+        }
+        self.assertEqual(_primary_model(row), "claude-haiku-4-5-20251001")
+
+    def test_missing_output_tokens_defaults_to_zero(self):
+        """Models missing outputTokens key default to 0."""
+        row = {
+            "models": {
+                "model-a": {"inputTokens": 100},
+                "model-b": {"outputTokens": 10},
+            }
+        }
+        self.assertEqual(_primary_model(row), "model-b")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1092

**Issue:** #1092 — Fix _primary_model: wrong key 'output_tokens' mislabels every cost row as Haiku

## PR Summary

### What this fixes
`_primary_model()` in `cai_lib/audit/cost.py` was using the snake_case key `"output_tokens"` to look up token counts, but the Claude SDK stores those values under camelCase keys (`"outputTokens"`). Every lookup returned 0, causing `max()` to fall back to the alphabetically-first model name (`claude-haiku-4-5-20251001`) regardless of actual token consumption.

### What was changed
- **`cai_lib/audit/cost.py` line 105** — changed `kv[1].get("output_tokens", 0)` to `kv[1].get("outputTokens", 0)` so the primary-model lookup correctly identifies the model with the most output tokens
- **`tests/test_audit_cost.py`** (new file) — added unit tests covering empty/missing models, single-model, multi-model Haiku-vs-Sonnet selection, and missing-key defaulting to zero

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
