### PR TITLE
Capture CLI stderr so intermittent SDK crashes stop breaking the cycle

### DIFF
--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -30,6 +30,33 @@ from cai_lib.logging_utils import log_cost
 _CLI_PATH = shutil.which("claude")
 
 
+# Bounds for the stderr-capture sink wired into ClaudeAgentOptions.stderr.
+# The SDK only pipes the `claude -p` subprocess's stderr when a callback is
+# attached — otherwise stderr inherits the parent fd and the CLI's real
+# crash reason (e.g. transient network / OOM / signal) vanishes into the
+# wrapper's own log stream, leaving callers staring at the SDK's hardcoded
+# placeholder "Check stderr output for details".
+_CAPTURED_STDERR_MAX_LINES = 200
+_CAPTURED_STDERR_MAX_CHARS = 4000
+
+
+def _make_stderr_sink(buf: list[str]):
+    def _sink(line: str) -> None:
+        if len(buf) < _CAPTURED_STDERR_MAX_LINES:
+            buf.append(line)
+    return _sink
+
+
+def _captured_stderr_text(buf: list[str]) -> str:
+    if not buf:
+        return ""
+    joined = "\n".join(buf)
+    if len(joined) > _CAPTURED_STDERR_MAX_CHARS:
+        # Keep the tail — the crash reason tends to be on the last lines.
+        joined = "[truncated]\n" + joined[-_CAPTURED_STDERR_MAX_CHARS:]
+    return joined
+
+
 def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
     """Thin wrapper around subprocess.run with text mode; defaults check=False.
 
@@ -232,6 +259,9 @@ def _run_claude_p(
     if _CLI_PATH:
         options.cli_path = _CLI_PATH
 
+    captured_stderr: list[str] = []
+    options.stderr = _make_stderr_sink(captured_stderr)
+
     prompt = input if input is not None else positional_prompt
 
     try:
@@ -247,25 +277,39 @@ def _run_claude_p(
             )
     except Exception as exc:  # noqa: BLE001
         preview = str(exc)[:200].replace("\n", " ")
-        print(
+        cli_stderr = _captured_stderr_text(captured_stderr)
+        cli_stderr_preview = cli_stderr.replace("\n", " | ")[:400]
+        msg = (
             f"[cai cost] claude-agent-sdk query failed "
-            f"({category}/{agent}): {preview}",
-            file=sys.stderr, flush=True,
+            f"({category}/{agent}): {preview}"
         )
+        if cli_stderr_preview:
+            msg += f" | cli_stderr={cli_stderr_preview!r}"
+        print(msg, file=sys.stderr, flush=True)
+        combined = str(exc)
+        if cli_stderr:
+            combined = f"{combined}\n--- cli stderr ---\n{cli_stderr}"
         return subprocess.CompletedProcess(
-            args=cmd, returncode=1, stdout="", stderr=str(exc),
+            args=cmd, returncode=1, stdout="", stderr=combined,
         )
 
     if not results:
         preview = (last_assistant or "")[:120].replace("\n", " ")
-        print(
+        cli_stderr = _captured_stderr_text(captured_stderr)
+        cli_stderr_preview = cli_stderr.replace("\n", " | ")[:400]
+        msg = (
             f"[cai cost] no ResultMessage from claude-agent-sdk "
-            f"({category}/{agent}); last assistant starts with: {preview!r}",
-            file=sys.stderr, flush=True,
+            f"({category}/{agent}); last assistant starts with: {preview!r}"
         )
+        if cli_stderr_preview:
+            msg += f" | cli_stderr={cli_stderr_preview!r}"
+        print(msg, file=sys.stderr, flush=True)
+        combined = f"no_ResultMessage last_assistant={preview!r}"
+        if cli_stderr:
+            combined = f"{combined}\n--- cli stderr ---\n{cli_stderr}"
         return subprocess.CompletedProcess(
             args=cmd, returncode=1, stdout=last_assistant or "",
-            stderr=f"no_ResultMessage last_assistant={preview!r}",
+            stderr=combined,
         )
 
     result = results[-1]

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -234,6 +234,101 @@ class TestStderrEnrichment(unittest.TestCase):
         self.assertIn("no_ResultMessage", proc.stderr)
 
 
+class TestCliStderrCapture(unittest.TestCase):
+    """The SDK's transport only pipes the `claude -p` subprocess's stderr
+    when ``ClaudeAgentOptions.stderr`` is set. Previously we never wired
+    that callback, so when the CLI crashed the SDK raised
+    ``ProcessError("Command failed with exit code 1", stderr="Check stderr
+    output for details")`` — the literal placeholder. The real crash
+    reason vanished into the parent's inherited stderr and we could not
+    diagnose the intermittent failures breaking the cycle loop.
+
+    These tests verify that ``_run_claude_p`` now attaches a stderr sink
+    and surfaces the captured lines in both the logged message and the
+    returned ``CompletedProcess.stderr``.
+    """
+
+    def test_exception_path_includes_captured_cli_stderr(self):
+        """SDK exception → stderr field must carry captured CLI stderr tail."""
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        cli_lines = [
+            "node: fatal: unexpected end of stream on stdin",
+            "    at /usr/lib/node_modules/@anthropic-ai/claude-code/cli.js:42",
+        ]
+
+        async def _fake_query(*, prompt, options=None, transport=None):
+            # Simulate the SDK transport feeding stderr lines through the
+            # callback before raising ProcessError the same way the real
+            # transport does on a subprocess crash.
+            sink = options.stderr
+            if sink:
+                for line in cli_lines:
+                    sink(line)
+            raise RuntimeError(
+                "Fatal error in message reader: Command failed with exit code 1"
+            )
+            yield  # pragma: no cover — make it an async generator
+
+        with patch.object(subprocess_utils, "query", _fake_query):
+            with patch("builtins.print") as mock_print:
+                proc = _run_claude_p(
+                    ["claude", "-p", "--agent", "cai-implement"],
+                    category="implement", agent="cai-implement",
+                )
+
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("unexpected end of stream", proc.stderr)
+        self.assertIn("cli.js:42", proc.stderr)
+        self.assertIn("--- cli stderr ---", proc.stderr)
+        # Log line must also mention cli_stderr=... so grepping the
+        # wrapper's own log surfaces the real cause.
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("cli_stderr=", printed)
+        self.assertIn("unexpected end of stream", printed)
+
+    def test_exception_without_captured_stderr_falls_back(self):
+        """When the CLI emitted no stderr, behaviour matches the pre-#1 contract."""
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        async def _fake_query(*, prompt, options=None, transport=None):
+            raise RuntimeError("boom")
+            yield  # pragma: no cover
+
+        with patch.object(subprocess_utils, "query", _fake_query):
+            with patch("builtins.print"):
+                proc = _run_claude_p(
+                    ["claude", "-p", "--agent", "cai-implement"],
+                    category="implement", agent="cai-implement",
+                )
+
+        self.assertEqual(proc.returncode, 1)
+        self.assertEqual(proc.stderr, "boom")
+
+    def test_stderr_capture_is_bounded(self):
+        """The sink must cap at _CAPTURED_STDERR_MAX_LINES to avoid leaks."""
+        from cai_lib.subprocess_utils import (
+            _CAPTURED_STDERR_MAX_LINES,
+            _captured_stderr_text,
+            _make_stderr_sink,
+        )
+
+        buf: list[str] = []
+        sink = _make_stderr_sink(buf)
+        for i in range(_CAPTURED_STDERR_MAX_LINES * 3):
+            sink(f"line {i}")
+
+        self.assertEqual(len(buf), _CAPTURED_STDERR_MAX_LINES)
+        # Early lines are preserved (bounded-append keeps the head —
+        # matches the "first crash symptom wins" shape the transport
+        # tends to produce).
+        self.assertEqual(buf[0], "line 0")
+        text = _captured_stderr_text(buf)
+        self.assertTrue(text)
+
+
 class TestSdkErrorSummary(unittest.TestCase):
     """Direct unit tests for the issue-#1106 summary helper."""
 


### PR DESCRIPTION
## Summary
- Intermittent `[cai implement] subagent claude -p failed (exit 1)` breakages surfaced only the SDK's hardcoded placeholder `Fatal error in message reader: Command failed with exit code 1 / Error output: Check stderr output for details`, because the `claude-agent-sdk` transport only pipes the `claude -p` subprocess's stderr when `ClaudeAgentOptions.stderr` is set. We never wired that callback, so the real crash reason vanished into the parent's inherited stderr.
- Attach a bounded stderr sink to every `_run_claude_p` invocation and include the captured tail in both the logged message and the returned `CompletedProcess.stderr` on the exception and no-ResultMessage paths. Next time a cycle dies on `subagent_failed`, the actual CLI error reaches the audit log.

## Changes
- `cai_lib/subprocess_utils.py`: add `_make_stderr_sink` / `_captured_stderr_text` (bounded — 200 lines / 4 000 chars), set `options.stderr` on every SDK call, enrich both the exception and no-ResultMessage branches with `cli_stderr=...` in the log line and a `--- cli stderr ---` section in `proc.stderr`.
- `tests/test_subprocess_utils.py`: three tests — exception path with captured stderr, exception path with no captured stderr (backwards-compat), sink bound enforcement.

## Test plan
- [x] `python -m pytest tests/test_subprocess_utils.py tests/test_implement_consecutive_failures.py -q` → 36 passed
- [ ] Observe the next real `subagent_failed` cycle: the log line should now include `cli_stderr=...` and the audit log's `stderr_tail=` field should no longer collapse to `empty` on transport crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)