### PR TITLE
auto-improve: Fix Read `offset` parameter type errors in review agents

### DIFF
--- a/.claude/agents/review/cai-review-docs.md
+++ b/.claude/agents/review/cai-review-docs.md
@@ -364,3 +364,10 @@ them inline — they are automatically converted to separate GitHub issues.
    in parallel rather than sequentially. Use Glob first to narrow
    the file set, then Grep the results, instead of running
    exploratory Grep calls one at a time.
+5. **Read tool parameter types.** The `offset` and `limit` parameters
+   on the Read tool must be raw integers — e.g., `offset: 200`, never
+   `offset: "200"`. Passing a quoted string causes an
+   `InputValidationError: The parameter 'offset' type is expected as
+   'number' but provided as 'string'` validation failure that wastes
+   the turn and forces a retry. Always emit bare numbers for these
+   parameters.

--- a/.claude/agents/review/cai-review-pr.md
+++ b/.claude/agents/review/cai-review-pr.md
@@ -188,3 +188,10 @@ GitHub issue will be created automatically instead.
    in parallel rather than sequentially. Use Glob first to narrow
    the file set, then Grep the results, instead of running
    exploratory Grep calls one at a time.
+5. **Read tool parameter types.** The `offset` and `limit` parameters
+   on the Read tool must be raw integers — e.g., `offset: 200`, never
+   `offset: "200"`. Passing a quoted string causes an
+   `InputValidationError: The parameter 'offset' type is expected as
+   'number' but provided as 'string'` validation failure that wastes
+   the turn and forces a retry. Always emit bare numbers for these
+   parameters.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1084

**Issue:** #1084 — Fix Read `offset` parameter type errors in review agents

## PR Summary

### What this fixes
The `cai-review-pr` and `cai-review-docs` agents were occasionally emitting `offset: "100"` (quoted string) instead of `offset: 100` (raw integer) in Read tool calls, causing `InputValidationError` validation failures that wasted turns and forced retries (5 of 19 controllable errors in the observed window).

### What was changed
- **`.claude/agents/review/cai-review-pr.md`** — Added item 5 "Read tool parameter types" to the "Agent-specific efficiency guidance" section, stating that `offset` and `limit` must be raw integers (never quoted strings) and referencing the `InputValidationError` failure pattern.
- **`.claude/agents/review/cai-review-docs.md`** — Added the same item 5 note to its "Agent-specific efficiency guidance" section, with identical wording and the same error-message anchor.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
