### PR TITLE
auto-improve: Rescue prevention: For issues where the admin has explicitly flagged a scale/complexity review requirement (as done here in the first diver

### DIFF
--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -175,6 +175,152 @@ def _plan_targets_only_docs(plan_text: str | None) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Admin-flagged scale / complexity persistence (#1131).
+#
+# Complements the cai-select ``requires_human_review=true`` flag
+# (#982) with a deterministic Python-side auto-flag. The select
+# agent's flag only fires when the selected plan knowingly diverges
+# from an explicit refined-issue preference; it does NOT fire for
+# the "plan is simply too large to auto-approve" case that motivates
+# #1131 (issue #1124 took 22 files at LOW confidence — 4-hourly
+# `cai rescue` passes kept burning a fresh autonomous-resume attempt
+# each tick instead of respecting the earlier admin flag).
+#
+# ``handle_plan_gate`` therefore also promotes the human-review
+# divert on two Python-detected signals at LOW / MISSING confidence:
+#
+#   (a) Large-scope cap — the issue body's first ``### Files to
+#       change`` section lists >= ``_LARGE_SCOPE_FILE_THRESHOLD``
+#       unique backticked ``path/with.ext`` tokens. 15 matches the
+#       empirical scale of #1124 with headroom for smaller but
+#       still-broad reworks. (In practice the first such section
+#       in a PLANNED issue body is the refined-issue scope list;
+#       the plan block appended below inside ``<!-- cai-plan-start
+#       --> / <!-- cai-plan-end -->`` markers contains its own
+#       section that ``re.search`` does NOT see first, so the
+#       signal is effectively 'declared refined-issue scale'.)
+#
+#   (b) Sticky scale/complexity phrase — any earlier MARKER divert
+#       comment on this issue (``🙋 Human attention needed``) carries
+#       one of the ``_SCALE_COMPLEXITY_PHRASES`` tokens. Makes the
+#       concern persist across subsequent plan iterations without
+#       requiring cai-select to rediscover it from scratch.
+#
+# Both signals route through the same divert branch as the #982
+# flag: ``fire_trigger("planned_to_human", divert_reason=...)`` + a
+# follow-up ``_set_labels(add=[LABEL_PLAN_NEEDS_REVIEW])`` so
+# ``cai rescue``'s ``_list_unresolved_human_needed_issues`` skips
+# the issue until an admin explicitly resumes it via
+# ``cai unblock`` or ``human:solved``. HIGH- and MEDIUM-confidence
+# plans are unaffected — the triggers never fire above LOW,
+# preserving the existing fast path for trusted plans.
+# ---------------------------------------------------------------------------
+_LARGE_SCOPE_FILE_THRESHOLD = 15
+
+_SCALE_COMPLEXITY_PHRASES = (
+    "scale alone warrants",
+    "warrants admin review",
+    "complexity warrants",
+    "too large to approve autonomously",
+    "warranting review beyond what",
+    "scale/complexity",
+)
+
+_HUMAN_REVIEW_MARKER_PHRASE = "🙋 Human attention needed"
+
+
+def _count_files_to_change(issue_body):
+    """Return the count of unique backticked path tokens in *issue_body*'s
+    first ``### Files to change`` section.
+
+    Uses the same regexes as :func:`_plan_targets_only_docs`
+    (``_FILES_TO_CHANGE_SECTION_RE`` bounds the section; only
+    backticked ``path/with.ext`` tokens with at least one ``/`` and
+    an extension count). Returns ``0`` when the section is missing,
+    contains no backticked paths, or the input is empty / ``None``.
+    """
+    if not issue_body:
+        return 0
+    section = _FILES_TO_CHANGE_SECTION_RE.search(issue_body)
+    if not section:
+        return 0
+    paths = set(_FILES_TO_CHANGE_PATH_RE.findall(section.group(1)))
+    return len(paths)
+
+
+def _prior_divert_cites_scale_complexity(comments):
+    """Return ``True`` if any MARKER comment on the issue cites a
+    scale/complexity phrase from ``_SCALE_COMPLEXITY_PHRASES``.
+
+    Matches case-insensitively and only against comment bodies that
+    also carry the ``🙋 Human attention needed`` marker, so an
+    unrelated admin comment that happens to contain one of the
+    phrases cannot trip the sticky signal. Returns ``False`` for
+    empty or ``None`` input.
+    """
+    if not comments:
+        return False
+    marker_lc = _HUMAN_REVIEW_MARKER_PHRASE.lower()
+    for c in comments:
+        body = (c.get("body") or "").lower()
+        if marker_lc not in body:
+            continue
+        if any(phrase in body for phrase in _SCALE_COMPLEXITY_PHRASES):
+            return True
+    return False
+
+
+def _auto_flagged_human_review_reason(issue, plan_confidence):
+    """Return a bespoke divert reason string when #1131's auto-flag
+    triggers fire, else ``None``.
+
+    Fires only when *plan_confidence* is ``Confidence.LOW`` or
+    ``None`` (MISSING). HIGH- and MEDIUM-confidence plans continue
+    through the ordinary confidence gate unaffected.
+
+    Fires when either:
+
+      (a) ``_count_files_to_change(issue["body"])`` >=
+          ``_LARGE_SCOPE_FILE_THRESHOLD``; or
+      (b) ``_prior_divert_cites_scale_complexity(issue["comments"])``
+          is ``True``.
+
+    The returned reason will be forwarded to
+    ``fire_trigger("planned_to_human", divert_reason=...)`` and
+    logged alongside the ``LABEL_PLAN_NEEDS_REVIEW`` application
+    in :func:`handle_plan_gate`.
+    """
+    from cai_lib.fsm import Confidence
+    if plan_confidence is not None and plan_confidence != Confidence.LOW:
+        return None
+    file_count = _count_files_to_change(issue.get("body", "") or "")
+    prior_scale = _prior_divert_cites_scale_complexity(
+        issue.get("comments") or []
+    )
+    if file_count < _LARGE_SCOPE_FILE_THRESHOLD and not prior_scale:
+        return None
+    signals = []
+    if file_count >= _LARGE_SCOPE_FILE_THRESHOLD:
+        signals.append(
+            f"the stored plan lists {file_count} files to change "
+            f"(\u2265 {_LARGE_SCOPE_FILE_THRESHOLD})"
+        )
+    if prior_scale:
+        signals.append(
+            "a prior divert on this issue flagged scale or complexity "
+            "as warranting admin review"
+        )
+    joined = "; ".join(signals)
+    return (
+        "Auto-flagged scale/complexity checkpoint (#1131): "
+        f"{joined}. Admin approval is required at each plan "
+        "iteration; while `auto-improve:plan-needs-review` is "
+        "applied, `cai rescue`'s autonomous resume pass will skip "
+        "this issue."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Helpers (moved from cai.py — only used by the plan phase).
 # ---------------------------------------------------------------------------
 
@@ -793,21 +939,46 @@ def handle_plan_gate(issue: dict) -> int:
         body = issue.get("body", "") or ""
         approvable_at_medium = parse_approvable_at_medium(body)
 
-    # Human-review override path (#982): if cai-select explicitly
-    # flagged the plan, divert unconditionally with a bespoke message
-    # rather than letting the confidence gate emit a generic "gate not
-    # met" comment. Independent of confidence level and of the
+    # Deterministic scale/complexity auto-flag (#1131). Promotes
+    # requires_human_review to True when the stored plan is LOW
+    # confidence AND either (a) lists >= _LARGE_SCOPE_FILE_THRESHOLD
+    # files to change or (b) a prior MARKER divert on this issue
+    # already cited scale/complexity. Only runs when cai-select did
+    # NOT already set requires_human_review=true (#982) — that
+    # branch owns its own bespoke reason. The promoted signal
+    # reuses the existing divert code path below (fire_trigger +
+    # _set_labels + log_run) so only the reason text differs.
+    auto_flagged_reason = None
+    if not requires_human_review:
+        auto_flagged_reason = _auto_flagged_human_review_reason(
+            issue, plan_confidence,
+        )
+        if auto_flagged_reason is not None:
+            requires_human_review = True
+
+    # Human-review override path (#982 + #1131): cai-select flagged
+    # the plan OR the Python-side scale/complexity auto-flag fired.
+    # Divert unconditionally with a bespoke message rather than
+    # letting the confidence gate emit a generic "gate not met"
+    # comment. Independent of confidence level and of the
     # anchor-mitigation marker.
     if requires_human_review:
+        divert_signal = (
+            "scale_complexity" if auto_flagged_reason is not None
+            else "refined_preference"
+        )
         print(
-            f"[cai plan] #{issue_number} requires_human_review=true — "
-            f"diverting to :human-needed via planned_to_human (#982)",
+            f"[cai plan] #{issue_number} human-review divert "
+            f"({divert_signal}) — routing via planned_to_human",
             flush=True,
         )
-        reason_lines = [
-            "Plan diverges from refined-issue preference — admin "
-            "approval required before the fix agent proceeds.",
-        ]
+        if auto_flagged_reason is not None:
+            reason_lines = [auto_flagged_reason]
+        else:
+            reason_lines = [
+                "Plan diverges from refined-issue preference \u2014 admin "
+                "approval required before the fix agent proceeds.",
+            ]
         if plan_confidence_reason:
             reason_lines.extend(["", plan_confidence_reason.rstrip()])
         ok, _ = fire_trigger(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,7 +52,7 @@ Issues enter the pipeline when a human files an issue labeled `auto-improve:rais
 | `auto-improve:planned` | Plan generated and stored in issue body; confidence gate pending |
 | `auto-improve:planning` | Plan generation in progress (transient) |
 | `auto-improve:plan-approved` | Plan approved (HIGH confidence auto-approval or admin resume); ready for implement subagent |
-| `auto-improve:plan-needs-review` | Supplementary marker set by `handle_plan_gate` when cai-select flagged `requires_human_review=true`; signals that this plan explicitly diverges from refined-issue preference and requires admin approval. Applied alongside `:human-needed`; auto-cleared when the issue leaves HUMAN_NEEDED via any `human_to_*` resume transition. Causes `cai rescue` to skip the issue during autonomous resume cycles. |
+| `auto-improve:plan-needs-review` | Supplementary marker set by `handle_plan_gate` when cai-select flagged `requires_human_review=true` (#982) OR the Python-side scale/complexity auto-flag fired (#1131 — LOW-confidence plan touching ≥ 15 files, or a prior MARKER divert on the issue cited scale/complexity). Applied alongside `:human-needed`; auto-cleared when the issue leaves HUMAN_NEEDED via any `human_to_*` resume transition. Causes `cai rescue` to skip the issue during autonomous resume cycles. |
 | `auto-improve:human-needed` | Awaiting admin review and decision; admin applies `human:solved` to resume |
 | `auto-improve:applying` | Maintenance ops are being applied (transient; Step 3 agent drains this state) |
 | `auto-improve:applied` | Maintenance ops applied; awaiting verification |

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1076,5 +1076,158 @@ class TestParseApprovableAtMedium(unittest.TestCase):
         ))
 
 
+class TestHandlePlanGateAutoFlaggedScaleComplexity(unittest.TestCase):
+    """#1131 — handle_plan_gate auto-flags plans for human review at
+    LOW confidence when the plan targets >= 15 files or a prior
+    divert MARKER comment cites scale/complexity. Fires the same
+    planned_to_human + LABEL_PLAN_NEEDS_REVIEW divert as the #982
+    requires_human_review=true path, using a bespoke reason."""
+
+    def _issue(self, *, body="", comments=None, confidence=Confidence.LOW):
+        return {
+            "number": 1131,
+            "title": "t",
+            "body": body,
+            "labels": [{"name": "auto-improve:planned"}],
+            "comments": comments or [],
+            "_cai_plan_confidence": confidence,
+            "_cai_plan_confidence_reason": "",
+            "_cai_plan_text": body,
+            "_cai_plan_requires_human_review": False,
+            "_cai_plan_approvable_at_medium": False,
+        }
+
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan.log_run")
+    def test_large_scope_low_confidence_diverts(
+        self, _mock_log, mock_fire, mock_set_labels
+    ):
+        from cai_lib.actions.plan import handle_plan_gate
+        from cai_lib.config import LABEL_PLAN_NEEDS_REVIEW
+        mock_fire.return_value = (True, False)
+        mock_set_labels.return_value = True
+        body = "### Files to change\n" + "\n".join(
+            f"- `pkg/file{i}.py`: change it" for i in range(16)
+        ) + "\n"
+        rc = handle_plan_gate(self._issue(body=body))
+        self.assertEqual(rc, 0)
+        call_args = mock_fire.call_args
+        self.assertEqual(call_args.args[1], "planned_to_human")
+        divert_reason = call_args.kwargs.get("divert_reason", "")
+        self.assertIn(
+            "Auto-flagged scale/complexity checkpoint (#1131)",
+            divert_reason,
+        )
+        mock_set_labels.assert_called_once()
+        self.assertEqual(
+            mock_set_labels.call_args.kwargs.get("add"),
+            [LABEL_PLAN_NEEDS_REVIEW],
+        )
+
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan.log_run")
+    def test_prior_divert_scale_phrase_low_confidence_diverts(
+        self, _mock_log, mock_fire, mock_set_labels
+    ):
+        from cai_lib.actions.plan import handle_plan_gate
+        mock_fire.return_value = (True, False)
+        mock_set_labels.return_value = True
+        comments = [{
+            "body": (
+                "**\U0001f64b Human attention needed**\n"
+                "the scale alone warrants admin review"
+            ),
+        }]
+        rc = handle_plan_gate(self._issue(comments=comments))
+        self.assertEqual(rc, 0)
+        divert_reason = mock_fire.call_args.kwargs.get("divert_reason", "")
+        self.assertIn("prior divert", divert_reason)
+        self.assertIn("scale or complexity", divert_reason)
+
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan.log_run")
+    def test_small_scope_low_confidence_falls_through(
+        self, _mock_log, mock_fire, mock_set_labels
+    ):
+        from cai_lib.actions.plan import handle_plan_gate
+        mock_fire.return_value = (True, True)
+        body = "### Files to change\n- `pkg/one.py`: change it\n"
+        rc = handle_plan_gate(self._issue(body=body))
+        self.assertEqual(rc, 0)
+        mock_set_labels.assert_not_called()
+
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan.log_run")
+    def test_large_scope_high_confidence_does_not_trigger(
+        self, _mock_log, mock_fire, mock_set_labels
+    ):
+        from cai_lib.actions.plan import handle_plan_gate
+        mock_fire.return_value = (True, False)
+        body = "### Files to change\n" + "\n".join(
+            f"- `pkg/file{i}.py`: change" for i in range(20)
+        ) + "\n"
+        issue = self._issue(body=body, confidence=Confidence.HIGH)
+        rc = handle_plan_gate(issue)
+        self.assertEqual(rc, 0)
+        mock_set_labels.assert_not_called()
+
+
+class TestAutoFlaggedScaleComplexityHelpers(unittest.TestCase):
+    """#1131 — helper functions backing the handle_plan_gate auto-flag."""
+
+    def test_count_files_to_change_counts_unique_paths(self):
+        from cai_lib.actions.plan import _count_files_to_change
+        body = (
+            "### Files to change\n"
+            "- `pkg/a.py`: change\n"
+            "- `pkg/b.py`: change\n"
+            "- `pkg/a.py`: again (duplicate)\n"
+            "### Other\n"
+            "- `pkg/c.py`: outside the section\n"
+        )
+        self.assertEqual(_count_files_to_change(body), 2)
+
+    def test_count_files_to_change_empty(self):
+        from cai_lib.actions.plan import _count_files_to_change
+        self.assertEqual(_count_files_to_change(""), 0)
+        self.assertEqual(_count_files_to_change(None), 0)
+
+    def test_count_files_to_change_no_section(self):
+        from cai_lib.actions.plan import _count_files_to_change
+        self.assertEqual(
+            _count_files_to_change("no section here, just prose"), 0
+        )
+
+    def test_prior_divert_cites_scale_complexity_matches_marker(self):
+        from cai_lib.actions.plan import _prior_divert_cites_scale_complexity
+        comments = [{"body": (
+            "**\U0001f64b Human attention needed**\n"
+            "the scale alone warrants admin review"
+        )}]
+        self.assertTrue(_prior_divert_cites_scale_complexity(comments))
+
+    def test_prior_divert_requires_marker_presence(self):
+        from cai_lib.actions.plan import _prior_divert_cites_scale_complexity
+        comments = [{"body": "the scale alone warrants admin review"}]
+        self.assertFalse(_prior_divert_cites_scale_complexity(comments))
+
+    def test_prior_divert_requires_scale_phrase(self):
+        from cai_lib.actions.plan import _prior_divert_cites_scale_complexity
+        comments = [{"body": (
+            "**\U0001f64b Human attention needed**\n"
+            "Automation paused because the confidence gate was not met."
+        )}]
+        self.assertFalse(_prior_divert_cites_scale_complexity(comments))
+
+    def test_prior_divert_empty(self):
+        from cai_lib.actions.plan import _prior_divert_cites_scale_complexity
+        self.assertFalse(_prior_divert_cites_scale_complexity([]))
+        self.assertFalse(_prior_divert_cites_scale_complexity(None))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1131

**Issue:** #1131 — Rescue prevention: For issues where the admin has explicitly flagged a scale/complexity review requirement (as done here in the first diver

## PR Summary

### What this fixes
Issue #1131: When `cai rescue` resumes a `human-needed` issue where the admin previously flagged scale/complexity as a concern, there was no mechanism to prevent the rescue agent from re-entering the pipeline and burning plan+select cycles every 4 hours. The fix adds a deterministic Python-side auto-flag in `handle_plan_gate` that parks the issue back at `:human-needed` with `LABEL_PLAN_NEEDS_REVIEW` — causing `cai rescue` to skip it — whenever a LOW-confidence plan touches ≥ 15 files or a prior MARKER divert on the issue cited scale/complexity phrases.

### What was changed
- **`cai_lib/actions/plan.py`**: Added module-level constants (`_LARGE_SCOPE_FILE_THRESHOLD = 15`, `_SCALE_COMPLEXITY_PHRASES`, `_HUMAN_REVIEW_MARKER_PHRASE`) and three new helpers (`_count_files_to_change`, `_prior_divert_cites_scale_complexity`, `_auto_flagged_human_review_reason`). In `handle_plan_gate`, inserted an `auto_flagged_reason` computation block immediately before the existing `requires_human_review` branch; when either signal fires at LOW/MISSING confidence, the branch reuses the existing `planned_to_human` + `LABEL_PLAN_NEEDS_REVIEW` divert path with a bespoke reason string.
- **`docs/architecture.md`**: Updated the `auto-improve:plan-needs-review` table row to mention the new #1131 Python-side auto-flag trigger in addition to the existing #982 `requires_human_review=true` trigger.
- **`tests/test_plan.py`**: Added `TestHandlePlanGateAutoFlaggedScaleComplexity` (four gate-behaviour tests: large-scope LOW diverts, prior-divert-phrase LOW diverts, small-scope LOW falls through, large-scope HIGH does not trigger) and `TestAutoFlaggedScaleComplexityHelpers` (seven unit tests for the three new helpers). All using `unittest.TestCase` per project conventions.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
