### PR TITLE
chore: raise CAI_MAX_DECOMPOSITION_DEPTH default from 2 to 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ If the refine subagent detects that work requires multiple independent steps, it
 2. Creates one sub-issue per step, with titles formatted as `[#{parent} Step X/Y] <title>` (e.g. `[#123 Step 1/3] Add schema migration`) so you can identify the parent from a list view. Each sub-issue is labeled with `depth:N` (where N is the decomposition depth, starting at 1 for top-level decompositions). Each sub-issue body includes a back-reference to the parent.
 3. Adds a checklist to the parent issue to track sub-issue completion
 
-Decomposition supports recursion: sub-issues can themselves be decomposed into further sub-issues up to a maximum depth (controlled by `CAI_MAX_DECOMPOSITION_DEPTH`, default: 2). Issues at maximum depth will not be decomposed further and will be refined as single units of work.
+Decomposition supports recursion: sub-issues can themselves be decomposed into further sub-issues up to a maximum depth (controlled by `CAI_MAX_DECOMPOSITION_DEPTH`, default: 5). Issues at maximum depth will not be decomposed further and will be refined as single units of work.
 
 You can watch the parent issue's checklist to monitor progress. Note: if an issue already has a structured `### Plan` section when filed, the refine subagent will skip refinement, and no sub-issues will be created — the implement subagent will execute the steps directly from the issue body.
 
@@ -662,7 +662,7 @@ the same global window settings.
   the [Confidence-gated auto-merge](#confidence-gated-auto-merge)
   section for details.
 - **`CAI_MAX_DECOMPOSITION_DEPTH`** — maximum recursion depth for
-  multi-step decomposition. Default: `2`. Sub-issues at this depth will
+  multi-step decomposition. Default: `5`. Sub-issues at this depth will
   be refined as single units of work without further decomposition. Increase
   to support deeper hierarchies of sub-issues, or decrease to limit
   decomposition to shallower hierarchies.

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -186,7 +186,7 @@ LABEL_TRIAGING         = "auto-improve:triaging"
 LABEL_KIND_CODE        = "kind:code"
 LABEL_KIND_MAINTENANCE = "kind:maintenance"
 LABEL_DEPTH_PREFIX = "depth:"
-MAX_DECOMPOSITION_DEPTH: int = int(os.environ.get("CAI_MAX_DECOMPOSITION_DEPTH", "2"))
+MAX_DECOMPOSITION_DEPTH: int = int(os.environ.get("CAI_MAX_DECOMPOSITION_DEPTH", "5"))
 
 # PR pipeline-state labels — one per PRState. Set by FSM transitions
 # (fire_trigger) and read by dispatch.


### PR DESCRIPTION
## Summary
- Raises the default decomposition depth cap from `2` to `5` so the split agent can further decompose deeply-nested refactors when warranted.
- Updates both mentions of the `2` default in `README.md`.

## Motivation
The depth-2 cap was hit by #1137 — a 9-file, ~41-call-site PR-side handler migration that the split agent could not further decompose because `cai_lib/actions/split.py:112-118` explicitly instructs the agent `Do NOT emit a Multi-Step Decomposition block` once `current_depth >= MAX_DECOMPOSITION_DEPTH`. The agent was forced into ATOMIC and the resulting 73-step plan failed 3× on Sonnet and 1× on Opus.

Tests patch the constant directly (`patch("cai_lib.actions.split.MAX_DECOMPOSITION_DEPTH", ...)`) so the default change does not affect them.

## Test plan
- [ ] `python -m unittest tests.test_split tests.test_multistep`
- [ ] Spot-check that the split agent now decomposes #1137 if re-routed through `:refined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)