### PR TITLE
auto-improve: Rescue prevention: The plan block in this issue embeds `requires_human_review: true` — `cai-select` should surface this flag as a mandatory

### DIFF
--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -29,11 +29,17 @@ from cai_lib.config import (
     REPO,
     LABEL_IN_PROGRESS,
     LABEL_PR_OPEN,
+    LABEL_PLAN_NEEDS_REVIEW,
     LABEL_REFINED,
     LABEL_PLANNING,
     LABEL_PLANNED,
 )
-from cai_lib.github import _gh_json, _build_issue_block, _post_issue_comment
+from cai_lib.github import (
+    _gh_json,
+    _build_issue_block,
+    _post_issue_comment,
+    _set_labels,
+)
 from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.logging_utils import log_run
 from cai_lib.cmd_helpers import (
@@ -826,6 +832,27 @@ def handle_plan_gate(issue: dict) -> int:
                     requires_human_review=1,
                     exit=1)
             return 1
+        # Surface the planner's explicit admin-review request as a
+        # supplementary label on top of :human-needed (#1128). Makes
+        # the human checkpoint visible in the FSM label trail rather
+        # than buried in the plan body, and lets `cai rescue` skip
+        # this issue instead of burning autonomous-resume cycles on a
+        # park the planner itself flagged as needing admin sign-off.
+        # Failure to apply the label is non-fatal — the FSM divert
+        # has already succeeded; log and continue so the caller still
+        # sees a 0 return code.
+        if not _set_labels(
+            issue_number,
+            add=[LABEL_PLAN_NEEDS_REVIEW],
+            log_prefix="cai plan",
+        ):
+            print(
+                f"[cai plan] #{issue_number} failed to apply "
+                f"{LABEL_PLAN_NEEDS_REVIEW}; divert already logged — "
+                f"continuing",
+                file=sys.stderr,
+                flush=True,
+            )
         print(
             f"[cai plan] #{issue_number} gate → :human-needed in {dur} "
             f"(requires_human_review=true, confidence={conf_name})",

--- a/cai_lib/cmd_misc.py
+++ b/cai_lib/cmd_misc.py
@@ -38,6 +38,13 @@ _ALL_MANAGED_ISSUE_LABELS: frozenset[str] = frozenset({
     # sweep so the next rescue pass can detect the one-shot has
     # already been burned and refuse a second escalation (#944).
     LABEL_OPUS_ATTEMPTED,
+    # Supplementary plan-needs-review marker (#1128) — set alongside
+    # :human-needed by `handle_plan_gate` when cai-select emitted
+    # requires_human_review=true. Must survive the hourly sweep so
+    # `cai rescue` keeps skipping the issue until the admin resumes
+    # it; auto-cleared on any `human_to_*` resume transition via
+    # the transition's `labels_remove`.
+    LABEL_PLAN_NEEDS_REVIEW,
     "auto-improve", "audit", "check-workflows", "check-workflows:raised",
 })
 

--- a/cai_lib/cmd_rescue.py
+++ b/cai_lib/cmd_rescue.py
@@ -31,6 +31,7 @@ from cai_lib.config import (
     LABEL_HUMAN_NEEDED,
     LABEL_HUMAN_SOLVED,
     LABEL_OPUS_ATTEMPTED,
+    LABEL_PLAN_NEEDS_REVIEW,
     LABEL_PR_HUMAN_NEEDED,
 )
 from cai_lib.fsm import (
@@ -130,6 +131,22 @@ def _list_unresolved_human_needed_issues() -> list[dict]:
         }
         if LABEL_HUMAN_SOLVED in names:
             # Admin already opted-in — leave it to cmd_unblock.
+            continue
+        if LABEL_PLAN_NEEDS_REVIEW in names:
+            # `handle_plan_gate` flagged this park for mandatory admin
+            # sign-off via cai-select's requires_human_review=true
+            # signal (#1128). The autonomous rescue pass cannot resolve
+            # a divert the planner itself said needs admin input —
+            # skip until an admin applies `human:solved` (handled by
+            # `cai unblock`) or directly resumes the issue, at which
+            # point the `human_to_*` transition also strips this label
+            # via its `labels_remove`.
+            print(
+                f"[cai rescue] #{issue['number']}: carries "
+                f"{LABEL_PLAN_NEEDS_REVIEW} — plan explicitly requires "
+                f"admin review, skipping autonomous rescue",
+                flush=True,
+            )
             continue
         blockers = blocking_issue_numbers(issue.get("labels", []))
         if blockers:

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -159,6 +159,18 @@ LABEL_HUMAN_SOLVED = "human:solved"
 # and prevents a second escalation on the same issue if the Opus run
 # also parks at :human-needed.
 LABEL_OPUS_ATTEMPTED = "auto-improve:opus-attempted"
+# Supplementary marker applied by `handle_plan_gate` (in addition to the
+# standard :human-needed state label) when `cai-select`'s structured
+# output set `requires_human_review=true` — i.e. the planner itself
+# flagged the chosen plan as needing admin sign-off. Makes the human
+# checkpoint explicit in the FSM label trail instead of leaving it
+# buried in the plan body, and lets `cai rescue` skip these issues so
+# the autonomous rescue pass does not repeatedly re-evaluate parks the
+# planner already said need admin input (#1128). Declared in
+# `labels_remove` on every `human_to_*` transition in
+# `cai_lib/fsm_transitions.py` so it auto-clears the moment the issue
+# leaves HUMAN_NEEDED.
+LABEL_PLAN_NEEDS_REVIEW = "auto-improve:plan-needs-review"
 LABEL_TRIAGING         = "auto-improve:triaging"
 LABEL_KIND_CODE        = "kind:code"
 LABEL_KIND_MAINTENANCE = "kind:maintenance"

--- a/cai_lib/fsm_transitions.py
+++ b/cai_lib/fsm_transitions.py
@@ -21,6 +21,7 @@ from cai_lib.config import (
     LABEL_IN_PROGRESS, LABEL_PR_OPEN, LABEL_MERGED, LABEL_SOLVED,
     LABEL_NEEDS_EXPLORATION, LABEL_HUMAN_NEEDED, LABEL_PR_HUMAN_NEEDED,
     LABEL_TRIAGING, LABEL_APPLYING, LABEL_APPLIED,
+    LABEL_PLAN_NEEDS_REVIEW,
     LABEL_PR_REVIEWING_CODE, LABEL_PR_REVISION_PENDING,
     LABEL_PR_REVIEWING_DOCS, LABEL_PR_APPROVED, LABEL_PR_REBASING,
     LABEL_PR_CI_FAILING,
@@ -242,23 +243,35 @@ ISSUE_TRANSITIONS: list[Transition] = [
     Transition("merged_to_solved",           IssueState.MERGED,            IssueState.SOLVED,
                labels_remove=[LABEL_MERGED],            labels_add=[LABEL_SOLVED]),
 
+    # Every `human_to_*` resume transition also strips the
+    # supplementary LABEL_PLAN_NEEDS_REVIEW marker (#1128) so the
+    # "plan explicitly flagged for admin review" signal never
+    # lingers after the admin has actually resolved the divert.
+    # `gh issue edit --remove-label` is idempotent when the label is
+    # not present, so the extra entry is a no-op for the common case
+    # where the label was never applied.
     Transition("human_to_raised",            IssueState.HUMAN_NEEDED,      IssueState.RAISED,
-               labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_RAISED]),
+               labels_remove=[LABEL_HUMAN_NEEDED, LABEL_PLAN_NEEDS_REVIEW],
+               labels_add=[LABEL_RAISED]),
     # Admin-comment-driven re-entries out of HUMAN_NEEDED. Fired by
     # cmd_unblock after a Haiku agent classifies the admin's reply.
     # Resume into REFINING (not REFINED) so the refine agent re-runs
     # with the admin's input in context — REFINED is an auto-advance
     # waypoint, not a sensible re-entry point.
     Transition("human_to_refining",          IssueState.HUMAN_NEEDED,      IssueState.REFINING,
-               labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_REFINING]),
+               labels_remove=[LABEL_HUMAN_NEEDED, LABEL_PLAN_NEEDS_REVIEW],
+               labels_add=[LABEL_REFINING]),
     # Admin greenlights the already-stored plan — jump past the
     # planned→approved gate.
     Transition("human_to_plan_approved",     IssueState.HUMAN_NEEDED,      IssueState.PLAN_APPROVED,
-               labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_PLAN_APPROVED]),
+               labels_remove=[LABEL_HUMAN_NEEDED, LABEL_PLAN_NEEDS_REVIEW],
+               labels_add=[LABEL_PLAN_APPROVED]),
     Transition("human_to_exploration",       IssueState.HUMAN_NEEDED,      IssueState.NEEDS_EXPLORATION,
-               labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_NEEDS_EXPLORATION]),
+               labels_remove=[LABEL_HUMAN_NEEDED, LABEL_PLAN_NEEDS_REVIEW],
+               labels_add=[LABEL_NEEDS_EXPLORATION]),
     Transition("human_to_solved",            IssueState.HUMAN_NEEDED,      IssueState.SOLVED,
-               labels_remove=[LABEL_HUMAN_NEEDED],      labels_add=[LABEL_SOLVED]),
+               labels_remove=[LABEL_HUMAN_NEEDED, LABEL_PLAN_NEEDS_REVIEW],
+               labels_add=[LABEL_SOLVED]),
 ]
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,7 @@ Issues enter the pipeline when a human files an issue labeled `auto-improve:rais
 | `auto-improve:planned` | Plan generated and stored in issue body; confidence gate pending |
 | `auto-improve:planning` | Plan generation in progress (transient) |
 | `auto-improve:plan-approved` | Plan approved (HIGH confidence auto-approval or admin resume); ready for implement subagent |
+| `auto-improve:plan-needs-review` | Supplementary marker set by `handle_plan_gate` when cai-select flagged `requires_human_review=true`; signals that this plan explicitly diverges from refined-issue preference and requires admin approval. Applied alongside `:human-needed`; auto-cleared when the issue leaves HUMAN_NEEDED via any `human_to_*` resume transition. Causes `cai rescue` to skip the issue during autonomous resume cycles. |
 | `auto-improve:human-needed` | Awaiting admin review and decision; admin applies `human:solved` to resume |
 | `auto-improve:applying` | Maintenance ops are being applied (transient; Step 3 agent drains this state) |
 | `auto-improve:applied` | Maintenance ops applied; awaiting verification |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ Cron schedules are configurable via environment variables. Default values are se
 |---|---|---|
 | `CAI_CYCLE_SCHEDULE` | `0 * * * *` | Restart-recovery + dispatch one actionable issue/PR |
 | `CAI_VERIFY_SCHEDULE` | `15 * * * *` | Label-state reconciliation — removes deprecated cai-managed labels from open issues, then keeps :pr-open / :merged / etc. consistent with actual GitHub state. |
-| `CAI_RESCUE_SCHEDULE` | `30 */4 * * *` | Every 4 hours at :30 — autonomously resume :human-needed issues without human:solved label |
+| `CAI_RESCUE_SCHEDULE` | `30 */4 * * *` | Every 4 hours at :30 — autonomously resume :human-needed issues without human:solved label, except those carrying `auto-improve:plan-needs-review` (which require admin approval because the plan explicitly diverges from refined-issue preference) |
 | `CAI_WORKSPACES_CONFIG` | `/app/workspaces.json` | Path to a JSON file listing additional repositories to maintain (optional; see Multi-workspace section below) |
 
 Schedule values use standard cron format: `minute hour day month weekday`. To disable a scheduled agent, set its variable to an empty string or a comment value.

--- a/tests/test_blocked_on.py
+++ b/tests/test_blocked_on.py
@@ -299,5 +299,56 @@ class TestRescueListRespectsBlockedOn(unittest.TestCase):
         self.assertEqual(result[0]["number"], 10)
 
 
+# ---------------------------------------------------------------------------
+# _list_unresolved_human_needed_issues skips LABEL_PLAN_NEEDS_REVIEW (#1128)
+# ---------------------------------------------------------------------------
+
+
+class TestRescueListSkipsPlanNeedsReview(unittest.TestCase):
+    """#1128 — issues whose plan block was flagged by cai-select with
+    requires_human_review=true carry `auto-improve:plan-needs-review` on
+    top of `:human-needed`, and `cai rescue` must skip them so the
+    autonomous rescue pass does not re-evaluate parks the planner itself
+    said need admin sign-off."""
+
+    def test_plan_needs_review_issue_excluded(self):
+        flagged = _rescue_issue(
+            1,
+            ["auto-improve:human-needed", "auto-improve:plan-needs-review"],
+        )
+        plain = _rescue_issue(2, ["auto-improve:human-needed"])
+
+        side_effect = _make_rescue_gh_json([flagged, plain], {})
+        with patch.object(R, "_gh_json", side_effect=side_effect), \
+             patch("cai_lib.github._gh_json", side_effect=side_effect):
+            result = R._list_unresolved_human_needed_issues()
+
+        numbers = [i["number"] for i in result]
+        self.assertNotIn(1, numbers)
+        self.assertIn(2, numbers)
+
+    def test_plan_needs_review_takes_precedence_over_blocker_check(self):
+        """When both plan-needs-review and blocked-on labels are present,
+        the plan-needs-review filter fires first and no blocker lookup
+        is required."""
+        flagged_and_blocked = _rescue_issue(
+            1,
+            [
+                "auto-improve:human-needed",
+                "auto-improve:plan-needs-review",
+                "blocked-on:99",
+            ],
+        )
+
+        # Return state=OPEN for #99 so the blocker path would skip too;
+        # either filter firing yields the same exclusion outcome.
+        side_effect = _make_rescue_gh_json([flagged_and_blocked], {99: "OPEN"})
+        with patch.object(R, "_gh_json", side_effect=side_effect), \
+             patch("cai_lib.github._gh_json", side_effect=side_effect):
+            result = R._list_unresolved_human_needed_issues()
+
+        self.assertEqual(result, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -391,14 +391,17 @@ class TestHandlePlanGateRequiresHumanReview(unittest.TestCase):
             "_cai_plan_requires_human_review": requires_review,
         }
 
+    @patch("cai_lib.actions.plan._set_labels")
     @patch("cai_lib.actions.plan._post_issue_comment")
     @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_requires_review_high_conf_still_diverts(
-        self, _mock_log, mock_fire, mock_post
+        self, _mock_log, mock_fire, mock_post, mock_set_labels
     ):
         from cai_lib.actions.plan import handle_plan_gate
+        from cai_lib.config import LABEL_PLAN_NEEDS_REVIEW
         mock_fire.return_value = (True, False)
+        mock_set_labels.return_value = True
 
         rc = handle_plan_gate(self._issue(
             confidence=Confidence.HIGH,
@@ -424,6 +427,13 @@ class TestHandlePlanGateRequiresHumanReview(unittest.TestCase):
         )
         self.assertIn("admin approval required", divert_reason)
         mock_post.assert_not_called()
+        # #1128 — supplementary plan-needs-review label must be applied
+        # on top of :human-needed so rescue skips the issue.
+        mock_set_labels.assert_called_once()
+        set_labels_kwargs = mock_set_labels.call_args.kwargs
+        self.assertEqual(
+            set_labels_kwargs.get("add"), [LABEL_PLAN_NEEDS_REVIEW],
+        )
 
     @patch("cai_lib.actions.plan._post_issue_comment")
     @patch("cai_lib.actions.plan.fire_trigger")
@@ -476,16 +486,19 @@ class TestHandlePlanGateRequiresHumanReview(unittest.TestCase):
         ]
         self.assertEqual(gated_calls, [])
 
+    @patch("cai_lib.actions.plan._set_labels")
     @patch("cai_lib.actions.plan._post_issue_comment")
     @patch("cai_lib.actions.plan.fire_trigger")
     @patch("cai_lib.actions.plan.log_run")
     def test_requires_review_reparsed_from_body_when_stash_missing(
-        self, _mock_log, mock_fire, mock_post
+        self, _mock_log, mock_fire, mock_post, mock_set_labels
     ):
         """When the in-process stash is absent, the flag must be
         re-parsed from the stored plan block in the issue body."""
         from cai_lib.actions.plan import handle_plan_gate
+        from cai_lib.config import LABEL_PLAN_NEEDS_REVIEW
         mock_fire.return_value = (True, False)
+        mock_set_labels.return_value = True
 
         body = (
             "<!-- cai-plan-start -->\n"
@@ -515,6 +528,35 @@ class TestHandlePlanGateRequiresHumanReview(unittest.TestCase):
         divert_reason = fire_call_kwargs.get("divert_reason", "")
         self.assertIn("admin approval required", divert_reason)
         mock_post.assert_not_called()
+        # #1128 — body-reparse path must also apply the supplementary
+        # plan-needs-review label.
+        mock_set_labels.assert_called_once()
+        set_labels_kwargs = mock_set_labels.call_args.kwargs
+        self.assertEqual(
+            set_labels_kwargs.get("add"), [LABEL_PLAN_NEEDS_REVIEW],
+        )
+
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan._post_issue_comment")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan.log_run")
+    def test_requires_review_set_labels_failure_still_returns_0(
+        self, _mock_log, mock_fire, _mock_post, mock_set_labels
+    ):
+        """#1128 — a `_set_labels` failure must NOT flip the return code
+        from 0 to 1. The FSM divert has already succeeded; failing to
+        stamp the supplementary marker is a logged-but-ignorable error."""
+        from cai_lib.actions.plan import handle_plan_gate
+        mock_fire.return_value = (True, False)
+        mock_set_labels.return_value = False  # label-apply failed
+
+        rc = handle_plan_gate(self._issue(
+            confidence=Confidence.MEDIUM,
+            requires_review=True,
+        ))
+
+        self.assertEqual(rc, 0)
+        mock_set_labels.assert_called_once()
 
 
 class TestParseRequiresHumanReview(unittest.TestCase):


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1128

**Issue:** #1128 — Rescue prevention: The plan block in this issue embeds `requires_human_review: true` — `cai-select` should surface this flag as a mandatory

## PR Summary

### What this fixes
When `cai-select` flags a plan with `requires_human_review=true`, the divert to `:human-needed` was invisible in the FSM label trail and the autonomous `cai rescue` pass would repeatedly re-evaluate the park — burning cycles on issues the planner itself said need admin sign-off.

### What was changed
- **`cai_lib/config.py`**: Added `LABEL_PLAN_NEEDS_REVIEW = "auto-improve:plan-needs-review"` constant after `LABEL_OPUS_ATTEMPTED`.
- **`cai_lib/cmd_misc.py`**: Added `LABEL_PLAN_NEEDS_REVIEW` to `_ALL_MANAGED_ISSUE_LABELS` so the hourly sweep does not strip it.
- **`cai_lib/fsm_transitions.py`**: Imported `LABEL_PLAN_NEEDS_REVIEW`; added it to `labels_remove` on all five `human_to_*` resume transitions so it auto-clears when an admin resolves the divert.
- **`cai_lib/actions/plan.py`**: Imported `LABEL_PLAN_NEEDS_REVIEW` and `_set_labels`; in `handle_plan_gate`'s `requires_human_review=True` branch, applies the supplementary label after a successful `planned_to_human` fire_trigger (failure is non-fatal).
- **`cai_lib/cmd_rescue.py`**: Imported `LABEL_PLAN_NEEDS_REVIEW`; added a skip-filter in `_list_unresolved_human_needed_issues` that skips issues carrying this label before the blocker check.
- **`tests/test_plan.py`**: Updated `test_requires_review_high_conf_still_diverts` and `test_requires_review_reparsed_from_body_when_stash_missing` to patch `_set_labels` and assert it is called with the new label; added `test_requires_review_set_labels_failure_still_returns_0` to enforce the non-fatal contract.
- **`tests/test_blocked_on.py`**: Added `TestRescueListSkipsPlanNeedsReview` class with two tests verifying the rescue filter excludes issues carrying `LABEL_PLAN_NEEDS_REVIEW`.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
