### PR TITLE
fix: silence SyntaxWarning in _parse_plan_scope docstring

### DIFF
--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -778,7 +778,7 @@ def _canonical_staging_aliases(rel: str) -> list[str]:
 
 
 def _parse_plan_scope(plan_text: str) -> set[str]:
-    """Return the set of relative clone-paths the plan declares in
+    r"""Return the set of relative clone-paths the plan declares in
     scope.
 
     Parses two sections:


### PR DESCRIPTION
## Summary
- `_parse_plan_scope` in `cai_lib/actions/implement.py` had `\`` sequences inside a regular triple-quoted docstring, producing `SyntaxWarning: invalid escape sequence '\`'` on every import under Python 3.12+.
- Fix: make that single docstring a raw string (`r"""`). The docstring contains no other escape sequences, so the change is semantically a no-op.

## Test plan
- [x] `python -W error::SyntaxWarning -c "import cai_lib.actions.implement"` now exits cleanly (previously raised `SyntaxError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)