### PR TITLE
auto-improve: cai-implement $3+ invocations with 40–85 turns keep exceeding budget on haiku

### DIFF
--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -1230,7 +1230,23 @@ def handle_implement(issue: dict) -> int:
                 flush=True,
             )
         else:
-            claude_cmd += ["--max-turns", "60"]
+            # Sonnet-tier caps: 60-turn (issue #934 / PR #1003) +
+            # $2.50 per-invocation cost ceiling (issue #1107). The
+            # budget cap catches runaway invocations that stay under
+            # 60 turns but rack up cost via large inputs or cache
+            # churn. On exhaustion, claude-agent-sdk returns
+            # ResultMessage with subtype="error_max_budget_usd" and
+            # is_error=True; _run_claude_p surfaces that as
+            # returncode=1 with the last-assistant salvage text,
+            # which flows through the existing `subagent_failed`
+            # rollback path below. Three consecutive failures (any
+            # kind) then trip _MAX_CONSECUTIVE_FAILED_ATTEMPTS and
+            # park the issue at :human-needed with
+            # result=retries_exhausted. Opus one-shot runs are
+            # deliberately uncapped (shared memory:
+            # implement-sonnet-turn-cap.md).
+            claude_cmd += ["--max-turns", "60",
+                           "--max-budget-usd", "2.50"]
         claude_cmd += ["--dangerously-skip-permissions",
                        "--add-dir", str(work_dir)]
         print(f"[cai implement] running cai-implement subagent for {work_dir}", flush=True)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1107

**Issue:** #1107 — cai-implement $3+ invocations with 40–85 turns keep exceeding budget on haiku

## PR Summary

### What this fixes
`cai-implement` Sonnet-tier invocations were spending $3+ on 40–85 turn runs with no hard cost ceiling, repeatedly exceeding budget on haiku model invocations. The existing 60-turn cap (issue #934) was insufficient to bound cost when large inputs or cache churn kept per-turn cost high.

### What was changed
- **`cai_lib/actions/implement.py`** (line ~1233): Extended the Sonnet-branch `claude_cmd` from `["--max-turns", "60"]` to `["--max-turns", "60", "--max-budget-usd", "2.50"]`. The Opus-escalation branch (`if opus_escalation:`) is left untouched, preserving the "Opus uncapped" policy from shared memory. Budget-exhaustion events collapse to `returncode=1` → `subagent_failed` in `_run_claude_p`, which the existing `_MAX_CONSECUTIVE_FAILED_ATTEMPTS=3` broad failure cap already handles.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
