### PR TITLE
auto-improve: Rescue prevention: When an issue is retroactively marked `human-needed` by the #1009 self-heal sweep, the generated comment should include 

### DIFF
--- a/cai_lib/fsm_transitions.py
+++ b/cai_lib/fsm_transitions.py
@@ -1107,28 +1107,70 @@ def _build_mermaid_machine(transitions_list: list[Transition]) -> GraphMachine:
     )
 
 
+# Detection patterns for cai-rescue prevention findings (issue #1150).
+# Findings carry a fingerprint comment of the form
+# ``<!-- fingerprint: rescue-prev-<hex> -->`` written by
+# :func:`cai_lib.cmd_rescue._stage_prevention_finding` and emitted
+# verbatim by :func:`cai_lib.publish.create_issue` (publish.py ~line
+# 579). The fingerprint prefix is the canonical structural signal
+# that an issue is a rescue prevention finding rather than a normal
+# implementation task; title-prefix matching is intentionally NOT
+# used because admins may rename titles on park, but the fingerprint
+# stays in the body forever.
+_PREVENTION_FINDING_FINGERPRINT_PREFIX = "<!-- fingerprint: rescue-prev-"
+_NO_STRUCTURAL_PREVENTION_PHRASE = "No structural prevention needed"
+
+
+def _is_rescue_prevention_finding(body: str) -> bool:
+    """True when *body* carries the canonical ``rescue-prev-``
+    fingerprint comment written by ``cai_lib.publish.create_issue``."""
+    return _PREVENTION_FINDING_FINGERPRINT_PREFIX in (body or "")
+
+
+def _has_no_structural_prevention(body: str) -> bool:
+    """True when *body* contains the literal phrase
+    ``No structural prevention needed`` (case-insensitive). Used by
+    :func:`backfill_silent_human_needed_comments` to auto-close
+    prevention findings whose recommendation is explicitly "no code
+    change required" — they would otherwise be parked indefinitely."""
+    return _NO_STRUCTURAL_PREVENTION_PHRASE.lower() in (body or "").lower()
+
+
 def backfill_silent_human_needed_comments(
     *,
     gh_json=None,
     post_issue_comment=None,
     post_pr_comment=None,
+    close_issue=None,
     log_prefix: str = "cai cycle",
 ) -> list[tuple[str, int]]:
     """Scan open issues/PRs parked at HUMAN_NEEDED / PR_HUMAN_NEEDED and
-    post a retroactive MARKER-bearing backfill comment on any entry that
-    has no MARKER comment in its history.
+    either post a retroactive MARKER-bearing backfill comment **or** —
+    for cai-rescue prevention findings whose body says "No structural
+    prevention needed" (issue #1150) — auto-close the issue as
+    ``not planned`` so it stops cycling through the rescue agent on
+    every tick.
 
-    This is the self-healing counterpart to the fire_trigger
-    divert-reason invariant added for issue #1009. The invariant guarantees *future*
+    For non-auto-close paths, the generated comment now includes a
+    suggested-action paragraph tuned to the issue type (prevention
+    finding vs. implementation task), so admins triaging the queue
+    see a concrete next step rather than a generic "review and
+    signal".
+
+    Self-healing counterpart to the fire_trigger divert-reason
+    invariant added for issue #1009. The invariant guarantees *future*
     diverts carry a MARKER comment; the backfill sweep closes the gap
     for issues parked before the fix (e.g. #932) so the audit agent's
     ``human_needed_reason_missing`` finder and ``cai unblock`` have
     context on pre-existing silent diverts. Returns the list of
-    ``(kind, number)`` tuples that were backfilled (empty when nothing
-    was missing). The caller is responsible for logging the result.
+    ``(kind, number)`` tuples that were *handled* — either backfilled
+    via comment OR auto-closed. The caller is responsible for logging
+    the returned count; per-item lines are emitted inside this
+    function so the two paths remain distinguishable in the log.
 
-    All dependencies (``gh_json``, the two comment posters) are
-    injectable for tests; defaults read from ``cai_lib.github``.
+    All dependencies (``gh_json``, the two comment posters, and
+    ``close_issue``) are injectable for tests; defaults read from
+    :mod:`cai_lib.github`.
     """
     MARKER = "🙋 Human attention needed"
     from cai_lib.config import LABEL_HUMAN_NEEDED, LABEL_PR_HUMAN_NEEDED, REPO
@@ -1139,8 +1181,10 @@ def backfill_silent_human_needed_comments(
         from cai_lib.github import _post_issue_comment as post_issue_comment
     if post_pr_comment is None:
         from cai_lib.github import _post_pr_comment as post_pr_comment
+    if close_issue is None:
+        from cai_lib.github import close_issue_not_planned as close_issue
 
-    backfilled: list[tuple[str, int]] = []
+    handled: list[tuple[str, int]] = []
     checks = [
         ("issue", LABEL_HUMAN_NEEDED, post_issue_comment),
         ("pr", LABEL_PR_HUMAN_NEEDED, post_pr_comment),
@@ -1152,7 +1196,7 @@ def backfill_silent_human_needed_comments(
                 "--repo", REPO,
                 "--label", label,
                 "--state", "open",
-                "--json", "number,labels,comments",
+                "--json", "number,title,body,labels,comments",
                 "--limit", "100",
             ]) or []
         except Exception as exc:
@@ -1168,6 +1212,69 @@ def backfill_silent_human_needed_comments(
             comments = it.get("comments") or []
             if any(MARKER in (c.get("body") or "") for c in comments):
                 continue
+
+            issue_body = it.get("body") or ""
+            is_prevention = (
+                kind == "issue"
+                and _is_rescue_prevention_finding(issue_body)
+            )
+
+            # Auto-close prevention findings explicitly tagged
+            # "No structural prevention needed" — they have no
+            # remediation work and only burn rescue cycles when parked.
+            if is_prevention and _has_no_structural_prevention(issue_body):
+                close_body = (
+                    f"**{MARKER}**\n\n"
+                    f"This rescue prevention finding states **No "
+                    f"structural prevention needed**, so there is no "
+                    f"code change to perform. Closing as `not planned` "
+                    f"to stop the rescue agent from re-attempting it "
+                    f"on every cycle. The recommendation in the body "
+                    f"is preserved for the audit trail; reopen if a "
+                    f"structural prevention is identified later.\n"
+                    f"\n"
+                    f"_Auto-closed by `cai cycle` self-heal "
+                    f"(issue #1150)._"
+                )
+                try:
+                    close_issue(number, close_body, log_prefix=log_prefix)
+                    handled.append((kind, number))
+                    print(
+                        f"[{log_prefix}] auto-closed prevention finding "
+                        f"with no structural remediation on "
+                        f"{kind} #{number}",
+                        flush=True,
+                    )
+                except Exception as exc:
+                    print(
+                        f"[{log_prefix}] auto-close failed for {kind} "
+                        f"#{number}: {exc}",
+                        file=sys.stderr,
+                    )
+                continue
+
+            # Choose a per-type suggested-action paragraph.
+            if is_prevention:
+                suggested_action = (
+                    "Review the **rescue prevention finding** above "
+                    "and choose one:\n"
+                    "- adopt the recommendation (open a follow-up "
+                    "issue or implement the change), then **close "
+                    "this issue as completed**, or\n"
+                    "- dismiss the recommendation as not actionable "
+                    "and **close this issue as not planned**, or\n"
+                    "- apply the `human:solved` label after leaving a "
+                    "comment to signal further action and have the "
+                    "FSM resume."
+                )
+            else:
+                suggested_action = (
+                    "Review the issue/PR body and recent logs to "
+                    "decide next steps. Apply the `human:solved` "
+                    "label after leaving a comment to signal the "
+                    "divert is resolved and have the FSM resume."
+                )
+
             body = (
                 f"**{MARKER}**\n\n"
                 f"Automation paused `(unknown)` — this {kind} was parked "
@@ -1178,17 +1285,14 @@ def backfill_silent_human_needed_comments(
                 f"- Required confidence: `(unknown)`\n"
                 f"- Reported confidence: `(unknown)`\n"
                 f"\n"
-                f"Review the issue/PR body and recent logs to decide "
-                f"next steps. Apply the `human:solved` label after "
-                f"leaving a comment to signal the divert is resolved "
-                f"and have the FSM resume.\n"
+                f"{suggested_action}\n"
                 f"\n"
                 f"_Retroactively posted by `cai cycle` self-heal "
                 f"(issue #1009)._"
             )
             try:
                 poster(number, body, log_prefix=log_prefix)
-                backfilled.append((kind, number))
+                handled.append((kind, number))
                 print(
                     f"[{log_prefix}] backfilled silent divert on "
                     f"{kind} #{number}",
@@ -1200,7 +1304,7 @@ def backfill_silent_human_needed_comments(
                     f"#{number}: {exc}",
                     file=sys.stderr,
                 )
-    return backfilled
+    return handled
 
 
 def render_fsm_mermaid(transitions: list[Transition], title: str = "FSM") -> str:

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -336,16 +336,23 @@ class TestBackfillSilentHumanNeeded(unittest.TestCase):
         from cai_lib.fsm import backfill_silent_human_needed_comments
 
         # Simulate two parked issues: one silent (no MARKER comment),
-        # one already has a MARKER comment and must be skipped.
+        # one already has a MARKER comment and must be skipped. Both
+        # are normal implementation issues — neither carries the
+        # rescue-prev fingerprint, so the auto-close branch must NOT
+        # fire even though close_issue defaults to the real helper.
         issue_lists = {
             LABEL_HUMAN_NEEDED: [
                 {
                     "number": 932,
+                    "title": "Refactor frobnicator",
+                    "body": "Move the frobnicator into cai_lib/frob.py.",
                     "labels": [{"name": LABEL_HUMAN_NEEDED}],
                     "comments": [{"body": "some unrelated comment"}],
                 },
                 {
                     "number": 980,
+                    "title": "Already-resolved divert",
+                    "body": "(implementation task body)",
                     "labels": [{"name": LABEL_HUMAN_NEEDED}],
                     "comments": [
                         {"body": "**🙋 Human attention needed**\n\n..."}
@@ -362,6 +369,7 @@ class TestBackfillSilentHumanNeeded(unittest.TestCase):
             return []
 
         posted = []
+        closed = []
 
         def _fake_post_issue(n, body, *, log_prefix="cai"):
             posted.append({"n": n, "body": body})
@@ -369,16 +377,200 @@ class TestBackfillSilentHumanNeeded(unittest.TestCase):
         def _fake_post_pr(n, body, *, log_prefix="cai"):
             posted.append({"n": n, "body": body})
 
+        def _fake_close(n, body, *, log_prefix="cai"):
+            closed.append({"n": n, "body": body})
+
         backfilled = backfill_silent_human_needed_comments(
             gh_json=_fake_gh_json,
             post_issue_comment=_fake_post_issue,
             post_pr_comment=_fake_post_pr,
+            close_issue=_fake_close,
         )
 
         self.assertEqual(backfilled, [("issue", 932)])
         self.assertEqual(len(posted), 1)
         self.assertEqual(posted[0]["n"], 932)
         self.assertIn("🙋 Human attention needed", posted[0]["body"])
+        # Implementation-task suggested-action paragraph.
+        self.assertIn("human:solved", posted[0]["body"])
+        # Auto-close branch must not fire for non-prevention issues.
+        self.assertEqual(closed, [])
+
+    def test_auto_closes_prevention_finding_with_no_structural_prevention(self):
+        """#1150 — rescue prevention findings whose remediation is
+        'No structural prevention needed' must be auto-closed (not
+        backfilled) so they stop cycling through the rescue agent."""
+        from cai_lib.fsm import backfill_silent_human_needed_comments
+
+        issue_lists = {
+            LABEL_HUMAN_NEEDED: [
+                {
+                    "number": 1145,
+                    "title": (
+                        "Rescue prevention: The retries-exhausted guard "
+                        "is working correctly."
+                    ),
+                    "body": (
+                        "<!-- fingerprint: rescue-prev-1fdf080c5e26341c -->\n"
+                        "**Category:** `reliability`\n\n"
+                        "## Remediation\n\n"
+                        "The guard is fine. No structural prevention "
+                        "needed — the Opus escalation path is the "
+                        "intended resolution.\n"
+                    ),
+                    "labels": [{"name": LABEL_HUMAN_NEEDED}],
+                    "comments": [],
+                },
+            ],
+        }
+
+        def _fake_gh_json(argv):
+            for i, tok in enumerate(argv):
+                if tok == "--label" and i + 1 < len(argv):
+                    return issue_lists.get(argv[i + 1], [])
+            return []
+
+        posted = []
+        closed = []
+
+        def _fake_post(n, body, *, log_prefix="cai"):
+            posted.append({"n": n, "body": body})
+
+        def _fake_close(n, body, *, log_prefix="cai"):
+            closed.append({"n": n, "body": body})
+
+        handled = backfill_silent_human_needed_comments(
+            gh_json=_fake_gh_json,
+            post_issue_comment=_fake_post,
+            post_pr_comment=_fake_post,
+            close_issue=_fake_close,
+        )
+
+        self.assertEqual(handled, [("issue", 1145)])
+        # Comment posters MUST NOT fire on the auto-close path.
+        self.assertEqual(posted, [])
+        # close_issue MUST be called with a body that names the
+        # auto-close path so the audit trail is unambiguous.
+        self.assertEqual(len(closed), 1)
+        self.assertEqual(closed[0]["n"], 1145)
+        self.assertIn("No structural prevention needed", closed[0]["body"])
+        self.assertIn("Auto-closed", closed[0]["body"])
+        self.assertIn("issue #1150", closed[0]["body"])
+
+    def test_prevention_finding_without_phrase_gets_typed_comment(self):
+        """#1150 — a rescue prevention finding lacking the auto-close
+        phrase must still be backfilled, and the comment must contain
+        the prevention-typed suggested-action paragraph rather than
+        the generic implementation-task wording."""
+        from cai_lib.fsm import backfill_silent_human_needed_comments
+
+        issue_lists = {
+            LABEL_HUMAN_NEEDED: [
+                {
+                    "number": 1146,
+                    "title": (
+                        "Rescue prevention: Add a blocked-on label "
+                        "for cyclic dependencies"
+                    ),
+                    "body": (
+                        "<!-- fingerprint: rescue-prev-deadbeefcafebabe -->\n"
+                        "**Category:** `reliability`\n\n"
+                        "## Remediation\n\n"
+                        "Add a `blocked-on:<N>` label mechanic to the "
+                        "rescue dispatcher.\n"
+                    ),
+                    "labels": [{"name": LABEL_HUMAN_NEEDED}],
+                    "comments": [],
+                },
+            ],
+        }
+
+        def _fake_gh_json(argv):
+            for i, tok in enumerate(argv):
+                if tok == "--label" and i + 1 < len(argv):
+                    return issue_lists.get(argv[i + 1], [])
+            return []
+
+        posted = []
+        closed = []
+
+        def _fake_post(n, body, *, log_prefix="cai"):
+            posted.append({"n": n, "body": body})
+
+        def _fake_close(n, body, *, log_prefix="cai"):
+            closed.append({"n": n, "body": body})
+
+        handled = backfill_silent_human_needed_comments(
+            gh_json=_fake_gh_json,
+            post_issue_comment=_fake_post,
+            post_pr_comment=_fake_post,
+            close_issue=_fake_close,
+        )
+
+        self.assertEqual(handled, [("issue", 1146)])
+        self.assertEqual(closed, [])
+        self.assertEqual(len(posted), 1)
+        self.assertEqual(posted[0]["n"], 1146)
+        # Prevention-typed suggested-action paragraph must mention the
+        # three options the admin can take.
+        self.assertIn("rescue prevention finding", posted[0]["body"])
+        self.assertIn("close this issue as completed", posted[0]["body"])
+        self.assertIn("close this issue as not planned", posted[0]["body"])
+        self.assertIn("human:solved", posted[0]["body"])
+
+    def test_pr_targets_never_take_auto_close_path(self):
+        """#1150 — the auto-close branch is issue-only. Even if a PR
+        body coincidentally contains the prevention-finding fingerprint
+        and the auto-close phrase (impossible in practice but worth
+        pinning), the PR must be backfilled via comment, not closed."""
+        from cai_lib.config import LABEL_PR_HUMAN_NEEDED
+        from cai_lib.fsm import backfill_silent_human_needed_comments
+
+        issue_lists = {
+            LABEL_PR_HUMAN_NEEDED: [
+                {
+                    "number": 4242,
+                    "title": "PR with weird body",
+                    "body": (
+                        "<!-- fingerprint: rescue-prev-faketoken -->\n"
+                        "No structural prevention needed."
+                    ),
+                    "labels": [{"name": LABEL_PR_HUMAN_NEEDED}],
+                    "comments": [],
+                },
+            ],
+        }
+
+        def _fake_gh_json(argv):
+            for i, tok in enumerate(argv):
+                if tok == "--label" and i + 1 < len(argv):
+                    return issue_lists.get(argv[i + 1], [])
+            return []
+
+        posted = []
+        closed = []
+
+        def _fake_post(n, body, *, log_prefix="cai"):
+            posted.append({"n": n, "body": body})
+
+        def _fake_close(n, body, *, log_prefix="cai"):
+            closed.append({"n": n, "body": body})
+
+        handled = backfill_silent_human_needed_comments(
+            gh_json=_fake_gh_json,
+            post_issue_comment=_fake_post,
+            post_pr_comment=_fake_post,
+            close_issue=_fake_close,
+        )
+
+        self.assertEqual(handled, [("pr", 4242)])
+        self.assertEqual(closed, [])
+        self.assertEqual(len(posted), 1)
+        self.assertEqual(posted[0]["n"], 4242)
+        # PR comments use the implementation-task suggested action
+        # (PRs are never rescue prevention findings even if their body
+        # happens to contain the fingerprint string).
+        self.assertIn("human:solved", posted[0]["body"])
 
 
 class TestResumeFromHuman(unittest.TestCase):


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1150

**Issue:** #1150 — Rescue prevention: When an issue is retroactively marked `human-needed` by the #1009 self-heal sweep, the generated comment should include 

## PR Summary

### What this fixes
The Phase 0.6 self-heal sweep (`backfill_silent_human_needed_comments`) generated the same generic "review and decide next steps" comment for all silently-parked issues, including cai-rescue prevention findings that explicitly stated no code change was needed — causing them to cycle through the rescue agent indefinitely.

### What was changed
- **`cai_lib/fsm_transitions.py`**: Added two module-level constants (`_PREVENTION_FINDING_FINGERPRINT_PREFIX`, `_NO_STRUCTURAL_PREVENTION_PHRASE`) and two helpers (`_is_rescue_prevention_finding`, `_has_no_structural_prevention`). Extended `backfill_silent_human_needed_comments` with a new `close_issue` injectable kwarg, fetches `title,body` in the `gh issue list` call, and branches on prevention-finding detection: auto-closes issues with "No structural prevention needed", posts a prevention-typed suggested-action comment for other prevention findings, and falls back to the original implementation-task wording for normal issues.
- **`tests/test_fsm.py`**: Updated the existing `test_backfills_issues_without_marker_comment` mock to include `title`/`body` fields and inject a `close_issue` spy (with assertion that it is not called for non-prevention issues). Added three new tests: `test_auto_closes_prevention_finding_with_no_structural_prevention`, `test_prevention_finding_without_phrase_gets_typed_comment`, and `test_pr_targets_never_take_auto_close_path`.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
