### PR TITLE
auto-improve: [#1089 Step 2/2] Migrate all call sites to `fire_trigger` and delete the four `apply_*` shims

### DIFF
--- a/cai_lib/actions/confirm.py
+++ b/cai_lib/actions/confirm.py
@@ -28,7 +28,7 @@ from cai_lib.config import (
 )
 from cai_lib import transcript_sync
 from cai_lib.cmd_helpers import _fetch_previous_fix_attempts
-from cai_lib.fsm import apply_transition
+from cai_lib.fsm import fire_trigger
 from cai_lib.github import _gh_json, _set_labels, close_issue_completed
 from cai_lib.logging_utils import (
     _get_issue_category,
@@ -207,7 +207,7 @@ def handle_confirm(issue: dict) -> int:
             prior_attempts = len(_fetch_previous_fix_attempts(issue_num))
             _log_outcome(issue_num, cat, "solved", prior_attempts)
             current_labels = [lbl["name"] for lbl in mi.get("labels", [])]
-            apply_transition(
+            fire_trigger(
                 issue_num, "merged_to_solved",
                 current_labels=current_labels,
                 log_prefix="cai confirm",

--- a/cai_lib/actions/fix_ci.py
+++ b/cai_lib/actions/fix_ci.py
@@ -23,7 +23,7 @@ from cai_lib.config import (
 )
 from cai_lib.fsm import (
     PRState,
-    apply_pr_transition,
+    fire_trigger,
     get_pr_state,
 )
 from cai_lib.github import _gh_json, _set_labels
@@ -288,18 +288,21 @@ def handle_fix_ci(pr: dict) -> int:
         pr_now = {}
     current_state = get_pr_state(pr_now) if pr_now else None
     if current_state == PRState.REVIEWING_CODE:
-        apply_pr_transition(
+        fire_trigger(
             pr_number, "reviewing_code_to_ci_failing",
+            is_pr=True,
             log_prefix="cai fix-ci",
         )
     elif current_state == PRState.REVISION_PENDING:
-        apply_pr_transition(
+        fire_trigger(
             pr_number, "revision_pending_to_ci_failing",
+            is_pr=True,
             log_prefix="cai fix-ci",
         )
     elif current_state == PRState.REVIEWING_DOCS:
-        apply_pr_transition(
+        fire_trigger(
             pr_number, "reviewing_docs_to_ci_failing",
+            is_pr=True,
             log_prefix="cai fix-ci",
         )
     # OPEN / CI_FAILING / PR_HUMAN_NEEDED: no transition needed.
@@ -466,8 +469,9 @@ def handle_fix_ci(pr: dict) -> int:
                 # next tick re-evaluates check status, and if still
                 # red _select_ci_fix_targets re-queues the PR
                 # (which re-enters CI_FAILING via step 1a above).
-                apply_pr_transition(
+                fire_trigger(
                     pr_number, "ci_failing_to_reviewing_code",
+                    is_pr=True,
                     log_prefix="cai fix-ci",
                 )
         else:

--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -126,7 +126,7 @@ def _park_in_progress_at_human_needed(
 ) -> bool:
     """Park an :in-progress issue at :human-needed with a parseable divert-reason comment.
 
-    Wraps :func:`apply_transition` for ``in_progress_to_human_needed``
+    Wraps :func:`fire_trigger` for ``in_progress_to_human_needed``
     so every implement-side escalation path goes through the PR #1072
     invariant (issue #1009) — which refuses silent HUMAN_NEEDED diverts
     and auto-posts a :func:`_render_human_divert_reason`-rendered
@@ -145,7 +145,7 @@ def _park_in_progress_at_human_needed(
     Returns True iff the park succeeded (labels changed + MARKER
     comment posted). Retries once on transient ``_set_labels`` failure
     — the same double-retry pattern the direct-label path had before
-    the refactor. The retry re-invokes ``apply_transition``; because
+    the refactor. The retry re-invokes ``fire_trigger``; because
     its comment post is gated on ``ok`` from ``_set_labels``, a failed
     first attempt does not double-post the comment on the second
     attempt.

--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -67,7 +67,7 @@ from cai_lib.actions.plan import (
     _FILES_TO_CHANGE_PATH_RE,
 )
 from cai_lib.fsm import (
-    apply_transition,
+    fire_trigger,
     Confidence,
     IssueState,
     get_issue_state,
@@ -151,13 +151,13 @@ def _park_in_progress_at_human_needed(
     attempt.
     """
     for _attempt in range(2):
-        if apply_transition(
+        if fire_trigger(
             issue_number,
             "in_progress_to_human_needed",
             extra_remove=list(extra_remove),
             log_prefix=log_prefix,
             divert_reason=reason,
-        ):
+        )[0]:
             return True
     return False
 
@@ -939,11 +939,11 @@ def handle_implement(issue: dict) -> int:
 
     # 1. Entry transition — idempotent.
     if state == IssueState.PLAN_APPROVED:
-        if not apply_transition(
+        if not fire_trigger(
             issue_number, "approved_to_in_progress",
             current_labels=label_names,
             log_prefix="cai implement",
-        ):
+        )[0]:
             print(f"[cai implement] could not lock #{issue_number}", file=sys.stderr)
             log_run("implement", repo=REPO, issue=issue_number, result="lock_failed", exit=1)
             return 1
@@ -1463,10 +1463,10 @@ def handle_implement(issue: dict) -> int:
                          "--body", comment_body],
                         capture_output=True,
                     )
-                    if not apply_transition(
+                    if not fire_trigger(
                         issue_number, "in_progress_to_refining",
                         log_prefix="cai implement",
-                    ):
+                    )[0]:
                         print(
                             f"[cai implement] WARNING: in_progress_to_refining "
                             f"failed for #{issue_number} — falling back to "
@@ -1586,18 +1586,18 @@ def handle_implement(issue: dict) -> int:
         pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
 
         # 10. Transition label :in-progress -> :pr-open via the FSM.
-        if not apply_transition(
+        if not fire_trigger(
             issue_number, "in_progress_to_pr",
             log_prefix="cai implement",
-        ):
+        )[0]:
             print(
                 f"[cai implement] label transition to :pr-open failed for #{issue_number}; retrying",
                 flush=True,
             )
-            if not apply_transition(
+            if not fire_trigger(
                 issue_number, "in_progress_to_pr",
                 log_prefix="cai implement",
-            ):
+            )[0]:
                 print(
                     f"[cai implement] WARNING: label transition to :pr-open failed twice for "
                     f"#{issue_number} — issue may be orphaned from PR {pr_url}",

--- a/cai_lib/actions/maintain.py
+++ b/cai_lib/actions/maintain.py
@@ -25,8 +25,7 @@ from pathlib import Path
 from cai_lib.config import REPO
 from cai_lib.cmd_helpers import _work_directory_block
 from cai_lib.fsm import (
-    apply_transition,
-    apply_transition_with_confidence,
+    fire_trigger,
     parse_confidence,
     parse_confidence_reason,
 )
@@ -141,10 +140,11 @@ def handle_maintain(issue: dict) -> int:
             flush=True,
         )
 
-    ok, diverted = apply_transition_with_confidence(
+    ok, diverted = fire_trigger(
         issue_number,
         transition_name,
-        confidence,
+        confidence=confidence,
+        _confidence_gated=True,
         current_labels=issue_labels,
         log_prefix="cai maintain",
         reason_extra=confidence_reason or "",
@@ -171,7 +171,7 @@ def handle_applied(issue: dict) -> int:
 
     print(f"[cai maintain] advancing #{issue_number} :applied → :solved",
           flush=True)
-    apply_transition(
+    fire_trigger(
         issue_number, "applied_to_solved",
         current_labels=issue_labels,
         log_prefix="cai maintain",

--- a/cai_lib/actions/maintain.py
+++ b/cai_lib/actions/maintain.py
@@ -59,7 +59,7 @@ def handle_maintain(issue: dict) -> int:
     block, and applies the FSM transition:
     - ``applying_to_applied``   on HIGH confidence.
     - ``applying_to_human``     on MEDIUM / LOW / missing confidence (via
-      :func:`apply_transition_with_confidence` divert path).
+      :func:`fire_trigger` divert path).
     """
     t0 = time.monotonic()
     issue_number = issue["number"]

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -39,7 +39,7 @@ from cai_lib.config import (
     LABEL_PR_NEEDS_WORKFLOW_REVIEW,
     LABEL_OPUS_ATTEMPTED,
 )
-from cai_lib.fsm import apply_pr_transition, apply_transition, get_pr_state, PRState
+from cai_lib.fsm import fire_trigger, get_pr_state, PRState
 from cai_lib.github import _gh_json, _set_labels, _issue_has_label, close_issue_not_planned
 from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.cmd_helpers import (
@@ -681,8 +681,9 @@ def handle_merge(pr: dict) -> int:
             f"migrating to PR_HUMAN_NEEDED",
             flush=True,
         )
-        apply_pr_transition(
+        fire_trigger(
             pr["number"], "approved_to_human",
+            is_pr=True,
             log_prefix="cai merge",
             divert_reason=(
                 f"PR still carries the legacy "
@@ -745,8 +746,9 @@ def handle_merge(pr: dict) -> int:
              f"this state."],
             capture_output=True,
         )
-        apply_pr_transition(
+        fire_trigger(
             pr_number, "approved_to_human",
+            is_pr=True,
             log_prefix="cai merge",
             divert_reason=(
                 f"PR is on branch `{branch}`, which is not an "
@@ -863,8 +865,9 @@ def handle_merge(pr: dict) -> int:
                     f"checks; diverting to CI_FAILING",
                     flush=True,
                 )
-                apply_pr_transition(
+                fire_trigger(
                     pr_number, "approved_to_ci_failing",
+                    is_pr=True,
                     log_prefix="cai merge",
                 )
                 log_run("merge", repo=REPO, pr=pr_number,
@@ -982,8 +985,9 @@ def handle_merge(pr: dict) -> int:
             f"human-needed",
             flush=True,
         )
-        apply_pr_transition(
+        fire_trigger(
             pr_number, "approved_to_human",
+            is_pr=True,
             log_prefix="cai merge",
             divert_reason=(
                 f"PR contains {len(unauthorized_deletions)} unauthorized "
@@ -1153,8 +1157,9 @@ def handle_merge(pr: dict) -> int:
                 log_prefix="cai merge",
             )
             if not closed_ok:
-                apply_pr_transition(
+                fire_trigger(
                     pr_number, "approved_to_human",
+                    is_pr=True,
                     log_prefix="cai merge",
                     divert_reason=(
                         "cai-merge closed this PR as a high-confidence "
@@ -1188,8 +1193,9 @@ def handle_merge(pr: dict) -> int:
                         f"after close failure on PR #{pr_number}",
                         file=sys.stderr, flush=True,
                     )
-            apply_pr_transition(
+            fire_trigger(
                 pr_number, "approved_to_human",
+                is_pr=True,
                 log_prefix="cai merge",
                 divert_reason=(
                     "cai-merge tried to close this PR as a high-"
@@ -1252,8 +1258,9 @@ def handle_merge(pr: dict) -> int:
                             result="merge_label_failed", exit=0)
                     return 0
             # Apply the APPROVED → MERGED transition on the PR itself.
-            apply_pr_transition(
+            fire_trigger(
                 pr_number, "approved_to_merged",
+                is_pr=True,
                 log_prefix="cai merge",
             )
             log_run("merge", repo=REPO, pr=pr_number,
@@ -1265,8 +1272,9 @@ def handle_merge(pr: dict) -> int:
                 f"{merge_result.stderr}",
                 file=sys.stderr,
             )
-            apply_pr_transition(
+            fire_trigger(
                 pr_number, "approved_to_human",
+                is_pr=True,
                 log_prefix="cai merge",
                 divert_reason=(
                     "cai-merge verdict was to merge, but `gh pr merge` "
@@ -1323,8 +1331,9 @@ def handle_merge(pr: dict) -> int:
                 f"concrete code bug; routing to REVISION_PENDING",
                 flush=True,
             )
-            apply_pr_transition(
+            fire_trigger(
                 pr_number, "approved_to_revision_pending",
+                is_pr=True,
                 log_prefix="cai merge",
             )
             log_run("merge", repo=REPO, pr=pr_number,
@@ -1375,8 +1384,9 @@ def handle_merge(pr: dict) -> int:
                     f"close failed:\n{close_result.stderr}",
                     file=sys.stderr,
                 )
-                apply_pr_transition(
+                fire_trigger(
                     pr_number, "approved_to_human",
+                    is_pr=True,
                     log_prefix="cai merge",
                     divert_reason=(
                         "cai-merge returned a hold verdict with "
@@ -1405,7 +1415,7 @@ def handle_merge(pr: dict) -> int:
                 (lb.get("name") if isinstance(lb, dict) else lb)
                 for lb in (issue.get("labels") or [])
             ]
-            transition_ok = apply_transition(
+            transition_ok, _ = fire_trigger(
                 issue_number, "pr_to_plan_approved",
                 current_labels=issue_labels_now,
                 log_prefix="cai merge",
@@ -1472,8 +1482,9 @@ def handle_merge(pr: dict) -> int:
                     flush=True,
                 )
                 held_result_tag = "held_workflow_review"
-        apply_pr_transition(
+        fire_trigger(
             pr_number, "approved_to_human",
+            is_pr=True,
             log_prefix="cai merge",
             divert_reason=(
                 f"cai-merge verdict was `{confidence}` (below the "

--- a/cai_lib/actions/open_pr.py
+++ b/cai_lib/actions/open_pr.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from cai_lib.actions.merge import _BOT_BRANCH_RE
 from cai_lib.config import REPO
-from cai_lib.fsm import apply_pr_transition
+from cai_lib.fsm import fire_trigger
 from cai_lib.logging_utils import log_run
 from cai_lib.subprocess_utils import _run
 
@@ -61,8 +61,9 @@ def handle_open_to_review(pr: dict) -> int:
              f"just re-enter this state."],
             capture_output=True,
         )
-        ok = apply_pr_transition(
+        ok, _ = fire_trigger(
             pr_number, "open_to_human",
+            is_pr=True,
             current_pr=pr,
             log_prefix="cai dispatch",
             divert_reason=(
@@ -74,8 +75,9 @@ def handle_open_to_review(pr: dict) -> int:
                 result="not_bot_branch_open", exit=0)
         return 0 if ok else 1
 
-    ok = apply_pr_transition(
+    ok, _ = fire_trigger(
         pr_number, "open_to_reviewing_code",
+        is_pr=True,
         current_pr=pr,
         log_prefix="cai dispatch",
     )

--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -43,8 +43,7 @@ from cai_lib.cmd_helpers import (
     _build_attempt_history_block,
 )
 from cai_lib.fsm import (
-    apply_transition,
-    apply_transition_with_confidence,
+    fire_trigger,
     IssueState,
     get_issue_state,
 )
@@ -526,7 +525,7 @@ def handle_plan(issue: dict) -> int:
 
     # 1. Entry transition :refined → :planning (only on fresh entry).
     if state == IssueState.REFINED:
-        apply_transition(
+        fire_trigger(
             issue_number, "refined_to_planning",
             current_labels=label_names,
             log_prefix="cai plan",
@@ -560,7 +559,7 @@ def handle_plan(issue: dict) -> int:
         if clone.returncode != 0:
             print(f"[cai plan] git clone failed:\n{clone.stderr}",
                   file=sys.stderr)
-            apply_transition(
+            fire_trigger(
                 issue_number, "planning_to_human",
                 current_labels=[LABEL_PLANNING],
                 log_prefix="cai plan",
@@ -592,7 +591,7 @@ def handle_plan(issue: dict) -> int:
         if pipeline_result is None:
             print(f"[cai plan] plan pipeline failed for #{issue_number}",
                   file=sys.stderr)
-            apply_transition(
+            fire_trigger(
                 issue_number, "planning_to_human",
                 current_labels=[LABEL_PLANNING],
                 log_prefix="cai plan",
@@ -640,7 +639,7 @@ def handle_plan(issue: dict) -> int:
         if update.returncode != 0:
             print(f"[cai plan] gh issue edit failed:\n{update.stderr}",
                   file=sys.stderr)
-            apply_transition(
+            fire_trigger(
                 issue_number, "planning_to_human",
                 current_labels=[LABEL_PLANNING],
                 log_prefix="cai plan",
@@ -677,7 +676,7 @@ def handle_plan(issue: dict) -> int:
         issue["_cai_plan_approvable_at_medium"] = plan_approvable_at_medium
 
         # 6. Transition labels: :planning → :planned (waypoint).
-        ok = apply_transition(
+        ok, _ = fire_trigger(
             issue_number, "planning_to_planned",
             current_labels=[LABEL_PLANNING],
             log_prefix="cai plan",
@@ -805,7 +804,7 @@ def handle_plan_gate(issue: dict) -> int:
         ]
         if plan_confidence_reason:
             reason_lines.extend(["", plan_confidence_reason.rstrip()])
-        ok = apply_transition(
+        ok, _ = fire_trigger(
             issue_number, "planned_to_human",
             current_labels=[LABEL_PLANNED],
             log_prefix="cai plan",
@@ -886,8 +885,10 @@ def handle_plan_gate(issue: dict) -> int:
 
     # Apply the gate. Threshold met → :plan-approved; below → :human-needed
     # via the configured divert target.
-    ok, diverted = apply_transition_with_confidence(
-        issue_number, transition_name, plan_confidence,
+    ok, diverted = fire_trigger(
+        issue_number, transition_name,
+        confidence=plan_confidence,
+        _confidence_gated=True,
         current_labels=[LABEL_PLANNED],
         log_prefix="cai plan",
         reason_extra=plan_confidence_reason or "",

--- a/cai_lib/actions/pr_bounce.py
+++ b/cai_lib/actions/pr_bounce.py
@@ -29,7 +29,7 @@ import sys
 from typing import Optional
 
 from cai_lib.config import REPO
-from cai_lib.fsm import apply_transition
+from cai_lib.fsm import fire_trigger
 from cai_lib.github import _gh_json
 
 
@@ -173,7 +173,7 @@ def handle_pr_bounce(issue: dict) -> int:
                 f"advancing pr_to_merged",
                 flush=True,
             )
-            ok = apply_transition(
+            ok, _ = fire_trigger(
                 issue_number, "pr_to_merged",
                 current_labels=label_names,
                 log_prefix="cai dispatch",
@@ -197,7 +197,7 @@ def handle_pr_bounce(issue: dict) -> int:
                 f"({close_actor}) — reverting pr_to_refined",
                 flush=True,
             )
-            ok = apply_transition(
+            ok, _ = fire_trigger(
                 issue_number, "pr_to_refined",
                 current_labels=label_names,
                 log_prefix="cai dispatch",
@@ -211,7 +211,7 @@ def handle_pr_bounce(issue: dict) -> int:
                 f"pr_to_human_needed",
                 flush=True,
             )
-            ok = apply_transition(
+            ok, _ = fire_trigger(
                 issue_number, "pr_to_human_needed",
                 current_labels=label_names,
                 log_prefix="cai dispatch",
@@ -233,7 +233,7 @@ def handle_pr_bounce(issue: dict) -> int:
         f"pr_to_human_needed",
         flush=True,
     )
-    ok = apply_transition(
+    ok, _ = fire_trigger(
         issue_number, "pr_to_human_needed",
         current_labels=label_names,
         log_prefix="cai dispatch",

--- a/cai_lib/actions/rebase.py
+++ b/cai_lib/actions/rebase.py
@@ -31,7 +31,7 @@ import uuid
 from pathlib import Path
 
 from cai_lib.config import REPO
-from cai_lib.fsm import apply_pr_transition
+from cai_lib.fsm import fire_trigger
 from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.cmd_helpers import _git, _gh_user_identity, _work_directory_block
 from cai_lib.logging_utils import log_run
@@ -63,8 +63,9 @@ def _post_pr_comment(pr_number: int, body: str) -> None:
 
 def _exit_to_review(pr_number: int) -> None:
     """Apply rebasing_to_reviewing_code so the next tick re-reviews."""
-    apply_pr_transition(
+    fire_trigger(
         pr_number, "rebasing_to_reviewing_code",
+        is_pr=True,
         log_prefix="cai rebase",
     )
 

--- a/cai_lib/actions/refine.py
+++ b/cai_lib/actions/refine.py
@@ -20,7 +20,7 @@ from cai_lib.config import (
     LABEL_DEPTH_PREFIX,
     MAX_DECOMPOSITION_DEPTH,
 )
-from cai_lib.fsm import apply_transition
+from cai_lib.fsm import fire_trigger
 from cai_lib.github import (
     _gh_json, _set_labels, _build_issue_block, _post_issue_comment,
 )
@@ -255,7 +255,7 @@ def handle_refine(issue: dict) -> int:
     # already in the working state.
     issue_label_names_initial = [l["name"] for l in issue.get("labels", [])]  # noqa: E741
     if LABEL_RAISED in issue_label_names_initial:
-        apply_transition(
+        fire_trigger(
             issue_number, "raise_to_refining",
             current_labels=issue_label_names_initial,
             log_prefix="cai refine",
@@ -302,7 +302,7 @@ def handle_refine(issue: dict) -> int:
             f"advancing :refining → :refined",
             flush=True,
         )
-        apply_transition(
+        fire_trigger(
             issue_number, "refining_to_refined",
             current_labels=[LABEL_REFINING],
             log_prefix="cai refine",
@@ -374,7 +374,7 @@ def handle_refine(issue: dict) -> int:
             "editing) or split the forbidden work into a predecessor "
             "issue and drop it from **Files to change** here."
         )
-        apply_transition(
+        fire_trigger(
             issue_number, "refining_to_human",
             current_labels=[LABEL_REFINING],
             log_prefix="cai refine",
@@ -426,7 +426,7 @@ def handle_refine(issue: dict) -> int:
     # for cmd_plan to pick up.
     dur = f"{int(time.monotonic() - t0)}s"
     if next_step == "EXPLORE":
-        apply_transition(
+        fire_trigger(
             issue_number, "refining_to_exploration",
             current_labels=[LABEL_REFINING],
             log_prefix="cai refine",
@@ -440,7 +440,7 @@ def handle_refine(issue: dict) -> int:
                 duration=dur, result="refined_explore", exit=0)
         return 0
 
-    apply_transition(
+    fire_trigger(
         issue_number, "refining_to_refined",
         current_labels=[LABEL_REFINING],
         log_prefix="cai refine",

--- a/cai_lib/actions/review_docs.py
+++ b/cai_lib/actions/review_docs.py
@@ -19,7 +19,7 @@ import uuid
 from pathlib import Path
 
 from cai_lib.config import REPO
-from cai_lib.fsm import apply_pr_transition, get_pr_state, PRState
+from cai_lib.fsm import fire_trigger, get_pr_state, PRState
 from cai_lib.github import _gh_json, _fetch_linked_issue_block
 from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.cmd_helpers import (
@@ -198,8 +198,9 @@ def handle_review_docs(pr: dict) -> int:
                 f"{head_sha[:8]} — advancing to APPROVED",
                 flush=True,
             )
-            apply_pr_transition(
+            fire_trigger(
                 pr_number, "reviewing_docs_to_approved",
+                is_pr=True,
                 log_prefix="cai review-docs",
             )
             log_run("review_docs", repo=REPO, pr=pr_number,
@@ -215,8 +216,9 @@ def handle_review_docs(pr: dict) -> int:
                 f"{head_sha[:8]} — advancing to APPROVED",
                 flush=True,
             )
-            apply_pr_transition(
+            fire_trigger(
                 pr_number, "reviewing_docs_to_approved",
+                is_pr=True,
                 log_prefix="cai review-docs",
             )
             log_run("review_docs", repo=REPO, pr=pr_number,
@@ -425,8 +427,9 @@ def handle_review_docs(pr: dict) -> int:
         # and the merge handler decides whether to merge. Bouncing back
         # to REVIEWING_CODE on a doc push caused review/docs ping-pong
         # loops that produced no new code findings.
-        apply_pr_transition(
+        fire_trigger(
             pr_number, "reviewing_docs_to_approved",
+            is_pr=True,
             log_prefix="cai review-docs",
         )
         if has_doc_changes:

--- a/cai_lib/actions/review_pr.py
+++ b/cai_lib/actions/review_pr.py
@@ -37,7 +37,7 @@ from cai_lib.config import (
 from cai_lib.actions.merge import _BOT_BRANCH_RE
 from cai_lib.fsm import (
     PRState,
-    apply_pr_transition,
+    fire_trigger,
     get_pr_state,
 )
 from cai_lib.github import _fetch_linked_issue_block
@@ -321,8 +321,9 @@ def handle_review_pr(pr: dict) -> int:
         if current_state == PRState.OPEN:
             branch = pr.get("headRefName", "") or ""
             if not _BOT_BRANCH_RE.match(branch):
-                apply_pr_transition(
+                fire_trigger(
                     pr_number, "open_to_human",
+                    is_pr=True,
                     current_pr=pr,
                     log_prefix="cai review-pr",
                     divert_reason=(
@@ -331,18 +332,21 @@ def handle_review_pr(pr: dict) -> int:
                     ),
                 )
                 return 1
-            apply_pr_transition(
+            fire_trigger(
                 pr_number, "open_to_reviewing_code",
+                is_pr=True,
                 log_prefix="cai review-pr",
             )
         if has_findings:
-            apply_pr_transition(
+            fire_trigger(
                 pr_number, "reviewing_code_to_revision_pending",
+                is_pr=True,
                 log_prefix="cai review-pr",
             )
         else:
-            apply_pr_transition(
+            fire_trigger(
                 pr_number, "reviewing_code_to_reviewing_docs",
+                is_pr=True,
                 log_prefix="cai review-pr",
             )
 

--- a/cai_lib/actions/revise.py
+++ b/cai_lib/actions/revise.py
@@ -25,7 +25,7 @@ from cai_lib.config import (
 )
 from cai_lib.fsm import (
     PRState,
-    apply_pr_transition,
+    fire_trigger,
     get_pr_state,
 )
 from cai_lib.github import _gh_json, _set_labels
@@ -941,18 +941,21 @@ def handle_revise(pr: dict) -> int:
                 pr_now = {}
             current_state = get_pr_state(pr_now) if pr_now else None
             if current_state == PRState.REVISION_PENDING:
-                apply_pr_transition(
+                fire_trigger(
                     pr_number, "revision_pending_to_reviewing_code",
+                    is_pr=True,
                     log_prefix="cai revise",
                 )
             elif current_state == PRState.CI_FAILING:
-                apply_pr_transition(
+                fire_trigger(
                     pr_number, "ci_failing_to_reviewing_code",
+                    is_pr=True,
                     log_prefix="cai revise",
                 )
             elif current_state == PRState.REVIEWING_DOCS:
-                apply_pr_transition(
+                fire_trigger(
                     pr_number, "reviewing_docs_to_reviewing_code",
+                    is_pr=True,
                     log_prefix="cai revise",
                 )
             # REVIEWING_CODE is already correct; OPEN / PR_HUMAN_NEEDED

--- a/cai_lib/actions/triage.py
+++ b/cai_lib/actions/triage.py
@@ -24,7 +24,7 @@ from cai_lib.dup_check import check_duplicate_or_resolved
 from cai_lib.fsm import (
     Confidence,
     IssueState,
-    apply_transition,
+    fire_trigger,
     get_issue_state,
 )
 from cai_lib.github import _post_issue_comment, _set_labels
@@ -175,7 +175,7 @@ def handle_triage(issue: dict) -> int:
 
     # 1. RAISED → TRIAGING (skip if already at :triaging — same handler resumes).
     if current_state == IssueState.RAISED:
-        apply_transition(
+        fire_trigger(
             issue_number, "raise_to_triaging",
             current_labels=issue_labels,
             log_prefix="cai triage",
@@ -299,7 +299,7 @@ def handle_triage(issue: dict) -> int:
 
     # 6. Execute verdict.
     if decision == "HUMAN":
-        apply_transition(
+        fire_trigger(
             issue_number, "triaging_to_human",
             current_labels=[LABEL_TRIAGING],
             log_prefix="cai triage",
@@ -328,7 +328,7 @@ def handle_triage(issue: dict) -> int:
                 f"[cai triage] #{issue_number}: {decision} {reason} — falling through to REFINE",
                 flush=True,
             )
-            apply_transition(
+            fire_trigger(
                 issue_number, "triaging_to_refining",
                 current_labels=[LABEL_TRIAGING],
                 log_prefix="cai triage",
@@ -358,7 +358,7 @@ def handle_triage(issue: dict) -> int:
                      "--repo", REPO, "--body", new_body],
                     capture_output=True, check=True,
                 )
-            apply_transition(
+            fire_trigger(
                 issue_number, "triaging_to_plan_approved",
                 current_labels=[LABEL_TRIAGING],
                 log_prefix="cai triage",
@@ -398,7 +398,7 @@ def handle_triage(issue: dict) -> int:
                      "--repo", REPO, "--body", new_body],
                     capture_output=True, check=True,
                 )
-                apply_transition(
+                fire_trigger(
                     issue_number, "triaging_to_applying",
                     current_labels=[LABEL_TRIAGING],
                     log_prefix="cai triage",
@@ -412,7 +412,7 @@ def handle_triage(issue: dict) -> int:
                 action_taken = "applying"
     else:
         # REFINE or any unrecognised decision → fall through to REFINE.
-        apply_transition(
+        fire_trigger(
             issue_number, "triaging_to_refining",
             current_labels=[LABEL_TRIAGING],
             log_prefix="cai triage",

--- a/cai_lib/cmd_rescue.py
+++ b/cai_lib/cmd_rescue.py
@@ -35,8 +35,7 @@ from cai_lib.config import (
 )
 from cai_lib.fsm import (
     Confidence,
-    apply_pr_transition,
-    apply_transition,
+    fire_trigger,
     resume_pr_transition_for,
     resume_transition_for,
 )
@@ -340,7 +339,7 @@ def _schedule_opus_attempt(
         (lb.get("name") if isinstance(lb, dict) else lb)
         for lb in issue.get("labels", []) or []
     ]
-    ok = apply_transition(
+    ok, _ = fire_trigger(
         issue_number, "human_to_plan_approved",
         current_labels=current_labels,
         log_prefix="cai rescue",
@@ -549,7 +548,7 @@ def _try_rescue_issue(
     )
 
     current_labels = [l["name"] for l in issue.get("labels", [])]  # noqa: E741
-    ok = apply_transition(
+    ok, _ = fire_trigger(
         issue_number, transition.name,
         current_labels=current_labels,
         log_prefix="cai rescue",
@@ -681,8 +680,9 @@ def _try_rescue_pr(
         reasoning=reasoning,
     )
 
-    ok = apply_pr_transition(
+    ok, _ = fire_trigger(
         pr_number, transition.name,
+        is_pr=True,
         log_prefix="cai rescue",
     )
     if not ok:

--- a/cai_lib/cmd_unblock.py
+++ b/cai_lib/cmd_unblock.py
@@ -461,7 +461,7 @@ def _try_unblock_pr(pr: dict) -> Optional[str]:
     Mirrors :func:`_try_unblock_issue`. Resume target maps to a
     ``pr_human_to_<state>`` transition via
     :func:`resume_pr_transition_for`, applied with
-    :func:`apply_pr_transition`.
+    :func:`fire_trigger`.
     """
     pr_number = pr["number"]
 
@@ -530,8 +530,7 @@ def _try_unblock_pr(pr: dict) -> Optional[str]:
         return "no_target"
 
     # The transition already clears :pr-human-needed via labels_remove.
-    # The human:solved label needs an explicit removal pass — unlike the
-    # issue-side helper, apply_pr_transition has no ``extra_remove`` kw.
+    # The human:solved label needs an explicit removal pass via _set_pr_labels.
     ok, _ = fire_trigger(
         pr_number, transition.name,
         is_pr=True,

--- a/cai_lib/cmd_unblock.py
+++ b/cai_lib/cmd_unblock.py
@@ -34,8 +34,7 @@ from cai_lib.config import (
 )
 from cai_lib.fsm import (
     Confidence,
-    apply_transition,
-    apply_pr_transition,
+    fire_trigger,
     resume_transition_for,
     resume_pr_transition_for,
 )
@@ -361,7 +360,7 @@ def _try_unblock_issue(issue: dict) -> Optional[str]:
     current_labels = [l["name"] for l in issue.get("labels", [])]  # noqa: E741
     # The transition already clears :human-needed; also drop the
     # human:solved signal so the label is one-shot.
-    ok = apply_transition(
+    ok, _ = fire_trigger(
         issue_number, transition.name,
         current_labels=current_labels,
         extra_remove=[LABEL_HUMAN_SOLVED],
@@ -533,8 +532,9 @@ def _try_unblock_pr(pr: dict) -> Optional[str]:
     # The transition already clears :pr-human-needed via labels_remove.
     # The human:solved label needs an explicit removal pass — unlike the
     # issue-side helper, apply_pr_transition has no ``extra_remove`` kw.
-    ok = apply_pr_transition(
+    ok, _ = fire_trigger(
         pr_number, transition.name,
+        is_pr=True,
         log_prefix="cai unblock",
     )
     if not ok:

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -178,7 +178,7 @@ LABEL_DEPTH_PREFIX = "depth:"
 MAX_DECOMPOSITION_DEPTH: int = int(os.environ.get("CAI_MAX_DECOMPOSITION_DEPTH", "2"))
 
 # PR pipeline-state labels — one per PRState. Set by FSM transitions
-# (apply_pr_transition) and read by dispatch.
+# (fire_trigger) and read by dispatch.
 LABEL_PR_REVIEWING_CODE   = "pr:reviewing-code"    # PRState.REVIEWING_CODE
 LABEL_PR_REVISION_PENDING = "pr:revision-pending"  # PRState.REVISION_PENDING
 LABEL_PR_REVIEWING_DOCS   = "pr:reviewing-docs"    # PRState.REVIEWING_DOCS

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -207,7 +207,7 @@ def _build_pr_registry() -> dict[PRState, PRHandler]:
 # Maps each from-state to the canonical ``*_to_rebasing`` transition name.
 # REBASING itself, MERGED, and OPEN are intentionally
 # excluded — REBASING is already running it; OPEN doesn't have a label
-# so apply_pr_transition wouldn't have one to remove.
+# so fire_trigger wouldn't have one to remove.
 _REBASE_ENTRY_TRANSITIONS: dict[PRState, str] = {
     PRState.REVIEWING_CODE:   "reviewing_code_to_rebasing",
     PRState.REVISION_PENDING: "revision_pending_to_rebasing",

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -337,7 +337,7 @@ def dispatch_pr(pr_number: int) -> int:
 
     # Conflict override: divert to REBASING regardless of pipeline label.
     if state in _REBASE_ENTRY_TRANSITIONS and _pr_needs_rebase(pr):
-        from cai_lib.fsm import apply_pr_transition
+        from cai_lib.fsm import fire_trigger
         from cai_lib.actions.rebase import handle_rebase
         entry = _REBASE_ENTRY_TRANSITIONS[state]
         print(f"[cai dispatch] PR #{pr_number} at {state.name} has "
@@ -349,8 +349,8 @@ def dispatch_pr(pr_number: int) -> int:
                   flush=True)
             return 0
         try:
-            apply_pr_transition(pr_number, entry, current_pr=pr,
-                                log_prefix="cai dispatch")
+            fire_trigger(pr_number, entry, is_pr=True, current_pr=pr,
+                         log_prefix="cai dispatch")
             return handle_rebase(pr)
         finally:
             _release_remote_lock("pr", pr_number)

--- a/cai_lib/fsm_transitions.py
+++ b/cai_lib/fsm_transitions.py
@@ -1,8 +1,8 @@
 """FSM transition data and logic for the auto-improve lifecycle.
 
 Defines the :class:`Transition` dataclass, the canonical transition lists
-(:data:`ISSUE_TRANSITIONS`, :data:`PR_TRANSITIONS`), and all functions that
-apply or query transitions. State enums live in :mod:`cai_lib.fsm_states`;
+(:data:`ISSUE_TRANSITIONS`, :data:`PR_TRANSITIONS`), and the :func:`fire_trigger`
+dispatch function. State enums live in :mod:`cai_lib.fsm_states`;
 confidence parsing lives in :mod:`cai_lib.fsm_confidence`.
 """
 from __future__ import annotations
@@ -211,7 +211,7 @@ ISSUE_TRANSITIONS: list[Transition] = [
     # spike verdict, subagent-no-change spike marker, repeated
     # test-failures on a non-MEDIUM plan). Caller-gated (no FSM-level
     # confidence threshold) — the handler decides when to park and
-    # supplies the divert_reason text that apply_transition renders
+    # supplies the divert_reason text that fire_trigger renders
     # into the MARKER-bearing comment the audit parser picks up. Added
     # in response to issue #1083: before this transition existed the
     # four code paths called ``_set_labels(add=[LABEL_HUMAN_NEEDED])``
@@ -529,8 +529,8 @@ def _confidence_ok(min_confidence: Optional[Confidence]) -> Callable:
     """Factory returning a pytransitions condition callable.
 
     When *_confidence_gated* is False in ``event_data.kwargs`` (e.g. from
-    the ``apply_transition`` shim which carries no confidence), the check is
-    bypassed so confidence-free callers never accidentally trigger a divert.
+    confidence-free callers), the check is
+    bypassed so such callers never accidentally trigger a divert.
     """
     def _check(event_data) -> bool:
         if not event_data.kwargs.get("_confidence_gated", False):
@@ -548,8 +548,7 @@ def _before_human_needed(event_data) -> None:
     Runs as a pytransitions ``before`` callback on all transitions whose
     destination is HUMAN_NEEDED or PR_HUMAN_NEEDED.  Raises ``MachineError``
     (cancelling the transition) when the caller has not supplied a non-empty
-    ``_divert_reason``, mirroring the invariant in the old ``apply_transition``
-    helper.
+    ``_divert_reason``, enforcing the divert-reason invariant.
     """
     divert_reason = event_data.kwargs.get("_divert_reason") or ""
     if not divert_reason.strip():
@@ -681,7 +680,7 @@ def _build_issue_machine(
     Returns ``(machine, model)``.  The model's initial state is derived from
     *current_labels*; when *current_labels* is ``None`` the state is set to
     the ``from_state`` of *trigger_name* so that state-mismatch validation is
-    skipped (backward-compat with ``apply_transition`` callers that omit
+    skipped (allows optional state validation for callers that omit
     ``current_labels``).
 
     Deprecation note: ``Transition.accepts()``, ``Transition.labels_add``,
@@ -832,10 +831,8 @@ def fire_trigger(
         confidence: Confidence level reported by the agent; only relevant
             when *_confidence_gated* is ``True``.
         _confidence_gated: When ``True`` the confidence check is applied and
-            a below-threshold confidence diverts to HUMAN_NEEDED.  Set by
-            the ``apply_transition_with_confidence`` shim; callers of the
-            bare ``apply_transition`` shim leave this ``False`` so the
-            transition fires unconditionally (no divert risk).
+            a below-threshold confidence diverts to HUMAN_NEEDED.  When
+            ``False`` the transition fires unconditionally (no divert risk).
         log_prefix: Prefix for log messages.
         current_labels: Current issue labels used to derive the initial FSM
             state.  When ``None`` the initial state is set to the
@@ -847,7 +844,7 @@ def fire_trigger(
             own ``labels_remove``.
         divert_reason: Non-empty string required when the transition's
             ``to_state`` is HUMAN_NEEDED / PR_HUMAN_NEEDED.  Enforces the
-            silent-divert invariant from apply_transition.
+            silent-divert invariant — human-needed transitions require a reason.
         reason_extra: Extra context appended to the confidence-gate divert
             comment posted when *_confidence_gated* is ``True`` and
             confidence falls below the threshold.
@@ -1074,8 +1071,8 @@ def backfill_silent_human_needed_comments(
     post a retroactive MARKER-bearing backfill comment on any entry that
     has no MARKER comment in its history.
 
-    This is the self-healing counterpart to the ``apply_transition``
-    invariant added for issue #1009. The invariant guarantees *future*
+    This is the self-healing counterpart to the fire_trigger
+    divert-reason invariant added for issue #1009. The invariant guarantees *future*
     diverts carry a MARKER comment; the backfill sweep closes the gap
     for issues parked before the fix (e.g. #932) so the audit agent's
     ``human_needed_reason_missing`` finder and ``cai unblock`` have

--- a/cai_lib/fsm_transitions.py
+++ b/cai_lib/fsm_transitions.py
@@ -929,42 +929,6 @@ def fire_trigger(
         return False, False
 
 
-def apply_transition(
-    issue_number: int,
-    transition_name: str,
-    *,
-    current_labels: Optional[list[str]] = None,
-    extra_remove: Sequence[str] = (),
-    log_prefix: str = "cai",
-    set_labels=None,
-    divert_reason: Optional[str] = None,
-    post_comment=None,
-) -> bool:
-    """Shim: delegates to :func:`fire_trigger` (issue side, no confidence gate).
-
-    Preserves the full public signature of the original implementation so all
-    19 call-site files remain unchanged.  The HUMAN_NEEDED invariant
-    (*divert_reason* required), state-mismatch refusal, and label-change /
-    comment posting are enforced inside ``fire_trigger`` via the Machine
-    callbacks.
-
-    *set_labels* and *post_comment* are injectable for tests (forwarded to
-    ``fire_trigger``).
-    """
-    ok, _ = fire_trigger(
-        issue_number, transition_name,
-        is_pr=False,
-        _confidence_gated=False,
-        log_prefix=log_prefix,
-        current_labels=current_labels,
-        extra_remove=extra_remove,
-        divert_reason=divert_reason or "",
-        set_labels=set_labels,
-        post_comment=post_comment,
-    )
-    return ok
-
-
 def _render_human_divert_reason(
     *,
     transition_name: str,
@@ -1002,40 +966,6 @@ def _render_human_divert_reason(
     return "\n".join(lines)
 
 
-def apply_transition_with_confidence(
-    issue_number: int,
-    transition_name: str,
-    confidence: Optional[Confidence],
-    *,
-    current_labels: Optional[list[str]] = None,
-    extra_remove: Sequence[str] = (),
-    log_prefix: str = "cai",
-    set_labels=None,
-    post_comment=None,
-    reason_extra: str = "",
-) -> tuple[bool, bool]:
-    """Shim: delegates to :func:`fire_trigger` with confidence gating enabled.
-
-    Returns ``(ok, diverted)``.  When *confidence* is ``None`` or below the
-    transition's ``min_confidence``, the issue is moved to HUMAN_NEEDED
-    (diverted=True); otherwise the primary destination is applied
-    (diverted=False).  *set_labels* and *post_comment* are injectable for
-    tests.
-    """
-    return fire_trigger(
-        issue_number, transition_name,
-        is_pr=False,
-        confidence=confidence,
-        _confidence_gated=True,
-        log_prefix=log_prefix,
-        current_labels=current_labels,
-        extra_remove=extra_remove,
-        reason_extra=reason_extra,
-        set_labels=set_labels,
-        post_comment=post_comment,
-    )
-
-
 def resume_transition_for(target_state_name: str) -> Optional[Transition]:
     """Map a ``ResumeTo: <STATE>`` token to the matching ``human_to_<state>`` transition.
 
@@ -1053,68 +983,6 @@ def resume_transition_for(target_state_name: str) -> Optional[Transition]:
         if t.from_state == IssueState.HUMAN_NEEDED and t.to_state == target:
             return t
     return None
-
-
-def apply_pr_transition(
-    pr_number: int,
-    transition_name: str,
-    *,
-    current_pr: Optional[dict] = None,
-    log_prefix: str = "cai",
-    set_pr_labels=None,
-    divert_reason: Optional[str] = None,
-    post_comment=None,
-) -> bool:
-    """Shim: delegates to :func:`fire_trigger` (PR side, no confidence gate).
-
-    Preserves the full public signature of the original implementation.  The
-    PR_HUMAN_NEEDED invariant (*divert_reason* required), state-mismatch
-    refusal, and label-change / comment posting are enforced inside
-    ``fire_trigger`` via the Machine callbacks.
-
-    *set_pr_labels* and *post_comment* are injectable for tests.
-    """
-    ok, _ = fire_trigger(
-        pr_number, transition_name,
-        is_pr=True,
-        _confidence_gated=False,
-        log_prefix=log_prefix,
-        current_pr=current_pr,
-        divert_reason=divert_reason or "",
-        set_pr_labels=set_pr_labels,
-        post_comment=post_comment,
-    )
-    return ok
-
-
-def apply_pr_transition_with_confidence(
-    pr_number: int,
-    transition_name: str,
-    confidence: Optional[Confidence],
-    *,
-    current_pr: Optional[dict] = None,
-    log_prefix: str = "cai",
-    set_pr_labels=None,
-    post_comment=None,
-    reason_extra: str = "",
-) -> tuple[bool, bool]:
-    """Shim: delegates to :func:`fire_trigger` with confidence gating (PR side).
-
-    Returns ``(ok, diverted)``.  Mirrors :func:`apply_transition_with_confidence`
-    for the PR submachine.  *set_pr_labels* and *post_comment* are injectable
-    for tests.
-    """
-    return fire_trigger(
-        pr_number, transition_name,
-        is_pr=True,
-        confidence=confidence,
-        _confidence_gated=True,
-        log_prefix=log_prefix,
-        current_pr=current_pr,
-        reason_extra=reason_extra,
-        set_pr_labels=set_pr_labels,
-        post_comment=post_comment,
-    )
 
 
 def resume_pr_transition_for(target_state_name: str) -> Optional[Transition]:

--- a/docs/modules/actions.md
+++ b/docs/modules/actions.md
@@ -87,7 +87,7 @@ PR-side handlers (take a PR dict):
   with worktree Read/Write.
 - **FSM invariant.** A handler must either advance the FSM or
   divert to `:human-needed`; silently returning 0 strands the
-  issue. Use `apply_transition_with_confidence` so a missing
+  issue. Use `fire_trigger` with `_confidence_gated=True` so a missing
   `Confidence:` line diverts safely.
 - **Worktree hygiene.** `handle_implement`, `handle_revise`,
   `handle_rebase`, `handle_fix_ci`, and `handle_maintain` each

--- a/docs/modules/fsm.md
+++ b/docs/modules/fsm.md
@@ -17,9 +17,8 @@ import from `cai_lib.fsm` rather than the split modules directly.
 - [`cai_lib/fsm_transitions.py`](../../cai_lib/fsm_transitions.py) —
   `Transition` dataclass; `ISSUE_TRANSITIONS` and `PR_TRANSITIONS`
   tables; `get_issue_state`, `get_pr_state`, `find_transition`,
-  `apply_transition`, `apply_transition_with_confidence`,
-  `resume_transition_for`, `apply_pr_transition`,
-  `apply_pr_transition_with_confidence`, `resume_pr_transition_for`,
+  `fire_trigger` (the canonical FSM dispatch entry point),
+  `resume_transition_for`, `resume_pr_transition_for`,
   `render_fsm_mermaid` (library-backed via
   `transitions.extensions.GraphMachine`; the Mermaid source is
   post-processed to strip the library's YAML front matter and restore
@@ -60,7 +59,7 @@ import from `cai_lib.fsm` rather than the split modules directly.
 ## Operational notes
 - **Invariants.** A single issue must carry exactly one state label
   from the `IssueState` enum (same for PR ↔ `PRState`). The
-  dispatcher enforces this through `apply_transition`; setting a
+  dispatcher enforces this through `fire_trigger`; setting a
   label by hand can leave the FSM in an unreachable state.
 - **Confidence parsing.** `parse_confidence` looks for
   `Confidence: HIGH|MEDIUM|LOW|STOP` in agent output; missing or

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -224,11 +224,11 @@ class TestDispatchPR(_LockNoopMixin, unittest.TestCase):
 
         def fake_apply_pr_transition(pr_number, transition_name, **kw):
             applied.append((pr_number, transition_name))
-            return True
+            return (True, False)
 
         with patch.object(dispatcher, "_gh_json", return_value=pr), \
              patch.object(dispatcher, "_pr_registry", return_value=registry), \
-             patch("cai_lib.fsm.apply_pr_transition",
+             patch("cai_lib.fsm.fire_trigger",
                    side_effect=fake_apply_pr_transition), \
              patch("cai_lib.actions.rebase.handle_rebase",
                    side_effect=rebase_handler):
@@ -252,7 +252,7 @@ class TestDispatchPR(_LockNoopMixin, unittest.TestCase):
 
         with patch.object(dispatcher, "_gh_json", return_value=pr), \
              patch.object(dispatcher, "_pr_registry", return_value=registry), \
-             patch("cai_lib.fsm.apply_pr_transition", return_value=True), \
+             patch("cai_lib.fsm.fire_trigger", return_value=(True, False)), \
              patch("cai_lib.actions.rebase.handle_rebase",
                    side_effect=rebase_handler):
             rc = dispatcher.dispatch_pr(99)

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -10,7 +10,7 @@ from cai_lib.fsm import (
     IssueState, PRState, Transition, Confidence,
     ISSUE_TRANSITIONS, PR_TRANSITIONS,
     get_issue_state, render_fsm_mermaid,
-    apply_transition, apply_transition_with_confidence, find_transition,
+    find_transition,
     parse_confidence, parse_confidence_reason, parse_resume_target,
     resume_transition_for, resume_pr_transition_for,
     fire_trigger,
@@ -296,135 +296,6 @@ class TestPlannedToPlanApprovedApprovable(unittest.TestCase):
         )
 
 
-class TestApplyTransition(unittest.TestCase):
-
-    def _recording_set_labels(self):
-        calls = []
-        def _fake(issue_number, *, add=(), remove=(), log_prefix="cai"):
-            calls.append({
-                "issue_number": issue_number,
-                "add": list(add),
-                "remove": list(remove),
-                "log_prefix": log_prefix,
-            })
-            return True
-        return calls, _fake
-
-    def test_happy_path_applies_labels(self):
-        calls, fake = self._recording_set_labels()
-        ok = apply_transition(
-            42, "raise_to_refining",
-            current_labels=[LABEL_RAISED],
-            set_labels=fake,
-        )
-        self.assertTrue(ok)
-        self.assertEqual(len(calls), 1)
-        self.assertEqual(calls[0]["issue_number"], 42)
-        self.assertIn(LABEL_REFINING, calls[0]["add"])
-        self.assertIn(LABEL_RAISED, calls[0]["remove"])
-
-    def test_extra_remove_is_forwarded(self):
-        calls, fake = self._recording_set_labels()
-        apply_transition(
-            7, "raise_to_refining",
-            current_labels=[LABEL_RAISED],
-            extra_remove=[LABEL_PARENT],
-            set_labels=fake,
-        )
-        self.assertIn(LABEL_PARENT, calls[0]["remove"])
-        self.assertIn(LABEL_RAISED, calls[0]["remove"])
-
-    def test_state_mismatch_refuses(self):
-        calls, fake = self._recording_set_labels()
-        ok = apply_transition(
-            9, "raise_to_refining",
-            current_labels=[LABEL_REFINED],
-            set_labels=fake,
-        )
-        self.assertFalse(ok)
-        self.assertEqual(calls, [])
-
-    def test_unknown_transition_raises(self):
-        with self.assertRaises(KeyError):
-            apply_transition(1, "not_a_real_transition", current_labels=[LABEL_RAISED])
-
-    def test_skip_validation_when_no_current_labels(self):
-        calls, fake = self._recording_set_labels()
-        ok = apply_transition(1, "raise_to_refining", set_labels=fake)
-        self.assertTrue(ok)
-        self.assertEqual(len(calls), 1)
-
-    def test_find_transition_roundtrip(self):
-        t = find_transition("raise_to_refining")
-        self.assertEqual(t.from_state, IssueState.RAISED)
-        self.assertEqual(t.to_state, IssueState.REFINING)
-
-    def test_human_needed_requires_divert_reason(self):
-        """apply_transition refuses a HUMAN_NEEDED divert without a reason (#1009)."""
-        calls, fake = self._recording_set_labels()
-        posted = []
-
-        def _fake_post(n, body, *, log_prefix="cai"):
-            posted.append({"n": n, "body": body})
-            return True
-
-        ok = apply_transition(
-            55, "triaging_to_human",
-            current_labels=[LABEL_TRIAGING],
-            set_labels=fake,
-            post_comment=_fake_post,
-        )
-        self.assertFalse(ok)
-        self.assertEqual(calls, [])
-        self.assertEqual(posted, [])
-
-    def test_human_needed_with_reason_posts_marker_comment(self):
-        """Successful HUMAN_NEEDED divert posts the MARKER-bearing comment (#1009)."""
-        calls, fake = self._recording_set_labels()
-        posted = []
-
-        def _fake_post(n, body, *, log_prefix="cai"):
-            posted.append({"n": n, "body": body})
-            return True
-
-        ok = apply_transition(
-            77, "triaging_to_human",
-            current_labels=[LABEL_TRIAGING],
-            set_labels=fake,
-            post_comment=_fake_post,
-            divert_reason="Triage verdict: HUMAN.",
-        )
-        self.assertTrue(ok)
-        self.assertEqual(len(calls), 1)
-        self.assertIn(LABEL_HUMAN_NEEDED, calls[0]["add"])
-        self.assertEqual(len(posted), 1)
-        body = posted[0]["body"]
-        self.assertIn("🙋 Human attention needed", body)
-        self.assertIn("Automation paused `triaging_to_human`", body)
-        self.assertIn("Required confidence:", body)
-        self.assertIn("Reported confidence:", body)
-        self.assertIn("Triage verdict: HUMAN.", body)
-
-    def test_non_human_transition_ignores_reason_kwarg(self):
-        """Non-HUMAN transitions don't require or post a reason."""
-        calls, fake = self._recording_set_labels()
-        posted = []
-
-        def _fake_post(n, body, *, log_prefix="cai"):
-            posted.append({"n": n, "body": body})
-            return True
-
-        ok = apply_transition(
-            11, "raise_to_refining",
-            current_labels=[LABEL_RAISED],
-            set_labels=fake,
-            post_comment=_fake_post,
-        )
-        self.assertTrue(ok)
-        self.assertEqual(len(calls), 1)
-        self.assertEqual(posted, [])
-
-
 class TestBackfillSilentHumanNeeded(unittest.TestCase):
     """Pins the self-healing backfill sweep (#1009, #932)."""
 
@@ -475,99 +346,6 @@ class TestBackfillSilentHumanNeeded(unittest.TestCase):
         self.assertEqual(len(posted), 1)
         self.assertEqual(posted[0]["n"], 932)
         self.assertIn("🙋 Human attention needed", posted[0]["body"])
-
-
-class TestApplyTransitionWithConfidence(unittest.TestCase):
-
-    def _recording_set_labels(self):
-        calls = []
-        def _fake(issue_number, *, add=(), remove=(), log_prefix="cai"):
-            calls.append({
-                "issue_number": issue_number,
-                "add": list(add),
-                "remove": list(remove),
-                "log_prefix": log_prefix,
-            })
-            return True
-        return calls, _fake
-
-    def _recording_post_comment(self):
-        calls = []
-        def _fake(issue_number, body, *, log_prefix="cai"):
-            calls.append({
-                "issue_number": issue_number,
-                "body": body,
-                "log_prefix": log_prefix,
-            })
-            return True
-        return calls, _fake
-
-    def test_high_confidence_applies_nominal_transition(self):
-        calls, fake = self._recording_set_labels()
-        comments, fake_comment = self._recording_post_comment()
-        ok, diverted = apply_transition_with_confidence(
-            11, "refining_to_refined", Confidence.HIGH,
-            current_labels=[LABEL_REFINING],
-            set_labels=fake,
-            post_comment=fake_comment,
-        )
-        self.assertTrue(ok)
-        self.assertFalse(diverted)
-        self.assertIn(LABEL_REFINED, calls[0]["add"])
-        # No divert → no human-needed comment should be posted.
-        self.assertEqual(comments, [])
-
-    def test_medium_confidence_diverts_to_human(self):
-        calls, fake = self._recording_set_labels()
-        comments, fake_comment = self._recording_post_comment()
-        ok, diverted = apply_transition_with_confidence(
-            12, "refining_to_refined", Confidence.MEDIUM,
-            current_labels=[LABEL_REFINING],
-            set_labels=fake,
-            post_comment=fake_comment,
-        )
-        self.assertTrue(ok)
-        self.assertTrue(diverted)
-        self.assertIn(LABEL_HUMAN_NEEDED, calls[0]["add"])
-        self.assertIn(LABEL_REFINING, calls[0]["remove"])
-        self.assertNotIn(LABEL_REFINED, calls[0]["add"])
-        # Divert → a reason comment must be posted with the failing transition
-        # and confidence values so the admin knows why they were summoned.
-        self.assertEqual(len(comments), 1)
-        body = comments[0]["body"]
-        self.assertIn("refining_to_refined", body)
-        self.assertIn("MEDIUM", body)
-        self.assertIn("HIGH", body)
-
-    def test_missing_confidence_diverts_to_human(self):
-        calls, fake = self._recording_set_labels()
-        comments, fake_comment = self._recording_post_comment()
-        ok, diverted = apply_transition_with_confidence(
-            13, "refining_to_refined", None,
-            current_labels=[LABEL_REFINING],
-            set_labels=fake,
-            post_comment=fake_comment,
-        )
-        self.assertTrue(ok)
-        self.assertTrue(diverted)
-        self.assertIn(LABEL_HUMAN_NEEDED, calls[0]["add"])
-        self.assertEqual(len(comments), 1)
-        self.assertIn("MISSING", comments[0]["body"])
-
-    def test_divert_respects_from_state_mismatch(self):
-        calls, fake = self._recording_set_labels()
-        comments, fake_comment = self._recording_post_comment()
-        ok, diverted = apply_transition_with_confidence(
-            14, "refining_to_refined", None,
-            current_labels=[LABEL_REFINED],  # wrong state
-            set_labels=fake,
-            post_comment=fake_comment,
-        )
-        self.assertFalse(ok)
-        self.assertFalse(diverted)
-        self.assertEqual(calls, [])
-        # State mismatch aborts before the divert → no comment either.
-        self.assertEqual(comments, [])
 
 
 class TestResumeFromHuman(unittest.TestCase):
@@ -982,9 +760,9 @@ class TestTriagingHandlerPairCheck(unittest.TestCase):
         )
         transitions_called = []
 
-        def fake_apply_transition(issue_number, transition_name, **kwargs):
-            transitions_called.append(transition_name)
-            return True
+        def fake_apply_transition(issue_number, trigger_name, **kwargs):
+            transitions_called.append(trigger_name)
+            return True, False
 
         labels_added = []
 
@@ -993,7 +771,7 @@ class TestTriagingHandlerPairCheck(unittest.TestCase):
             return True
 
         with mock.patch.object(T, "_run_claude_p", return_value=fake_result), \
-             mock.patch.object(T, "apply_transition", side_effect=fake_apply_transition), \
+             mock.patch.object(T, "fire_trigger", side_effect=fake_apply_transition), \
              mock.patch.object(T, "_set_labels", side_effect=fake_set_labels), \
              mock.patch.object(T, "check_duplicate_or_resolved", return_value=None), \
              mock.patch.object(T, "log_run"):
@@ -1023,9 +801,9 @@ class TestTriagingHandlerPairCheck(unittest.TestCase):
         )
         transitions_called = []
 
-        def fake_apply_transition(issue_number, transition_name, **kwargs):
-            transitions_called.append(transition_name)
-            return True
+        def fake_apply_transition(issue_number, trigger_name, **kwargs):
+            transitions_called.append(trigger_name)
+            return True, False
 
         labels_added = []
 
@@ -1034,7 +812,7 @@ class TestTriagingHandlerPairCheck(unittest.TestCase):
             return True
 
         with mock.patch.object(T, "_run_claude_p", return_value=fake_result), \
-             mock.patch.object(T, "apply_transition", side_effect=fake_apply_transition), \
+             mock.patch.object(T, "fire_trigger", side_effect=fake_apply_transition), \
              mock.patch.object(T, "_set_labels", side_effect=fake_set_labels), \
              mock.patch.object(T, "check_duplicate_or_resolved", return_value=None), \
              mock.patch.object(T, "log_run"):
@@ -1102,9 +880,9 @@ class TestTriagingHandlerOpsValidation(unittest.TestCase):
         )
         transitions_called = []
 
-        def fake_apply_transition(issue_number, transition_name, **kwargs):
-            transitions_called.append(transition_name)
-            return True
+        def fake_apply_transition(issue_number, trigger_name, **kwargs):
+            transitions_called.append(trigger_name)
+            return True, False
 
         labels_added = []
 
@@ -1113,7 +891,7 @@ class TestTriagingHandlerOpsValidation(unittest.TestCase):
             return True
 
         with mock.patch.object(T, "_run_claude_p", return_value=fake_result), \
-             mock.patch.object(T, "apply_transition", side_effect=fake_apply_transition), \
+             mock.patch.object(T, "fire_trigger", side_effect=fake_apply_transition), \
              mock.patch.object(T, "_set_labels", side_effect=fake_set_labels), \
              mock.patch.object(T, "check_duplicate_or_resolved", return_value=None), \
              mock.patch.object(T, "log_run"):
@@ -1150,9 +928,9 @@ class TestTriagingHandlerOpsValidation(unittest.TestCase):
         )
         transitions_called = []
 
-        def fake_apply_transition(issue_number, transition_name, **kwargs):
-            transitions_called.append(transition_name)
-            return True
+        def fake_apply_transition(issue_number, trigger_name, **kwargs):
+            transitions_called.append(trigger_name)
+            return True, False
 
         labels_added = []
 
@@ -1162,7 +940,7 @@ class TestTriagingHandlerOpsValidation(unittest.TestCase):
 
         with mock.patch.object(T, "_run_claude_p", return_value=fake_result), \
              mock.patch.object(T, "_run", return_value=fake_run), \
-             mock.patch.object(T, "apply_transition", side_effect=fake_apply_transition), \
+             mock.patch.object(T, "fire_trigger", side_effect=fake_apply_transition), \
              mock.patch.object(T, "_set_labels", side_effect=fake_set_labels), \
              mock.patch.object(T, "check_duplicate_or_resolved", return_value=None), \
              mock.patch.object(T, "log_run"):
@@ -1233,9 +1011,9 @@ class TestTriagingPrelabeledKindOverride(unittest.TestCase):
         )
         transitions_called = []
 
-        def fake_apply_transition(issue_number, transition_name, **kwargs):
-            transitions_called.append(transition_name)
-            return True
+        def fake_apply_transition(issue_number, trigger_name, **kwargs):
+            transitions_called.append(trigger_name)
+            return True, False
 
         labels_added = []
 
@@ -1244,7 +1022,7 @@ class TestTriagingPrelabeledKindOverride(unittest.TestCase):
             return True
 
         with mock.patch.object(T, "_run_claude_p", return_value=fake_result), \
-             mock.patch.object(T, "apply_transition", side_effect=fake_apply_transition), \
+             mock.patch.object(T, "fire_trigger", side_effect=fake_apply_transition), \
              mock.patch.object(T, "_set_labels", side_effect=fake_set_labels), \
              mock.patch.object(T, "check_duplicate_or_resolved", return_value=None), \
              mock.patch.object(T, "log_run"):

--- a/tests/test_merge_approach_mismatch.py
+++ b/tests/test_merge_approach_mismatch.py
@@ -107,8 +107,7 @@ class TestHandleMergeApproachMismatchRouting(unittest.TestCase):
         fetch_review_mock = MagicMock(return_value=[])
         has_label_mock = MagicMock(return_value=False)
         set_labels_mock = MagicMock(return_value=True)
-        pr_transition_mock = MagicMock(return_value=True)
-        issue_transition_mock = MagicMock(return_value=True)
+        fire_trigger_mock = MagicMock(return_value=(True, False))
         log_mock = MagicMock()
         git_mock = MagicMock()
 
@@ -123,31 +122,31 @@ class TestHandleMergeApproachMismatchRouting(unittest.TestCase):
              patch.object(merge_mod, "_issue_has_label",
                           has_label_mock), \
              patch.object(merge_mod, "_set_labels", set_labels_mock), \
-             patch.object(merge_mod, "apply_pr_transition",
-                          pr_transition_mock), \
-             patch.object(merge_mod, "apply_transition",
-                          issue_transition_mock), \
+             patch.object(merge_mod, "fire_trigger",
+                          fire_trigger_mock), \
              patch.object(merge_mod, "log_run", log_mock):
             rc = merge_mod.handle_merge(pr)
 
         self.assertEqual(rc, 0)
         return {
-            "pr_transition": pr_transition_mock,
-            "issue_transition": issue_transition_mock,
+            "pr_transition": fire_trigger_mock,
+            "issue_transition": fire_trigger_mock,
             "set_labels": set_labels_mock,
             "run": run_mock,
         }
 
-    def _pr_transition_names(self, pr_transition_mock) -> list:
+    def _pr_transition_names(self, fire_trigger_mock) -> list:
         return [
-            c.args[1] for c in pr_transition_mock.call_args_list
+            c.args[1] for c in fire_trigger_mock.call_args_list
             if len(c.args) >= 2 and isinstance(c.args[1], str)
+            and c.kwargs.get("is_pr", False)
         ]
 
-    def _issue_transition_names(self, issue_transition_mock) -> list:
+    def _issue_transition_names(self, fire_trigger_mock) -> list:
         return [
-            c.args[1] for c in issue_transition_mock.call_args_list
+            c.args[1] for c in fire_trigger_mock.call_args_list
             if len(c.args) >= 2 and isinstance(c.args[1], str)
+            and not c.kwargs.get("is_pr", False)
         ]
 
     def test_hold_with_approach_mismatch_closes_and_transitions(self):

--- a/tests/test_merge_ci_failing_divert.py
+++ b/tests/test_merge_ci_failing_divert.py
@@ -61,7 +61,7 @@ class TestHandleMergeDivertsOnFailedCI(unittest.TestCase):
             return {}
 
         with patch.object(merge_mod, "_gh_json", side_effect=fake_gh_json), \
-             patch.object(merge_mod, "apply_pr_transition",
+             patch.object(merge_mod, "fire_trigger",
                           side_effect=fake_apply), \
              patch.object(merge_mod, "get_pr_state",
                           return_value=PRState.APPROVED), \

--- a/tests/test_merge_low_to_revision.py
+++ b/tests/test_merge_low_to_revision.py
@@ -192,7 +192,7 @@ class TestHandleMergeLowHoldRouting(unittest.TestCase):
                           fetch_review_mock), \
              patch.object(merge_mod, "_issue_has_label", has_label_mock), \
              patch.object(merge_mod, "_set_labels", set_labels_mock), \
-             patch.object(merge_mod, "apply_pr_transition",
+             patch.object(merge_mod, "fire_trigger",
                           transition_mock), \
              patch.object(merge_mod, "log_run", log_mock):
             rc = merge_mod.handle_merge(pr)

--- a/tests/test_merge_non_bot_branch.py
+++ b/tests/test_merge_non_bot_branch.py
@@ -48,7 +48,7 @@ class TestHandleMergeNonBotBranch(unittest.TestCase):
         log_mock = MagicMock()
 
         with patch.object(merge_mod, "_run", run_mock), \
-             patch.object(merge_mod, "apply_pr_transition", transition_mock), \
+             patch.object(merge_mod, "fire_trigger", transition_mock), \
              patch.object(merge_mod, "log_run", log_mock):
             rc = merge_mod.handle_merge(pr)
 
@@ -83,7 +83,7 @@ class TestHandleMergeNonBotBranch(unittest.TestCase):
 
         with patch.object(merge_mod, "_run", run_mock), \
              patch.object(merge_mod, "_run_claude_p", claude_mock), \
-             patch.object(merge_mod, "apply_pr_transition",
+             patch.object(merge_mod, "fire_trigger",
                           MagicMock(return_value=True)), \
              patch.object(merge_mod, "log_run", MagicMock()):
             merge_mod.handle_merge(pr)

--- a/tests/test_merge_workflow_review_label.py
+++ b/tests/test_merge_workflow_review_label.py
@@ -151,7 +151,7 @@ class TestHandleMergeWorkflowReviewLabel(unittest.TestCase):
                           MagicMock(return_value=False)), \
              patch.object(merge_mod, "_set_labels",
                           MagicMock(return_value=True)), \
-             patch.object(merge_mod, "apply_pr_transition",
+             patch.object(merge_mod, "fire_trigger",
                           MagicMock(return_value=True)), \
              patch.object(merge_mod, "_git",
                           MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))), \

--- a/tests/test_multistep.py
+++ b/tests/test_multistep.py
@@ -168,7 +168,7 @@ class TestCreateSubIssuesDepth(unittest.TestCase):
 
 class TestDepthGate(unittest.TestCase):
     @patch("cai_lib.actions.refine._run_claude_p")
-    @patch("cai_lib.actions.refine.apply_transition")
+    @patch("cai_lib.actions.refine.fire_trigger")
     @patch("cai_lib.actions.refine._build_issue_block", return_value="issue text")
     def test_max_depth_injects_no_decompose(self, mock_build, mock_transition, mock_claude):
         """At max depth, user_message should instruct agent not to decompose."""

--- a/tests/test_open_pr_non_bot_branch.py
+++ b/tests/test_open_pr_non_bot_branch.py
@@ -45,11 +45,11 @@ class TestHandleOpenToReviewNonBotBranch(unittest.TestCase):
         run_mock.return_value.returncode = 0
         run_mock.return_value.stdout = ""
         run_mock.return_value.stderr = ""
-        transition_mock = MagicMock(return_value=True)
+        transition_mock = MagicMock(return_value=(True, False))
         log_mock = MagicMock()
 
         with patch.object(open_pr_mod, "_run", run_mock), \
-             patch.object(open_pr_mod, "apply_pr_transition", transition_mock), \
+             patch.object(open_pr_mod, "fire_trigger", transition_mock), \
              patch.object(open_pr_mod, "log_run", log_mock):
             rc = open_pr_mod.handle_open_to_review(pr)
 
@@ -77,11 +77,11 @@ class TestHandleOpenToReviewNonBotBranch(unittest.TestCase):
         pr = _pr(946, "auto-improve/945-some-slug")
         run_mock = MagicMock()
         run_mock.return_value.returncode = 0
-        transition_mock = MagicMock(return_value=True)
+        transition_mock = MagicMock(return_value=(True, False))
         log_mock = MagicMock()
 
         with patch.object(open_pr_mod, "_run", run_mock), \
-             patch.object(open_pr_mod, "apply_pr_transition", transition_mock), \
+             patch.object(open_pr_mod, "fire_trigger", transition_mock), \
              patch.object(open_pr_mod, "log_run", log_mock):
             rc = open_pr_mod.handle_open_to_review(pr)
 
@@ -102,11 +102,11 @@ class TestHandleOpenToReviewNonBotBranch(unittest.TestCase):
         pr = _pr(947, "")
         run_mock = MagicMock()
         run_mock.return_value.returncode = 0
-        transition_mock = MagicMock(return_value=True)
+        transition_mock = MagicMock(return_value=(True, False))
         log_mock = MagicMock()
 
         with patch.object(open_pr_mod, "_run", run_mock), \
-             patch.object(open_pr_mod, "apply_pr_transition", transition_mock), \
+             patch.object(open_pr_mod, "fire_trigger", transition_mock), \
              patch.object(open_pr_mod, "log_run", log_mock):
             rc = open_pr_mod.handle_open_to_review(pr)
 

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -228,7 +228,7 @@ class TestHandlePlanGateAnchorMitigation(unittest.TestCase):
             "_cai_plan_text": plan_text,
         }
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_medium_with_marker_uses_mitigated_transition(
         self, _mock_log, mock_apply
@@ -248,9 +248,9 @@ class TestHandlePlanGateAnchorMitigation(unittest.TestCase):
         self.assertEqual(args[1], "planned_to_plan_approved_mitigated")
         # Reported confidence is passed through unchanged — gating is a
         # property of the selected transition, not a confidence upgrade.
-        self.assertEqual(args[2], Confidence.MEDIUM)
+        self.assertEqual(mock_apply.call_args.kwargs.get("confidence"), Confidence.MEDIUM)
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_medium_without_marker_uses_default_transition(
         self, _mock_log, mock_apply
@@ -267,9 +267,9 @@ class TestHandlePlanGateAnchorMitigation(unittest.TestCase):
         self.assertEqual(rc, 0)
         args = mock_apply.call_args[0]
         self.assertEqual(args[1], "planned_to_plan_approved")
-        self.assertEqual(args[2], Confidence.MEDIUM)
+        self.assertEqual(mock_apply.call_args.kwargs.get("confidence"), Confidence.MEDIUM)
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_low_with_marker_still_diverts(
         self, _mock_log, mock_apply
@@ -287,9 +287,9 @@ class TestHandlePlanGateAnchorMitigation(unittest.TestCase):
         # Marker present → mitigated transition is picked; LOW < MEDIUM
         # so the gate still diverts (required=MEDIUM, reported=LOW).
         self.assertEqual(args[1], "planned_to_plan_approved_mitigated")
-        self.assertEqual(args[2], Confidence.LOW)
+        self.assertEqual(mock_apply.call_args.kwargs.get("confidence"), Confidence.LOW)
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_high_with_marker_uses_mitigated_transition(
         self, _mock_log, mock_apply
@@ -307,9 +307,9 @@ class TestHandlePlanGateAnchorMitigation(unittest.TestCase):
         # Marker present → mitigated transition regardless of reported
         # confidence. HIGH >= MEDIUM so the gate passes.
         self.assertEqual(args[1], "planned_to_plan_approved_mitigated")
-        self.assertEqual(args[2], Confidence.HIGH)
+        self.assertEqual(mock_apply.call_args.kwargs.get("confidence"), Confidence.HIGH)
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_high_without_marker_uses_default_transition(
         self, _mock_log, mock_apply
@@ -325,7 +325,7 @@ class TestHandlePlanGateAnchorMitigation(unittest.TestCase):
         self.assertEqual(rc, 0)
         args = mock_apply.call_args[0]
         self.assertEqual(args[1], "planned_to_plan_approved")
-        self.assertEqual(args[2], Confidence.HIGH)
+        self.assertEqual(mock_apply.call_args.kwargs.get("confidence"), Confidence.HIGH)
 
 
 class TestPlanHasAnchorMitigationHelper(unittest.TestCase):
@@ -392,14 +392,13 @@ class TestHandlePlanGateRequiresHumanReview(unittest.TestCase):
         }
 
     @patch("cai_lib.actions.plan._post_issue_comment")
-    @patch("cai_lib.actions.plan.apply_transition")
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_requires_review_high_conf_still_diverts(
-        self, _mock_log, mock_gated, mock_apply, mock_post
+        self, _mock_log, mock_fire, mock_post
     ):
         from cai_lib.actions.plan import handle_plan_gate
-        mock_apply.return_value = True
+        mock_fire.return_value = (True, False)
 
         rc = handle_plan_gate(self._issue(
             confidence=Confidence.HIGH,
@@ -407,15 +406,18 @@ class TestHandlePlanGateRequiresHumanReview(unittest.TestCase):
         ))
 
         self.assertEqual(rc, 0)
-        # The confidence-gated transition must NOT have been called.
-        mock_gated.assert_not_called()
-        # Instead, the direct planned_to_human transition must fire.
-        args, kwargs = mock_apply.call_args
-        self.assertEqual(args[0], 982)
-        self.assertEqual(args[1], "planned_to_human")
-        # The divert reason must be passed as a kwarg to apply_transition
-        # (which now posts the MARKER comment itself — no direct _post_issue_comment).
-        divert_reason = kwargs.get("divert_reason", "")
+        # fire_trigger must be called exactly once with the non-gated
+        # planned_to_human transition.
+        calls_by_name = [c.args[1] for c in mock_fire.call_args_list]
+        self.assertIn("planned_to_human", calls_by_name)
+        gated_calls = [
+            c for c in mock_fire.call_args_list
+            if c.kwargs.get("_confidence_gated")
+        ]
+        self.assertEqual(gated_calls, [])
+        # divert_reason kwarg must carry the admin-approval message.
+        fire_call_kwargs = mock_fire.call_args.kwargs
+        divert_reason = fire_call_kwargs.get("divert_reason", "")
         self.assertIn(
             "Plan diverges from refined-issue preference",
             divert_reason,
@@ -424,14 +426,13 @@ class TestHandlePlanGateRequiresHumanReview(unittest.TestCase):
         mock_post.assert_not_called()
 
     @patch("cai_lib.actions.plan._post_issue_comment")
-    @patch("cai_lib.actions.plan.apply_transition")
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_requires_review_false_falls_through_to_confidence_gate(
-        self, _mock_log, mock_gated, mock_apply, mock_post
+        self, _mock_log, mock_fire, mock_post
     ):
         from cai_lib.actions.plan import handle_plan_gate
-        mock_gated.return_value = (True, False)
+        mock_fire.return_value = (True, False)
 
         rc = handle_plan_gate(self._issue(
             confidence=Confidence.HIGH,
@@ -439,23 +440,29 @@ class TestHandlePlanGateRequiresHumanReview(unittest.TestCase):
         ))
 
         self.assertEqual(rc, 0)
-        # No bespoke divert — the confidence gate handles the promotion.
-        mock_apply.assert_not_called()
         mock_post.assert_not_called()
-        # apply_transition_with_confidence must have been called on the
-        # default transition because HIGH meets its threshold.
-        call_args = mock_gated.call_args[0]
-        self.assertEqual(call_args[1], "planned_to_plan_approved")
+        # The confidence-gated call must have been made with the default transition.
+        gated_calls = [
+            c for c in mock_fire.call_args_list
+            if c.kwargs.get("_confidence_gated")
+        ]
+        self.assertEqual(len(gated_calls), 1)
+        self.assertEqual(gated_calls[0].args[1], "planned_to_plan_approved")
+        # No non-gated call (human-review divert path must NOT fire).
+        non_gated_calls = [
+            c for c in mock_fire.call_args_list
+            if not c.kwargs.get("_confidence_gated")
+        ]
+        self.assertEqual(non_gated_calls, [])
 
     @patch("cai_lib.actions.plan._post_issue_comment")
-    @patch("cai_lib.actions.plan.apply_transition")
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_requires_review_refused_returns_1(
-        self, _mock_log, mock_gated, mock_apply, _mock_post
+        self, _mock_log, mock_fire, _mock_post
     ):
         from cai_lib.actions.plan import handle_plan_gate
-        mock_apply.return_value = False  # transition refused
+        mock_fire.return_value = (False, False)  # transition refused
 
         rc = handle_plan_gate(self._issue(
             confidence=Confidence.MEDIUM,
@@ -463,19 +470,22 @@ class TestHandlePlanGateRequiresHumanReview(unittest.TestCase):
         ))
 
         self.assertEqual(rc, 1)
-        mock_gated.assert_not_called()
+        gated_calls = [
+            c for c in mock_fire.call_args_list
+            if c.kwargs.get("_confidence_gated")
+        ]
+        self.assertEqual(gated_calls, [])
 
     @patch("cai_lib.actions.plan._post_issue_comment")
-    @patch("cai_lib.actions.plan.apply_transition")
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_requires_review_reparsed_from_body_when_stash_missing(
-        self, _mock_log, mock_gated, mock_apply, mock_post
+        self, _mock_log, mock_fire, mock_post
     ):
         """When the in-process stash is absent, the flag must be
         re-parsed from the stored plan block in the issue body."""
         from cai_lib.actions.plan import handle_plan_gate
-        mock_apply.return_value = True
+        mock_fire.return_value = (True, False)
 
         body = (
             "<!-- cai-plan-start -->\n"
@@ -494,11 +504,15 @@ class TestHandlePlanGateRequiresHumanReview(unittest.TestCase):
         rc = handle_plan_gate(issue)
 
         self.assertEqual(rc, 0)
-        mock_gated.assert_not_called()
-        args, kwargs = mock_apply.call_args
-        self.assertEqual(args[1], "planned_to_human")
-        # divert_reason kwarg must carry the admin-approval message
-        divert_reason = kwargs.get("divert_reason", "")
+        gated_calls = [
+            c for c in mock_fire.call_args_list
+            if c.kwargs.get("_confidence_gated")
+        ]
+        self.assertEqual(gated_calls, [])
+        calls_by_name = [c.args[1] for c in mock_fire.call_args_list]
+        self.assertIn("planned_to_human", calls_by_name)
+        fire_call_kwargs = mock_fire.call_args.kwargs
+        divert_reason = fire_call_kwargs.get("divert_reason", "")
         self.assertIn("admin approval required", divert_reason)
         mock_post.assert_not_called()
 
@@ -682,7 +696,7 @@ class TestHandlePlanGateDocsOnly(unittest.TestCase):
             "_cai_plan_text": plan_text,
         }
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_medium_docs_only_uses_docs_only_transition(
         self, _mock_log, mock_apply
@@ -701,9 +715,9 @@ class TestHandlePlanGateDocsOnly(unittest.TestCase):
         self.assertEqual(args[1], "planned_to_plan_approved_docs_only")
         # Reported confidence passes through unchanged — gating is a
         # property of the selected transition, not a confidence upgrade.
-        self.assertEqual(args[2], Confidence.MEDIUM)
+        self.assertEqual(mock_apply.call_args.kwargs.get("confidence"), Confidence.MEDIUM)
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_low_docs_only_still_diverts(
         self, _mock_log, mock_apply
@@ -721,9 +735,9 @@ class TestHandlePlanGateDocsOnly(unittest.TestCase):
         # Docs-only transition is picked; LOW < MEDIUM so the gate
         # still diverts (required=MEDIUM, reported=LOW).
         self.assertEqual(args[1], "planned_to_plan_approved_docs_only")
-        self.assertEqual(args[2], Confidence.LOW)
+        self.assertEqual(mock_apply.call_args.kwargs.get("confidence"), Confidence.LOW)
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_high_docs_only_uses_docs_only_transition(
         self, _mock_log, mock_apply
@@ -741,9 +755,9 @@ class TestHandlePlanGateDocsOnly(unittest.TestCase):
         # HIGH-confidence docs-only plans route through the docs-only
         # transition too; HIGH >= MEDIUM so the gate passes.
         self.assertEqual(args[1], "planned_to_plan_approved_docs_only")
-        self.assertEqual(args[2], Confidence.HIGH)
+        self.assertEqual(mock_apply.call_args.kwargs.get("confidence"), Confidence.HIGH)
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_docs_only_takes_precedence_over_anchor_mitigation(
         self, _mock_log, mock_apply
@@ -767,7 +781,7 @@ class TestHandlePlanGateDocsOnly(unittest.TestCase):
         args = mock_apply.call_args[0]
         self.assertEqual(args[1], "planned_to_plan_approved_docs_only")
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_medium_non_docs_falls_through_to_default(
         self, _mock_log, mock_apply
@@ -789,9 +803,9 @@ class TestHandlePlanGateDocsOnly(unittest.TestCase):
         self.assertEqual(rc, 0)
         args = mock_apply.call_args[0]
         self.assertEqual(args[1], "planned_to_plan_approved")
-        self.assertEqual(args[2], Confidence.MEDIUM)
+        self.assertEqual(mock_apply.call_args.kwargs.get("confidence"), Confidence.MEDIUM)
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_mixed_docs_and_source_uses_default(
         self, _mock_log, mock_apply
@@ -840,7 +854,7 @@ class TestHandlePlanGateApprovableAtMedium(unittest.TestCase):
             "_cai_plan_approvable_at_medium": approvable,
         }
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_medium_approvable_uses_approvable_transition(
         self, _mock_log, mock_apply
@@ -859,9 +873,9 @@ class TestHandlePlanGateApprovableAtMedium(unittest.TestCase):
         self.assertEqual(args[1], "planned_to_plan_approved_approvable")
         # Reported confidence passes through unchanged — gating is a
         # property of the selected transition, not a confidence upgrade.
-        self.assertEqual(args[2], Confidence.MEDIUM)
+        self.assertEqual(mock_apply.call_args.kwargs.get("confidence"), Confidence.MEDIUM)
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_low_approvable_still_diverts(
         self, _mock_log, mock_apply
@@ -879,9 +893,9 @@ class TestHandlePlanGateApprovableAtMedium(unittest.TestCase):
         # Flag picks the approvable transition; LOW < MEDIUM so the
         # gate still diverts (required=MEDIUM, reported=LOW).
         self.assertEqual(args[1], "planned_to_plan_approved_approvable")
-        self.assertEqual(args[2], Confidence.LOW)
+        self.assertEqual(mock_apply.call_args.kwargs.get("confidence"), Confidence.LOW)
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_medium_not_approvable_falls_through_to_default(
         self, _mock_log, mock_apply
@@ -898,9 +912,9 @@ class TestHandlePlanGateApprovableAtMedium(unittest.TestCase):
         self.assertEqual(rc, 0)
         args = mock_apply.call_args[0]
         self.assertEqual(args[1], "planned_to_plan_approved")
-        self.assertEqual(args[2], Confidence.MEDIUM)
+        self.assertEqual(mock_apply.call_args.kwargs.get("confidence"), Confidence.MEDIUM)
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_docs_only_takes_precedence_over_approvable(
         self, _mock_log, mock_apply
@@ -925,7 +939,7 @@ class TestHandlePlanGateApprovableAtMedium(unittest.TestCase):
         args = mock_apply.call_args[0]
         self.assertEqual(args[1], "planned_to_plan_approved_docs_only")
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_anchor_mitigation_takes_precedence_over_approvable(
         self, _mock_log, mock_apply
@@ -948,7 +962,7 @@ class TestHandlePlanGateApprovableAtMedium(unittest.TestCase):
         args = mock_apply.call_args[0]
         self.assertEqual(args[1], "planned_to_plan_approved_mitigated")
 
-    @patch("cai_lib.actions.plan.apply_transition_with_confidence")
+    @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_approvable_reparsed_from_body_when_stash_missing(
         self, _mock_log, mock_apply
@@ -978,7 +992,7 @@ class TestHandlePlanGateApprovableAtMedium(unittest.TestCase):
         self.assertEqual(rc, 0)
         args = mock_apply.call_args[0]
         self.assertEqual(args[1], "planned_to_plan_approved_approvable")
-        self.assertEqual(args[2], Confidence.MEDIUM)
+        self.assertEqual(mock_apply.call_args.kwargs.get("confidence"), Confidence.MEDIUM)
 
 
 class TestParseApprovableAtMedium(unittest.TestCase):

--- a/tests/test_pr_bounce.py
+++ b/tests/test_pr_bounce.py
@@ -33,7 +33,7 @@ class TestHandlePrBounce(unittest.TestCase):
         open_pr = {"number": 643, "headRefName": "auto-improve/620-foo"}
         with patch.object(pr_bounce, "_find_open_linked_pr", return_value=open_pr), \
              patch.object(pr_bounce, "_find_recent_closed_linked_pr") as closed_lookup, \
-             patch.object(pr_bounce, "apply_transition") as apply_t, \
+             patch.object(pr_bounce, "fire_trigger") as apply_t, \
              patch("cai_lib.dispatcher.dispatch_pr", return_value=0) as dpr:
             rc = pr_bounce.handle_pr_bounce(issue)
         self.assertEqual(rc, 0)
@@ -51,7 +51,7 @@ class TestHandlePrBounce(unittest.TestCase):
         with patch.object(pr_bounce, "_find_open_linked_pr", return_value=None), \
              patch.object(pr_bounce, "_find_recent_closed_linked_pr",
                           return_value=closed_pr), \
-             patch.object(pr_bounce, "apply_transition", return_value=True) as apply_t, \
+             patch.object(pr_bounce, "fire_trigger", return_value=(True, False)) as apply_t, \
              patch("cai_lib.dispatcher.dispatch_pr") as dpr:
             rc = pr_bounce.handle_pr_bounce(issue)
         self.assertEqual(rc, 0)
@@ -73,7 +73,7 @@ class TestHandlePrBounce(unittest.TestCase):
                           return_value=closed_pr), \
              patch.object(pr_bounce, "_pr_close_actor", return_value="cai-bot"), \
              patch.object(pr_bounce, "_our_gh_login", return_value="cai-bot"), \
-             patch.object(pr_bounce, "apply_transition", return_value=True) as apply_t, \
+             patch.object(pr_bounce, "fire_trigger", return_value=(True, False)) as apply_t, \
              patch("cai_lib.dispatcher.dispatch_pr") as dpr:
             rc = pr_bounce.handle_pr_bounce(issue)
         self.assertEqual(rc, 0)
@@ -94,7 +94,7 @@ class TestHandlePrBounce(unittest.TestCase):
              patch.object(pr_bounce, "_pr_close_actor",
                           return_value="damien-robotsix"), \
              patch.object(pr_bounce, "_our_gh_login", return_value="cai-bot"), \
-             patch.object(pr_bounce, "apply_transition", return_value=True) as apply_t, \
+             patch.object(pr_bounce, "fire_trigger", return_value=(True, False)) as apply_t, \
              patch("cai_lib.dispatcher.dispatch_pr") as dpr:
             rc = pr_bounce.handle_pr_bounce(issue)
         self.assertEqual(rc, 0)
@@ -115,7 +115,7 @@ class TestHandlePrBounce(unittest.TestCase):
                           return_value=closed_pr), \
              patch.object(pr_bounce, "_pr_close_actor", return_value=None), \
              patch.object(pr_bounce, "_our_gh_login", return_value="cai-bot"), \
-             patch.object(pr_bounce, "apply_transition", return_value=True) as apply_t, \
+             patch.object(pr_bounce, "fire_trigger", return_value=(True, False)) as apply_t, \
              patch("cai_lib.dispatcher.dispatch_pr") as dpr:
             rc = pr_bounce.handle_pr_bounce(issue)
         self.assertEqual(rc, 0)
@@ -126,7 +126,7 @@ class TestHandlePrBounce(unittest.TestCase):
         with patch.object(pr_bounce, "_find_open_linked_pr", return_value=None), \
              patch.object(pr_bounce, "_find_recent_closed_linked_pr",
                           return_value=None), \
-             patch.object(pr_bounce, "apply_transition", return_value=True) as apply_t, \
+             patch.object(pr_bounce, "fire_trigger", return_value=(True, False)) as apply_t, \
              patch("cai_lib.dispatcher.dispatch_pr") as dpr:
             rc = pr_bounce.handle_pr_bounce(issue)
         self.assertEqual(rc, 0)
@@ -139,7 +139,7 @@ class TestHandlePrBounce(unittest.TestCase):
         with patch.object(pr_bounce, "_find_open_linked_pr", return_value=None), \
              patch.object(pr_bounce, "_find_recent_closed_linked_pr",
                           return_value=None), \
-             patch.object(pr_bounce, "apply_transition", return_value=False):
+             patch.object(pr_bounce, "fire_trigger", return_value=(False, False)):
             rc = pr_bounce.handle_pr_bounce(issue)
         self.assertEqual(rc, 1)
 

--- a/tests/test_rescue_opus.py
+++ b/tests/test_rescue_opus.py
@@ -90,7 +90,7 @@ class TestScheduleOpusAttempt(unittest.TestCase):
             {"name": LABEL_OPUS_ATTEMPTED},
         ])
         with mock.patch.object(R, "_set_labels") as set_labels, \
-             mock.patch.object(R, "apply_transition") as apply_t, \
+             mock.patch.object(R, "fire_trigger") as apply_t, \
              mock.patch.object(R, "_post_opus_escalation_comment") as cmt:
             tag = R._schedule_opus_attempt(issue, reasoning="r")
         self.assertEqual(tag, "opus_already_attempted")
@@ -101,7 +101,7 @@ class TestScheduleOpusAttempt(unittest.TestCase):
     def test_refuses_when_no_stored_plan(self):
         issue = self._issue(body="no plan block here")
         with mock.patch.object(R, "_set_labels") as set_labels, \
-             mock.patch.object(R, "apply_transition") as apply_t, \
+             mock.patch.object(R, "fire_trigger") as apply_t, \
              mock.patch.object(R, "_post_opus_escalation_comment") as cmt:
             tag = R._schedule_opus_attempt(issue, reasoning="r")
         self.assertEqual(tag, "opus_no_plan")
@@ -112,7 +112,7 @@ class TestScheduleOpusAttempt(unittest.TestCase):
     def test_happy_path_stamps_label_and_fires_transition(self):
         issue = self._issue()
         with mock.patch.object(R, "_set_labels", return_value=True) as set_labels, \
-             mock.patch.object(R, "apply_transition", return_value=True) as apply_t, \
+             mock.patch.object(R, "fire_trigger", return_value=(True, False)) as apply_t, \
              mock.patch.object(R, "_post_opus_escalation_comment", return_value=True) as cmt:
             tag = R._schedule_opus_attempt(issue, reasoning="plan looks sound")
         self.assertEqual(tag, "opus_attempt_scheduled")
@@ -132,7 +132,7 @@ class TestScheduleOpusAttempt(unittest.TestCase):
     def test_propagates_label_apply_failure(self):
         issue = self._issue()
         with mock.patch.object(R, "_set_labels", return_value=False), \
-             mock.patch.object(R, "apply_transition") as apply_t, \
+             mock.patch.object(R, "fire_trigger") as apply_t, \
              mock.patch.object(R, "_post_opus_escalation_comment", return_value=True):
             tag = R._schedule_opus_attempt(issue, reasoning="r")
         self.assertEqual(tag, "agent_failed")
@@ -228,7 +228,7 @@ class TestTryRescuePr(unittest.TestCase):
         with mock.patch.object(
             R, "_run_claude_p", return_value=self._claude_reply(claude_payload)
         ), mock.patch.object(
-            R, "apply_pr_transition", return_value=True
+            R, "fire_trigger", return_value=(True, False)
         ) as apply_pr, mock.patch.object(
             R, "_post_pr_rescue_comment", return_value=True
         ) as cmt:
@@ -248,7 +248,7 @@ class TestTryRescuePr(unittest.TestCase):
         }
         with mock.patch.object(
             R, "_run_claude_p", return_value=self._claude_reply(claude_payload)
-        ), mock.patch.object(R, "apply_pr_transition") as apply_pr, \
+        ), mock.patch.object(R, "fire_trigger") as apply_pr, \
              mock.patch.object(R, "_schedule_opus_attempt") as sched:
             tag = R._try_rescue_pr(pr, prevention_findings=[])
         self.assertEqual(tag, "truly_human_needed")
@@ -265,7 +265,7 @@ class TestTryRescuePr(unittest.TestCase):
         }
         with mock.patch.object(
             R, "_run_claude_p", return_value=self._claude_reply(claude_payload)
-        ), mock.patch.object(R, "apply_pr_transition") as apply_pr:
+        ), mock.patch.object(R, "fire_trigger") as apply_pr:
             tag = R._try_rescue_pr(pr, prevention_findings=[])
         self.assertEqual(tag, "low_confidence")
         apply_pr.assert_not_called()

--- a/tests/test_unblock.py
+++ b/tests/test_unblock.py
@@ -174,10 +174,10 @@ class TestResumeStripsHumanSolvedLabel(unittest.TestCase):
             captured["issue_number"] = issue_number
             captured["transition_name"] = transition_name
             captured["kwargs"] = kwargs
-            return True
+            return (True, False)
 
         with mock.patch.object(U, "_run_claude_p", return_value=fake_agent), \
-             mock.patch.object(U, "apply_transition", side_effect=fake_apply):
+             mock.patch.object(U, "fire_trigger", side_effect=fake_apply):
             result = U._try_unblock_issue(issue)
 
         self.assertEqual(result, "resumed")
@@ -284,7 +284,7 @@ class TestTryUnblockPrSkips(unittest.TestCase):
 
         def fake_pr_transition(pr_number, transition_name, **kwargs):
             transitions.append(transition_name)
-            return True
+            return (True, False)
 
         set_label_calls: list[dict] = []
 
@@ -293,7 +293,7 @@ class TestTryUnblockPrSkips(unittest.TestCase):
             return True
 
         with mock.patch.object(U, "_run_claude_p", return_value=fake_agent), \
-             mock.patch.object(U, "apply_pr_transition", side_effect=fake_pr_transition), \
+             mock.patch.object(U, "fire_trigger", side_effect=fake_pr_transition), \
              mock.patch.object(U, "_set_pr_labels", side_effect=fake_set_pr_labels):
             result = U._try_unblock_pr(pr)
 
@@ -473,14 +473,14 @@ class TestTryUnblockIssueAppendsAmendmentsForPlanApproved(unittest.TestCase):
 
         def fake_apply(issue_number, transition_name, **kwargs):
             calls["transition"].append(transition_name)
-            return True
+            return (True, False)
 
         issue = self._issue_with_plan()
 
         with mock.patch.object(U, "_run_claude_p", return_value=fake_agent), \
              mock.patch.object(U, "_append_admin_amendments_to_plan",
                                side_effect=fake_append), \
-             mock.patch.object(U, "apply_transition", side_effect=fake_apply):
+             mock.patch.object(U, "fire_trigger", side_effect=fake_apply):
             result = U._try_unblock_issue(issue)
         return result, calls
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1100

**Issue:** #1100 — [#1089 Step 2/2] Migrate all call sites to `fire_trigger` and delete the four `apply_*` shims

## PR Summary

### What this fixes
This is Step 2/2 of FSM inversion (#1089): the four `apply_transition*` shim functions in `cai_lib/fsm_transitions.py` existed only to preserve backward-compatibility while `fire_trigger` was being introduced. Now that `fire_trigger` is the canonical FSM dispatch entry point, the shims can be deleted and all 19 call-site files migrated directly to `fire_trigger`.

### What was changed
- **`cai_lib/fsm_transitions.py`** — deleted `apply_transition`, `apply_transition_with_confidence`, `apply_pr_transition`, and `apply_pr_transition_with_confidence` shim functions
- **14 `cai_lib/actions/*.py` files** (`fix_ci`, `plan`, `revise`, `review_docs`, `maintain`, `implement`, `refine`, `merge`, `rebase`, `confirm`, `open_pr`, `triage`, `pr_bounce`, `review_pr`) — replaced all shim calls with equivalent `fire_trigger(...)` calls and updated imports
- **3 `cai_lib/*.py` files** (`dispatcher`, `cmd_unblock`, `cmd_rescue`) — same migration
- **`tests/test_fsm.py`, `tests/test_unblock.py`, `tests/test_rescue_opus.py`, `tests/test_dispatcher.py`** — updated mock patches from shim names to `fire_trigger` and updated stub return values to `(True, False)` tuples

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
