### PR TITLE
auto-improve: Issue #910 implement loop: 5 consecutive subagent_failed over 5h with no PR

### DIFF
--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -117,6 +117,45 @@ _COUNTED_IMPLEMENT_FAILURES: frozenset[str] = frozenset({
     "pr_create_failed",
 })
 
+
+# Length cap for the ``stderr_tail=`` field stamped on the
+# ``result=subagent_failed`` log row (issue #1106). 120 chars keeps
+# the log line readable while still carrying enough signal to tell a
+# ``sdk_subtype=error_max_turns`` run apart from an
+# ``sdk_subtype=error_max_structured_output_retries`` run. The token
+# is always a single whitespace-free run so the
+# ``_RESULT_TAG_RE = re.compile(r" result=(\S+)")`` classifier in
+# :func:`_count_consecutive_failed_attempts` keeps matching
+# ``subagent_failed`` unchanged.
+_STDERR_TAIL_LIMIT = 120
+
+
+def _format_stderr_tail(stderr: str) -> str:
+    """Sanitize ``agent.stderr`` for inclusion as a key=value log field.
+
+    Whitespace (spaces, tabs, newlines) collapses to ``_`` so the
+    token is space-free; ``=`` is rewritten to ``:`` so a downstream
+    key=value parser cannot accidentally split ``stderr_tail=foo=bar``
+    into two fields. The result is truncated to
+    :data:`_STDERR_TAIL_LIMIT` characters and coerced to at least
+    ``"empty"`` when *stderr* is blank (the pre-#1106 shape, retained
+    for a fresh ``stderr=""`` path the SDK may surface in future).
+
+    Returned tokens are always non-empty, contain no whitespace and
+    no ``=``, so they are safe to log between ``result=<tag>`` and
+    ``exit=<code>`` without breaking either the existing
+    :data:`_RESULT_TAG_RE` classifier or the audit agent's column
+    layout.
+    """
+    text = (stderr or "").strip()
+    if not text:
+        return "empty"
+    text = re.sub(r"\s+", "_", text)
+    text = text.replace("=", ":")
+    tail = text[:_STDERR_TAIL_LIMIT]
+    return tail or "empty"
+
+
 def _park_in_progress_at_human_needed(
     issue_number: int,
     *,
@@ -1250,8 +1289,14 @@ def handle_implement(issue: dict) -> int:
                 file=sys.stderr,
             )
             rollback()
-            log_run("implement", repo=REPO, issue=issue_number,
-                    result="subagent_failed", exit=agent.returncode)
+            log_run(
+                "implement",
+                repo=REPO,
+                issue=issue_number,
+                result="subagent_failed",
+                stderr_tail=_format_stderr_tail(agent.stderr or ""),
+                exit=agent.returncode,
+            )
             return agent.returncode
 
         # 5b. Create any suggested issues the subagent raised.

--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -146,6 +146,43 @@ async def _collect_results(
     return results, last_assistant
 
 
+def _sdk_error_summary(result) -> str:
+    """Render a single-line diagnostic for a non-zero SDK result.
+
+    Called by :func:`_run_claude_p` when the terminal
+    :class:`ResultMessage` reports ``is_error=True`` (or the
+    downstream ``no-ResultMessage`` fallback). The returned string
+    is stuffed into the ``stderr`` field of the returned
+    :class:`subprocess.CompletedProcess` so downstream callers —
+    notably ``cai_lib.actions.implement.handle_implement`` — have
+    *something* to log on the ``result=subagent_failed`` branch.
+
+    Before issue #1106 both the no-results fallback and the terminal
+    ``is_error=True`` return path set ``stderr=""``, which is why
+    issue #910's five consecutive ``subagent_failed`` runs were
+    byte-identical at the audit-log layer: the SDK subtype
+    (``error_max_turns`` vs. ``error_max_structured_output_retries``
+    vs. an API error) never reached the log row.
+
+    The output is whitespace-tolerant (``_format_stderr_tail`` on
+    the caller side collapses whitespace) and opaque — it is not
+    classified into a fixed tag set, so new SDK subtypes land in
+    the log verbatim without requiring a prompt update.
+    """
+    subtype = getattr(result, "subtype", None) or "none"
+    is_error = bool(getattr(result, "is_error", False))
+    text = getattr(result, "result", None)
+    preview = ""
+    if isinstance(text, str):
+        preview = text.replace("\n", " ").strip()[:160]
+    if preview:
+        return (
+            f"sdk_subtype={subtype} is_error={is_error} "
+            f"result={preview!r}"
+        )
+    return f"sdk_subtype={subtype} is_error={is_error}"
+
+
 def _run_claude_p(
     cmd: list[str],
     *,
@@ -227,7 +264,8 @@ def _run_claude_p(
             file=sys.stderr, flush=True,
         )
         return subprocess.CompletedProcess(
-            args=cmd, returncode=1, stdout=last_assistant or "", stderr="",
+            args=cmd, returncode=1, stdout=last_assistant or "",
+            stderr=f"no_ResultMessage last_assistant={preview!r}",
         )
 
     result = results[-1]
@@ -278,6 +316,15 @@ def _run_claude_p(
     else:
         stdout = last_assistant
 
+    stderr = ""
+    if returncode != 0:
+        # Issue #1106: populate stderr with a diagnostic summary so the
+        # downstream implement handler can record *why* the subagent
+        # exited (sdk_subtype, is_error, and the first 160 chars of
+        # result text). Without this the log row is byte-identical
+        # across every SDK failure mode, which is what left issue #910
+        # spinning through 5 consecutive subagent_failed runs.
+        stderr = _sdk_error_summary(result)
     return subprocess.CompletedProcess(
-        args=cmd, returncode=returncode, stdout=stdout, stderr="",
+        args=cmd, returncode=returncode, stdout=stdout, stderr=stderr,
     )

--- a/tests/test_implement_consecutive_failures.py
+++ b/tests/test_implement_consecutive_failures.py
@@ -295,5 +295,125 @@ class TestRetriesExhaustedConstants(unittest.TestCase):
             self.assertNotIn(tag, _COUNTED_IMPLEMENT_FAILURES)
 
 
+class TestFormatStderrTail(unittest.TestCase):
+    """Issue #1106: the sanitizer must collapse whitespace, neutralise
+    ``=``, cap length, and always return a non-empty single token so
+    the existing ``_RESULT_TAG_RE = re.compile(r" result=(\\S+)")``
+    classifier in :func:`_count_consecutive_failed_attempts` keeps
+    matching ``subagent_failed`` unchanged when the new
+    ``stderr_tail=<token>`` field is stamped between ``result=`` and
+    ``exit=``."""
+
+    def test_empty_returns_empty_tag(self):
+        from cai_lib.actions.implement import _format_stderr_tail
+        self.assertEqual(_format_stderr_tail(""), "empty")
+        self.assertEqual(_format_stderr_tail("   \n\t"), "empty")
+
+    def test_whitespace_is_collapsed_to_underscore(self):
+        from cai_lib.actions.implement import _format_stderr_tail
+        self.assertEqual(
+            _format_stderr_tail("hit max turns"),
+            "hit_max_turns",
+        )
+        self.assertEqual(
+            _format_stderr_tail("line one\nline two"),
+            "line_one_line_two",
+        )
+
+    def test_equals_is_rewritten_to_colon(self):
+        """``=`` must not leak into the token or a downstream
+        key=value parser could split ``stderr_tail=foo=bar`` in two."""
+        from cai_lib.actions.implement import _format_stderr_tail
+        self.assertEqual(
+            _format_stderr_tail("sdk_subtype=error_max_turns"),
+            "sdk_subtype:error_max_turns",
+        )
+
+    def test_truncation_caps_length(self):
+        from cai_lib.actions.implement import (
+            _format_stderr_tail,
+            _STDERR_TAIL_LIMIT,
+        )
+        huge = "x" * (_STDERR_TAIL_LIMIT * 3)
+        self.assertEqual(
+            len(_format_stderr_tail(huge)),
+            _STDERR_TAIL_LIMIT,
+        )
+
+    def test_token_is_single_token_safe_for_log_parser(self):
+        """The token stamped between ``result=`` and ``exit=`` must
+        never contain whitespace — otherwise ``_RESULT_TAG_RE``
+        (``" result=(\\S+)"``) would grab the wrong ``result=`` token
+        downstream and the consecutive-failure guard would undercount."""
+        import re as _re
+        from cai_lib.actions.implement import _format_stderr_tail
+        rx = _re.compile(r" result=(\S+)")
+        for sample in (
+            "sdk_subtype=error_max_turns is_error=True "
+            "result='Agent exhausted max_turns=60'",
+            "",
+            "\nspaced  out\tvalue\n",
+            "no_ResultMessage last_assistant='oops'",
+        ):
+            tok = _format_stderr_tail(sample)
+            self.assertNotIn(" ", tok)
+            self.assertNotIn("\t", tok)
+            self.assertNotIn("\n", tok)
+            self.assertNotIn("=", tok)
+            line = (
+                "2026-04-21T05:16:05Z [implement] repo=foo issue=910 "
+                f"result=subagent_failed stderr_tail={tok} exit=1"
+            )
+            m = rx.search(line)
+            self.assertIsNotNone(m)
+            self.assertEqual(m.group(1), "subagent_failed")
+
+
+class TestConsecutiveCounterStillMatchesEnrichedLine(unittest.TestCase):
+    """Pin that :func:`_count_consecutive_failed_attempts` still counts
+    three consecutive ``subagent_failed`` rows correctly when each
+    carries the new issue-#1106 ``stderr_tail=<token>`` field (which
+    sits between ``result=`` and ``exit=``). If this regresses, the
+    existing :data:`_MAX_CONSECUTIVE_FAILED_ATTEMPTS` guard would stop
+    firing and issue #910's failure mode would reappear."""
+
+    def test_three_consecutive_with_stderr_tail_field_counted_as_three(self):
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+        from cai_lib.actions.implement import (
+            _count_consecutive_failed_attempts,
+        )
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".log", delete=False,
+        )
+        tmp.close()
+        log_path = Path(tmp.name)
+        try:
+            log_path.write_text(
+                "\n".join([
+                    "2026-04-21T00:30:57Z [implement] repo=foo issue=910 "
+                    "result=subagent_failed "
+                    "stderr_tail=sdk_subtype:error_max_turns_is_error:True "
+                    "exit=1",
+                    "2026-04-21T00:47:28Z [implement] repo=foo issue=910 "
+                    "result=subagent_failed stderr_tail=empty exit=1",
+                    "2026-04-21T03:08:55Z [implement] repo=foo issue=910 "
+                    "result=subagent_failed "
+                    "stderr_tail=no_ResultMessage_last_assistant:oops "
+                    "exit=1",
+                ]) + "\n"
+            )
+            with patch(
+                "cai_lib.actions.implement.LOG_PATH", log_path,
+            ):
+                self.assertEqual(
+                    _count_consecutive_failed_attempts(910), 3,
+                )
+        finally:
+            if log_path.exists():
+                log_path.unlink()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -139,5 +139,130 @@ class TestRunClaudePEnvelope(unittest.TestCase):
         self.assertEqual(proc.stdout, "fallback text")
 
 
+class TestStderrEnrichment(unittest.TestCase):
+    """Issue #1106: ``_run_claude_p`` must populate ``stderr`` with a
+    diagnostic summary on every non-zero returncode path so the
+    downstream implement handler has something to log. Before #1106
+    both the ``is_error=True`` and ``no-ResultMessage`` branches set
+    ``stderr=""``, which is why issue #910 produced five
+    byte-identical ``result=subagent_failed exit=1`` rows."""
+
+    @patch("cai_lib.subprocess_utils.log_cost")
+    def test_is_error_populates_stderr_with_subtype(self, _mock_log):
+        """is_error=True must surface sdk_subtype and is_error in stderr."""
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        msg = _mk_result(
+            subtype="error_max_turns",
+            is_error=True,
+            result="Agent exhausted max_turns=60 before producing a plan.",
+            total_cost_usd=0.4,
+        )
+        with patch.object(subprocess_utils, "query", _mock_query(msg)):
+            proc = _run_claude_p(
+                ["claude", "-p", "--agent", "cai-implement"],
+                category="implement", agent="cai-implement",
+            )
+
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("sdk_subtype=error_max_turns", proc.stderr)
+        self.assertIn("is_error=True", proc.stderr)
+        self.assertIn("Agent exhausted max_turns", proc.stderr)
+
+    @patch("cai_lib.subprocess_utils.log_cost")
+    def test_is_error_without_result_text_still_has_summary(self, _mock_log):
+        """is_error=True with result=None must still carry subtype/is_error."""
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        msg = _mk_result(
+            subtype="error_max_structured_output_retries",
+            is_error=True,
+            result=None,
+            total_cost_usd=0.2,
+        )
+        with patch.object(subprocess_utils, "query", _mock_query(msg)):
+            with patch("builtins.print"):
+                proc = _run_claude_p(
+                    ["claude", "-p", "--agent", "cai-triage",
+                     "--json-schema", "{}"],
+                    category="triage", agent="cai-triage",
+                )
+
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn(
+            "sdk_subtype=error_max_structured_output_retries",
+            proc.stderr,
+        )
+        self.assertIn("is_error=True", proc.stderr)
+
+    @patch("cai_lib.subprocess_utils.log_cost")
+    def test_success_leaves_stderr_empty(self, _mock_log):
+        """returncode=0 must NOT leak a diagnostic summary into stderr."""
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        msg = _mk_result(result="ok", total_cost_usd=0.05)
+        with patch.object(subprocess_utils, "query", _mock_query(msg)):
+            proc = _run_claude_p(
+                ["claude", "-p", "--agent", "cai-plan"],
+                category="plan.plan", agent="cai-plan",
+            )
+
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(proc.stderr, "")
+
+    def test_no_result_message_populates_stderr(self):
+        """The no-ResultMessage fallback path must surface a diagnostic."""
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        # No ResultMessage and no AssistantMessage — the empty-iterator case.
+        async def _empty_gen(*, prompt, options=None, transport=None):
+            if False:
+                yield  # pragma: no cover
+
+        with patch.object(subprocess_utils, "query", _empty_gen):
+            with patch("builtins.print"):
+                proc = _run_claude_p(
+                    ["claude", "-p", "--agent", "cai-implement"],
+                    category="implement", agent="cai-implement",
+                )
+
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("no_ResultMessage", proc.stderr)
+
+
+class TestSdkErrorSummary(unittest.TestCase):
+    """Direct unit tests for the issue-#1106 summary helper."""
+
+    def test_summary_with_subtype_and_result_text(self):
+        from cai_lib.subprocess_utils import _sdk_error_summary
+
+        class _R:
+            subtype = "error_max_turns"
+            is_error = True
+            result = "hit the cap\nbailing out"
+
+        s = _sdk_error_summary(_R())
+        self.assertIn("sdk_subtype=error_max_turns", s)
+        self.assertIn("is_error=True", s)
+        self.assertIn("hit the cap", s)
+        # The newline in result must be collapsed to a space by
+        # the helper so the caller's log line stays single-line.
+        self.assertNotIn("\n", s)
+
+    def test_summary_with_missing_fields_defaults_to_none(self):
+        from cai_lib.subprocess_utils import _sdk_error_summary
+
+        class _R:  # no subtype, no is_error, no result
+            pass
+
+        s = _sdk_error_summary(_R())
+        self.assertIn("sdk_subtype=none", s)
+        self.assertIn("is_error=False", s)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1106

**Issue:** #1106 — Issue #910 implement loop: 5 consecutive subagent_failed over 5h with no PR

## PR Summary

### What this fixes
Issue #910 produced 5 consecutive `result=subagent_failed exit=1` log rows that were byte-identical because `_run_claude_p` returned `stderr=""` on both SDK non-zero exit paths (the `not results` fallback and the terminal `is_error=True` return). Without any stderr content, the audit log had no signal to distinguish `error_max_turns` from `error_max_structured_output_retries` or an API error.

### What was changed
- **`cai_lib/subprocess_utils.py`**: Added `_sdk_error_summary(result)` helper that renders a single-line diagnostic (`sdk_subtype=<subtype> is_error=<bool> result=<preview>`) from a `ResultMessage`'s fields. Replaced the two `stderr=""` return paths in `_run_claude_p` with enriched stderr strings — the `not results` fallback now emits `no_ResultMessage last_assistant=<preview>` and the terminal `is_error=True` path calls `_sdk_error_summary(result)`.
- **`cai_lib/actions/implement.py`**: Added `_STDERR_TAIL_LIMIT = 120` constant and `_format_stderr_tail(stderr)` helper (collapses whitespace → `_`, rewrites `=` → `:`, caps at 120 chars) after `_COUNTED_IMPLEMENT_FAILURES`. Updated the `subagent_failed` `log_run` call to include `stderr_tail=_format_stderr_tail(agent.stderr or "")` as a new field between `result=` and `exit=`, preserving `_RESULT_TAG_RE` parse compatibility.
- **`tests/test_subprocess_utils.py`**: Added `TestStderrEnrichment` (three exit paths) and `TestSdkErrorSummary` (direct unit tests for the helper).
- **`tests/test_implement_consecutive_failures.py`**: Added `TestFormatStderrTail` (sanitizer contract) and `TestConsecutiveCounterStillMatchesEnrichedLine` (pins that the consecutive-failure counter still counts correctly with the new `stderr_tail=` field in the log line).

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
