### PR TITLE
auto-improve: Replace depth:N label with walking GitHub native sub-issue parent chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,10 @@ approach and this guidance does not apply.
 
 If the refine subagent detects that work requires multiple independent steps, it produces a `## Multi-Step Decomposition` output. The wrapper then:
 1. Labels the parent issue `auto-improve:parent`
-2. Creates one sub-issue per step, with titles formatted as `[#{parent} Step X/Y] <title>` (e.g. `[#123 Step 1/3] Add schema migration`) so you can identify the parent from a list view. Each sub-issue is labeled with `depth:N` (where N is the decomposition depth, starting at 1 for top-level decompositions). Each sub-issue body includes a back-reference to the parent.
+2. Creates one sub-issue per step, with titles formatted as `[#{parent} Step X/Y] <title>` (e.g. `[#123 Step 1/3] Add schema migration`) so you can identify the parent from a list view. Each sub-issue body includes a back-reference to the parent and is linked via GitHub's native sub-issues API.
 3. Adds a checklist to the parent issue to track sub-issue completion
 
-Decomposition supports recursion: sub-issues can themselves be decomposed into further sub-issues up to a maximum depth (controlled by `CAI_MAX_DECOMPOSITION_DEPTH`, default: 5). Issues at maximum depth will not be decomposed further and will be refined as single units of work.
+Decomposition supports recursion: sub-issues can themselves be decomposed into further sub-issues up to a maximum depth (controlled by `CAI_MAX_DECOMPOSITION_DEPTH`, default: 5). Issues at maximum depth will not be decomposed further and will be refined as single units of work. Decomposition depth is computed dynamically by walking the GitHub native sub-issue parent chain, enabling safe recursive decomposition without label-based tracking.
 
 You can watch the parent issue's checklist to monitor progress. Note: if an issue already has a structured `### Plan` section when filed, the refine subagent will skip refinement, and no sub-issues will be created — the implement subagent will execute the steps directly from the issue body.
 

--- a/cai_lib/actions/refine.py
+++ b/cai_lib/actions/refine.py
@@ -16,14 +16,13 @@ from cai_lib.config import (
     REPO,
     LABEL_RAISED,
     LABEL_REFINING,
-    LABEL_DEPTH_PREFIX,
 )
 from cai_lib.fsm import fire_trigger
 from cai_lib.github import _build_issue_block
 from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.logging_utils import log_run
 from cai_lib.cmd_helpers import _strip_stored_plan_block
-from cai_lib.issues import create_issue, link_sub_issue, list_sub_issues
+from cai_lib.issues import create_issue, get_parent_issue, link_sub_issue, list_sub_issues
 
 
 _REFINE_NEXT_STEP_RE = re.compile(
@@ -142,19 +141,21 @@ def _detect_guardrail_contradictions(refined_body: str) -> list[str]:
     return [p for p in both if not p.startswith("docs/")]
 
 
-def _issue_depth(issue: dict) -> int:
-    """Return the decomposition depth of *issue* from its ``depth:N`` label.
+def _issue_depth(issue_number: int) -> int:
+    """Compute decomposition depth by walking the native GitHub sub-issue parent chain.
 
-    Returns 0 if no ``depth:`` label is present (top-level issue).
+    Depth 0 means the issue has no parent (top-level).
+    Depth N means the issue's parent has depth N-1.
+    Treats any API failure as "no parent" so the loop terminates safely.
     """
-    for label in issue.get("labels", []):
-        name = label if isinstance(label, str) else label.get("name", "")
-        if name.startswith(LABEL_DEPTH_PREFIX):
-            try:
-                return int(name[len(LABEL_DEPTH_PREFIX):])
-            except ValueError:
-                pass
-    return 0
+    depth = 0
+    current = issue_number
+    while True:
+        parent = get_parent_issue(current)
+        if parent is None:
+            return depth
+        depth += 1
+        current = parent["number"]
 
 
 def _find_sub_issue(parent_number: int, step: int) -> "int | None":
@@ -175,7 +176,6 @@ def _find_sub_issue(parent_number: int, step: int) -> "int | None":
 
 def _create_sub_issues(
     steps: list[dict], parent_number: int, parent_title: str,
-    depth: int = 0,
 ) -> list[int]:
     """Create GitHub sub-issues for a multi-step decomposition.
 
@@ -212,7 +212,7 @@ def _create_sub_issues(
             f"Step {s['step']} of {total}._\n"
         )
         title = f"[#{parent_number} Step {s['step']}/{total}] {s['title']}"
-        labels = ["auto-improve", LABEL_RAISED, f"{LABEL_DEPTH_PREFIX}{depth}"]
+        labels = ["auto-improve", LABEL_RAISED]
         # Use create_issue() (REST API) instead of gh issue create so we
         # get back the internal `id` needed for link_sub_issue().
         meta = create_issue(title, body, labels)

--- a/cai_lib/actions/split.py
+++ b/cai_lib/actions/split.py
@@ -33,7 +33,6 @@ from cai_lib.config import (
     LABEL_REFINED,
     LABEL_SPLITTING,
     LABEL_PARENT,
-    LABEL_DEPTH_PREFIX,
     MAX_DECOMPOSITION_DEPTH,
 )
 from cai_lib.fsm import (
@@ -107,7 +106,7 @@ def handle_split(issue: dict) -> int:
         return 1
 
     # 2. Build the agent input and invoke cai-split.
-    current_depth = _issue_depth(issue)
+    current_depth = _issue_depth(issue_number)
     user_message = _build_issue_block(issue)
     if current_depth >= MAX_DECOMPOSITION_DEPTH:
         user_message += (
@@ -217,7 +216,7 @@ def handle_split(issue: dict) -> int:
             flush=True,
         )
         sub_nums = _create_sub_issues(
-            steps, issue_number, title, depth=current_depth + 1,
+            steps, issue_number, title,
         )
         _set_labels(
             issue_number,

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -185,7 +185,6 @@ LABEL_PLAN_NEEDS_REVIEW = "auto-improve:plan-needs-review"
 LABEL_TRIAGING         = "auto-improve:triaging"
 LABEL_KIND_CODE        = "kind:code"
 LABEL_KIND_MAINTENANCE = "kind:maintenance"
-LABEL_DEPTH_PREFIX = "depth:"
 MAX_DECOMPOSITION_DEPTH: int = int(os.environ.get("CAI_MAX_DECOMPOSITION_DEPTH", "5"))
 
 # PR pipeline-state labels — one per PRState. Set by FSM transitions

--- a/cai_lib/issues.py
+++ b/cai_lib/issues.py
@@ -101,6 +101,44 @@ def list_sub_issues(parent_number: int) -> list[dict]:
         return []
 
 
+def get_parent_issue(issue_number: int) -> dict | None:
+    """Return the parent issue of *issue_number* via GraphQL, or None.
+
+    Walks the GitHub native sub-issues parent relation (``subIssuesParent``
+    GraphQL field).  Returns a dict with at least ``{'number': int}`` if a
+    parent exists, or ``None`` if the issue has no parent.  Treats any API
+    failure as "no parent" so callers can safely loop.
+    """
+    owner, name = REPO.split("/", 1)
+    query = (
+        "query($owner: String!, $name: String!, $number: Int!) {"
+        "  repository(owner: $owner, name: $name) {"
+        "    issue(number: $number) {"
+        "      subIssuesParent { number }"
+        "    }"
+        "  }"
+        "}"
+    )
+    try:
+        result = _gh_json([
+            "api", "graphql",
+            "-f", f"query={query}",
+            "-F", f"owner={owner}",
+            "-F", f"name={name}",
+            "-F", f"number={issue_number}",
+        ])
+        parent = (
+            (result or {})
+            .get("data", {})
+            .get("repository", {})
+            .get("issue", {})
+            .get("subIssuesParent")
+        )
+        return parent if parent else None
+    except (subprocess.CalledProcessError, AttributeError, TypeError):
+        return None
+
+
 def all_sub_issues_closed(parent_number: int) -> bool | None:
     """Check whether every native sub-issue of *parent_number* is closed.
 

--- a/docs/modules/github-glue.md
+++ b/docs/modules/github-glue.md
@@ -31,6 +31,7 @@ through this module.
   sub-issues API wrappers: `create_issue(title, body, labels)`,
   `link_sub_issue(parent_number, child_id)`,
   `list_sub_issues(parent_number)`,
+  `get_parent_issue(issue_number)` (walks GitHub parent chain),
   `all_sub_issues_closed(parent_number)`.
 - [`cai_lib/dup_check.py`](../../cai_lib/dup_check.py) —
   `DupCheckVerdict` dataclass; `parse_dup_check_verdict(text)`,

--- a/tests/test_multistep.py
+++ b/tests/test_multistep.py
@@ -129,41 +129,35 @@ from cai_lib.actions.refine import _issue_depth, _create_sub_issues, handle_refi
 
 
 class TestIssueDepth(unittest.TestCase):
-    def test_no_depth_label_returns_zero(self):
-        issue = {"labels": [{"name": "auto-improve"}, {"name": "auto-improve:raised"}]}
-        self.assertEqual(_issue_depth(issue), 0)
+    @patch("cai_lib.actions.refine.get_parent_issue", return_value=None)
+    def test_no_parent_returns_zero(self, mock_parent):
+        self.assertEqual(_issue_depth(42), 0)
 
-    def test_depth_label_returns_n(self):
-        issue = {"labels": [{"name": "auto-improve"}, {"name": "depth:1"}]}
-        self.assertEqual(_issue_depth(issue), 1)
+    @patch("cai_lib.actions.refine.get_parent_issue")
+    def test_one_parent_returns_one(self, mock_parent):
+        mock_parent.side_effect = [{"number": 5}, None]
+        self.assertEqual(_issue_depth(42), 1)
 
-    def test_depth_two(self):
-        issue = {"labels": [{"name": "depth:2"}, {"name": "auto-improve:raised"}]}
-        self.assertEqual(_issue_depth(issue), 2)
+    @patch("cai_lib.actions.refine.get_parent_issue")
+    def test_two_parents_returns_two(self, mock_parent):
+        mock_parent.side_effect = [{"number": 5}, {"number": 3}, None]
+        self.assertEqual(_issue_depth(42), 2)
 
-    def test_empty_labels(self):
-        issue = {"labels": []}
-        self.assertEqual(_issue_depth(issue), 0)
-
-    def test_no_labels_key(self):
-        issue = {}
-        self.assertEqual(_issue_depth(issue), 0)
-
-    def test_malformed_depth_label_ignored(self):
-        issue = {"labels": [{"name": "depth:abc"}]}
-        self.assertEqual(_issue_depth(issue), 0)
+    @patch("cai_lib.actions.refine.get_parent_issue", return_value=None)
+    def test_top_level_issue_returns_zero(self, mock_parent):
+        self.assertEqual(_issue_depth(99), 0)
 
 
-class TestCreateSubIssuesDepth(unittest.TestCase):
+class TestCreateSubIssuesNoDepthLabel(unittest.TestCase):
     @patch("cai_lib.actions.refine.link_sub_issue")
     @patch("cai_lib.actions.refine.create_issue")
     @patch("cai_lib.actions.refine._find_sub_issue", return_value=None)
-    def test_depth_label_applied(self, mock_find, mock_create, mock_link):
+    def test_no_depth_label_applied(self, mock_find, mock_create, mock_link):
         mock_create.return_value = {"number": 42, "id": 999, "html_url": "http://x"}
         steps = [{"step": 1, "title": "T", "body": "B"}]
-        _create_sub_issues(steps, 10, "Parent", depth=1)
+        _create_sub_issues(steps, 10, "Parent")
         labels = mock_create.call_args[0][2]
-        self.assertIn("depth:1", labels)
+        self.assertFalse(any(l.startswith("depth:") for l in labels))
 
 
 class TestSplitDepthGate(unittest.TestCase):
@@ -176,8 +170,9 @@ class TestSplitDepthGate(unittest.TestCase):
     @patch("cai_lib.actions.split._run_claude_p")
     @patch("cai_lib.actions.split.fire_trigger")
     @patch("cai_lib.actions.split._build_issue_block", return_value="issue text")
+    @patch("cai_lib.actions.split._issue_depth", return_value=2)
     def test_max_depth_injects_no_decompose(
-        self, mock_build, mock_transition, mock_claude, mock_log_run,
+        self, mock_depth, mock_build, mock_transition, mock_claude, mock_log_run,
     ):
         mock_claude.return_value = MagicMock(
             returncode=0,
@@ -188,7 +183,7 @@ class TestSplitDepthGate(unittest.TestCase):
             from cai_lib.actions.split import handle_split
             issue = {
                 "number": 5, "title": "Test",
-                "labels": [{"name": "depth:2"}, {"name": "auto-improve:refined"}],
+                "labels": [{"name": "auto-improve:refined"}],
                 "body": "test body",
             }
             handle_split(issue)

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -22,11 +22,10 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from cai_lib.actions.split import handle_split
 
 
-def _refined_issue(number: int = 1, depth: int = 0) -> dict:
+def _refined_issue(number: int = 1) -> dict:
     labels = [
         {"name": "auto-improve"},
         {"name": "auto-improve:refined"},
-        {"name": f"depth:{depth}"},
     ]
     return {
         "number": number,
@@ -36,11 +35,10 @@ def _refined_issue(number: int = 1, depth: int = 0) -> dict:
     }
 
 
-def _splitting_issue(number: int = 1, depth: int = 0) -> dict:
+def _splitting_issue(number: int = 1) -> dict:
     labels = [
         {"name": "auto-improve"},
         {"name": "auto-improve:splitting"},
-        {"name": f"depth:{depth}"},
     ]
     return {
         "number": number,
@@ -156,7 +154,7 @@ class TestSplitDecomposeVerdict(unittest.TestCase):
             ),
             stderr="",
         )
-        handle_split(_refined_issue(depth=0))
+        handle_split(_refined_issue())
         mock_create_subs.assert_called_once()
         # _set_labels must add auto-improve:parent and remove :splitting.
         call_kwargs = mock_set_labels.call_args.kwargs
@@ -195,8 +193,9 @@ class TestSplitDecomposeVerdict(unittest.TestCase):
     @patch("cai_lib.actions.split._run_claude_p")
     @patch("cai_lib.actions.split.fire_trigger")
     @patch("cai_lib.actions.split._build_issue_block", return_value="issue text")
+    @patch("cai_lib.actions.split._issue_depth", return_value=1)
     def test_decompose_over_max_depth_diverts_to_human(
-        self, mock_build, mock_fire, mock_claude, mock_create_subs,
+        self, mock_depth, mock_build, mock_fire, mock_claude, mock_create_subs,
         mock_set_labels, mock_log_run,
     ):
         mock_claude.return_value = MagicMock(
@@ -210,7 +209,7 @@ class TestSplitDecomposeVerdict(unittest.TestCase):
             stderr="",
         )
         with patch("cai_lib.actions.split.MAX_DECOMPOSITION_DEPTH", 1):
-            handle_split(_refined_issue(depth=1))
+            handle_split(_refined_issue())
         mock_create_subs.assert_not_called()
         fired = [c.args[1] for c in mock_fire.call_args_list]
         self.assertIn("splitting_to_human", fired)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1155

**Issue:** #1155 — Replace depth:N label with walking GitHub native sub-issue parent chain

## PR Summary

### What this fixes
Decomposition depth was tracked via a `depth:N` label applied to each sub-issue at creation time, which drifts when issues are re-parented and adds label namespace noise. This replaces the label-based approach with a function that walks GitHub's native sub-issue parent chain via GraphQL to compute depth on demand.

### What was changed
- **`cai_lib/issues.py`**: Added `get_parent_issue(issue_number)` helper that queries the GraphQL `subIssuesParent` field; returns `{"number": N}` or `None` on no parent/failure
- **`cai_lib/actions/refine.py`**: Replaced label-based `_issue_depth(issue: dict)` with parent-chain-walking `_issue_depth(issue_number: int)`; removed `depth: int = 0` parameter and `depth:N` label application from `_create_sub_issues()`; updated imports
- **`cai_lib/actions/split.py`**: Updated `_issue_depth(issue)` → `_issue_depth(issue_number)` call site; removed `depth=current_depth + 1` from `_create_sub_issues()` call; removed `LABEL_DEPTH_PREFIX` import
- **`cai_lib/config.py`**: Deleted `LABEL_DEPTH_PREFIX = "depth:"` constant
- **`tests/test_multistep.py`**: Rewrote `TestIssueDepth` to mock `get_parent_issue`; updated `TestCreateSubIssuesDepth` to assert no depth label is applied; patched `_issue_depth` directly in `TestSplitDepthGate`
- **`tests/test_split.py`**: Removed `depth` parameter from `_refined_issue()`/`_splitting_issue()` helpers; patched `_issue_depth` in `test_decompose_over_max_depth_diverts_to_human`

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
