### PR TITLE
auto-improve: Rescue prevention: For large mechanical refactors spanning ≥8 files and ≥50 individual edit sites, `cai-plan` should emit a `depth:3` tag (

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ that diverges from the refined-issue's stated preference) divert to
 all others divert to `:human-needed` for admin review with a comment
 explaining why the plan didn't reach the required confidence (e.g.,
 unverified assumptions, ambiguous scope, missing edge cases). An admin
-comment resumes them via `cai unblock`.
+comment resumes them via `cai unblock`. Additionally, plans that qualify
+as large mechanical refactors (spanning ≥8 files and ≥50 individual edit
+steps) are automatically marked for pre-emptive Opus-tier implementation,
+bypassing the normal Sonnet-first attempt to avoid exhausting retries on
+large-scale refactoring tasks.
 
 A flock in `cmd_cycle` serializes overlapping runs. For manual or
 targeted invocation, `cai.py dispatch --issue N` and

--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -966,28 +966,45 @@ def handle_plan_gate(issue: dict) -> int:
     diverts to :human-needed (`planned_to_human`) so an admin can
     review.
 
+    The gate also handles several confidence-relaxation paths and
+    post-approval Opus escalation:
+
+    **Docs-only structural relaxation (#989):** when every path in the
+    plan's ``### Files to change`` section targets only ``docs/``, the
+    gate routes through ``planned_to_plan_approved_docs_only`` — a
+    MEDIUM-threshold sibling that auto-approves because blast radius
+    is minimal and residual drift can be corrected by ``cai-review-docs``.
+
     **Anchor-mitigation relaxation (#918):** when the selected plan
     text contains the marker phrase ``locate edits by anchor text ...
     not by line number``, the gate routes through
-    ``planned_to_plan_approved_mitigated`` instead — a sibling
-    transition that performs the same label move but accepts
-    :attr:`Confidence.MEDIUM`. This lets plans whose only residual
-    risk is implementation-detail (line-number drift, fence escaping,
-    cosmetic wording) auto-approve because the fix agent is
-    explicitly instructed to anchor on surrounding text. Plans
-    without the marker continue to require HIGH via the default
-    transition.
+    ``planned_to_plan_approved_mitigated`` — a MEDIUM-threshold sibling
+    that auto-approves because the fix agent is instructed to anchor on
+    surrounding text rather than line numbers.
+
+    **Approvable-at-medium relaxation (#1008):** when ``cai-select`` set
+    ``approvable_at_medium=true`` in its structured output, the gate
+    routes through ``planned_to_plan_approved_approvable`` — a MEDIUM-
+    threshold sibling that auto-approves when the residual risks are
+    soft / non-blocking.
 
     **Human-review override (#982):** when ``cai-select`` set
-    ``requires_human_review=true`` in its structured output (stashed
-    under ``_cai_plan_requires_human_review`` or re-parsed from the
-    ``Requires human review: true`` marker in the stored plan block),
-    the gate diverts directly to ``:human-needed`` via
-    ``planned_to_human`` with a bespoke admin-approval message —
-    independent of the reported confidence and of the anchor-mitigation
-    marker. This surfaces a clearer divert reason than the generic
-    confidence-gate trip when the selected plan knowingly diverges
-    from the refined-issue's stated preference.
+    ``requires_human_review=true`` in its structured output, the gate
+    diverts directly to ``:human-needed`` via ``planned_to_human`` with
+    a bespoke admin-approval message independent of confidence level.
+
+    **Scale/complexity auto-flag (#1131):** when a LOW-confidence plan
+    lists ≥15 files in ``### Files to change`` or a prior divert on
+    this issue cited scale/complexity concerns, the gate diverts to
+    ``:human-needed`` with a reason explaining the auto-flag.
+
+    **Large-refactor Opus pre-escalation (#1139):** after a successful
+    confidence-gated transition to ``:plan-approved``, when the plan
+    qualifies as a large mechanical refactor (≥8 files AND ≥50 edit
+    steps), the gate applies :data:`LABEL_OPUS_ATTEMPTED` so
+    :func:`cai_lib.actions.implement.handle_implement` routes the
+    implementation to Opus from the start, avoiding the Sonnet-retry
+    loop on large-scale refactoring.
     """
     from cai_lib.fsm import (
         parse_confidence,

--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from cai_lib.config import (
     REPO,
     LABEL_IN_PROGRESS,
+    LABEL_OPUS_ATTEMPTED,
     LABEL_PR_OPEN,
     LABEL_PLAN_NEEDS_REVIEW,
     LABEL_REFINED,
@@ -318,6 +319,104 @@ def _auto_flagged_human_review_reason(issue, plan_confidence):
         "applied, `cai rescue`'s autonomous resume pass will skip "
         "this issue."
     )
+
+
+# ---------------------------------------------------------------------------
+# Pre-emptive Opus-tier escalation for large mechanical refactors (#1139).
+#
+# A plan whose ``### Files to change`` section lists at least
+# ``_LARGE_REFACTOR_FILE_THRESHOLD`` unique backticked path tokens AND
+# whose body contains at least ``_LARGE_REFACTOR_EDIT_SITE_THRESHOLD``
+# ``#### Step N — Edit/Write`` headers is treated as a large mechanical
+# refactor. On successful ``planned_to_plan_approved*`` transition,
+# :func:`handle_plan_gate` stamps :data:`LABEL_OPUS_ATTEMPTED` on the
+# issue so :func:`cai_lib.actions.implement.handle_implement` reads
+# ``opus_escalation = True`` on the next dispatch tick — skipping the
+# Sonnet subagent entirely and running the implementation on Opus from
+# the start. This prevents the three-Sonnet-retry loop observed on
+# #1136 (the divert that motivated this issue) without requiring any
+# handler-side changes: ``handle_implement`` already treats
+# ``LABEL_OPUS_ATTEMPTED`` as the Opus-tier signal, and ``cai rescue``'s
+# ``_issue_has_opus_attempted`` guard correctly refuses a second
+# escalation if Opus also fails.
+#
+# Detection is deliberately **structural** — counting the planner's
+# canonical ``### Files to change`` declarations and its ``#### Step N
+# — Edit/Write`` step headers — matching the "Prefer structural
+# detection over marker phrases" guidance in the shared-memory
+# ``fsm-transition-threshold-relaxation.md`` entry and the
+# :func:`_plan_targets_only_docs` pattern established in #989. The
+# signal is stored as an FSM label (not a plan-body marker), keeping
+# the information visible in the GitHub UI and consumable by the
+# existing label-based ``opus_escalation`` path without introducing a
+# new ``parse_*`` helper or a new plan-body field.
+#
+# The label is applied only when the gate has already successfully
+# transitioned the issue to ``:plan-approved`` (non-diverted outcome of
+# the ``planned_to_plan_approved*`` siblings). Divert paths
+# (``planned_to_human`` via confidence gate, requires_human_review,
+# or #1131 scale/complexity auto-flag) skip the label so the admin can
+# choose the tier when resuming.
+# ---------------------------------------------------------------------------
+_LARGE_REFACTOR_FILE_THRESHOLD = 8
+
+_LARGE_REFACTOR_EDIT_SITE_THRESHOLD = 50
+
+# Count each ``#### Step N — Edit `<path>` `` / ``#### Step N — Write
+# `<path>` `` header once. Accepts em-dash (\u2014), en-dash (\u2013),
+# and plain hyphen between ``Step N`` and the verb to match the
+# cai-plan template plus real-world drift. The separate
+# ``_STEP_HEADER_RE`` in ``cai_lib/actions/implement.py`` captures the
+# path (for scope enforcement) and is intentionally not reused here —
+# we only need the header count, and a path-capturing regex would
+# force an implement.py import from a plan-phase helper.
+_STEP_EDIT_HEADER_RE = re.compile(
+    r"^####\s+Step\s+\d+\s+[\u2014\u2013\-]\s+(?:Edit|Write)\s+`",
+    re.MULTILINE,
+)
+
+
+def _count_edit_steps(plan_text):
+    """Return the count of ``#### Step N — Edit/Write`` headers in
+    *plan_text*.
+
+    Uses :data:`_STEP_EDIT_HEADER_RE` — one increment per header
+    regardless of the target path. Returns ``0`` on empty or ``None``
+    input. Non-``Edit``/``Write`` step verbs (e.g. ``Read``, ``Verify``)
+    are ignored so the count reflects *edit sites* only.
+    """
+    if not plan_text:
+        return 0
+    return len(_STEP_EDIT_HEADER_RE.findall(plan_text))
+
+
+def _plan_is_large_mechanical_refactor(plan_text):
+    """Return ``True`` when *plan_text* qualifies as a large mechanical
+    refactor worth pre-emptively routing to the Opus implement tier
+    (#1139).
+
+    Both thresholds must be met:
+
+      * ``_count_files_to_change(plan_text) >= _LARGE_REFACTOR_FILE_THRESHOLD``
+        — at least 8 unique backticked ``path/with.ext`` tokens in the
+        plan's ``### Files to change`` section.
+      * ``_count_edit_steps(plan_text) >= _LARGE_REFACTOR_EDIT_SITE_THRESHOLD``
+        — at least 50 ``#### Step N — Edit/Write`` headers.
+
+    Returns ``False`` on empty or ``None`` input. Used by
+    :func:`handle_plan_gate` to stamp :data:`LABEL_OPUS_ATTEMPTED`
+    directly on the issue after a successful ``planned_to_plan_approved*``
+    transition — so :func:`cai_lib.actions.implement.handle_implement`
+    reads ``opus_escalation = True`` on the next dispatch tick and
+    skips the Sonnet attempt entirely.
+    """
+    if not plan_text:
+        return False
+    if _count_files_to_change(plan_text) < _LARGE_REFACTOR_FILE_THRESHOLD:
+        return False
+    if _count_edit_steps(plan_text) < _LARGE_REFACTOR_EDIT_SITE_THRESHOLD:
+        return False
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -1118,6 +1217,80 @@ def handle_plan_gate(issue: dict) -> int:
         f"(confidence={conf_name}, transition={transition_name})",
         flush=True,
     )
+
+    # Pre-emptive Opus-tier escalation for large mechanical refactors
+    # (#1139). When the plan was just approved (non-diverted) AND the
+    # plan body qualifies as a large mechanical refactor (>= 8 files in
+    # ### Files to change AND >= 50 #### Step N — Edit/Write headers),
+    # apply LABEL_OPUS_ATTEMPTED directly. handle_implement reads this
+    # label via ``opus_escalation = LABEL_OPUS_ATTEMPTED in label_names``
+    # and will run the subagent with ``--model claude-opus-4-7`` from
+    # the start — skipping the Sonnet retry loop that normally consumes
+    # 2–3 slots on a large-refactor plan (see #1136).
+    #
+    # Guarded by ``not diverted`` so we never stamp the label on a plan
+    # the gate just parked at :human-needed — the admin can then choose
+    # the implement tier when resuming. Also short-circuits if the label
+    # is already present (e.g. the plan was re-run after a rescue
+    # escalation) so we don't spam duplicate comments.
+    if not diverted and _plan_is_large_mechanical_refactor(plan_text):
+        current_labels = {
+            lbl["name"] for lbl in issue.get("labels", [])
+        }
+        if LABEL_OPUS_ATTEMPTED not in current_labels:
+            file_count = _count_files_to_change(plan_text)
+            step_count = _count_edit_steps(plan_text)
+            print(
+                f"[cai plan] #{issue_number} plan is a large mechanical "
+                f"refactor "
+                f"(files={file_count} "
+                f">= {_LARGE_REFACTOR_FILE_THRESHOLD}, "
+                f"edit_steps={step_count} "
+                f">= {_LARGE_REFACTOR_EDIT_SITE_THRESHOLD}); "
+                f"applying {LABEL_OPUS_ATTEMPTED} to pre-empt the "
+                f"Sonnet attempt and route `cai implement` to Opus "
+                f"(#1139)",
+                flush=True,
+            )
+            if _set_labels(
+                issue_number,
+                add=[LABEL_OPUS_ATTEMPTED],
+                log_prefix="cai plan",
+            ):
+                _post_issue_comment(
+                    issue_number,
+                    (
+                        "## Pre-emptive Opus-tier escalation (#1139)\n\n"
+                        f"This plan lists **{file_count} files** in "
+                        f"`### Files to change` and **{step_count} "
+                        f"`#### Step N — Edit/Write` headers**, both "
+                        f"at or above the large-mechanical-refactor "
+                        f"thresholds "
+                        f"({_LARGE_REFACTOR_FILE_THRESHOLD} files / "
+                        f"{_LARGE_REFACTOR_EDIT_SITE_THRESHOLD} edit "
+                        f"sites). `cai implement` will therefore run "
+                        f"the Opus tier from the start instead of "
+                        f"attempting Sonnet first — avoiding the "
+                        f"three-Sonnet-retry loop observed on similar "
+                        f"plans (see #1136).\n\n"
+                        f"---\n"
+                        f"_Applied by `cai plan` structural detector. "
+                        f"If Opus also fails, `cai rescue` will not "
+                        f"re-escalate; remove `"
+                        f"{LABEL_OPUS_ATTEMPTED}` manually to force a "
+                        f"Sonnet attempt._"
+                    ),
+                    log_prefix="cai plan",
+                )
+            else:
+                print(
+                    f"[cai plan] #{issue_number} failed to apply "
+                    f"{LABEL_OPUS_ATTEMPTED}; implement will run at "
+                    f"the Sonnet tier as a fallback",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
     log_run("plan", repo=REPO, issue=issue_number,
             duration=dur, result="gate_ok",
             confidence=conf_name, diverted=int(diverted),

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1229,5 +1229,268 @@ class TestAutoFlaggedScaleComplexityHelpers(unittest.TestCase):
         self.assertFalse(_prior_divert_cites_scale_complexity(None))
 
 
+class TestCountEditStepsHelper(unittest.TestCase):
+    """#1139 — structural counter for `#### Step N — Edit/Write` headers."""
+
+    def test_empty_and_none_return_zero(self):
+        from cai_lib.actions.plan import _count_edit_steps
+        self.assertEqual(_count_edit_steps(""), 0)
+        self.assertEqual(_count_edit_steps(None), 0)
+
+    def test_counts_edit_and_write_headers(self):
+        from cai_lib.actions.plan import _count_edit_steps
+        plan = (
+            "## Plan\n\n"
+            "### Detailed steps\n\n"
+            "#### Step 1 \u2014 Edit `foo.py`\n"
+            "body\n\n"
+            "#### Step 2 \u2014 Write `bar.py`\n"
+            "body\n\n"
+            "#### Step 3 \u2014 Edit `baz.py`\n"
+            "body\n"
+        )
+        self.assertEqual(_count_edit_steps(plan), 3)
+
+    def test_ignores_non_edit_step_verbs(self):
+        from cai_lib.actions.plan import _count_edit_steps
+        plan = (
+            "#### Step 1 \u2014 Read `foo.py`\n"
+            "#### Step 2 \u2014 Verify behaviour\n"
+            "#### Step 3 \u2014 Edit `bar.py`\n"
+        )
+        self.assertEqual(_count_edit_steps(plan), 1)
+
+    def test_accepts_em_dash_en_dash_and_hyphen(self):
+        from cai_lib.actions.plan import _count_edit_steps
+        plan = (
+            "#### Step 1 \u2014 Edit `a.py`\n"
+            "#### Step 2 \u2013 Edit `b.py`\n"
+            "#### Step 3 - Edit `c.py`\n"
+        )
+        self.assertEqual(_count_edit_steps(plan), 3)
+
+
+class TestPlanIsLargeMechanicalRefactorHelper(unittest.TestCase):
+    """#1139 — both-threshold gate for the large-mechanical-refactor
+    detection."""
+
+    def _plan(self, n_files, n_steps):
+        files_section = "### Files to change\n" + "".join(
+            f"- **`pkg/file_{i}.py`**: change\n" for i in range(n_files)
+        )
+        steps_section = "### Detailed steps\n" + "".join(
+            f"#### Step {i + 1} \u2014 Edit "
+            f"`pkg/file_{i % max(n_files, 1)}.py`\n\nbody\n\n"
+            for i in range(n_steps)
+        )
+        return f"## Plan\n\n{files_section}\n{steps_section}"
+
+    def test_fires_when_both_thresholds_met(self):
+        from cai_lib.actions.plan import _plan_is_large_mechanical_refactor
+        self.assertTrue(_plan_is_large_mechanical_refactor(
+            self._plan(n_files=8, n_steps=50)
+        ))
+
+    def test_fires_on_large_excess(self):
+        from cai_lib.actions.plan import _plan_is_large_mechanical_refactor
+        self.assertTrue(_plan_is_large_mechanical_refactor(
+            self._plan(n_files=20, n_steps=80)
+        ))
+
+    def test_below_file_threshold_returns_false(self):
+        from cai_lib.actions.plan import _plan_is_large_mechanical_refactor
+        self.assertFalse(_plan_is_large_mechanical_refactor(
+            self._plan(n_files=7, n_steps=60)
+        ))
+
+    def test_below_step_threshold_returns_false(self):
+        from cai_lib.actions.plan import _plan_is_large_mechanical_refactor
+        self.assertFalse(_plan_is_large_mechanical_refactor(
+            self._plan(n_files=12, n_steps=49)
+        ))
+
+    def test_empty_and_none_return_false(self):
+        from cai_lib.actions.plan import _plan_is_large_mechanical_refactor
+        self.assertFalse(_plan_is_large_mechanical_refactor(None))
+        self.assertFalse(_plan_is_large_mechanical_refactor(""))
+        self.assertFalse(_plan_is_large_mechanical_refactor(
+            "plan without sections"
+        ))
+
+
+class TestHandlePlanGateAppliesOpusLabel(unittest.TestCase):
+    """#1139 — handle_plan_gate applies LABEL_OPUS_ATTEMPTED directly on
+    a successfully-approved large-mechanical-refactor plan, so
+    handle_implement reads opus_escalation=True on the next tick."""
+
+    def _large_plan(self):
+        files = "### Files to change\n" + "".join(
+            f"- **`pkg/file_{i}.py`**: change\n" for i in range(10)
+        )
+        steps = "### Detailed steps\n" + "".join(
+            f"#### Step {i + 1} \u2014 Edit "
+            f"`pkg/file_{i % 10}.py`\n\nbody\n\n"
+            for i in range(60)
+        )
+        return f"## Plan\n\n{files}\n{steps}"
+
+    def _small_plan(self):
+        return (
+            "## Plan\n\n"
+            "### Files to change\n"
+            "- **`pkg/a.py`**: tweak\n\n"
+            "### Detailed steps\n"
+            "#### Step 1 \u2014 Edit `pkg/a.py`\n\nbody\n"
+        )
+
+    def _issue(self, *, plan_text, labels=None):
+        return {
+            "number": 1139,
+            "title": "t",
+            "body": "",
+            "labels": [
+                {"name": n} for n in (labels or ["auto-improve:planned"])
+            ],
+            "_cai_plan_confidence": Confidence.HIGH,
+            "_cai_plan_confidence_reason": "",
+            "_cai_plan_text": plan_text,
+            "_cai_plan_requires_human_review": False,
+            "_cai_plan_approvable_at_medium": False,
+        }
+
+    @patch("cai_lib.actions.plan._post_issue_comment", return_value=True)
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan.log_run")
+    def test_large_plan_applies_opus_label_on_approval(
+        self, _mock_log, mock_fire, mock_set_labels, mock_post,
+    ):
+        from cai_lib.actions.plan import handle_plan_gate
+        from cai_lib.config import LABEL_OPUS_ATTEMPTED
+        mock_fire.return_value = (True, False)  # approved, not diverted
+        mock_set_labels.return_value = True
+
+        rc = handle_plan_gate(self._issue(plan_text=self._large_plan()))
+
+        self.assertEqual(rc, 0)
+        # The gate transition fired with planned_to_plan_approved.
+        self.assertEqual(
+            mock_fire.call_args[0][1], "planned_to_plan_approved",
+        )
+        # The post-approval label application ran.
+        opus_calls = [
+            c for c in mock_set_labels.call_args_list
+            if LABEL_OPUS_ATTEMPTED in (c.kwargs.get("add") or [])
+        ]
+        self.assertEqual(len(opus_calls), 1)
+        # An informational comment was posted.
+        mock_post.assert_called_once()
+        self.assertIn(
+            "Pre-emptive Opus-tier escalation",
+            mock_post.call_args[0][1],
+        )
+
+    @patch("cai_lib.actions.plan._post_issue_comment", return_value=True)
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan.log_run")
+    def test_small_plan_does_not_apply_opus_label(
+        self, _mock_log, mock_fire, mock_set_labels, mock_post,
+    ):
+        from cai_lib.actions.plan import handle_plan_gate
+        from cai_lib.config import LABEL_OPUS_ATTEMPTED
+        mock_fire.return_value = (True, False)
+        mock_set_labels.return_value = True
+
+        rc = handle_plan_gate(self._issue(plan_text=self._small_plan()))
+
+        self.assertEqual(rc, 0)
+        opus_calls = [
+            c for c in mock_set_labels.call_args_list
+            if LABEL_OPUS_ATTEMPTED in (c.kwargs.get("add") or [])
+        ]
+        self.assertEqual(opus_calls, [])
+        mock_post.assert_not_called()
+
+    @patch("cai_lib.actions.plan._post_issue_comment", return_value=True)
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan.log_run")
+    def test_diverted_large_plan_does_not_apply_opus_label(
+        self, _mock_log, mock_fire, mock_set_labels, mock_post,
+    ):
+        """When the confidence gate diverts to :human-needed we MUST
+        NOT stamp LABEL_OPUS_ATTEMPTED — the admin should choose the
+        tier when resuming."""
+        from cai_lib.actions.plan import handle_plan_gate
+        from cai_lib.config import LABEL_OPUS_ATTEMPTED
+        # approved-call succeeds but diverted=True (below-threshold).
+        mock_fire.return_value = (True, True)
+        mock_set_labels.return_value = True
+
+        issue = self._issue(plan_text=self._large_plan())
+        issue["_cai_plan_confidence"] = Confidence.LOW
+        rc = handle_plan_gate(issue)
+
+        self.assertEqual(rc, 0)
+        opus_calls = [
+            c for c in mock_set_labels.call_args_list
+            if LABEL_OPUS_ATTEMPTED in (c.kwargs.get("add") or [])
+        ]
+        self.assertEqual(opus_calls, [])
+        mock_post.assert_not_called()
+
+    @patch("cai_lib.actions.plan._post_issue_comment", return_value=True)
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan.log_run")
+    def test_existing_opus_label_short_circuits(
+        self, _mock_log, mock_fire, mock_set_labels, mock_post,
+    ):
+        """A plan that already carries LABEL_OPUS_ATTEMPTED (e.g. this
+        is a re-plan after a rescue escalation) must NOT spam a second
+        comment or a redundant _set_labels call."""
+        from cai_lib.actions.plan import handle_plan_gate
+        from cai_lib.config import LABEL_OPUS_ATTEMPTED
+        mock_fire.return_value = (True, False)
+        mock_set_labels.return_value = True
+
+        rc = handle_plan_gate(self._issue(
+            plan_text=self._large_plan(),
+            labels=[
+                "auto-improve:planned",
+                LABEL_OPUS_ATTEMPTED,
+            ],
+        ))
+
+        self.assertEqual(rc, 0)
+        opus_calls = [
+            c for c in mock_set_labels.call_args_list
+            if LABEL_OPUS_ATTEMPTED in (c.kwargs.get("add") or [])
+        ]
+        self.assertEqual(opus_calls, [])
+        mock_post.assert_not_called()
+
+    @patch("cai_lib.actions.plan._post_issue_comment", return_value=True)
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan.log_run")
+    def test_set_labels_failure_skips_comment_and_continues(
+        self, _mock_log, mock_fire, mock_set_labels, mock_post,
+    ):
+        """When _set_labels fails we must NOT post the comment (so the
+        admin doesn't see 'pre-empting to Opus' on an issue still
+        queued for Sonnet) and must still return 0 — the gate
+        transition already succeeded."""
+        from cai_lib.actions.plan import handle_plan_gate
+        mock_fire.return_value = (True, False)
+        mock_set_labels.return_value = False
+
+        rc = handle_plan_gate(self._issue(plan_text=self._large_plan()))
+
+        self.assertEqual(rc, 0)
+        mock_post.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1139

**Issue:** #1139 — Rescue prevention: For large mechanical refactors spanning ≥8 files and ≥50 individual edit sites, `cai-plan` should emit a `depth:3` tag (

## PR Summary

### What this fixes
Large mechanical refactors spanning many files and edit steps were being dispatched to the Sonnet implement tier first, consuming 2–3 retry slots before escalating to Opus via `cai rescue` — as observed in issue #1136. This adds a structural detector in `handle_plan_gate` that pre-emptively applies `LABEL_OPUS_ATTEMPTED` on plans approved with ≥8 files in `### Files to change` AND ≥50 `#### Step N — Edit/Write` headers, so `handle_implement` routes directly to the Opus tier from the first attempt.

### What was changed
- **`cai_lib/actions/plan.py`**: Added `LABEL_OPUS_ATTEMPTED` to the config import block; added `_LARGE_REFACTOR_FILE_THRESHOLD = 8`, `_LARGE_REFACTOR_EDIT_SITE_THRESHOLD = 50`, `_STEP_EDIT_HEADER_RE`, `_count_edit_steps()`, and `_plan_is_large_mechanical_refactor()` helpers; inserted a post-approval label-application block inside `handle_plan_gate` that stamps `LABEL_OPUS_ATTEMPTED` when the plan qualifies and the gate was not diverted.
- **`tests/test_plan.py`**: Added three new test classes — `TestCountEditStepsHelper` (4 tests), `TestPlanIsLargeMechanicalRefactorHelper` (5 tests), and `TestHandlePlanGateAppliesOpusLabel` (5 tests) — covering the helpers and the gate's post-approval label logic including no-op cases (small plan, diverted plan, existing label, `_set_labels` failure).

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
