### PR TITLE
auto-improve: CLAUDE.md still references CODEBASE_INDEX.md after the file is deleted

### DIFF
--- a/.claude/agents/audit/cai-audit-code-reduction.md
+++ b/.claude/agents/audit/cai-audit-code-reduction.md
@@ -16,7 +16,9 @@ You have Read, Grep, Glob, Agent, and Write. Use the Agent tool to spawn `Explor
 
 ### Module
 
-Name of the module being audited, a one-paragraph summary of its purpose, a documentation snippet (e.g. the module's README or the relevant section of `CODEBASE_INDEX.md`), and the list of file globs that define the module's scope. Every finding you raise must cite a `file:line` inside these globs.
+Name of the module being audited, a one-paragraph summary of its purpose, a
+documentation snippet (e.g. the corresponding narrative in `docs/modules/<name>.md`
+or the module entry in `docs/modules.yaml`), and the list of file globs that define the module's scope. Every finding you raise must cite a `file:line` inside these globs.
 
 ### Findings file
 

--- a/.claude/agents/audit/cai-audit-cost-reduction.md
+++ b/.claude/agents/audit/cai-audit-cost-reduction.md
@@ -26,8 +26,8 @@ The user message contains the following sections, in order:
 ### Module
 
 Name of the module being audited, a one-paragraph summary of its purpose, a
-documentation snippet (e.g. the module's README or relevant section of
-`CODEBASE_INDEX.md`), and the list of file globs that define the module's
+documentation snippet (e.g. the corresponding narrative in `docs/modules/<name>.md`
+or the module entry in `docs/modules.yaml`), and the list of file globs that define the module's
 scope.
 
 ### Findings file

--- a/.claude/agents/audit/cai-audit-external-libs.md
+++ b/.claude/agents/audit/cai-audit-external-libs.md
@@ -18,7 +18,7 @@ Prefer conservative judgment: one well-justified proposal is worth more than sev
 
 ### Module
 
-Name of the module being audited, a one-paragraph summary of its purpose, a documentation snippet (e.g. the module's README or the relevant section of `CODEBASE_INDEX.md`), and the list of file globs that define the module's scope. Every finding you raise must cite a `file:line` inside these globs.
+Name of the module being audited, a one-paragraph summary of its purpose, a documentation snippet (e.g. the corresponding narrative in `docs/modules/<name>.md` or the module entry in `docs/modules.yaml`), and the list of file globs that define the module's scope. Every finding you raise must cite a `file:line` inside these globs.
 
 ### Findings file
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,13 @@ This file is loaded by all Claude Code subagents in headless mode.
 
 ## Efficiency guidance (all agents)
 
-0. **Consult `CODEBASE_INDEX.md` first.** Before using Glob or
-   Grep for file discovery, check `CODEBASE_INDEX.md` at the repo
-   root — it lists every tracked file with a one-line description
-   and eliminates the need for an initial discovery round.
+0. **Consult `docs/modules.yaml` first.** Before using Glob or
+   Grep for file discovery, check `docs/modules.yaml` at the repo
+   root — it is the primary index of every module with file locations
+   and descriptions. For deeper detail on a specific module, read the
+   corresponding narrative in `docs/modules/<name>.md`. These files
+   are the single source of truth for codebase structure and eliminate
+   the need for an initial discovery round.
 1. **Grep before Read.** Use Grep to locate the relevant file(s)
    and line numbers before opening them with Read. Do not
    sequentially Read files to search for content — reserve Read for


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1118

**Issue:** #1118 — CLAUDE.md still references CODEBASE_INDEX.md after the file is deleted

## PR Summary

### What this fixes
After issue #912 deleted `CODEBASE_INDEX.md`, the root `CLAUDE.md` still referenced it in the efficiency guidance bullet 0, directing agents to a non-existent file for codebase discovery.

### What was changed
- **CLAUDE.md** (via `.cai-staging/claudemd/CLAUDE.md`): Replaced the stale "Consult `CODEBASE_INDEX.md` first" bullet with updated guidance directing agents to consult `docs/modules.yaml` (primary module index) and the per-module narratives in `docs/modules/<name>.md` as the single source of truth for codebase structure.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
