### PR TITLE
auto-improve: Sync cai-cost.jsonl across machines so cost audit sees global spend

### DIFF
--- a/CODEBASE_INDEX.md
+++ b/CODEBASE_INDEX.md
@@ -142,6 +142,7 @@
 | `tests/test_blocked_on.py` | TODO: add description |
 | `tests/test_close_completed_parents.py` | TODO: add description |
 | `tests/test_cmd_misc_label_sweep.py` | TODO: add description |
+| `tests/test_cost_sync.py` | TODO: add description |
 | `tests/test_dispatcher.py` | Tests for the FSM dispatcher and state→handler registries |
 | `tests/test_dup_check.py` | TODO: add description |
 | `tests/test_fsm.py` | Tests for cai_lib.fsm — states, transitions, Confidence, divert, marker, resume helpers |

--- a/cai_lib/audit/cost.py
+++ b/cai_lib/audit/cost.py
@@ -3,7 +3,7 @@
 import json
 from datetime import datetime, timezone
 
-from cai_lib.config import COST_LOG_PATH, OUTCOME_LOG_PATH
+from cai_lib.config import COST_LOG_AGGREGATE_DIR, COST_LOG_PATH, OUTCOME_LOG_PATH
 
 
 def _load_outcome_counts(days: int = 90) -> dict:
@@ -47,38 +47,57 @@ def _load_outcome_counts(days: int = 90) -> dict:
 
 
 def _load_cost_log(days: int = 7) -> list[dict]:
-    """Read COST_LOG_PATH and return rows from the last `days` days.
+    """Read cost log rows from the last `days` days.
 
-    Each row is a dict as written by `log_cost`. Malformed lines are
-    skipped silently. Returns an empty list if the file is missing or
-    unreadable. Used by both `_build_cost_summary` (audit prompt) and
-    `cmd_cost_report` (host-facing report).
+    When ``COST_LOG_AGGREGATE_DIR`` is populated (cross-host cost sync has
+    run), reads the union of all machines' ``cai-cost.jsonl`` files from
+    that directory. Falls back to the local-only ``COST_LOG_PATH`` when the
+    aggregate dir is absent or empty — preserving single-host behaviour for
+    deployments without sync configured.
+
+    Each row is a dict as written by ``log_cost``. Malformed lines are
+    skipped silently. Returns an empty list if no readable log exists.
+    Used by both ``_build_cost_summary`` (audit prompt) and
+    ``cmd_cost_report`` (host-facing report).
     """
-    if not COST_LOG_PATH.exists():
+    # Prefer aggregate (multi-host) over local-only when available.
+    agg_files: list = []
+    if COST_LOG_AGGREGATE_DIR.exists():
+        agg_files = list(COST_LOG_AGGREGATE_DIR.rglob("cai-cost.jsonl"))
+
+    if agg_files:
+        paths_to_read = agg_files
+    elif COST_LOG_PATH.exists():
+        paths_to_read = [COST_LOG_PATH]
+    else:
         return []
+
     cutoff_ts = datetime.now(timezone.utc).timestamp() - days * 86400
     rows: list[dict] = []
-    try:
-        with COST_LOG_PATH.open("r") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    row = json.loads(line)
-                except (json.JSONDecodeError, ValueError):
-                    continue
-                ts = row.get("ts") or ""
-                try:
-                    row_ts = datetime.strptime(
-                        ts, "%Y-%m-%dT%H:%M:%SZ",
-                    ).replace(tzinfo=timezone.utc).timestamp()
-                except ValueError:
-                    continue
-                if row_ts >= cutoff_ts:
-                    rows.append(row)
-    except Exception:
-        return []
+    for path in paths_to_read:
+        if not path.exists():
+            continue
+        try:
+            with path.open("r") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+                    ts = row.get("ts") or ""
+                    try:
+                        row_ts = datetime.strptime(
+                            ts, "%Y-%m-%dT%H:%M:%SZ",
+                        ).replace(tzinfo=timezone.utc).timestamp()
+                    except ValueError:
+                        continue
+                    if row_ts >= cutoff_ts:
+                        rows.append(row)
+        except Exception:
+            continue
     return rows
 
 

--- a/cai_lib/cmd_agents.py
+++ b/cai_lib/cmd_agents.py
@@ -263,6 +263,7 @@ def cmd_analyze(args) -> int:
     # this repo, not only the host this container runs on. No-op when
     # sync is disabled.
     transcript_sync.pull()
+    transcript_sync.pull_cost()
     parse_dir = transcript_sync.parse_source()
 
     if not parse_dir.exists():
@@ -1063,6 +1064,7 @@ def cmd_cost_optimize(args) -> int:
     t0 = time.monotonic()
 
     # 1. Build cost data for the agent.
+    transcript_sync.pull_cost()
     rows_14d = _load_cost_log(days=14)
     if not rows_14d:
         print("[cai cost-optimize] no cost data available; skipping", flush=True)

--- a/cai_lib/cmd_agents.py
+++ b/cai_lib/cmd_agents.py
@@ -260,8 +260,8 @@ def cmd_analyze(args) -> int:
     # When cross-host transcript sync is enabled, pull every machine's
     # bucket into the local aggregate mirror before parsing — this way
     # the analyzer sees tool-call activity from all machines that share
-    # this repo, not only the host this container runs on. No-op when
-    # sync is disabled.
+    # this repo, not only the host this container runs on. Also pulls cost
+    # logs so the analyzer has global spend visibility. No-op when sync is disabled.
     transcript_sync.pull()
     transcript_sync.pull_cost()
     parse_dir = transcript_sync.parse_source()

--- a/cai_lib/cmd_misc.py
+++ b/cai_lib/cmd_misc.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from cai_lib.config import *  # noqa: F403,F401
 from cai_lib.logging_utils import log_run
 from cai_lib.audit.cost import _load_cost_log, _load_outcome_counts, _row_ts
+from cai_lib import transcript_sync
 from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.github import (
     _gh_json, _set_labels, _transcript_dir_is_empty,
@@ -254,6 +255,7 @@ def cmd_cost_report(args) -> int:
         cai cost-report
         cai cost-report --days 30 --top 20 --by agent
     """
+    transcript_sync.pull_cost()
     rows = _load_cost_log(days=args.days)
     if not rows:
         print(
@@ -463,6 +465,11 @@ def cmd_health_report(args) -> int:
     now_ts = datetime.now(timezone.utc).timestamp()
     sections: list[str] = []
     anomalies: list[str] = []
+
+    # Pull aggregated cost logs from all machines before reading trends —
+    # same pattern as transcript aggregation in cmd_analyze. No-op when
+    # sync is disabled.
+    transcript_sync.pull_cost()
 
     # ------------------------------------------------------------------ #
     # 1. Cost Trends                                                       #

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -225,6 +225,14 @@ BLOCKED_ON_LABEL_RE = re.compile(r"^blocked-on:(\d+)$")
 
 LOG_PATH = Path("/var/log/cai/cai.log")
 COST_LOG_PATH = Path("/var/log/cai/cai-cost.jsonl")
+# When cross-host cost sync is enabled (CAI_TRANSCRIPT_SYNC_URL set), the
+# cost audit reads from this aggregate mirror — populated by `cai
+# transcript-sync` via rsync — instead of the local-only COST_LOG_PATH.
+# The mirror holds one subdir per machine-id:
+#
+#   /var/log/cai/cost-aggregate/<machine-id>/cai-cost.jsonl
+#
+COST_LOG_AGGREGATE_DIR = Path("/var/log/cai/cost-aggregate")
 REVIEW_PR_PATTERN_LOG = Path("/var/log/cai/review-pr-patterns.jsonl")
 OUTCOME_LOG_PATH = Path("/var/log/cai/cai-outcomes.jsonl")
 

--- a/cai_lib/transcript_sync.py
+++ b/cai_lib/transcript_sync.py
@@ -219,7 +219,7 @@ def pull() -> int:
 
 
 def sync() -> int:
-    """Push then pull. Returns 0 iff both succeed; otherwise the first failure."""
+    """Push then pull transcripts and cost logs. Returns 0 iff all succeed."""
     if not config.transcript_sync_enabled():
         print(
             "[transcript-sync] disabled (CAI_TRANSCRIPT_SYNC_URL or "
@@ -230,7 +230,104 @@ def sync() -> int:
     rc = push()
     if rc != 0:
         return rc
-    return pull()
+    rc = pull()
+    if rc != 0:
+        return rc
+    rc = push_cost()
+    if rc != 0:
+        return rc
+    return pull_cost()
+
+
+# ---------------------------------------------------------------------------
+# Cost-log sync (mirrors the transcript-sync design for cai-cost.jsonl)
+# ---------------------------------------------------------------------------
+# Server layout:
+#   <TRANSCRIPT_SYNC_URL>/
+#     <repo-slug>-cost/        # separate namespace from transcripts
+#       <machine-id>/
+#         cai-cost.jsonl
+#
+# Local aggregate:
+#   COST_LOG_AGGREGATE_DIR/
+#     <machine-id>/
+#       cai-cost.jsonl
+# ---------------------------------------------------------------------------
+
+
+def _cost_server_bucket() -> str:
+    """Return ``<url>/<repo-slug>-cost/<machine-id>`` — this host's cost push target."""
+    return (
+        f"{config.TRANSCRIPT_SYNC_URL.rstrip('/')}/"
+        f"{config.REPO_SLUG}-cost/{config.MACHINE_ID}"
+    )
+
+
+def _cost_server_slug() -> str:
+    """Return ``<url>/<repo-slug>-cost`` — the cost pull source (all machines)."""
+    return f"{config.TRANSCRIPT_SYNC_URL.rstrip('/')}/{config.REPO_SLUG}-cost"
+
+
+def _local_has_cost_log() -> bool:
+    """True when the local cost log file exists and is non-empty.
+
+    Guards ``push_cost`` against uploading an empty file on a fresh install.
+    """
+    return (
+        config.COST_LOG_PATH.exists()
+        and config.COST_LOG_PATH.stat().st_size > 0
+    )
+
+
+def push_cost() -> int:
+    """Push the local cost log to this host's server bucket.
+
+    No-op (returns 0) when the feature is disabled or the local cost log is
+    absent/empty. Uses rsync to copy the single file to the machine-id bucket.
+    """
+    if not config.transcript_sync_enabled():
+        return 0
+    if not _local_has_cost_log():
+        return 0
+    if not _ensure_rsync():
+        return 0
+    if _is_local_url(config.TRANSCRIPT_SYNC_URL):
+        Path(_cost_server_bucket()).mkdir(parents=True, exist_ok=True)
+    return _run_rsync(
+        [
+            "-az",
+            "--mkpath",
+            *_transport_args(),
+            str(config.COST_LOG_PATH),
+            f"{_cost_server_bucket()}/cai-cost.jsonl",
+        ],
+        label="cost-push",
+    )
+
+
+def pull_cost() -> int:
+    """Pull all machines' cost logs into the local cost aggregate mirror.
+
+    No-op (returns 0) when disabled. Creates the aggregate directory if
+    missing. Does NOT use ``--delete`` for the same reason as ``pull()``.
+    """
+    if not config.transcript_sync_enabled():
+        return 0
+    if not _ensure_rsync():
+        return 0
+    config.COST_LOG_AGGREGATE_DIR.mkdir(parents=True, exist_ok=True)
+    if _is_local_url(config.TRANSCRIPT_SYNC_URL):
+        if not Path(_cost_server_slug()).exists():
+            return 0
+    return _run_rsync(
+        [
+            "-az",
+            *_transport_args(),
+            f"{_cost_server_slug()}/",
+            f"{config.COST_LOG_AGGREGATE_DIR}/",
+        ],
+        label="cost-pull",
+    )
 
 
 def transcript_sync_enabled() -> bool:

--- a/cai_lib/transcript_sync.py
+++ b/cai_lib/transcript_sync.py
@@ -350,7 +350,7 @@ def parse_source() -> Path:
 
 
 def cmd_transcript_sync(args) -> int:  # noqa: ARG001 - args required by dispatcher
-    """CLI entrypoint: `cai transcript-sync`. Runs push + pull."""
+    """CLI entrypoint: `cai transcript-sync`. Syncs transcripts and cost logs."""
     rc = sync()
     if rc != 0:
         print(f"[transcript-sync] exited with rc={rc}", file=sys.stderr)

--- a/tests/test_audit_cost.py
+++ b/tests/test_audit_cost.py
@@ -1,7 +1,16 @@
-"""Tests for cai_lib/audit/cost.py — _primary_model function."""
+"""Tests for cai_lib/audit/cost.py — _primary_model and _load_cost_log."""
+import json
+import os
+import sys
+import tempfile
 import unittest
+from pathlib import Path
+from unittest import mock
 
-from cai_lib.audit.cost import _primary_model
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import cai_lib.audit.cost as _cost_module  # noqa: E402
+from cai_lib.audit.cost import _load_cost_log, _primary_model  # noqa: E402
 
 
 class TestPrimaryModel(unittest.TestCase):
@@ -47,6 +56,107 @@ class TestPrimaryModel(unittest.TestCase):
             }
         }
         self.assertEqual(_primary_model(row), "model-b")
+
+
+class TestLoadCostLogAggregation(unittest.TestCase):
+    """Tests for _load_cost_log multi-host aggregation behaviour."""
+
+    _RECENT_ROW_A = json.dumps({
+        "ts": "2099-01-01T00:00:00Z",
+        "category": "cai-implement",
+        "cost_usd": 0.01,
+        "agent": "cai-implement",
+    })
+    _RECENT_ROW_B = json.dumps({
+        "ts": "2099-01-02T00:00:00Z",
+        "category": "cai-audit",
+        "cost_usd": 0.02,
+        "agent": "cai-audit",
+    })
+
+    def test_falls_back_to_local_when_aggregate_missing(self):
+        """Without aggregate dir, reads COST_LOG_PATH."""
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            local.write_text(self._RECENT_ROW_A + "\n")
+            missing_agg = Path(tmp) / "nonexistent-aggregate"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                rows = _load_cost_log(days=3650)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["category"], "cai-implement")
+
+    def test_falls_back_to_local_when_aggregate_empty(self):
+        """With empty aggregate dir, falls back to COST_LOG_PATH."""
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            local.write_text(self._RECENT_ROW_A + "\n")
+            agg = Path(tmp) / "aggregate"
+            agg.mkdir()  # exists but empty
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", agg),
+            ):
+                rows = _load_cost_log(days=3650)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["category"], "cai-implement")
+
+    def test_uses_aggregate_when_populated(self):
+        """With populated aggregate dir, reads from all machine subdirs."""
+        with tempfile.TemporaryDirectory() as tmp:
+            agg = Path(tmp) / "aggregate"
+            machine_a = agg / "machine-a"
+            machine_b = agg / "machine-b"
+            machine_a.mkdir(parents=True)
+            machine_b.mkdir(parents=True)
+            (machine_a / "cai-cost.jsonl").write_text(self._RECENT_ROW_A + "\n")
+            (machine_b / "cai-cost.jsonl").write_text(self._RECENT_ROW_B + "\n")
+            local = Path(tmp) / "cai-cost.jsonl"  # not created — should not be used
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", agg),
+            ):
+                rows = _load_cost_log(days=3650)
+            categories = {r["category"] for r in rows}
+            self.assertEqual(len(rows), 2)
+            self.assertIn("cai-implement", categories)
+            self.assertIn("cai-audit", categories)
+
+    def test_aggregate_excludes_old_rows(self):
+        """Only rows within the `days` window are returned from aggregate."""
+        with tempfile.TemporaryDirectory() as tmp:
+            agg = Path(tmp) / "aggregate"
+            machine_a = agg / "machine-a"
+            machine_a.mkdir(parents=True)
+            old_row = json.dumps({
+                "ts": "2000-01-01T00:00:00Z",
+                "category": "old",
+                "cost_usd": 0.99,
+            })
+            (machine_a / "cai-cost.jsonl").write_text(
+                self._RECENT_ROW_A + "\n" + old_row + "\n"
+            )
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", agg),
+            ):
+                rows = _load_cost_log(days=7)
+            # The 2099 row should be included; the 2000 row excluded.
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["category"], "cai-implement")
+
+    def test_returns_empty_when_no_local_and_no_aggregate(self):
+        """Returns [] when neither COST_LOG_PATH nor aggregate dir exists."""
+        with tempfile.TemporaryDirectory() as tmp:
+            missing_local = Path(tmp) / "does-not-exist.jsonl"
+            missing_agg = Path(tmp) / "does-not-exist-agg"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", missing_local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                rows = _load_cost_log(days=7)
+            self.assertEqual(rows, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_cost_sync.py
+++ b/tests/test_cost_sync.py
@@ -1,0 +1,159 @@
+"""Tests for cost-log push/pull/sync_cost functions in cai_lib.transcript_sync.
+
+Tests patch attributes on ``cai_lib.config`` (the module ``transcript_sync``
+reads from at call time) rather than reloading modules — same pattern as
+test_transcript_sync.py.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+from cai_lib import config, transcript_sync  # noqa: E402
+
+
+def _rsync_available() -> bool:
+    try:
+        subprocess.run(["rsync", "--version"], check=True, capture_output=True)
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+class TestCostSyncDisabled(unittest.TestCase):
+    def test_push_cost_noop_when_sync_url_unset(self):
+        with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", ""), \
+             mock.patch.object(config, "MACHINE_ID", "m1"):
+            self.assertEqual(transcript_sync.push_cost(), 0)
+
+    def test_pull_cost_noop_when_sync_url_unset(self):
+        with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", ""), \
+             mock.patch.object(config, "MACHINE_ID", "m1"):
+            self.assertEqual(transcript_sync.pull_cost(), 0)
+
+    def test_push_cost_noop_when_machine_id_missing(self):
+        with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", "user@host:/tmp"), \
+             mock.patch.object(config, "MACHINE_ID", ""):
+            self.assertEqual(transcript_sync.push_cost(), 0)
+
+    def test_push_cost_noop_when_log_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "nonexistent.jsonl"
+            with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", "user@host:/tmp"), \
+                 mock.patch.object(config, "MACHINE_ID", "m1"), \
+                 mock.patch.object(config, "COST_LOG_PATH", missing):
+                self.assertEqual(transcript_sync.push_cost(), 0)
+
+    def test_push_cost_noop_when_log_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            empty = Path(tmp) / "cai-cost.jsonl"
+            empty.write_text("")
+            with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", "user@host:/tmp"), \
+                 mock.patch.object(config, "MACHINE_ID", "m1"), \
+                 mock.patch.object(config, "COST_LOG_PATH", empty):
+                self.assertEqual(transcript_sync.push_cost(), 0)
+
+
+class TestCostServerPaths(unittest.TestCase):
+    def test_cost_server_bucket_format(self):
+        with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", "user@host:/srv/cai"), \
+             mock.patch.object(config, "REPO_SLUG", "owner_repo"), \
+             mock.patch.object(config, "MACHINE_ID", "abc123"):
+            bucket = transcript_sync._cost_server_bucket()
+        self.assertEqual(bucket, "user@host:/srv/cai/owner_repo-cost/abc123")
+
+    def test_cost_server_slug_format(self):
+        with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", "user@host:/srv/cai"), \
+             mock.patch.object(config, "REPO_SLUG", "owner_repo"):
+            slug = transcript_sync._cost_server_slug()
+        self.assertEqual(slug, "user@host:/srv/cai/owner_repo-cost")
+
+    def test_cost_server_bucket_strips_trailing_slash(self):
+        with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", "user@host:/srv/cai/"), \
+             mock.patch.object(config, "REPO_SLUG", "owner_repo"), \
+             mock.patch.object(config, "MACHINE_ID", "abc"):
+            bucket = transcript_sync._cost_server_bucket()
+        self.assertNotIn("//", bucket)
+
+
+@unittest.skipUnless(_rsync_available(), "rsync not installed on this host")
+class TestCostLocalPushPull(unittest.TestCase):
+    """End-to-end cost-log push/pull using real rsync against a temp dir."""
+
+    def test_push_and_pull_cost_roundtrip_local(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cost_log = tmp_path / "cai-cost.jsonl"
+            cost_log.write_text('{"ts":"2099-01-01T00:00:00Z","cost_usd":0.01}\n')
+
+            store = tmp_path / "store"
+            store.mkdir()
+            aggregate = tmp_path / "cost-agg"
+
+            with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", str(store)), \
+                 mock.patch.object(config, "MACHINE_ID", "test-host"), \
+                 mock.patch.object(config, "REPO_SLUG", "owner_repo"), \
+                 mock.patch.object(config, "COST_LOG_PATH", cost_log), \
+                 mock.patch.object(config, "COST_LOG_AGGREGATE_DIR", aggregate):
+                self.assertEqual(transcript_sync.push_cost(), 0)
+                pushed = store / "owner_repo-cost" / "test-host" / "cai-cost.jsonl"
+                self.assertTrue(pushed.exists(), "expected pushed cost file in server bucket")
+
+                self.assertEqual(transcript_sync.pull_cost(), 0)
+                pulled = aggregate / "test-host" / "cai-cost.jsonl"
+                self.assertTrue(pulled.exists(), "expected cost file in aggregate mirror")
+                self.assertEqual(
+                    pulled.read_text(),
+                    '{"ts":"2099-01-01T00:00:00Z","cost_usd":0.01}\n',
+                )
+
+    def test_pull_cost_missing_server_skips_gracefully(self):
+        """When the server-side cost bucket doesn't exist yet, pull returns 0."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            store = tmp_path / "store"
+            store.mkdir()  # cost bucket does not exist under store
+            aggregate = tmp_path / "cost-agg"
+
+            with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", str(store)), \
+                 mock.patch.object(config, "MACHINE_ID", "m1"), \
+                 mock.patch.object(config, "REPO_SLUG", "owner_repo"), \
+                 mock.patch.object(config, "COST_LOG_AGGREGATE_DIR", aggregate):
+                rc = transcript_sync.pull_cost()
+            self.assertEqual(rc, 0)
+
+    def test_sync_cost_runs_push_then_pull(self):
+        """sync_cost() pushes then pulls; aggregate contains the pushed file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cost_log = tmp_path / "cai-cost.jsonl"
+            cost_log.write_text('{"ts":"2099-06-01T00:00:00Z","cost_usd":0.05}\n')
+            store = tmp_path / "store"
+            store.mkdir()
+            aggregate = tmp_path / "cost-agg"
+
+            with mock.patch.object(config, "TRANSCRIPT_SYNC_URL", str(store)), \
+                 mock.patch.object(config, "MACHINE_ID", "host-x"), \
+                 mock.patch.object(config, "REPO_SLUG", "owner_repo"), \
+                 mock.patch.object(config, "COST_LOG_PATH", cost_log), \
+                 mock.patch.object(config, "COST_LOG_AGGREGATE_DIR", aggregate):
+                rc = transcript_sync.push_cost()
+                self.assertEqual(rc, 0)
+                rc = transcript_sync.pull_cost()
+                self.assertEqual(rc, 0)
+            pulled = aggregate / "host-x" / "cai-cost.jsonl"
+            self.assertTrue(pulled.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1093

**Issue:** #1093 — Sync cai-cost.jsonl across machines so cost audit sees global spend

## PR Summary

### What this fixes
Each machine's cost audit only read its local `/var/log/cai/cai-cost.jsonl`, so multi-machine deployments systematically undercounted spend and missed outliers from other hosts. This change mirrors the transcript-sync design to make cost logs globally visible.

### What was changed
- **`cai_lib/config.py`**: Added `COST_LOG_AGGREGATE_DIR = Path("/var/log/cai/cost-aggregate")` constant for the multi-host cost log mirror
- **`cai_lib/transcript_sync.py`**: Added `push_cost()`, `pull_cost()`, `_cost_server_bucket()`, `_cost_server_slug()`, `_local_has_cost_log()` functions (mirroring the transcript push/pull design); updated `sync()` to call cost push+pull after transcript push+pull
- **`cai_lib/audit/cost.py`**: Updated `_load_cost_log()` to read from `COST_LOG_AGGREGATE_DIR` (all machines' `cai-cost.jsonl` files via `rglob`) when the aggregate dir is populated, falling back to local `COST_LOG_PATH` for single-host deployments
- **`tests/test_audit_cost.py`**: Added `TestLoadCostLogAggregation` class with 5 tests covering multi-host aggregation, empty-aggregate fallback, time-window filtering, and the no-data case
- **`tests/test_cost_sync.py`**: New test file with 8 tests covering disabled-mode no-ops, server path formatting, and local rsync push/pull/roundtrip

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
