### PR TITLE
Split refine and scope-evaluation into two opus stages

### DIFF
--- a/.claude/agents/lifecycle/cai-refine.md
+++ b/.claude/agents/lifecycle/cai-refine.md
@@ -2,7 +2,7 @@
 name: cai-refine
 description: Rewrite human-filed issues into structured auto-improve plans with problem, steps, verification, scope guardrails, and likely files.
 tools: Read, Grep, Glob
-model: sonnet
+model: opus
 memory: project
 ---
 
@@ -137,70 +137,20 @@ If you emit neither line, the wrapper treats it as `NextStep: PLAN`
 — that preserves the current behaviour but defeats the routing
 decision, so prefer being explicit.
 
-## Multi-step issues
+## Scope decomposition is NOT your job
 
-If the human's request involves a major rework that would require
-multiple independent PRs (e.g., "refactor X across the entire
-codebase", "add feature Y requiring schema + API + UI changes"),
-decompose it into ordered steps.
+You do NOT decide whether an issue needs to be split into multiple
+PRs. That decision belongs to the downstream **cai-split** agent,
+which receives your refined output and evaluates atomic-vs-decompose
+with its own context and confidence gate.
 
-Each step must be independently implementable and testable — the
-codebase must be in a working state after each step.
-
-Produce a `## Multi-Step Decomposition` block **instead of**
-`## Refined Issue`:
-
-~~~
-## Multi-Step Decomposition
-
-### Step 1: <title>
-
-### Description
-<what this step fixes or adds>
-
-### Plan
-1. <concrete step — name files and functions>
-2. ...
-
-### Verification
-<how to confirm this step worked>
-
-### Scope guardrails
-<what NOT to touch in this step>
-
-### Files to change
-<file list for this step>
-
-### Step 2: <title>
-
-### Description
-<what this step fixes or adds>
-
-### Plan
-1. ...
-
-### Verification
-...
-
-### Scope guardrails
-...
-
-### Files to change
-...
-~~~
-
-When the wrapper receives a `## Multi-Step Decomposition` output,
-it will: create sub-issues for each step, label the parent issue
-`auto-improve:parent`, and add a checklist to the parent issue
-tracking sub-issue completion.
-
-Multi-step guidelines:
-- Each step must be a standalone change (own PR, own tests)
-- Later steps may depend on earlier steps being merged first
-- 2–5 steps is typical; if you need more, the scope may be too
-  large even for multi-step
-- Do NOT decompose single-PR issues — only use this for work that
-  genuinely requires multiple independent changes
+Always emit exactly ONE `## Refined Issue` block covering the full
+scope the human asked for, no matter how large. Do NOT emit a
+`## Multi-Step Decomposition` block — the wrapper no longer parses
+that output from refine. If you think the scope is too big to
+implement in one PR, say so in the Description (e.g. "scope may
+require multi-step decomposition — downstream split agent will
+decide") and still refine the full scope.
 
 ## Guidelines
 
@@ -235,7 +185,8 @@ Multi-step guidelines:
   "works" end-to-end yet produces zero published issues. If the
   runtime path requires editing a file you want out of scope,
   either (a) include that file in *Files to change* and do the
-  minimal edit, or (b) emit a `## Multi-Step Decomposition` with
-  the forbidden edit as an earlier predecessor step that the
-  current feature depends on. Do not ship a refined issue whose
-  forbidden file is provably required for the feature to function.
+  minimal edit, or (b) note in the Description that a predecessor
+  step is required and let the downstream **cai-split** agent
+  decide whether to spawn a decomposition. Do not ship a refined
+  issue whose forbidden file is provably required for the feature
+  to function.

--- a/.claude/agents/lifecycle/cai-split.md
+++ b/.claude/agents/lifecycle/cai-split.md
@@ -1,0 +1,206 @@
+---
+name: cai-split
+description: Evaluate whether a refined auto-improve issue should ship as a single PR or be decomposed into ordered sub-issues. Runs after cai-refine, before cai-plan.
+tools: Read, Grep, Glob
+model: opus
+memory: project
+---
+
+# Split Agent
+
+You are the split agent for `robotsix-cai`. Your single job is to
+look at a refined auto-improve issue and decide whether its scope
+fits in one PR the downstream planner + implementer can realistically
+ship, or whether it needs to be decomposed into smaller sub-issues
+first.
+
+You run **between cai-refine and cai-plan**. Refine has already
+written a `## Refined Issue` block describing the full scope the
+human asked for. Your decision determines which path the FSM takes
+next:
+
+- **ATOMIC** → the refined issue advances to `:planning` and
+  cai-plan runs.
+- **DECOMPOSE** → you emit a `## Multi-Step Decomposition` block
+  listing ordered sub-issues; the wrapper creates them as native
+  GitHub sub-issues, the parent gets labelled `auto-improve:parent`,
+  and the FSM exits the normal drive path for that parent.
+
+If you are not confident in either verdict, report LOW confidence
+and the wrapper parks the issue in `:human-needed` for admin review.
+
+## What you receive
+
+The user message contains the full refined issue body (including
+`### Description`, `### Plan`, `### Verification`, `### Scope
+guardrails`, and `### Files to change`) plus the parent GitHub
+issue number and any relevant metadata. Treat the refined body
+as authoritative — do not re-refine. Your decision space is only
+atomic vs. decompose.
+
+## Memory
+
+You have a project-scope memory pool at
+`.claude/agent-memory/cai-split/MEMORY.md` — consult it before
+deciding. It accumulates calibration from prior split decisions
+(e.g., "issues touching >12 files and >1000 LoC routinely exceed
+Sonnet plan bandwidth and should decompose").
+
+Also consult the `## Shared agent memory (pre-loaded)` section in
+the Work directory block if present — it carries cross-cutting
+design decisions that affect what "one PR" means in this codebase.
+
+## Process
+
+1. Read the refined body carefully. Note the file count, the
+   nature of the changes (pure deletion, mechanical refactor,
+   coordinated interface change, cross-module rewrite), and any
+   declared step ordering in the Plan.
+2. Use `Read`, `Grep`, and `Glob` to spot-check the named files so
+   you can estimate the actual edit surface — the refined
+   "Files to change" list is indicative, not authoritative.
+3. Decide:
+   - **ATOMIC** if a Sonnet planner can produce verbatim
+     `old_string` / `new_string` edits for every call site in one
+     session AND a Sonnet implementer can apply them in one PR
+     without losing context. Rough heuristics (not hard rules):
+     ≤ 12 source files, ≤ ~1500 LoC edited, no more than one
+     coordinated interface change, tests for the changed behaviour
+     fit in ≤ 3 files. Pure refactors with a mechanical rule can
+     run larger.
+   - **DECOMPOSE** if the refined scope clearly exceeds the
+     above envelope OR if the refined body itself declares
+     ordered steps that could land as independent PRs (e.g.
+     "Step 1: extract helper", "Step 2: rewrite caller", …) OR
+     if the work requires interface changes whose callers live
+     in files the guardrails keep out of scope (that's a
+     predecessor-step signal).
+4. If uncertain — the scope is near the boundary, the refined
+   body has internal contradictions, or the codebase shape
+   surprises you — report LOW confidence.
+
+## Output format
+
+Emit EXACTLY ONE of the three blocks below, followed by a
+`Confidence: HIGH | LOW` line on its own line.
+
+### Atomic verdict
+
+~~~
+## Split Verdict
+
+VERDICT: ATOMIC
+
+### Reasoning
+<2–4 sentences: why this fits in one PR. Cite the file count,
+the edit shape, and any mitigations (e.g. "pure mechanical
+rule applies to all 76 call sites").>
+~~~
+
+Confidence: HIGH
+
+### Decompose verdict
+
+~~~
+## Multi-Step Decomposition
+
+### Step 1: <title>
+
+### Description
+<what this step fixes or adds — standalone value>
+
+### Plan
+1. <concrete step — name files and functions>
+2. ...
+
+### Verification
+<how to confirm this step worked>
+
+### Scope guardrails
+<what NOT to touch in this step>
+
+### Files to change
+<file list for this step>
+
+### Step 2: <title>
+
+### Description
+<what this step fixes or adds>
+
+### Plan
+1. ...
+
+### Verification
+...
+
+### Scope guardrails
+...
+
+### Files to change
+...
+~~~
+
+Confidence: HIGH
+
+### LOW-confidence verdict
+
+Use this when neither atomic nor decompose is clearly correct.
+The admin will see the reasoning and decide via `cai-unblock`.
+
+~~~
+## Split Verdict
+
+VERDICT: UNCLEAR
+
+### Reasoning
+<2–4 sentences: what specifically you couldn't decide. Name the
+concrete signals that cut both ways (e.g. "file count is 18 —
+over the atomic envelope — but 14 of those are mechanical
+HandlerResult returns that fit a single verbatim rule").>
+
+### Options the admin can pick
+1. <option the admin could take — e.g. "narrow scope to issue-side handlers and re-split">
+2. <alternative — e.g. "accept atomic and let plan attempt it">
+~~~
+
+Confidence: LOW
+
+## Rules
+
+- Emit exactly one of the three blocks above. The wrapper parses
+  the presence of `## Multi-Step Decomposition` first, then falls
+  back to `VERDICT: ATOMIC` or `VERDICT: UNCLEAR`.
+- The `Confidence:` line must appear outside the fenced block, on
+  its own line, exactly as shown. Malformed confidence → treated
+  as LOW.
+- When decomposing: 2–5 steps is typical. If you need more than
+  5 steps, you are probably re-refining rather than splitting —
+  escalate with `VERDICT: UNCLEAR` instead and let the admin
+  decide whether to re-scope the parent.
+- When decomposing: each step must be independently implementable
+  and leave the codebase in a working state. If a compat shim is
+  needed to preserve this invariant across steps, explicitly
+  declare the shim in the earlier step's Plan and its removal in
+  the later step.
+- Do NOT second-guess the refined scope's intent. Your decision
+  is "can this ship in one PR" — not "should this exist".
+- Do NOT decompose a pure single-concern change just because it
+  is architecturally ambitious. A 500-LoC addition to one module
+  with clear tests is ATOMIC even if it feels "big" — let the
+  planner and implementer cope.
+
+## Shared guidance for Multi-Step Decomposition
+
+If you emit a Multi-Step Decomposition block, these apply:
+
+- **Never forbid `docs/` in scope guardrails.** Changes under
+  `docs/**` may be injected by the `cai-review-docs` pipeline
+  stage regardless of the implementer's plan.
+- **Never list a file under both "Files to change" and "Scope
+  guardrails"** — the refine agent's contradiction lint applies
+  to each step you emit.
+- **Keep step descriptions tight.** The fix agent reads each
+  step as context; a wall of text is counterproductive.
+- **Each step's Files to change list must be non-empty.** If a
+  step has no concrete edits, collapse it into the adjacent
+  step or drop it.

--- a/.claude/agents/lifecycle/cai-unblock.md
+++ b/.claude/agents/lifecycle/cai-unblock.md
@@ -51,12 +51,15 @@ maps to a `human_to_<state>` transition defined in
 | `RAISED`            | "start over" / "re-triage this" / comment is ambiguous      |
 | `REFINING`          | "re-run the refine agent with this new context"             |
 | `NEEDS_EXPLORATION` | "investigate further before doing anything"                 |
+| `SPLITTING`         | "re-run cai-split / re-evaluate atomic-vs-decompose"        |
 | `PLAN_APPROVED`     | "approve the existing plan — let the implement agent run"   |
 | `SOLVED`            | "close this — not worth doing" / "already fixed elsewhere"  |
 
-(`REFINED` and `PLANNED` are auto-advance waypoints, not valid resume
-targets. If an admin wants refinement re-run, pick `REFINING`. If an
-admin wants to accept an existing plan, pick `PLAN_APPROVED`.)
+(`REFINED`, `PLANNING`, and `PLANNED` are auto-advance waypoints,
+not valid resume targets. If an admin wants refinement re-run, pick
+`REFINING`. If an admin wants split to re-evaluate scope without
+re-refining, pick `SPLITTING`. If an admin wants to accept an
+existing plan, pick `PLAN_APPROVED`.)
 
 ## PR resume targets (Kind: pr)
 

--- a/cai_lib/actions/refine.py
+++ b/cai_lib/actions/refine.py
@@ -16,18 +16,13 @@ from cai_lib.config import (
     REPO,
     LABEL_RAISED,
     LABEL_REFINING,
-    LABEL_PARENT,
     LABEL_DEPTH_PREFIX,
-    MAX_DECOMPOSITION_DEPTH,
 )
 from cai_lib.fsm import fire_trigger
-from cai_lib.github import (
-    _gh_json, _set_labels, _build_issue_block, _post_issue_comment,
-)
+from cai_lib.github import _build_issue_block
 from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.logging_utils import log_run
 from cai_lib.cmd_helpers import _strip_stored_plan_block
-from cai_lib.cmd_implement import _parse_decomposition
 from cai_lib.issues import create_issue, link_sub_issue, list_sub_issues
 
 
@@ -264,14 +259,9 @@ def handle_refine(issue: dict) -> int:
     # the agent may rewrite the body to incorporate exploration findings
     # and re-decide NextStep.
     user_message = _build_issue_block(issue)
-    current_depth = _issue_depth(issue)
-    if current_depth >= MAX_DECOMPOSITION_DEPTH:
-        user_message += (
-            f"\n\nIMPORTANT: This issue is at decomposition depth {current_depth} "
-            f"(max {MAX_DECOMPOSITION_DEPTH}). Do NOT produce a "
-            f"`## Multi-Step Decomposition` section. Refine this issue as a single "
-            f"unit of work."
-        )
+    # Decomposition depth awareness is handled by cai-split (the
+    # downstream scope evaluator). Refine now always refines a
+    # single unit of work regardless of depth.
     result = _run_claude_p(
         ["claude", "-p", "--agent", "cai-refine",
          "--dangerously-skip-permissions"],
@@ -311,38 +301,10 @@ def handle_refine(issue: dict) -> int:
                 duration=dur, result="already_structured", exit=0)
         return 0
 
-    # Check for multi-step decomposition. Parent issues take on
-    # :parent and drop out of the normal FSM; sub-issues become the
-    # new units of work at :raised.
-    if "## Multi-Step Decomposition" in stdout:
-        steps = _parse_decomposition(stdout)
-        if steps and len(steps) >= 2:
-            print(
-                f"[cai refine] #{issue_number} decomposed into "
-                f"{len(steps)} steps",
-                flush=True,
-            )
-            sub_nums = _create_sub_issues(steps, issue_number, title, depth=current_depth + 1)
-            _set_labels(
-                issue_number,
-                add=[LABEL_PARENT],
-                remove=[LABEL_REFINING],
-                log_prefix="cai refine",
-            )
-            dur = f"{int(time.monotonic() - t0)}s"
-            log_run(
-                "refine", repo=REPO, issue=issue_number,
-                duration=dur, result="decomposed",
-                sub_issues=len(sub_nums), steps=len(steps), exit=0,
-            )
-            return 0
-        # Malformed decomposition (< 2 steps) — fall through to normal
-        # refinement.
-        print(
-            f"[cai refine] #{issue_number} decomposition had "
-            f"{len(steps)} step(s); falling through to normal refinement",
-            flush=True,
-        )
+    # Scope decomposition (Multi-Step Decomposition) is now the
+    # responsibility of the downstream cai-split agent. If refine
+    # emits a decomposition block anyway we silently ignore it here
+    # — split re-evaluates from the refined body on the next cycle.
 
     # Parse the refined issue block.
     marker = "## Refined Issue"

--- a/cai_lib/actions/split.py
+++ b/cai_lib/actions/split.py
@@ -1,0 +1,301 @@
+"""cai_lib.actions.split — handler for IssueState.REFINED / SPLITTING.
+
+Invoked by the FSM dispatcher after ``cai-refine`` has written a
+``## Refined Issue`` block and advanced the issue to ``:refined``.
+Runs the ``cai-split`` agent to decide whether the refined scope
+fits in a single PR (atomic) or needs to be decomposed into
+ordered sub-issues.
+
+Three possible outcomes per run:
+
+- **Atomic + HIGH confidence** → fire ``splitting_to_planning`` so
+  ``cai-plan`` picks the issue up next cycle.
+- **Decompose + HIGH confidence** → create native GitHub sub-issues
+  for each step, label the parent ``auto-improve:parent``, and drop
+  the parent out of the normal drive path.
+- **Anything else** (LOW confidence, missing confidence line,
+  malformed decomposition, already at max depth, …) → divert to
+  ``:human-needed`` via ``splitting_to_human`` with a reasoned
+  comment so the admin can decide.
+
+State-machine entry is idempotent across resumes: a fresh entry at
+``IssueState.REFINED`` fires ``refined_to_splitting`` first; a
+resume at ``IssueState.SPLITTING`` skips the entry fire and
+re-invokes the agent.
+"""
+from __future__ import annotations
+
+import sys
+import time
+
+from cai_lib.config import (
+    REPO,
+    LABEL_REFINED,
+    LABEL_SPLITTING,
+    LABEL_PARENT,
+    LABEL_DEPTH_PREFIX,
+    MAX_DECOMPOSITION_DEPTH,
+)
+from cai_lib.fsm import (
+    fire_trigger,
+    get_issue_state,
+    IssueState,
+)
+from cai_lib.fsm_confidence import Confidence, parse_confidence
+from cai_lib.github import _build_issue_block, _set_labels
+from cai_lib.subprocess_utils import _run_claude_p
+from cai_lib.logging_utils import log_run
+from cai_lib.cmd_implement import _parse_decomposition
+from cai_lib.actions.refine import _create_sub_issues, _issue_depth
+
+
+_ATOMIC_MARKER = "VERDICT: ATOMIC"
+_UNCLEAR_MARKER = "VERDICT: UNCLEAR"
+_DECOMPOSITION_MARKER = "## Multi-Step Decomposition"
+
+
+def _extract_verdict_block(stdout: str, marker: str) -> str:
+    """Return the slice starting at *marker* (trimmed), or empty string."""
+    pos = stdout.find(marker)
+    if pos == -1:
+        return ""
+    return stdout[pos:].strip()
+
+
+def handle_split(issue: dict) -> int:
+    """Evaluate scope of a refined issue via cai-split.
+
+    Entry states:
+    - :class:`IssueState.REFINED` (fresh entry — apply
+      ``refined_to_splitting`` first).
+    - :class:`IssueState.SPLITTING` (resume after crash or partial
+      run — skip the entry fire).
+
+    Returns the exit code of the ``cai-split`` invocation, or 0 on
+    any clean routing decision (atomic, decomposed, or human-needed
+    divert).
+    """
+    t0 = time.monotonic()
+
+    issue_number = issue["number"]
+    title = issue["title"]
+    label_names = [l["name"] for l in issue.get("labels", [])]  # noqa: E741
+    state = get_issue_state(label_names)
+
+    print(f"[cai split] targeting #{issue_number}: {title}", flush=True)
+
+    # 1. Entry transition :refined → :splitting (only on fresh entry).
+    if state == IssueState.REFINED:
+        fire_trigger(
+            issue_number, "refined_to_splitting",
+            current_labels=label_names,
+            log_prefix="cai split",
+        )
+    elif state == IssueState.SPLITTING:
+        print(
+            f"[cai split] resuming #{issue_number} already at :splitting",
+            flush=True,
+        )
+    else:
+        print(
+            f"[cai split] #{issue_number} unexpected state {state!r} "
+            f"— aborting to prevent label corruption",
+            file=sys.stderr, flush=True,
+        )
+        log_run("split", repo=REPO, issue=issue_number,
+                result="unexpected_state", exit=1)
+        return 1
+
+    # 2. Build the agent input and invoke cai-split.
+    current_depth = _issue_depth(issue)
+    user_message = _build_issue_block(issue)
+    if current_depth >= MAX_DECOMPOSITION_DEPTH:
+        user_message += (
+            f"\n\nIMPORTANT: This issue is at decomposition depth "
+            f"{current_depth} (max {MAX_DECOMPOSITION_DEPTH}). Do NOT "
+            f"emit a `## Multi-Step Decomposition` block. Evaluate "
+            f"only ATOMIC vs. UNCLEAR for this run."
+        )
+
+    result = _run_claude_p(
+        ["claude", "-p", "--agent", "cai-split",
+         "--dangerously-skip-permissions"],
+        category="split",
+        agent="cai-split",
+        input=user_message,
+    )
+    print(result.stdout, flush=True)
+
+    if result.returncode != 0:
+        print(
+            f"[cai split] claude -p failed (exit {result.returncode}):\n"
+            f"{result.stderr}",
+            flush=True,
+        )
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run("split", repo=REPO, issue=issue_number,
+                duration=dur, result="agent_failed", exit=result.returncode)
+        return result.returncode
+
+    stdout = result.stdout
+    confidence = parse_confidence(stdout)
+
+    # 3. Route on the verdict. Decomposition takes priority over ATOMIC
+    # because a stray "VERDICT: ATOMIC" token inside a Step body must
+    # not beat an explicit decomposition block.
+    has_decomposition = _DECOMPOSITION_MARKER in stdout
+    has_atomic = _ATOMIC_MARKER in stdout
+    has_unclear = _UNCLEAR_MARKER in stdout
+
+    # 3a. Decomposition path.
+    if has_decomposition:
+        if current_depth >= MAX_DECOMPOSITION_DEPTH:
+            divert_reason = (
+                f"cai-split emitted a Multi-Step Decomposition but this "
+                f"issue is already at depth {current_depth} "
+                f"(max {MAX_DECOMPOSITION_DEPTH}). Decomposing further "
+                f"would exceed the allowed depth — the admin should "
+                f"either re-scope the parent or approve this as a "
+                f"single unit of work."
+            )
+            fire_trigger(
+                issue_number, "splitting_to_human",
+                current_labels=[LABEL_SPLITTING],
+                log_prefix="cai split",
+                divert_reason=divert_reason,
+            )
+            dur = f"{int(time.monotonic() - t0)}s"
+            log_run("split", repo=REPO, issue=issue_number,
+                    duration=dur, result="decompose_over_depth", exit=0)
+            return 0
+
+        if confidence != Confidence.HIGH:
+            divert_reason = (
+                f"cai-split emitted a Multi-Step Decomposition with "
+                f"confidence {confidence.name if confidence else 'MISSING'} "
+                f"(HIGH required). Admin review needed before creating "
+                f"sub-issues."
+            )
+            fire_trigger(
+                issue_number, "splitting_to_human",
+                current_labels=[LABEL_SPLITTING],
+                log_prefix="cai split",
+                divert_reason=divert_reason,
+            )
+            dur = f"{int(time.monotonic() - t0)}s"
+            log_run("split", repo=REPO, issue=issue_number,
+                    duration=dur, result="decompose_low_confidence",
+                    confidence=confidence.name if confidence else "MISSING",
+                    exit=0)
+            return 0
+
+        steps = _parse_decomposition(stdout)
+        if not steps or len(steps) < 2:
+            divert_reason = (
+                f"cai-split emitted a Multi-Step Decomposition block "
+                f"but parsing yielded {len(steps)} step(s) — a valid "
+                f"decomposition requires at least 2 steps. The agent "
+                f"output may be malformed."
+            )
+            fire_trigger(
+                issue_number, "splitting_to_human",
+                current_labels=[LABEL_SPLITTING],
+                log_prefix="cai split",
+                divert_reason=divert_reason,
+            )
+            dur = f"{int(time.monotonic() - t0)}s"
+            log_run("split", repo=REPO, issue=issue_number,
+                    duration=dur, result="decompose_malformed",
+                    steps=len(steps), exit=0)
+            return 0
+
+        # HIGH + well-formed decomposition — create sub-issues and
+        # transition the parent out of the drive path.
+        print(
+            f"[cai split] #{issue_number} decomposed into "
+            f"{len(steps)} steps",
+            flush=True,
+        )
+        sub_nums = _create_sub_issues(
+            steps, issue_number, title, depth=current_depth + 1,
+        )
+        _set_labels(
+            issue_number,
+            add=[LABEL_PARENT],
+            remove=[LABEL_SPLITTING],
+            log_prefix="cai split",
+        )
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run(
+            "split", repo=REPO, issue=issue_number,
+            duration=dur, result="decomposed",
+            sub_issues=len(sub_nums), steps=len(steps), exit=0,
+        )
+        return 0
+
+    # 3b. Atomic path. Require HIGH confidence; anything else diverts.
+    if has_atomic:
+        if confidence != Confidence.HIGH:
+            divert_reason = (
+                f"cai-split returned ATOMIC with confidence "
+                f"{confidence.name if confidence else 'MISSING'} "
+                f"(HIGH required). Admin review needed to approve or "
+                f"re-split at narrower scope."
+            )
+            fire_trigger(
+                issue_number, "splitting_to_human",
+                current_labels=[LABEL_SPLITTING],
+                log_prefix="cai split",
+                divert_reason=divert_reason,
+            )
+            dur = f"{int(time.monotonic() - t0)}s"
+            log_run("split", repo=REPO, issue=issue_number,
+                    duration=dur, result="atomic_low_confidence",
+                    confidence=confidence.name if confidence else "MISSING",
+                    exit=0)
+            return 0
+
+        fire_trigger(
+            issue_number, "splitting_to_planning",
+            current_labels=[LABEL_SPLITTING],
+            log_prefix="cai split",
+        )
+        dur = f"{int(time.monotonic() - t0)}s"
+        print(
+            f"[cai split] #{issue_number} verdict ATOMIC, advancing "
+            f":splitting → :planning in {dur}",
+            flush=True,
+        )
+        log_run("split", repo=REPO, issue=issue_number,
+                duration=dur, result="atomic", exit=0)
+        return 0
+
+    # 3c. Unclear verdict or missing marker — divert to human.
+    if has_unclear:
+        verdict_block = _extract_verdict_block(stdout, _UNCLEAR_MARKER)
+        divert_reason = (
+            "cai-split returned VERDICT: UNCLEAR — the agent was not "
+            "confident enough to decide atomic vs. decompose. Admin "
+            "input needed.\n\n"
+            f"{verdict_block}"
+        )
+    else:
+        divert_reason = (
+            "cai-split output did not contain a recognised verdict "
+            "marker (expected `## Multi-Step Decomposition`, "
+            "`VERDICT: ATOMIC`, or `VERDICT: UNCLEAR`). Agent output "
+            "appears malformed."
+        )
+
+    fire_trigger(
+        issue_number, "splitting_to_human",
+        current_labels=[LABEL_SPLITTING],
+        log_prefix="cai split",
+        divert_reason=divert_reason,
+    )
+    dur = f"{int(time.monotonic() - t0)}s"
+    log_run("split", repo=REPO, issue=issue_number,
+            duration=dur,
+            result="unclear" if has_unclear else "no_marker",
+            exit=0)
+    return 0

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -142,6 +142,7 @@ LABEL_PLAN_APPROVED = "auto-improve:plan-approved"
 # corresponding agent runs. Confidence gates on their exit transitions
 # divert to :human-needed instead of the nominal target.
 LABEL_REFINING = "auto-improve:refining"
+LABEL_SPLITTING = "auto-improve:splitting"
 LABEL_PLANNING = "auto-improve:planning"
 LABEL_APPLYING = "auto-improve:applying"
 LABEL_APPLIED  = "auto-improve:applied"

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -148,6 +148,7 @@ def _build_issue_registry() -> dict[IssueState, IssueHandler]:
     from cai_lib.actions.triage    import handle_triage
     from cai_lib.actions.refine    import handle_refine
     from cai_lib.actions.explore   import handle_explore
+    from cai_lib.actions.split     import handle_split
     from cai_lib.actions.plan      import handle_plan, handle_plan_gate
     from cai_lib.actions.implement import handle_implement
     from cai_lib.actions.maintain  import handle_maintain, handle_applied
@@ -160,7 +161,8 @@ def _build_issue_registry() -> dict[IssueState, IssueHandler]:
         IssueState.TRIAGING:          handle_triage,      # resume
         IssueState.REFINING:          handle_refine,
         IssueState.NEEDS_EXPLORATION: handle_explore,
-        IssueState.REFINED:           handle_plan,
+        IssueState.REFINED:           handle_split,
+        IssueState.SPLITTING:         handle_split,       # resume
         IssueState.PLANNING:          handle_plan,        # resume
         IssueState.PLANNED:           handle_plan_gate,
         IssueState.PLAN_APPROVED:     handle_implement,

--- a/cai_lib/fsm_states.py
+++ b/cai_lib/fsm_states.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 from enum import Enum
 
 from cai_lib.config import (
-    LABEL_RAISED, LABEL_REFINING, LABEL_REFINED, LABEL_PLANNING,
-    LABEL_PLANNED, LABEL_PLAN_APPROVED,
+    LABEL_RAISED, LABEL_REFINING, LABEL_REFINED, LABEL_SPLITTING,
+    LABEL_PLANNING, LABEL_PLANNED, LABEL_PLAN_APPROVED,
     LABEL_IN_PROGRESS, LABEL_PR_OPEN, LABEL_MERGED, LABEL_SOLVED,
     LABEL_NEEDS_EXPLORATION, LABEL_HUMAN_NEEDED, LABEL_PR_HUMAN_NEEDED,
     LABEL_TRIAGING, LABEL_APPLYING, LABEL_APPLIED,
@@ -26,7 +26,8 @@ class IssueState(str, Enum):
     APPLYING          = LABEL_APPLYING     # cai-maintain is actively applying ops
     APPLIED           = LABEL_APPLIED      # ops applied; awaiting verification
     REFINING          = LABEL_REFINING     # cai-refine is actively running
-    REFINED           = LABEL_REFINED      # refine done, awaiting plan pickup
+    REFINED           = LABEL_REFINED      # refine done, awaiting split pickup
+    SPLITTING         = LABEL_SPLITTING    # cai-split is actively running (scope evaluation)
     PLANNING          = LABEL_PLANNING     # cai-plan is actively running
     PLANNED           = LABEL_PLANNED      # plan stored, awaiting approval
     PLAN_APPROVED     = LABEL_PLAN_APPROVED

--- a/cai_lib/fsm_transitions.py
+++ b/cai_lib/fsm_transitions.py
@@ -16,8 +16,8 @@ from transitions import Machine, MachineError
 from transitions.extensions import GraphMachine
 
 from cai_lib.config import (
-    LABEL_RAISED, LABEL_REFINING, LABEL_REFINED, LABEL_PLANNING,
-    LABEL_PLANNED, LABEL_PLAN_APPROVED,
+    LABEL_RAISED, LABEL_REFINING, LABEL_REFINED, LABEL_SPLITTING,
+    LABEL_PLANNING, LABEL_PLANNED, LABEL_PLAN_APPROVED,
     LABEL_IN_PROGRESS, LABEL_PR_OPEN, LABEL_MERGED, LABEL_SOLVED,
     LABEL_NEEDS_EXPLORATION, LABEL_HUMAN_NEEDED, LABEL_PR_HUMAN_NEEDED,
     LABEL_TRIAGING, LABEL_APPLYING, LABEL_APPLIED,
@@ -126,12 +126,26 @@ ISSUE_TRANSITIONS: list[Transition] = [
     Transition("exploration_to_refining",    IssueState.NEEDS_EXPLORATION, IssueState.REFINING,
                labels_remove=[LABEL_NEEDS_EXPLORATION], labels_add=[LABEL_REFINING]),
 
-    # REFINED → PLANNING is the auto-advance: whoever drives the
-    # pipeline (cmd_plan / unified driver) picks up a :refined issue
-    # and immediately moves it to :planning when it starts the plan
-    # agent. There is no human gate here.
+    # REFINED → SPLITTING is the auto-advance: the dispatcher picks up
+    # a :refined issue and hands it to cai-split for scope evaluation
+    # before any plan work. The legacy refined_to_planning edge is kept
+    # for backwards compatibility with resume paths but is no longer
+    # fired by the unified driver.
+    Transition("refined_to_splitting",       IssueState.REFINED,           IssueState.SPLITTING,
+               labels_remove=[LABEL_REFINED],           labels_add=[LABEL_SPLITTING]),
     Transition("refined_to_planning",        IssueState.REFINED,           IssueState.PLANNING,
                labels_remove=[LABEL_REFINED],           labels_add=[LABEL_PLANNING]),
+
+    # SPLITTING is transient — cai-split is evaluating whether the
+    # refined scope is atomic (single PR) or needs multi-step
+    # decomposition. Atomic + HIGH → PLANNING (cai-plan runs next).
+    # Decompose + HIGH is handled by handle_split directly via
+    # _set_labels(LABEL_PARENT) — no state transition for that branch.
+    # LOW confidence or malformed output diverts to HUMAN_NEEDED.
+    Transition("splitting_to_planning",      IssueState.SPLITTING,         IssueState.PLANNING,
+               labels_remove=[LABEL_SPLITTING],         labels_add=[LABEL_PLANNING]),
+    Transition("splitting_to_human",         IssueState.SPLITTING,         IssueState.HUMAN_NEEDED,
+               labels_remove=[LABEL_SPLITTING],         labels_add=[LABEL_HUMAN_NEEDED]),
 
     # PLANNING is transient — cai-plan is running. Same confidence gate
     # pattern as refining.
@@ -261,6 +275,12 @@ ISSUE_TRANSITIONS: list[Transition] = [
     Transition("human_to_refining",          IssueState.HUMAN_NEEDED,      IssueState.REFINING,
                labels_remove=[LABEL_HUMAN_NEEDED, LABEL_PLAN_NEEDS_REVIEW],
                labels_add=[LABEL_REFINING]),
+    # Admin wants cai-split to re-evaluate scope without re-running
+    # cai-refine (e.g. they've manually narrowed the refined body and
+    # want a fresh atomic/decompose verdict).
+    Transition("human_to_splitting",         IssueState.HUMAN_NEEDED,      IssueState.SPLITTING,
+               labels_remove=[LABEL_HUMAN_NEEDED, LABEL_PLAN_NEEDS_REVIEW],
+               labels_add=[LABEL_SPLITTING]),
     # Admin greenlights the already-stored plan — jump past the
     # planned→approved gate.
     Transition("human_to_plan_approved",     IssueState.HUMAN_NEEDED,      IssueState.PLAN_APPROVED,

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -41,6 +41,8 @@ stateDiagram-v2
   Class REFINED s_default
   state "NEEDS_EXPLORATION" as NEEDS_EXPLORATION
   Class NEEDS_EXPLORATION s_default
+  state "SPLITTING" as SPLITTING
+  Class SPLITTING s_default
   state "PLANNING" as PLANNING
   Class PLANNING s_default
   state "PLANNED" as PLANNED
@@ -66,7 +68,10 @@ stateDiagram-v2
   REFINING --> NEEDS_EXPLORATION: refining_to_exploration [≥HIGH]
   REFINING --> HUMAN_NEEDED: refining_to_human [≥HIGH]
   NEEDS_EXPLORATION --> REFINING: exploration_to_refining [≥HIGH]
+  REFINED --> SPLITTING: refined_to_splitting [≥HIGH]
   REFINED --> PLANNING: refined_to_planning [≥HIGH]
+  SPLITTING --> PLANNING: splitting_to_planning [≥HIGH]
+  SPLITTING --> HUMAN_NEEDED: splitting_to_human [≥HIGH]
   PLANNING --> PLANNED: planning_to_planned [≥HIGH]
   PLANNING --> HUMAN_NEEDED: planning_to_human [≥HIGH]
   PLANNED --> PLAN_APPROVED: planned_to_plan_approved [≥HIGH] | planned_to_plan_approved_mitigated [≥MEDIUM] | planned_to_plan_approved_docs_only [≥MEDIUM] | planned_to_plan_approved_approvable [≥MEDIUM]
@@ -82,6 +87,7 @@ stateDiagram-v2
   MERGED --> SOLVED: merged_to_solved [≥HIGH]
   HUMAN_NEEDED --> RAISED: human_to_raised [≥HIGH]
   HUMAN_NEEDED --> REFINING: human_to_refining [≥HIGH]
+  HUMAN_NEEDED --> SPLITTING: human_to_splitting [≥HIGH]
   HUMAN_NEEDED --> PLAN_APPROVED: human_to_plan_approved [≥HIGH]
   HUMAN_NEEDED --> NEEDS_EXPLORATION: human_to_exploration [≥HIGH]
   HUMAN_NEEDED --> SOLVED: human_to_solved [≥HIGH]

--- a/docs/modules/actions.md
+++ b/docs/modules/actions.md
@@ -16,8 +16,16 @@ Issue-side handlers (take an issue dict):
   into REFINE / PLAN_APPROVE / APPLY / HUMAN; runs the dup-check
   pre-filter first.
 - [`refine.py`](../../cai_lib/actions/refine.py) —
-  `handle_refine`: runs `cai-refine` and, for multi-step
-  decompositions, creates sub-issues via `_create_sub_issues`.
+  `handle_refine`: runs `cai-refine` (opus) to rewrite a raised
+  issue into a structured `## Refined Issue` block. Scope
+  decomposition is NOT handled here — the downstream
+  `handle_split` owns that decision.
+- [`split.py`](../../cai_lib/actions/split.py) —
+  `handle_split`: runs `cai-split` (opus) on a `:refined` or
+  `:splitting` issue; fires `splitting_to_planning` on ATOMIC +
+  HIGH confidence, creates sub-issues via `_create_sub_issues`
+  on DECOMPOSE + HIGH confidence, and diverts to `:human-needed`
+  on LOW confidence / malformed output / depth-gate violations.
 - [`plan.py`](../../cai_lib/actions/plan.py) — `handle_plan`
   (dual-planner + `cai-select` pipeline) and `handle_plan_gate`
   (confidence-based gate into PLAN_APPROVED / HUMAN).

--- a/docs/modules/agents-lifecycle.md
+++ b/docs/modules/agents-lifecycle.md
@@ -12,7 +12,13 @@ issues move through their state machine.
   HUMAN). No tools; full issue body arrives in the user message.
 - [`.claude/agents/lifecycle/cai-refine.md`](../../.claude/agents/lifecycle/cai-refine.md)
   — opus issue rewriter; emits structured plans with problem,
-  steps, verification, scope guardrails.
+  steps, verification, scope guardrails. Scope decomposition is
+  NOT refine's job — `cai-split` handles that downstream.
+- [`.claude/agents/lifecycle/cai-split.md`](../../.claude/agents/lifecycle/cai-split.md)
+  — opus scope evaluator; runs after refine and decides whether
+  the refined issue ships as one PR (ATOMIC) or must be broken
+  into ordered sub-issues (emits a `## Multi-Step Decomposition`
+  block). LOW confidence diverts to `:human-needed`.
 - [`.claude/agents/lifecycle/cai-explore.md`](../../.claude/agents/lifecycle/cai-explore.md)
   — sonnet exploration / benchmarking agent with Bash.
 - [`.claude/agents/lifecycle/cai-propose.md`](../../.claude/agents/lifecycle/cai-propose.md)
@@ -33,7 +39,8 @@ issues move through their state machine.
 
 ## Inter-module dependencies
 - Invoked by **actions** — `handle_triage` (cai-triage),
-  `handle_refine` (cai-refine), `handle_explore` (cai-explore).
+  `handle_refine` (cai-refine), `handle_split` (cai-split),
+  `handle_explore` (cai-explore).
 - Invoked by **cli** — `cmd_propose` / `cmd_propose_review`
   (weekly creative cycle); `cmd_rescue` (cai-rescue); `cmd_unblock`
   (cai-unblock); `dup_check.check_duplicate_or_resolved`
@@ -48,9 +55,11 @@ issues move through their state machine.
 - **Cost sensitivity varies widely.** `cai-triage` and
   `cai-dup-check` are the cheapest in the pipeline (haiku, inline,
   no tools) and run on every raised issue — latency and cost
-  must stay low. `cai-refine`, `cai-propose`,
+  must stay low. `cai-refine`, `cai-split`, `cai-propose`,
   `cai-propose-review`, `cai-rescue` are opus and therefore
-  expensive per invocation but rare.
+  expensive per invocation but rare. Every issue that clears
+  triage hits both `cai-refine` and `cai-split` — two opus
+  passes in sequence — before any plan work begins.
 - **FSM invariant.** Triage and dup-check emit a verdict string
   the Python caller parses; introducing new verdict values
   requires matched updates to the parser

--- a/docs/modules/fsm.md
+++ b/docs/modules/fsm.md
@@ -9,11 +9,16 @@ import from `cai_lib.fsm` rather than the split modules directly.
 
 ## Key entry points
 - [`cai_lib/fsm_states.py`](../../cai_lib/fsm_states.py) —
-  `IssueState` (RAISED, REFINED, PLANNED, IN_PROGRESS, …) and
-  `PRState` (OPEN, REVIEWING_CODE, REVIEWING_DOCS, APPROVED,
-  CI_FAILING, REVISION_PENDING, REBASING, …). Enum values are the
-  GitHub label suffixes, so `str(state)` round-trips through
-  labels.
+  `IssueState` (RAISED, REFINED, SPLITTING, PLANNED, IN_PROGRESS,
+  …) and `PRState` (OPEN, REVIEWING_CODE, REVIEWING_DOCS,
+  APPROVED, CI_FAILING, REVISION_PENDING, REBASING, …). Enum
+  values are the GitHub label suffixes, so `str(state)`
+  round-trips through labels. `SPLITTING` sits between `REFINED`
+  and `PLANNING`: after refine writes a structured plan, the
+  dispatcher hands the issue to `cai-split` for atomic-vs-decompose
+  evaluation; atomic verdicts advance to `PLANNING` (cai-plan),
+  decompose verdicts create sub-issues and park the parent at
+  `:parent`, LOW confidence diverts to `:human-needed`.
 - [`cai_lib/fsm_transitions.py`](../../cai_lib/fsm_transitions.py) —
   `Transition` dataclass; `ISSUE_TRANSITIONS` and `PR_TRANSITIONS`
   tables; `get_issue_state`, `get_pr_state`, `find_transition`,

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -28,6 +28,7 @@ class TestActionableStateSets(unittest.TestCase):
             IssueState.REFINING,
             IssueState.NEEDS_EXPLORATION,
             IssueState.REFINED,
+            IssueState.SPLITTING,
             IssueState.PLANNING,
             IssueState.PLANNED,
             IssueState.PLAN_APPROVED,

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -498,22 +498,33 @@ class TestTransientStatesShape(unittest.TestCase):
         }
         self.assertEqual(dests, {IssueState.PLAN_APPROVED, IssueState.HUMAN_NEEDED})
 
-    def test_refined_only_auto_advances(self):
-        """REFINED is a waypoint — the only next stop is PLANNING."""
+    def test_refined_advances_to_splitting_or_planning(self):
+        """REFINED is a waypoint — next stop is either SPLITTING
+        (normal drive via cai-split) or PLANNING (legacy compat)."""
         dests = {
             t.to_state
             for t in ISSUE_TRANSITIONS
             if t.from_state == IssueState.REFINED
         }
-        self.assertEqual(dests, {IssueState.PLANNING})
+        self.assertEqual(dests, {IssueState.SPLITTING, IssueState.PLANNING})
+
+    def test_splitting_routes_to_planning_or_human(self):
+        """SPLITTING exits only to PLANNING (atomic) or HUMAN_NEEDED (LOW)."""
+        dests = {
+            t.to_state
+            for t in ISSUE_TRANSITIONS
+            if t.from_state == IssueState.SPLITTING
+        }
+        self.assertEqual(dests, {IssueState.PLANNING, IssueState.HUMAN_NEEDED})
 
     def test_no_refine_to_in_progress_shortcut(self):
         """No transition may bypass PLANNED → PLAN_APPROVED en route to IN_PROGRESS."""
         forbidden_pairs = [
-            (IssueState.REFINED,  IssueState.IN_PROGRESS),
-            (IssueState.REFINING, IssueState.IN_PROGRESS),
-            (IssueState.PLANNING, IssueState.IN_PROGRESS),
-            (IssueState.PLANNED,  IssueState.IN_PROGRESS),
+            (IssueState.REFINED,   IssueState.IN_PROGRESS),
+            (IssueState.REFINING,  IssueState.IN_PROGRESS),
+            (IssueState.SPLITTING, IssueState.IN_PROGRESS),
+            (IssueState.PLANNING,  IssueState.IN_PROGRESS),
+            (IssueState.PLANNED,   IssueState.IN_PROGRESS),
         ]
         for f, to in forbidden_pairs:
             self.assertFalse(

--- a/tests/test_multistep.py
+++ b/tests/test_multistep.py
@@ -166,49 +166,42 @@ class TestCreateSubIssuesDepth(unittest.TestCase):
         self.assertIn("depth:1", labels)
 
 
-class TestDepthGate(unittest.TestCase):
-    @patch("cai_lib.actions.refine.log_run")
-    @patch("cai_lib.actions.refine._run_claude_p")
-    @patch("cai_lib.actions.refine.fire_trigger")
-    @patch("cai_lib.actions.refine._build_issue_block", return_value="issue text")
+class TestSplitDepthGate(unittest.TestCase):
+    """At max depth, cai-split's user_message instructs the agent not to
+    emit a decomposition block. Decomposition responsibility moved from
+    cai-refine to cai-split in the refine-split-architecture change.
+    """
+
+    @patch("cai_lib.actions.split.log_run")
+    @patch("cai_lib.actions.split._run_claude_p")
+    @patch("cai_lib.actions.split.fire_trigger")
+    @patch("cai_lib.actions.split._build_issue_block", return_value="issue text")
     def test_max_depth_injects_no_decompose(
         self, mock_build, mock_transition, mock_claude, mock_log_run,
     ):
-        """At max depth, user_message should instruct agent not to decompose.
-
-        Also patches ``cai_lib.actions.refine.log_run`` (issue #1109) so the
-        test does not append a real ``[refine] issue=5 duration=0s
-        result=refined exit=0`` entry to ``/var/log/cai/cai.log`` every time
-        ``cai implement``'s in-clone regression gate
-        (``cai_lib/actions/implement.py:1406``) runs
-        ``python -m unittest discover -s tests -v``.
-        """
         mock_claude.return_value = MagicMock(
-            returncode=0, stdout="## Refined Issue\nContent", stderr=""
+            returncode=0,
+            stdout="## Split Verdict\n\nVERDICT: ATOMIC\n\nConfidence: HIGH\n",
+            stderr="",
         )
-        with patch("cai_lib.actions.refine._run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stderr="")
-            with patch("cai_lib.actions.refine.MAX_DECOMPOSITION_DEPTH", 2):
-                issue = {
-                    "number": 5, "title": "Test",
-                    "labels": [{"name": "depth:2"}],
-                    "body": "test body",
-                }
-                handle_refine(issue)
+        with patch("cai_lib.actions.split.MAX_DECOMPOSITION_DEPTH", 2):
+            from cai_lib.actions.split import handle_split
+            issue = {
+                "number": 5, "title": "Test",
+                "labels": [{"name": "depth:2"}, {"name": "auto-improve:refined"}],
+                "body": "test body",
+            }
+            handle_split(issue)
         call_kwargs = mock_claude.call_args
         input_msg = call_kwargs.kwargs.get("input") or call_kwargs[1].get("input", "")
-        self.assertIn("Do NOT produce", input_msg)
-        # Regression guard: if a future refactor removes the log_run patch,
-        # this assertion fires before the real logger can write to
-        # /var/log/cai/cai.log. handle_refine's success path always ends in
-        # a log_run call, so the mock must see at least one invocation.
+        self.assertIn("Do NOT", input_msg)
+        self.assertIn("Multi-Step Decomposition", input_msg)
+        # Regression guard: handle_split's success path always ends in a
+        # log_run call, so the mock must see at least one invocation.
         mock_log_run.assert_called()
-        # All recorded calls must carry category="refine" and issue=5 so an
-        # accidental bypass (e.g. a real log_run leaking through a partial
-        # patch) is visible.
         for call in mock_log_run.call_args_list:
             args, kwargs = call
-            self.assertEqual(args[0], "refine")
+            self.assertEqual(args[0], "split")
             self.assertEqual(kwargs.get("issue"), 5)
 
 

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,0 +1,284 @@
+"""Tests for cai_lib.actions.split — the SPLITTING-state handler.
+
+Covers the three verdict branches:
+
+- Atomic + HIGH confidence → fires ``splitting_to_planning``.
+- Decompose + HIGH confidence → creates sub-issues, labels parent
+  ``auto-improve:parent``.
+- Anything else (LOW confidence, missing marker, malformed
+  decomposition, over-depth decomposition) → fires
+  ``splitting_to_human`` with a reasoned divert.
+
+Plus entry-transition handling: fresh :refined entry fires
+``refined_to_splitting``; :splitting resume does not.
+"""
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.actions.split import handle_split
+
+
+def _refined_issue(number: int = 1, depth: int = 0) -> dict:
+    labels = [
+        {"name": "auto-improve"},
+        {"name": "auto-improve:refined"},
+        {"name": f"depth:{depth}"},
+    ]
+    return {
+        "number": number,
+        "title": "Test issue",
+        "body": "## Refined Issue\n\n### Description\nSomething.",
+        "labels": labels,
+    }
+
+
+def _splitting_issue(number: int = 1, depth: int = 0) -> dict:
+    labels = [
+        {"name": "auto-improve"},
+        {"name": "auto-improve:splitting"},
+        {"name": f"depth:{depth}"},
+    ]
+    return {
+        "number": number,
+        "title": "Test issue",
+        "body": "## Refined Issue\n\n### Description\nSomething.",
+        "labels": labels,
+    }
+
+
+class TestSplitEntryTransition(unittest.TestCase):
+    """The entry fire refined_to_splitting must happen only on fresh entry."""
+
+    @patch("cai_lib.actions.split.log_run")
+    @patch("cai_lib.actions.split._run_claude_p")
+    @patch("cai_lib.actions.split.fire_trigger")
+    @patch("cai_lib.actions.split._build_issue_block", return_value="issue text")
+    def test_refined_entry_fires_refined_to_splitting(
+        self, mock_build, mock_fire, mock_claude, mock_log_run,
+    ):
+        mock_claude.return_value = MagicMock(
+            returncode=0,
+            stdout="## Split Verdict\n\nVERDICT: ATOMIC\n\nConfidence: HIGH\n",
+            stderr="",
+        )
+        handle_split(_refined_issue())
+        fired = [c.args[1] for c in mock_fire.call_args_list]
+        self.assertIn("refined_to_splitting", fired)
+
+    @patch("cai_lib.actions.split.log_run")
+    @patch("cai_lib.actions.split._run_claude_p")
+    @patch("cai_lib.actions.split.fire_trigger")
+    @patch("cai_lib.actions.split._build_issue_block", return_value="issue text")
+    def test_splitting_resume_skips_entry_fire(
+        self, mock_build, mock_fire, mock_claude, mock_log_run,
+    ):
+        mock_claude.return_value = MagicMock(
+            returncode=0,
+            stdout="## Split Verdict\n\nVERDICT: ATOMIC\n\nConfidence: HIGH\n",
+            stderr="",
+        )
+        handle_split(_splitting_issue())
+        fired = [c.args[1] for c in mock_fire.call_args_list]
+        self.assertNotIn("refined_to_splitting", fired)
+
+
+class TestSplitAtomicVerdict(unittest.TestCase):
+
+    @patch("cai_lib.actions.split.log_run")
+    @patch("cai_lib.actions.split._run_claude_p")
+    @patch("cai_lib.actions.split.fire_trigger")
+    @patch("cai_lib.actions.split._build_issue_block", return_value="issue text")
+    def test_atomic_high_confidence_fires_splitting_to_planning(
+        self, mock_build, mock_fire, mock_claude, mock_log_run,
+    ):
+        mock_claude.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "## Split Verdict\n\n"
+                "VERDICT: ATOMIC\n\n"
+                "### Reasoning\nFits in one PR.\n\n"
+                "Confidence: HIGH\n"
+            ),
+            stderr="",
+        )
+        self.assertEqual(handle_split(_refined_issue()), 0)
+        fired = [c.args[1] for c in mock_fire.call_args_list]
+        self.assertIn("splitting_to_planning", fired)
+        self.assertNotIn("splitting_to_human", fired)
+
+    @patch("cai_lib.actions.split.log_run")
+    @patch("cai_lib.actions.split._run_claude_p")
+    @patch("cai_lib.actions.split.fire_trigger")
+    @patch("cai_lib.actions.split._build_issue_block", return_value="issue text")
+    def test_atomic_low_confidence_diverts_to_human(
+        self, mock_build, mock_fire, mock_claude, mock_log_run,
+    ):
+        mock_claude.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "## Split Verdict\n\n"
+                "VERDICT: ATOMIC\n\n"
+                "Confidence: LOW\n"
+            ),
+            stderr="",
+        )
+        handle_split(_refined_issue())
+        fired = [c.args[1] for c in mock_fire.call_args_list]
+        self.assertIn("splitting_to_human", fired)
+        self.assertNotIn("splitting_to_planning", fired)
+
+
+class TestSplitDecomposeVerdict(unittest.TestCase):
+
+    @patch("cai_lib.actions.split.log_run")
+    @patch("cai_lib.actions.split._set_labels")
+    @patch("cai_lib.actions.split._create_sub_issues", return_value=[10, 11])
+    @patch("cai_lib.actions.split._run_claude_p")
+    @patch("cai_lib.actions.split.fire_trigger")
+    @patch("cai_lib.actions.split._build_issue_block", return_value="issue text")
+    def test_decompose_high_confidence_creates_sub_issues(
+        self, mock_build, mock_fire, mock_claude, mock_create_subs,
+        mock_set_labels, mock_log_run,
+    ):
+        mock_claude.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "## Multi-Step Decomposition\n\n"
+                "### Step 1: First step\n"
+                "Body one.\n\n"
+                "### Step 2: Second step\n"
+                "Body two.\n\n"
+                "Confidence: HIGH\n"
+            ),
+            stderr="",
+        )
+        handle_split(_refined_issue(depth=0))
+        mock_create_subs.assert_called_once()
+        # _set_labels must add auto-improve:parent and remove :splitting.
+        call_kwargs = mock_set_labels.call_args.kwargs
+        self.assertIn("auto-improve:parent", call_kwargs["add"])
+        self.assertIn("auto-improve:splitting", call_kwargs["remove"])
+
+    @patch("cai_lib.actions.split.log_run")
+    @patch("cai_lib.actions.split._set_labels")
+    @patch("cai_lib.actions.split._create_sub_issues")
+    @patch("cai_lib.actions.split._run_claude_p")
+    @patch("cai_lib.actions.split.fire_trigger")
+    @patch("cai_lib.actions.split._build_issue_block", return_value="issue text")
+    def test_decompose_low_confidence_diverts_to_human(
+        self, mock_build, mock_fire, mock_claude, mock_create_subs,
+        mock_set_labels, mock_log_run,
+    ):
+        mock_claude.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "## Multi-Step Decomposition\n\n"
+                "### Step 1: First\nA.\n\n"
+                "### Step 2: Second\nB.\n\n"
+                "Confidence: LOW\n"
+            ),
+            stderr="",
+        )
+        handle_split(_refined_issue())
+        mock_create_subs.assert_not_called()
+        mock_set_labels.assert_not_called()
+        fired = [c.args[1] for c in mock_fire.call_args_list]
+        self.assertIn("splitting_to_human", fired)
+
+    @patch("cai_lib.actions.split.log_run")
+    @patch("cai_lib.actions.split._set_labels")
+    @patch("cai_lib.actions.split._create_sub_issues")
+    @patch("cai_lib.actions.split._run_claude_p")
+    @patch("cai_lib.actions.split.fire_trigger")
+    @patch("cai_lib.actions.split._build_issue_block", return_value="issue text")
+    def test_decompose_over_max_depth_diverts_to_human(
+        self, mock_build, mock_fire, mock_claude, mock_create_subs,
+        mock_set_labels, mock_log_run,
+    ):
+        mock_claude.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "## Multi-Step Decomposition\n\n"
+                "### Step 1: First\nA.\n\n"
+                "### Step 2: Second\nB.\n\n"
+                "Confidence: HIGH\n"
+            ),
+            stderr="",
+        )
+        with patch("cai_lib.actions.split.MAX_DECOMPOSITION_DEPTH", 1):
+            handle_split(_refined_issue(depth=1))
+        mock_create_subs.assert_not_called()
+        fired = [c.args[1] for c in mock_fire.call_args_list]
+        self.assertIn("splitting_to_human", fired)
+
+    @patch("cai_lib.actions.split.log_run")
+    @patch("cai_lib.actions.split._set_labels")
+    @patch("cai_lib.actions.split._create_sub_issues")
+    @patch("cai_lib.actions.split._run_claude_p")
+    @patch("cai_lib.actions.split.fire_trigger")
+    @patch("cai_lib.actions.split._build_issue_block", return_value="issue text")
+    def test_decompose_single_step_is_malformed(
+        self, mock_build, mock_fire, mock_claude, mock_create_subs,
+        mock_set_labels, mock_log_run,
+    ):
+        mock_claude.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "## Multi-Step Decomposition\n\n"
+                "### Step 1: Only step\nA.\n\n"
+                "Confidence: HIGH\n"
+            ),
+            stderr="",
+        )
+        handle_split(_refined_issue())
+        mock_create_subs.assert_not_called()
+        fired = [c.args[1] for c in mock_fire.call_args_list]
+        self.assertIn("splitting_to_human", fired)
+
+
+class TestSplitUnclearAndMalformed(unittest.TestCase):
+
+    @patch("cai_lib.actions.split.log_run")
+    @patch("cai_lib.actions.split._run_claude_p")
+    @patch("cai_lib.actions.split.fire_trigger")
+    @patch("cai_lib.actions.split._build_issue_block", return_value="issue text")
+    def test_unclear_verdict_diverts_to_human(
+        self, mock_build, mock_fire, mock_claude, mock_log_run,
+    ):
+        mock_claude.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "## Split Verdict\n\n"
+                "VERDICT: UNCLEAR\n\n"
+                "### Reasoning\nBoundary case.\n\n"
+                "Confidence: LOW\n"
+            ),
+            stderr="",
+        )
+        handle_split(_refined_issue())
+        fired = [c.args[1] for c in mock_fire.call_args_list]
+        self.assertIn("splitting_to_human", fired)
+
+    @patch("cai_lib.actions.split.log_run")
+    @patch("cai_lib.actions.split._run_claude_p")
+    @patch("cai_lib.actions.split.fire_trigger")
+    @patch("cai_lib.actions.split._build_issue_block", return_value="issue text")
+    def test_no_marker_diverts_to_human(
+        self, mock_build, mock_fire, mock_claude, mock_log_run,
+    ):
+        mock_claude.return_value = MagicMock(
+            returncode=0,
+            stdout="nothing structured here",
+            stderr="",
+        )
+        handle_split(_refined_issue())
+        fired = [c.args[1] for c in mock_fire.call_args_list]
+        self.assertIn("splitting_to_human", fired)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Introduces a dedicated **`cai-split`** agent (opus) that sits between `cai-refine` and `cai-plan` to decide whether a refined issue ships as a single PR (ATOMIC) or needs multi-step decomposition. Closes the pipeline gap where oversized issues (e.g. #1124 — the 22-file FSM-collapse) pass refine fine but then repeatedly fail at the Sonnet-bandwidth-limited planner with no auto-kickback to scope re-evaluation.

- **Refine is now opus** and narrowed to "structure human intent" — no longer emits Multi-Step Decomposition blocks.
- **Split is opus** and owns the atomic-vs-decompose decision with its own confidence gate. LOW verdict diverts to `:human-needed` so the admin can route via `cai-unblock`.
- **FSM adds `IssueState.SPLITTING`** + 3 new transitions (`refined_to_splitting`, `splitting_to_planning`, `splitting_to_human`) + `human_to_splitting` as a resume target.
- Every issue that clears triage now gets two opus passes (refine → split) in sequence before any plan work begins. Worth the cost vs. the repeated Sonnet planning cycles the current flow burns on oversized issues.

## Flow

```
RAISED → cai-triage → REFINING → cai-refine (opus) → REFINED
       → cai-split (opus)   → SPLITTING
            ├─ ATOMIC + HIGH        → PLANNING → cai-plan
            ├─ DECOMPOSE + HIGH     → sub-issues created, parent :parent
            └─ LOW / malformed      → HUMAN_NEEDED (admin unblocks via cai-unblock)
```

## Test plan

- [x] `python -m unittest discover -s tests` — all 605 tests pass (including 9 new split-handler cases in `tests/test_split.py` and migrated `TestDepthGate` from refine → split).
- [x] `python scripts/generate-fsm-docs.py` — regenerated FSM diagram in `docs/fsm.md` reflects the new SPLITTING waypoint.
- [ ] First live issue clears the full pipeline end-to-end (RAISED → refine → split → plan → implement → merge) — will be exercised naturally by the next refined issue.
- [ ] First oversized issue hits split with a DECOMPOSE verdict and auto-creates sub-issues — will confirm on next large auto-improve finding.

## Rollout notes

Hard cutover: refine's Multi-Step Decomposition handling is removed outright. Any in-flight issues currently parked at `:refined` will be picked up by `handle_split` on the next dispatcher cycle; nothing about the on-disk issue body needs updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
