### PR TITLE
[#1124 Step 2/3] Migrate PR-side handlers to HandlerResult and drop dispatch_pr compat shim

### DIFF
--- a/cai_lib/actions/fix_ci.py
+++ b/cai_lib/actions/fix_ci.py
@@ -21,6 +21,7 @@ from cai_lib.config import (
     LABEL_PR_NEEDS_HUMAN,
     LABEL_MERGE_BLOCKED,
 )
+from cai_lib.dispatcher import HandlerResult
 from cai_lib.fsm import (
     PRState,
     fire_trigger,
@@ -202,7 +203,7 @@ def _fetch_ci_failure_log(detail_url: str) -> str:
     return "\n".join(lines[-200:])
 
 
-def handle_fix_ci(pr: dict) -> int:
+def handle_fix_ci(pr: dict) -> HandlerResult:
     """Auto-diagnose and fix CI failures on an auto-improve PR.
 
     The dispatcher has already verified the PR is at ``PRState.CI_FAILING``
@@ -217,7 +218,7 @@ def handle_fix_ci(pr: dict) -> int:
     if pr_number is None:
         print("[cai fix-ci] handler called without pr['number']", file=sys.stderr)
         log_run("fix-ci", repo=REPO, result="missing_pr_number", exit=1)
-        return 1
+        return HandlerResult(trigger="")
 
     try:
         pr_detail = _gh_json([
@@ -228,7 +229,7 @@ def handle_fix_ci(pr: dict) -> int:
     except subprocess.CalledProcessError as e:
         print(f"[cai fix-ci] gh pr view #{pr_number} failed:\n{e.stderr}", file=sys.stderr)
         log_run("fix-ci", repo=REPO, pr=pr_number, result="pr_lookup_failed", exit=1)
-        return 1
+        return HandlerResult(trigger="")
     branch = pr_detail.get("headRefName", "")
     m = re.match(r"^auto-improve/(\d+)-", branch)
     if not m:
@@ -238,7 +239,7 @@ def handle_fix_ci(pr: dict) -> int:
             file=sys.stderr,
         )
         log_run("fix-ci", repo=REPO, pr=pr_number, result="not_auto_improve", exit=1)
-        return 1
+        return HandlerResult(trigger="")
     issue_number = int(m.group(1))
     checks = pr_detail.get("statusCheckRollup") or []
     failing = [
@@ -259,6 +260,7 @@ def handle_fix_ci(pr: dict) -> int:
     print("[cai fix-ci] found 1 PR(s) with failing CI", flush=True)
 
     had_failure = False
+    pending_transition = ""
     pr_number = target["pr_number"]
     issue_number = target["issue_number"]
     branch = target["branch"]
@@ -274,7 +276,7 @@ def handle_fix_ci(pr: dict) -> int:
     if not _set_labels(issue_number, add=[LABEL_REVISING], log_prefix="cai fix-ci"):
         print(f"[cai fix-ci] could not lock #{issue_number}", file=sys.stderr)
         log_run("fix-ci", repo=REPO, pr=pr_number, result="lock_failed", exit=1)
-        return 1
+        return HandlerResult(trigger="")
 
     # 1a. Advance PR FSM into CI_FAILING. The wrapper detected red
     # checks via _select_ci_fix_targets; formalize that in the FSM
@@ -325,7 +327,7 @@ def handle_fix_ci(pr: dict) -> int:
             print(f"[cai fix-ci] clone failed:\n{clone.stderr}", file=sys.stderr)
             _set_labels(issue_number, remove=[LABEL_REVISING], log_prefix="cai fix-ci")
             log_run("fix-ci", repo=REPO, pr=pr_number, result="clone_failed", exit=1)
-            return 1
+            return HandlerResult(trigger="")
 
         _git(work_dir, "fetch", "origin", branch)
         _git(work_dir, "checkout", branch)
@@ -358,7 +360,7 @@ def handle_fix_ci(pr: dict) -> int:
             )
             _set_labels(issue_number, remove=[LABEL_REVISING], log_prefix="cai fix-ci")
             log_run("fix-ci", repo=REPO, pr=pr_number, result="rebase_conflict", exit=0)
-            return 0
+            return HandlerResult(trigger="")
 
         # 5. Fetch CI failure logs (first two failing checks).
         ci_log_section = "## CI failure log\n\n"
@@ -469,11 +471,7 @@ def handle_fix_ci(pr: dict) -> int:
                 # next tick re-evaluates check status, and if still
                 # red _select_ci_fix_targets re-queues the PR
                 # (which re-enters CI_FAILING via step 1a above).
-                fire_trigger(
-                    pr_number, "ci_failing_to_reviewing_code",
-                    is_pr=True,
-                    log_prefix="cai fix-ci",
-                )
+                pending_transition = "ci_failing_to_reviewing_code"
         else:
             print(
                 f"[cai fix-ci] no changes produced by agent for PR #{pr_number}",
@@ -509,4 +507,4 @@ def handle_fix_ci(pr: dict) -> int:
         if work_dir.exists():
             shutil.rmtree(work_dir, ignore_errors=True)
 
-    return 1 if had_failure else 0
+    return HandlerResult(trigger="" if had_failure else pending_transition)

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -39,6 +39,7 @@ from cai_lib.config import (
     LABEL_PR_NEEDS_WORKFLOW_REVIEW,
     LABEL_OPUS_ATTEMPTED,
 )
+from cai_lib.dispatcher import HandlerResult
 from cai_lib.fsm import fire_trigger, get_pr_state, PRState
 from cai_lib.github import _gh_json, _set_labels, _issue_has_label, close_issue_not_planned
 from cai_lib.subprocess_utils import _run, _run_claude_p
@@ -639,7 +640,7 @@ def _pr_touches_workflow_files(raw_diff: str) -> bool:
     return bool(_WORKFLOW_DIFF_HEADER_RE.search(raw_diff))
 
 
-def handle_merge(pr: dict) -> int:
+def handle_merge(pr: dict) -> HandlerResult:
     """Confidence-gated auto-merge for a single APPROVED bot PR.
 
     The dispatcher has already resolved *pr* to state
@@ -681,10 +682,10 @@ def handle_merge(pr: dict) -> int:
             f"migrating to PR_HUMAN_NEEDED",
             flush=True,
         )
-        fire_trigger(
-            pr["number"], "approved_to_human",
-            is_pr=True,
-            log_prefix="cai merge",
+        log_run("merge", repo=REPO, pr=pr["number"],
+                result="legacy_park_migration", exit=0)
+        return HandlerResult(
+            trigger="approved_to_human",
             divert_reason=(
                 f"PR still carries the legacy "
                 f"`{LABEL_PR_NEEDS_HUMAN}` flag while at "
@@ -693,9 +694,6 @@ def handle_merge(pr: dict) -> int:
                 f"re-routing to handle_merge."
             ),
         )
-        log_run("merge", repo=REPO, pr=pr["number"],
-                result="legacy_park_migration", exit=0)
-        return 0
 
     if _MERGE_THRESHOLD == "disabled":
         print(
@@ -703,7 +701,7 @@ def handle_merge(pr: dict) -> int:
             flush=True,
         )
         log_run("merge", repo=REPO, result="disabled", exit=0)
-        return 0
+        return HandlerResult(trigger="")
 
     if _MERGE_THRESHOLD not in ("high", "medium"):
         print(
@@ -746,10 +744,10 @@ def handle_merge(pr: dict) -> int:
              f"this state."],
             capture_output=True,
         )
-        fire_trigger(
-            pr_number, "approved_to_human",
-            is_pr=True,
-            log_prefix="cai merge",
+        log_run("merge", repo=REPO, pr=pr_number,
+                result="not_bot_branch", exit=0)
+        return HandlerResult(
+            trigger="approved_to_human",
             divert_reason=(
                 f"PR is on branch `{branch}`, which is not an "
                 f"`auto-improve/<issue>-…` bot branch. The cai merge "
@@ -757,9 +755,6 @@ def handle_merge(pr: dict) -> int:
                 f"admin must merge this PR manually."
             ),
         )
-        log_run("merge", repo=REPO, pr=pr_number,
-                result="not_bot_branch", exit=0)
-        return 0
     issue_number = int(m.group(1))
 
     # Safety filter 2: unmergeable PRs (conflicts).
@@ -772,7 +767,7 @@ def handle_merge(pr: dict) -> int:
         )
         log_run("merge", repo=REPO, pr=pr_number,
                 result="conflicting", exit=0)
-        return 0
+        return HandlerResult(trigger="")
 
     # Safety filter 3: linked issue must be in :pr-open state.
     try:
@@ -789,7 +784,7 @@ def handle_merge(pr: dict) -> int:
         )
         log_run("merge", repo=REPO, pr=pr_number,
                 result="issue_fetch_failed", exit=0)
-        return 0
+        return HandlerResult(trigger="")
 
     issue_labels = [l["name"] for l in issue.get("labels", [])]  # noqa: E741
     if LABEL_PR_OPEN not in issue_labels:
@@ -800,7 +795,7 @@ def handle_merge(pr: dict) -> int:
         )
         log_run("merge", repo=REPO, pr=pr_number,
                 result="issue_not_pr_open", exit=0)
-        return 0
+        return HandlerResult(trigger="")
 
     # State gate (defensive — dispatcher should already have verified).
     if get_pr_state(pr) != PRState.APPROVED:
@@ -810,7 +805,7 @@ def handle_merge(pr: dict) -> int:
         )
         log_run("merge", repo=REPO, pr=pr_number,
                 result="wrong_state", exit=0)
-        return 0
+        return HandlerResult(trigger="")
 
     # NOTE: the previous SHA gate that diverted APPROVED → REVIEWING_CODE
     # when the current HEAD had no `(clean)` docs-review comment caused
@@ -841,7 +836,7 @@ def handle_merge(pr: dict) -> int:
         )
         log_run("merge", repo=REPO, pr=pr_number,
                 result="unaddressed_comments", exit=0)
-        return 0
+        return HandlerResult(trigger="")
 
     # Safety filter 5: failed CI checks. Divert to CI_FAILING so
     # handle_fix_ci picks the PR up on the next drive step. Returning
@@ -865,14 +860,9 @@ def handle_merge(pr: dict) -> int:
                     f"checks; diverting to CI_FAILING",
                     flush=True,
                 )
-                fire_trigger(
-                    pr_number, "approved_to_ci_failing",
-                    is_pr=True,
-                    log_prefix="cai merge",
-                )
                 log_run("merge", repo=REPO, pr=pr_number,
                         result="ci_failing", exit=0)
-                return 0
+                return HandlerResult(trigger="approved_to_ci_failing")
     except (subprocess.CalledProcessError, json.JSONDecodeError, TypeError):
         pass  # no CI checks is fine
 
@@ -906,7 +896,7 @@ def handle_merge(pr: dict) -> int:
             )
             log_run("merge", repo=REPO, pr=pr_number,
                     result="already_evaluated", exit=0)
-            return 0
+            return HandlerResult(trigger="")
         print(
             f"[cai merge] PR #{pr_number}: re-evaluating — new human "
             f"comment since last verdict",
@@ -939,7 +929,7 @@ def handle_merge(pr: dict) -> int:
         )
         log_run("merge", repo=REPO, pr=pr_number,
                 result="diff_failed", exit=0)
-        return 0
+        return HandlerResult(trigger="")
 
     # Safety filter 7: unauthorized agent-file deletions (issue #1024).
     # If the PR deletes any .claude/agents/**/*.md file that is NOT
@@ -985,10 +975,12 @@ def handle_merge(pr: dict) -> int:
             f"human-needed",
             flush=True,
         )
-        fire_trigger(
-            pr_number, "approved_to_human",
-            is_pr=True,
-            log_prefix="cai merge",
+        dur_tag = f"{int(time.monotonic() - t0)}s"
+        log_run("merge", repo=REPO, pr=pr_number,
+                duration=dur_tag,
+                result="unauthorized_agent_deletions", exit=0)
+        return HandlerResult(
+            trigger="approved_to_human",
             divert_reason=(
                 f"PR contains {len(unauthorized_deletions)} unauthorized "
                 f"agent-file deletion(s). Bot PRs must not delete "
@@ -997,11 +989,6 @@ def handle_merge(pr: dict) -> int:
                 f"the deletions and decide next steps."
             ),
         )
-        dur_tag = f"{int(time.monotonic() - t0)}s"
-        log_run("merge", repo=REPO, pr=pr_number,
-                duration=dur_tag,
-                result="unauthorized_agent_deletions", exit=0)
-        return 0
 
     pr_diff = _assemble_diff(diff_result.stdout, _MERGE_MAX_DIFF_LEN)
 
@@ -1080,7 +1067,7 @@ def handle_merge(pr: dict) -> int:
         )
         log_run("merge", repo=REPO, pr=pr_number,
                 result="agent_failed", exit=result.returncode)
-        return result.returncode
+        return HandlerResult(trigger="")
 
     try:
         tool_input = json.loads(result.stdout)
@@ -1111,7 +1098,7 @@ def handle_merge(pr: dict) -> int:
         )
         log_run("merge", repo=REPO, pr=pr_number,
                 result="verdict_unparseable", exit=0)
-        return 0
+        return HandlerResult(trigger="")
 
     # Post the verdict as a PR comment.
     comment_body = (
@@ -1157,10 +1144,11 @@ def handle_merge(pr: dict) -> int:
                 log_prefix="cai merge",
             )
             if not closed_ok:
-                fire_trigger(
-                    pr_number, "approved_to_human",
-                    is_pr=True,
-                    log_prefix="cai merge",
+                log_run("merge", repo=REPO, pr=pr_number,
+                        duration=dur(), result="close_label_failed",
+                        exit=0)
+                return HandlerResult(
+                    trigger="approved_to_human",
                     divert_reason=(
                         "cai-merge closed this PR as a high-confidence "
                         "reject, but relabelling the linked issue as "
@@ -1168,13 +1156,9 @@ def handle_merge(pr: dict) -> int:
                         "human can clean up the issue label state."
                     ),
                 )
-                log_run("merge", repo=REPO, pr=pr_number,
-                        duration=dur(), result="close_label_failed",
-                        exit=0)
-                return 0
             log_run("merge", repo=REPO, pr=pr_number,
                     duration=dur(), result="closed", exit=0)
-            return 0
+            return HandlerResult(trigger="")
         else:
             print(
                 f"[cai merge] PR #{pr_number}: close failed:\n"
@@ -1193,10 +1177,10 @@ def handle_merge(pr: dict) -> int:
                         f"after close failure on PR #{pr_number}",
                         file=sys.stderr, flush=True,
                     )
-            fire_trigger(
-                pr_number, "approved_to_human",
-                is_pr=True,
-                log_prefix="cai merge",
+            log_run("merge", repo=REPO, pr=pr_number,
+                    duration=dur(), result="close_failed", exit=0)
+            return HandlerResult(
+                trigger="approved_to_human",
                 divert_reason=(
                     "cai-merge tried to close this PR as a high-"
                     "confidence reject, but `gh pr close` failed. The "
@@ -1204,9 +1188,6 @@ def handle_merge(pr: dict) -> int:
                     "A human must close the PR manually."
                 ),
             )
-            log_run("merge", repo=REPO, pr=pr_number,
-                    duration=dur(), result="close_failed", exit=0)
-            return 0
     elif action == "merge" and verdict_rank >= threshold_rank:
         print(
             f"[cai merge] PR #{pr_number}: verdict={confidence} "
@@ -1256,26 +1237,21 @@ def handle_merge(pr: dict) -> int:
                     log_run("merge", repo=REPO, pr=pr_number,
                             duration=dur(),
                             result="merge_label_failed", exit=0)
-                    return 0
+                    return HandlerResult(trigger="")
             # Apply the APPROVED → MERGED transition on the PR itself.
-            fire_trigger(
-                pr_number, "approved_to_merged",
-                is_pr=True,
-                log_prefix="cai merge",
-            )
             log_run("merge", repo=REPO, pr=pr_number,
                     duration=dur(), result="merged", exit=0)
-            return 0
+            return HandlerResult(trigger="approved_to_merged")
         else:
             print(
                 f"[cai merge] PR #{pr_number}: merge failed:\n"
                 f"{merge_result.stderr}",
                 file=sys.stderr,
             )
-            fire_trigger(
-                pr_number, "approved_to_human",
-                is_pr=True,
-                log_prefix="cai merge",
+            log_run("merge", repo=REPO, pr=pr_number,
+                    duration=dur(), result="merge_failed", exit=0)
+            return HandlerResult(
+                trigger="approved_to_human",
                 divert_reason=(
                     "cai-merge verdict was to merge, but `gh pr merge` "
                     "failed. The PR is still open; a human must "
@@ -1283,9 +1259,6 @@ def handle_merge(pr: dict) -> int:
                     "manually or revise the PR."
                 ),
             )
-            log_run("merge", repo=REPO, pr=pr_number,
-                    duration=dur(), result="merge_failed", exit=0)
-            return 0
     else:
         print(
             f"[cai merge] PR #{pr_number}: verdict={confidence} "
@@ -1331,14 +1304,9 @@ def handle_merge(pr: dict) -> int:
                 f"concrete code bug; routing to REVISION_PENDING",
                 flush=True,
             )
-            fire_trigger(
-                pr_number, "approved_to_revision_pending",
-                is_pr=True,
-                log_prefix="cai merge",
-            )
             log_run("merge", repo=REPO, pr=pr_number,
                     duration=dur(), result="held_fixable_bug", exit=0)
-            return 0
+            return HandlerResult(trigger="approved_to_revision_pending")
         # Issue #1075: when a held verdict is tagged
         # ``issue_type == "approach_mismatch"``, the implementation took
         # the wrong fundamental approach (wrong API / wrong algorithm /
@@ -1384,10 +1352,11 @@ def handle_merge(pr: dict) -> int:
                     f"close failed:\n{close_result.stderr}",
                     file=sys.stderr,
                 )
-                fire_trigger(
-                    pr_number, "approved_to_human",
-                    is_pr=True,
-                    log_prefix="cai merge",
+                log_run("merge", repo=REPO, pr=pr_number,
+                        duration=dur(),
+                        result="approach_mismatch_close_failed", exit=0)
+                return HandlerResult(
+                    trigger="approved_to_human",
                     divert_reason=(
                         "cai-merge returned a hold verdict with "
                         "`issue_type=approach_mismatch` but `gh pr "
@@ -1396,10 +1365,6 @@ def handle_merge(pr: dict) -> int:
                         "linked issue."
                     ),
                 )
-                log_run("merge", repo=REPO, pr=pr_number,
-                        duration=dur(),
-                        result="approach_mismatch_close_failed", exit=0)
-                return 0
             if not _set_labels(
                 issue_number,
                 add=[LABEL_OPUS_ATTEMPTED],
@@ -1437,7 +1402,11 @@ def handle_merge(pr: dict) -> int:
                     duration=dur(),
                     result="held_approach_mismatch_opus_triggered",
                     exit=0)
-            return 0
+            # Cross-entity fire above already transitioned the linked
+            # issue back to PLAN_APPROVED. The PR itself is closed on
+            # GitHub (gh pr close succeeded) — no PR-side transition is
+            # needed or meaningful here.
+            return HandlerResult(trigger="")
         if not _issue_has_label(issue_number, LABEL_MERGED):
             if not _set_labels(
                 issue_number,
@@ -1482,10 +1451,10 @@ def handle_merge(pr: dict) -> int:
                     flush=True,
                 )
                 held_result_tag = "held_workflow_review"
-        fire_trigger(
-            pr_number, "approved_to_human",
-            is_pr=True,
-            log_prefix="cai merge",
+        log_run("merge", repo=REPO, pr=pr_number,
+                duration=dur(), result=held_result_tag, exit=0)
+        return HandlerResult(
+            trigger="approved_to_human",
             divert_reason=(
                 f"cai-merge verdict was `{confidence}` (below the "
                 f"configured threshold `{_MERGE_THRESHOLD}`). Holding "
@@ -1493,6 +1462,3 @@ def handle_merge(pr: dict) -> int:
                 f"merge verdict comment and decides next steps."
             ),
         )
-        log_run("merge", repo=REPO, pr=pr_number,
-                duration=dur(), result=held_result_tag, exit=0)
-        return 0

--- a/cai_lib/actions/open_pr.py
+++ b/cai_lib/actions/open_pr.py
@@ -18,12 +18,12 @@ from __future__ import annotations
 
 from cai_lib.actions.merge import _BOT_BRANCH_RE
 from cai_lib.config import REPO
-from cai_lib.fsm import fire_trigger
+from cai_lib.dispatcher import HandlerResult
 from cai_lib.logging_utils import log_run
 from cai_lib.subprocess_utils import _run
 
 
-def handle_open_to_review(pr: dict) -> int:
+def handle_open_to_review(pr: dict) -> HandlerResult:
     """Route a brand-new PR based on its head branch.
 
     The PR dict is passed by the dispatcher; it has no pipeline
@@ -61,24 +61,14 @@ def handle_open_to_review(pr: dict) -> int:
              f"just re-enter this state."],
             capture_output=True,
         )
-        ok, _ = fire_trigger(
-            pr_number, "open_to_human",
-            is_pr=True,
-            current_pr=pr,
-            log_prefix="cai dispatch",
+        log_run("dispatch", repo=REPO, pr=pr_number,
+                result="not_bot_branch_open", exit=0)
+        return HandlerResult(
+            trigger="open_to_human",
             divert_reason=(
                 f"Non-bot-branch PR (branch={branch!r}) cannot be "
                 f"auto-merged; requires manual review."
             ),
         )
-        log_run("dispatch", repo=REPO, pr=pr_number,
-                result="not_bot_branch_open", exit=0)
-        return 0 if ok else 1
 
-    ok, _ = fire_trigger(
-        pr_number, "open_to_reviewing_code",
-        is_pr=True,
-        current_pr=pr,
-        log_prefix="cai dispatch",
-    )
-    return 0 if ok else 1
+    return HandlerResult(trigger="open_to_reviewing_code")

--- a/cai_lib/actions/pr_bounce.py
+++ b/cai_lib/actions/pr_bounce.py
@@ -29,7 +29,7 @@ import sys
 from typing import Optional
 
 from cai_lib.config import REPO
-from cai_lib.fsm import fire_trigger
+from cai_lib.dispatcher import HandlerResult
 from cai_lib.github import _gh_json
 
 
@@ -148,15 +148,20 @@ def _was_merged(pr: dict) -> bool:
     return bool(pr.get("mergedAt")) or pr.get("state") == "MERGED"
 
 
-def handle_pr_bounce(issue: dict) -> int:
+def handle_pr_bounce(issue: dict) -> HandlerResult | int:
     """Bounce to the linked PR if open; otherwise recover the issue's state.
 
     See module docstring for the recovery decision tree.
+
+    Returns an ``int`` exit code only for the bounce case (where the
+    caller fully delegates processing to :func:`dispatch_pr` on the
+    linked PR). Every recovery path returns a :class:`HandlerResult`
+    so ``dispatch_issue`` fires the recovery transition via
+    ``_driver_fire``.
     """
     from cai_lib.dispatcher import dispatch_pr  # local to avoid import cycle
 
     issue_number = issue["number"]
-    label_names = [lb["name"] for lb in issue.get("labels", [])]
 
     # 1. Open PR? Bounce to it.
     open_pr = _find_open_linked_pr(issue_number)
@@ -173,12 +178,7 @@ def handle_pr_bounce(issue: dict) -> int:
                 f"advancing pr_to_merged",
                 flush=True,
             )
-            ok, _ = fire_trigger(
-                issue_number, "pr_to_merged",
-                current_labels=label_names,
-                log_prefix="cai dispatch",
-            )
-            return 0 if ok else 1
+            return HandlerResult(trigger="pr_to_merged")
 
         # Closed unmerged — inspect who closed it. If it's us (the bot),
         # safely re-plan. If it's a human or another account, the close
@@ -197,34 +197,27 @@ def handle_pr_bounce(issue: dict) -> int:
                 f"({close_actor}) — reverting pr_to_refined",
                 flush=True,
             )
-            ok, _ = fire_trigger(
-                issue_number, "pr_to_refined",
-                current_labels=label_names,
-                log_prefix="cai dispatch",
-            )
-        else:
-            actor_str = close_actor or "unknown"
-            print(
-                f"[cai dispatch] issue #{issue_number}: linked PR "
-                f"#{closed_pr['number']} closed unmerged by {actor_str} "
-                f"(our login: {our_login or 'unknown'}) — diverting "
-                f"pr_to_human_needed",
-                flush=True,
-            )
-            ok, _ = fire_trigger(
-                issue_number, "pr_to_human_needed",
-                current_labels=label_names,
-                log_prefix="cai dispatch",
-                divert_reason=(
-                    f"Linked PR #{closed_pr['number']} was closed "
-                    f"unmerged by `{actor_str}` (our login: "
-                    f"`{our_login or 'unknown'}`). Because the closer "
-                    f"is not this container, the close was a deliberate "
-                    f"human decision — a human must decide the next "
-                    f"move for this issue."
-                ),
-            )
-        return 0 if ok else 1
+            return HandlerResult(trigger="pr_to_refined")
+
+        actor_str = close_actor or "unknown"
+        print(
+            f"[cai dispatch] issue #{issue_number}: linked PR "
+            f"#{closed_pr['number']} closed unmerged by {actor_str} "
+            f"(our login: {our_login or 'unknown'}) — diverting "
+            f"pr_to_human_needed",
+            flush=True,
+        )
+        return HandlerResult(
+            trigger="pr_to_human_needed",
+            divert_reason=(
+                f"Linked PR #{closed_pr['number']} was closed "
+                f"unmerged by `{actor_str}` (our login: "
+                f"`{our_login or 'unknown'}`). Because the closer "
+                f"is not this container, the close was a deliberate "
+                f"human decision — a human must decide the next "
+                f"move for this issue."
+            ),
+        )
 
     # 3. No PR found at all — orphaned :pr-open label, needs a human.
     print(
@@ -233,10 +226,8 @@ def handle_pr_bounce(issue: dict) -> int:
         f"pr_to_human_needed",
         flush=True,
     )
-    ok, _ = fire_trigger(
-        issue_number, "pr_to_human_needed",
-        current_labels=label_names,
-        log_prefix="cai dispatch",
+    return HandlerResult(
+        trigger="pr_to_human_needed",
         divert_reason=(
             f"Issue was at `:pr-open` but no PR (open or recently "
             f"closed) could be found for branch "
@@ -245,4 +236,3 @@ def handle_pr_bounce(issue: dict) -> int:
             f"reopen a PR or revert the issue to a pre-PR state."
         ),
     )
-    return 0 if ok else 1

--- a/cai_lib/actions/rebase.py
+++ b/cai_lib/actions/rebase.py
@@ -31,7 +31,7 @@ import uuid
 from pathlib import Path
 
 from cai_lib.config import REPO
-from cai_lib.fsm import fire_trigger
+from cai_lib.dispatcher import HandlerResult
 from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.cmd_helpers import _git, _gh_user_identity, _work_directory_block
 from cai_lib.logging_utils import log_run
@@ -61,21 +61,16 @@ def _post_pr_comment(pr_number: int, body: str) -> None:
               file=sys.stderr)
 
 
-def _exit_to_review(pr_number: int) -> None:
-    """Apply rebasing_to_reviewing_code so the next tick re-reviews."""
-    fire_trigger(
-        pr_number, "rebasing_to_reviewing_code",
-        is_pr=True,
-        log_prefix="cai rebase",
-    )
+_REBASE_EXIT_RESULT = HandlerResult(trigger="rebasing_to_reviewing_code")
 
 
-def handle_rebase(pr: dict) -> int:
+def handle_rebase(pr: dict) -> HandlerResult:
     """Attempt a rebase against origin/main and bounce back to REVIEWING_CODE.
 
-    Always returns 0 unless there is an infrastructure failure (clone /
-    push). The success-vs-failure of the rebase itself is captured in
-    the PR comment for the reviewer to consume on the next tick.
+    Always returns ``HandlerResult(trigger="rebasing_to_reviewing_code")``
+    so the next tick re-reviews the (possibly updated) branch. The
+    success-vs-failure of the rebase itself is captured in the PR
+    comment for the reviewer to consume.
     """
     t0 = time.monotonic()
 
@@ -88,9 +83,8 @@ def handle_rebase(pr: dict) -> int:
     if not branch:
         print(f"[cai rebase] PR #{pr_number}: missing headRefName; bouncing",
               file=sys.stderr)
-        _exit_to_review(pr_number)
         log_run("rebase", repo=REPO, pr=pr_number, result="missing_branch", exit=0)
-        return 0
+        return _REBASE_EXIT_RESULT
 
     _uid = uuid.uuid4().hex[:8]
     work_dir = Path(f"/tmp/cai-rebase-{pr_number}-{_uid}")
@@ -109,10 +103,9 @@ def handle_rebase(pr: dict) -> int:
                 f"[cai rebase] clone failed for PR #{pr_number}:\n{clone.stderr}",
                 file=sys.stderr,
             )
-            _exit_to_review(pr_number)
             log_run("rebase", repo=REPO, pr=pr_number,
                     result="clone_failed", exit=0)
-            return 0
+            return _REBASE_EXIT_RESULT
 
         _git(work_dir, "fetch", "origin", "main")
         _git(work_dir, "fetch", "origin", branch)
@@ -149,10 +142,9 @@ def handle_rebase(pr: dict) -> int:
                     "was rejected.\n\n```\n" + (push.stderr or "")
                     + "\n```\n\n---\n_Posted by `cai rebase`._",
                 )
-                _exit_to_review(pr_number)
                 log_run("rebase", repo=REPO, pr=pr_number,
                         result="push_failed", exit=0)
-                return 0
+                return _REBASE_EXIT_RESULT
 
             _post_pr_comment(
                 pr_number,
@@ -160,11 +152,10 @@ def handle_rebase(pr: dict) -> int:
                 + f"\n\nDeterministic rebase against `origin/main` succeeded; "
                 f"new HEAD is `{new_sha}`.\n\n---\n_Posted by `cai rebase`._",
             )
-            _exit_to_review(pr_number)
             dur = f"{int(time.monotonic() - t0)}s"
             log_run("rebase", repo=REPO, pr=pr_number, duration=dur,
                     result="auto_success", exit=0)
-            return 0
+            return _REBASE_EXIT_RESULT
 
         # Conflicts exist (or rebase aborted). Hand to cai-rebase agent.
         conflict_files = _rebase_conflict_files(work_dir)
@@ -223,12 +214,11 @@ def handle_rebase(pr: dict) -> int:
                 + "---\n_Posted by `cai rebase`. The next review tick will "
                 "see this comment; expect findings or a human-needed divert._",
             )
-            _exit_to_review(pr_number)
             dur = f"{int(time.monotonic() - t0)}s"
             log_run("rebase", repo=REPO, pr=pr_number, duration=dur,
                     result="agent_failed", conflict_count=len(conflict_files),
                     exit=0)
-            return 0
+            return _REBASE_EXIT_RESULT
 
         # Agent claims success — sanity check by confirming origin/main is
         # an ancestor of HEAD, then push.
@@ -244,11 +234,10 @@ def handle_rebase(pr: dict) -> int:
                 "ancestor of HEAD. Refusing to push a non-rebased branch.\n\n"
                 "---\n_Posted by `cai rebase`._",
             )
-            _exit_to_review(pr_number)
             dur = f"{int(time.monotonic() - t0)}s"
             log_run("rebase", repo=REPO, pr=pr_number, duration=dur,
                     result="ancestry_check_failed", exit=0)
-            return 0
+            return _REBASE_EXIT_RESULT
 
         new_sha = _git(work_dir, "rev-parse", "HEAD").stdout.strip()
         push = _run(
@@ -264,11 +253,10 @@ def handle_rebase(pr: dict) -> int:
                 + "```\n" + (push.stderr or "") + "\n```\n\n"
                 + "---\n_Posted by `cai rebase`._",
             )
-            _exit_to_review(pr_number)
             dur = f"{int(time.monotonic() - t0)}s"
             log_run("rebase", repo=REPO, pr=pr_number, duration=dur,
                     result="push_failed", exit=0)
-            return 0
+            return _REBASE_EXIT_RESULT
 
         _post_pr_comment(
             pr_number,
@@ -277,19 +265,17 @@ def handle_rebase(pr: dict) -> int:
             f"`origin/main`. New HEAD is `{new_sha}`.\n\n"
             + "---\n_Posted by `cai rebase`._",
         )
-        _exit_to_review(pr_number)
         dur = f"{int(time.monotonic() - t0)}s"
         log_run("rebase", repo=REPO, pr=pr_number, duration=dur,
                 result="agent_success", exit=0)
-        return 0
+        return _REBASE_EXIT_RESULT
 
     except Exception as exc:
         print(f"[cai rebase] unexpected error on PR #{pr_number}: {exc}",
               file=sys.stderr)
-        _exit_to_review(pr_number)
         log_run("rebase", repo=REPO, pr=pr_number,
                 result="unexpected_error", exit=1)
-        return 1
+        return _REBASE_EXIT_RESULT
     finally:
         if work_dir.exists():
             shutil.rmtree(work_dir, ignore_errors=True)

--- a/cai_lib/actions/review_docs.py
+++ b/cai_lib/actions/review_docs.py
@@ -19,7 +19,8 @@ import uuid
 from pathlib import Path
 
 from cai_lib.config import REPO
-from cai_lib.fsm import fire_trigger, get_pr_state, PRState
+from cai_lib.dispatcher import HandlerResult
+from cai_lib.fsm import get_pr_state, PRState
 from cai_lib.github import _gh_json, _fetch_linked_issue_block
 from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.cmd_helpers import (
@@ -167,7 +168,7 @@ def _run_module_coverage_check(work_dir: Path) -> str:
     )
 
 
-def handle_review_docs(pr: dict) -> int:
+def handle_review_docs(pr: dict) -> HandlerResult:
     """Run cai-review-docs on *pr* (already at PRState.REVIEWING_DOCS)."""
     t0 = time.monotonic()
 
@@ -197,14 +198,9 @@ def handle_review_docs(pr: dict) -> int:
                 f"{head_sha[:8]} — advancing to APPROVED",
                 flush=True,
             )
-            fire_trigger(
-                pr_number, "reviewing_docs_to_approved",
-                is_pr=True,
-                log_prefix="cai review-docs",
-            )
             log_run("review_docs", repo=REPO, pr=pr_number,
                     result="cached_clean_advanced", exit=0)
-            return 0
+            return HandlerResult(trigger="reviewing_docs_to_approved")
         if first_line.startswith(_DOCS_REVIEW_COMMENT_HEADING_APPLIED):
             # A docs-fix push happened at this SHA. Docs review is the
             # last gate before merge; we do not bounce back to code
@@ -215,14 +211,9 @@ def handle_review_docs(pr: dict) -> int:
                 f"{head_sha[:8]} — advancing to APPROVED",
                 flush=True,
             )
-            fire_trigger(
-                pr_number, "reviewing_docs_to_approved",
-                is_pr=True,
-                log_prefix="cai review-docs",
-            )
             log_run("review_docs", repo=REPO, pr=pr_number,
                     result="cached_applied_advanced", exit=0)
-            return 0
+            return HandlerResult(trigger="reviewing_docs_to_approved")
         # Heading prefix matched but suffix is unfamiliar — fall through
         # to a fresh review rather than guess.
         break
@@ -236,7 +227,7 @@ def handle_review_docs(pr: dict) -> int:
         )
         log_run("review_docs", repo=REPO, pr=pr_number,
                 result="wrong_state", exit=0)
-        return 0
+        return HandlerResult(trigger="")
 
     _uid = uuid.uuid4().hex[:8]
     work_dir = Path(f"/tmp/cai-review-docs-{pr_number}-{_uid}")
@@ -258,7 +249,7 @@ def handle_review_docs(pr: dict) -> int:
             dur = f"{int(time.monotonic() - t0)}s"
             log_run("review_docs", repo=REPO, pr=pr_number,
                     duration=dur, result="clone_failed", exit=1)
-            return 1
+            return HandlerResult(trigger="")
 
         _git(work_dir, "fetch", "origin", branch)
         _git(work_dir, "checkout", branch)
@@ -348,7 +339,7 @@ def handle_review_docs(pr: dict) -> int:
             log_run("review_docs", repo=REPO, pr=pr_number,
                     duration=dur, result="agent_failed",
                     exit=agent.returncode)
-            return agent.returncode
+            return HandlerResult(trigger="")
 
         agent_output = (agent.stdout or "").strip()
 
@@ -395,7 +386,7 @@ def handle_review_docs(pr: dict) -> int:
                 dur = f"{int(time.monotonic() - t0)}s"
                 log_run("review_docs", repo=REPO, pr=pr_number,
                         duration=dur, result="push_failed", exit=1)
-                return 1
+                return HandlerResult(trigger="")
             new_sha = _git(work_dir, "rev-parse", "HEAD").stdout.strip()
             comment_body = (
                 f"{_DOCS_REVIEW_COMMENT_HEADING_APPLIED} \u2014 {new_sha}\n\n"
@@ -426,11 +417,6 @@ def handle_review_docs(pr: dict) -> int:
         # and the merge handler decides whether to merge. Bouncing back
         # to REVIEWING_CODE on a doc push caused review/docs ping-pong
         # loops that produced no new code findings.
-        fire_trigger(
-            pr_number, "reviewing_docs_to_approved",
-            is_pr=True,
-            log_prefix="cai review-docs",
-        )
         if has_doc_changes:
             result_word = "fixes pushed"
             result_tag = "fixes_pushed"
@@ -446,7 +432,7 @@ def handle_review_docs(pr: dict) -> int:
         dur = f"{int(time.monotonic() - t0)}s"
         log_run("review_docs", repo=REPO, pr=pr_number,
                 duration=dur, result=result_tag, exit=0)
-        return 0
+        return HandlerResult(trigger="reviewing_docs_to_approved")
 
     except subprocess.CalledProcessError as e:
         print(
@@ -457,7 +443,7 @@ def handle_review_docs(pr: dict) -> int:
         dur = f"{int(time.monotonic() - t0)}s"
         log_run("review_docs", repo=REPO, pr=pr_number,
                 duration=dur, result="subprocess_error", exit=1)
-        return 1
+        return HandlerResult(trigger="")
     except Exception as e:
         print(
             f"[cai review-docs] unexpected failure for PR #{pr_number}: "
@@ -467,7 +453,7 @@ def handle_review_docs(pr: dict) -> int:
         dur = f"{int(time.monotonic() - t0)}s"
         log_run("review_docs", repo=REPO, pr=pr_number,
                 duration=dur, result="unexpected_error", exit=1)
-        return 1
+        return HandlerResult(trigger="")
     finally:
         if work_dir.exists():
             shutil.rmtree(work_dir, ignore_errors=True)

--- a/cai_lib/actions/review_pr.py
+++ b/cai_lib/actions/review_pr.py
@@ -35,6 +35,7 @@ from cai_lib.config import (
     REVIEW_PR_PATTERN_LOG,
 )
 from cai_lib.actions.merge import _BOT_BRANCH_RE
+from cai_lib.dispatcher import HandlerResult
 from cai_lib.fsm import (
     PRState,
     fire_trigger,
@@ -83,7 +84,7 @@ def _log_review_pr_findings(pr_number: int, head_sha: str, agent_output: str) ->
 # ---------------------------------------------------------------------------
 
 
-def handle_review_pr(pr: dict) -> int:
+def handle_review_pr(pr: dict) -> HandlerResult:
     """Review a single PR handed by the dispatcher (state REVIEWING_CODE).
 
     Runs the ``cai-review-pr`` agent against a fresh clone of the PR
@@ -108,6 +109,7 @@ def handle_review_pr(pr: dict) -> int:
     head_sha = pr["headRefOid"]
     branch = pr.get("headRefName", "")
     title = pr["title"]
+    pending_transition = ""
 
     # Check if we already posted a review for this SHA. Match
     # either heading variant (findings or clean) — both include
@@ -136,7 +138,7 @@ def handle_review_pr(pr: dict) -> int:
         )
         log_run("review_pr", repo=REPO, reviewed=reviewed, skipped=skipped,
                 duration=dur, exit=0)
-        return 0
+        return HandlerResult(trigger="")
 
     print(f"[cai review-pr] reviewing PR #{pr_number}: {title}", flush=True)
 
@@ -165,7 +167,7 @@ def handle_review_pr(pr: dict) -> int:
             )
             log_run("review_pr", repo=REPO, reviewed=reviewed, skipped=skipped,
                     duration=dur, exit=0)
-            return 0
+            return HandlerResult(trigger="")
         if branch:
             _git(work_dir, "fetch", "origin", branch)
             _git(work_dir, "checkout", branch)
@@ -253,7 +255,7 @@ def handle_review_pr(pr: dict) -> int:
             )
             log_run("review_pr", repo=REPO, reviewed=reviewed, skipped=skipped,
                     duration=dur, exit=0)
-            return 0
+            return HandlerResult(trigger="")
         if agent.returncode != 0 and has_verdict:
             print(
                 f"[cai review-pr] agent exited {agent.returncode} "
@@ -321,34 +323,29 @@ def handle_review_pr(pr: dict) -> int:
         if current_state == PRState.OPEN:
             branch = pr.get("headRefName", "") or ""
             if not _BOT_BRANCH_RE.match(branch):
-                fire_trigger(
-                    pr_number, "open_to_human",
-                    is_pr=True,
-                    current_pr=pr,
-                    log_prefix="cai review-pr",
+                return HandlerResult(
+                    trigger="open_to_human",
                     divert_reason=(
                         f"Non-bot-branch PR (branch={branch!r}) cannot "
                         f"be auto-merged; requires manual review."
                     ),
                 )
-                return 1
+            # Normalize OPEN → REVIEWING_CODE so the subsequent
+            # transition's from_state check passes. Fired here
+            # directly because the driver translates the handler's
+            # single returned HandlerResult into one fire_trigger
+            # call — the second transition below is the one that
+            # rides on that return.
             fire_trigger(
                 pr_number, "open_to_reviewing_code",
                 is_pr=True,
                 log_prefix="cai review-pr",
             )
-        if has_findings:
-            fire_trigger(
-                pr_number, "reviewing_code_to_revision_pending",
-                is_pr=True,
-                log_prefix="cai review-pr",
-            )
-        else:
-            fire_trigger(
-                pr_number, "reviewing_code_to_reviewing_docs",
-                is_pr=True,
-                log_prefix="cai review-pr",
-            )
+        pending_transition = (
+            "reviewing_code_to_revision_pending"
+            if has_findings
+            else "reviewing_code_to_reviewing_docs"
+        )
 
         _log_review_pr_findings(pr_number, head_sha, agent_output)
 
@@ -375,4 +372,4 @@ def handle_review_pr(pr: dict) -> int:
     )
     log_run("review_pr", repo=REPO, reviewed=reviewed, skipped=skipped,
             duration=dur, exit=0)
-    return 0
+    return HandlerResult(trigger=pending_transition)

--- a/cai_lib/actions/revise.py
+++ b/cai_lib/actions/revise.py
@@ -17,6 +17,7 @@ import sys
 import uuid
 from pathlib import Path
 
+from cai_lib.dispatcher import HandlerResult
 from cai_lib.config import (
     REPO,
     LABEL_REVISING,
@@ -378,7 +379,7 @@ def _recover_stuck_rebase_prs() -> int:
 
 
 
-def handle_revise(pr: dict) -> int:
+def handle_revise(pr: dict) -> HandlerResult:
     """Iterate on an open PR based on review comments.
 
     The dispatcher has already verified the PR is at
@@ -408,7 +409,7 @@ def handle_revise(pr: dict) -> int:
     if pr_number_in is None:
         print("[cai revise] handler called without pr['number']", file=sys.stderr)
         log_run("revise", repo=REPO, result="missing_pr_number", exit=1)
-        return 1
+        return HandlerResult(trigger="")
 
     # Resolve the single target: fetch fresh PR detail for the handed
     # PR and build a one-item target list (matches the direct-targeting
@@ -422,7 +423,7 @@ def handle_revise(pr: dict) -> int:
     except subprocess.CalledProcessError as e:
         print(f"[cai revise] gh pr view #{pr_number_in} failed:\n{e.stderr}", file=sys.stderr)
         log_run("revise", repo=REPO, pr=pr_number_in, result="pr_lookup_failed", exit=1)
-        return 1
+        return HandlerResult(trigger="")
     branch = pr_detail.get("headRefName", "")
     m = re.match(r"^auto-improve/(\d+)-", branch)
     if not m:
@@ -431,7 +432,7 @@ def handle_revise(pr: dict) -> int:
             file=sys.stderr,
         )
         log_run("revise", repo=REPO, pr=pr_number_in, result="not_auto_improve", exit=1)
-        return 1
+        return HandlerResult(trigger="")
     issue_number = int(m.group(1))
     # Collect comments (issue-level + line-by-line review).
     issue_comments = pr_detail.get("comments", [])
@@ -453,7 +454,7 @@ def handle_revise(pr: dict) -> int:
         print("[cai revise] no PRs need revision; nothing to do", flush=True)
         log_run("revise", repo=REPO, result="no_targets",
                 recovered=recovered, exit=0)
-        return 0
+        return HandlerResult(trigger="")
 
     print(f"[cai revise] found {len(targets)} PR(s) to revise", flush=True)
 
@@ -1002,4 +1003,4 @@ def handle_revise(pr: dict) -> int:
             if work_dir.exists():
                 shutil.rmtree(work_dir, ignore_errors=True)
 
-    return 1 if had_failure else 0
+    return HandlerResult(trigger="")

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -263,7 +263,7 @@ def _build_ordering_gate() -> dict[int, tuple[int, int]]:
 # the admin has applied ``human:solved`` and no-ops otherwise.
 
 IssueHandler = Callable[[dict], Union[int, HandlerResult]]
-PRHandler    = Callable[[dict], Union[int, HandlerResult]]
+PRHandler    = Callable[[dict], HandlerResult]
 
 
 def _build_issue_registry() -> dict[IssueState, IssueHandler]:
@@ -484,7 +484,12 @@ def dispatch_pr(pr_number: int) -> int:
         try:
             fire_trigger(pr_number, entry, is_pr=True, current_pr=pr,
                          log_prefix="cai dispatch")
-            return handle_rebase(pr)
+            result = handle_rebase(pr)
+            ok, _ = _driver_fire(
+                pr_number, result,
+                is_pr=True, current_pr=pr,
+            )
+            return 0 if ok else 1
         finally:
             _release_remote_lock("pr", pr_number)
 
@@ -501,14 +506,12 @@ def dispatch_pr(pr_number: int) -> int:
               flush=True)
         return 0
     try:
-        rc = handler(pr)
-        if isinstance(rc, HandlerResult):
-            ok, _ = _driver_fire(
-                pr_number, rc,
-                is_pr=True, current_pr=pr,
-            )
-            return 0 if ok else 1
-        return rc
+        result = handler(pr)
+        ok, _ = _driver_fire(
+            pr_number, result,
+            is_pr=True, current_pr=pr,
+        )
+        return 0 if ok else 1
     finally:
         _release_remote_lock("pr", pr_number)
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -245,7 +245,7 @@ class TestDispatchPR(_LockNoopMixin, unittest.TestCase):
     """dispatch_pr fetches the PR and routes by FSM label / merged flag."""
 
     def _run_routing(self, pr: dict, expected_state: PRState):
-        handler = MagicMock(return_value=0)
+        handler = MagicMock(return_value=HandlerResult(trigger=""))
         handler.__name__ = "mock_handler"
         registry = {expected_state: handler}
         with patch.object(dispatcher, "_gh_json", return_value=pr), \
@@ -277,9 +277,11 @@ class TestDispatchPR(_LockNoopMixin, unittest.TestCase):
         """mergeable=CONFLICTING overrides the pipeline label and routes to handle_rebase."""
         pr = _pr(99, "pr:reviewing-code")
         pr["mergeable"] = "CONFLICTING"
-        rebase_handler = MagicMock(return_value=0)
+        rebase_handler = MagicMock(
+            return_value=HandlerResult(trigger="rebasing_to_reviewing_code"))
         rebase_handler.__name__ = "handle_rebase"
-        review_handler = MagicMock(return_value=0)
+        review_handler = MagicMock(
+            return_value=HandlerResult(trigger=""))
         review_handler.__name__ = "handle_review_pr"
         registry = {PRState.REVIEWING_CODE: review_handler}
         applied: list[tuple[int, str]] = []
@@ -299,16 +301,19 @@ class TestDispatchPR(_LockNoopMixin, unittest.TestCase):
         self.assertEqual(rc, 0)
         review_handler.assert_not_called()
         rebase_handler.assert_called_once_with(pr)
-        self.assertEqual(applied, [(99, "reviewing_code_to_rebasing")])
+        self.assertIn((99, "reviewing_code_to_rebasing"), applied)
+        self.assertIn((99, "rebasing_to_reviewing_code"), applied)
 
     def test_dirty_merge_state_diverts_to_rebase(self):
         """mergeStateStatus=DIRTY also triggers the rebase divert."""
         pr = _pr(99, "pr:approved")
         pr["mergeable"] = "MERGEABLE"
         pr["mergeStateStatus"] = "DIRTY"
-        rebase_handler = MagicMock(return_value=0)
+        rebase_handler = MagicMock(
+            return_value=HandlerResult(trigger="rebasing_to_reviewing_code"))
         rebase_handler.__name__ = "handle_rebase"
-        merge_handler = MagicMock(return_value=0)
+        merge_handler = MagicMock(
+            return_value=HandlerResult(trigger=""))
         merge_handler.__name__ = "handle_merge"
         registry = {PRState.APPROVED: merge_handler}
 
@@ -327,12 +332,14 @@ class TestDispatchPR(_LockNoopMixin, unittest.TestCase):
         """A PR already at REBASING runs handle_rebase normally without re-applying entry transition."""
         pr = _pr(99, "pr:rebasing")
         pr["mergeable"] = "CONFLICTING"
-        rebase_handler = MagicMock(return_value=0)
+        rebase_handler = MagicMock(
+            return_value=HandlerResult(trigger="rebasing_to_reviewing_code"))
         rebase_handler.__name__ = "handle_rebase"
         registry = {PRState.REBASING: rebase_handler}
 
         with patch.object(dispatcher, "_gh_json", return_value=pr), \
-             patch.object(dispatcher, "_pr_registry", return_value=registry):
+             patch.object(dispatcher, "_pr_registry", return_value=registry), \
+             patch("cai_lib.fsm.fire_trigger", return_value=(True, False)):
             rc = dispatcher.dispatch_pr(99)
 
         self.assertEqual(rc, 0)

--- a/tests/test_merge_approach_mismatch.py
+++ b/tests/test_merge_approach_mismatch.py
@@ -19,6 +19,7 @@ from cai_lib.config import (
     LABEL_PLAN_APPROVED,
     LABEL_PR_OPEN,
 )
+from cai_lib.dispatcher import HandlerResult
 from cai_lib.fsm_states import IssueState
 from cai_lib.fsm_transitions import ISSUE_TRANSITIONS
 
@@ -125,22 +126,21 @@ class TestHandleMergeApproachMismatchRouting(unittest.TestCase):
              patch.object(merge_mod, "fire_trigger",
                           fire_trigger_mock), \
              patch.object(merge_mod, "log_run", log_mock):
-            rc = merge_mod.handle_merge(pr)
+            result = merge_mod.handle_merge(pr)
 
-        self.assertEqual(rc, 0)
+        self.assertIsInstance(result, HandlerResult)
         return {
-            "pr_transition": fire_trigger_mock,
+            "result": result,
             "issue_transition": fire_trigger_mock,
             "set_labels": set_labels_mock,
             "run": run_mock,
         }
 
-    def _pr_transition_names(self, fire_trigger_mock) -> list:
-        return [
-            c.args[1] for c in fire_trigger_mock.call_args_list
-            if len(c.args) >= 2 and isinstance(c.args[1], str)
-            and c.kwargs.get("is_pr", False)
-        ]
+    def _pr_transition_names(self, mocks) -> list:
+        """PR-side transitions are returned in the HandlerResult. Empty
+        trigger is the no-op sentinel."""
+        trig = mocks["result"].trigger
+        return [trig] if trig else []
 
     def _issue_transition_names(self, fire_trigger_mock) -> list:
         return [
@@ -156,7 +156,7 @@ class TestHandleMergeApproachMismatchRouting(unittest.TestCase):
         )
         # No PR FSM transition fires on the success path (close + issue
         # transition is the entire recovery).
-        self.assertEqual(self._pr_transition_names(mocks["pr_transition"]), [])
+        self.assertEqual(self._pr_transition_names(mocks), [])
         # Exactly one issue FSM transition, pointing at PLAN_APPROVED.
         self.assertEqual(
             self._issue_transition_names(mocks["issue_transition"]),
@@ -185,7 +185,7 @@ class TestHandleMergeApproachMismatchRouting(unittest.TestCase):
             issue_type="<omit>",
         )
         self.assertEqual(
-            self._pr_transition_names(mocks["pr_transition"]),
+            self._pr_transition_names(mocks),
             ["approved_to_human"],
         )
         self.assertEqual(
@@ -199,7 +199,7 @@ class TestHandleMergeApproachMismatchRouting(unittest.TestCase):
             issue_type=None,
         )
         self.assertEqual(
-            self._pr_transition_names(mocks["pr_transition"]),
+            self._pr_transition_names(mocks),
             ["approved_to_human"],
         )
         self.assertEqual(
@@ -213,7 +213,7 @@ class TestHandleMergeApproachMismatchRouting(unittest.TestCase):
             issue_type="other",
         )
         self.assertEqual(
-            self._pr_transition_names(mocks["pr_transition"]),
+            self._pr_transition_names(mocks),
             ["approved_to_human"],
         )
         self.assertEqual(
@@ -229,7 +229,7 @@ class TestHandleMergeApproachMismatchRouting(unittest.TestCase):
             issue_type="scope_creep",
         )
         self.assertEqual(
-            self._pr_transition_names(mocks["pr_transition"]),
+            self._pr_transition_names(mocks),
             ["approved_to_human"],
         )
         self.assertEqual(

--- a/tests/test_merge_ci_failing_divert.py
+++ b/tests/test_merge_ci_failing_divert.py
@@ -3,8 +3,10 @@
 Regression guard for the gap where the merge handler used to log "has
 failed CI checks; skipping" and return 0 with no state change, leaving
 the PR stuck at ``pr:approved`` (dispatcher then treated it as
-"blocked, moving on"). The handler must apply
-``approved_to_ci_failing`` so ``handle_fix_ci`` picks the PR up.
+"blocked, moving on"). The handler must return
+``HandlerResult(trigger="approved_to_ci_failing")`` so the dispatcher's
+``_driver_fire`` applies the transition and ``handle_fix_ci`` picks
+the PR up on the next tick.
 """
 import os
 import sys
@@ -14,6 +16,7 @@ from unittest.mock import patch
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from cai_lib.actions import merge as merge_mod
+from cai_lib.dispatcher import HandlerResult
 from cai_lib.fsm import PRState
 
 
@@ -36,11 +39,6 @@ class TestHandleMergeDivertsOnFailedCI(unittest.TestCase):
 
     def test_failed_check_triggers_approved_to_ci_failing(self):
         pr = _pr(1057)
-        applied: list[tuple[int, str]] = []
-
-        def fake_apply(pr_number, transition_name, **kw):
-            applied.append((pr_number, transition_name))
-            return True
 
         issue_payload = {
             "labels": [{"name": "auto-improve:pr-open"}],
@@ -61,8 +59,6 @@ class TestHandleMergeDivertsOnFailedCI(unittest.TestCase):
             return {}
 
         with patch.object(merge_mod, "_gh_json", side_effect=fake_gh_json), \
-             patch.object(merge_mod, "fire_trigger",
-                          side_effect=fake_apply), \
              patch.object(merge_mod, "get_pr_state",
                           return_value=PRState.APPROVED), \
              patch.object(merge_mod, "_filter_comments_with_haiku",
@@ -70,10 +66,10 @@ class TestHandleMergeDivertsOnFailedCI(unittest.TestCase):
              patch.object(merge_mod, "_fetch_review_comments",
                           return_value=[]), \
              patch.object(merge_mod, "log_run"):
-            rc = merge_mod.handle_merge(pr)
+            result = merge_mod.handle_merge(pr)
 
-        self.assertEqual(rc, 0)
-        self.assertEqual(applied, [(1057, "approved_to_ci_failing")])
+        self.assertIsInstance(result, HandlerResult)
+        self.assertEqual(result.trigger, "approved_to_ci_failing")
 
 
 if __name__ == "__main__":

--- a/tests/test_merge_low_to_revision.py
+++ b/tests/test_merge_low_to_revision.py
@@ -18,6 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from cai_lib.actions import merge as merge_mod
 from cai_lib.actions.merge import _verdict_cites_concrete_code_bug
+from cai_lib.dispatcher import HandlerResult
 from cai_lib.fsm_transitions import PR_TRANSITIONS
 
 
@@ -138,7 +139,7 @@ class TestHandleMergeLowHoldRouting(unittest.TestCase):
     """handle_merge must pick the right transition for a held verdict."""
 
     def _invoke(self, reasoning: str, confidence: str = "low",
-                action: str = "hold") -> tuple[MagicMock, MagicMock]:
+                action: str = "hold") -> tuple[HandlerResult, MagicMock]:
         pr = _pr_fixture()
 
         # Mock gh + git subprocess calls used by filters + verdict post.
@@ -195,10 +196,10 @@ class TestHandleMergeLowHoldRouting(unittest.TestCase):
              patch.object(merge_mod, "fire_trigger",
                           transition_mock), \
              patch.object(merge_mod, "log_run", log_mock):
-            rc = merge_mod.handle_merge(pr)
+            result = merge_mod.handle_merge(pr)
 
-        self.assertEqual(rc, 0)
-        return transition_mock, run_mock
+        self.assertIsInstance(result, HandlerResult)
+        return result, run_mock
 
     def test_low_hold_with_attribute_error_routes_to_revision(self):
         reasoning = (
@@ -206,15 +207,8 @@ class TestHandleMergeLowHoldRouting(unittest.TestCase):
             "defines a `globs` field. Any invocation crashes with "
             "AttributeError inside _build_module_message."
         )
-        transition_mock, run_mock = self._invoke(reasoning)
-        transition_calls = [
-            c for c in transition_mock.call_args_list
-            if c.args and isinstance(c.args[1], str)
-        ]
-        # Exactly one FSM transition, pointing at REVISION_PENDING.
-        self.assertEqual(len(transition_calls), 1)
-        self.assertEqual(transition_calls[0].args[1],
-                         "approved_to_revision_pending")
+        result, run_mock = self._invoke(reasoning)
+        self.assertEqual(result.trigger, "approved_to_revision_pending")
         # A follow-up comment with the new heading must be posted
         # so cai-comment-filter does NOT silently resolve it.
         comment_bodies = [
@@ -232,13 +226,8 @@ class TestHandleMergeLowHoldRouting(unittest.TestCase):
             "PR scope is broader than the issue requested; extra file "
             "edits under scripts/ are not mentioned in the remediation."
         )
-        transition_mock, _run_mock = self._invoke(reasoning)
-        transition_calls = [
-            c for c in transition_mock.call_args_list
-            if c.args and isinstance(c.args[1], str)
-        ]
-        self.assertEqual(len(transition_calls), 1)
-        self.assertEqual(transition_calls[0].args[1], "approved_to_human")
+        result, _run_mock = self._invoke(reasoning)
+        self.assertEqual(result.trigger, "approved_to_human")
 
     def test_medium_hold_with_attribute_error_still_parks_as_human(self):
         """The redirect is gated on confidence=='low' only — MEDIUM
@@ -248,15 +237,10 @@ class TestHandleMergeLowHoldRouting(unittest.TestCase):
             "Possible AttributeError on the new helper's return path, "
             "but unclear whether the branch is reachable."
         )
-        transition_mock, _run_mock = self._invoke(
+        result, _run_mock = self._invoke(
             reasoning, confidence="medium"
         )
-        transition_calls = [
-            c for c in transition_mock.call_args_list
-            if c.args and isinstance(c.args[1], str)
-        ]
-        self.assertEqual(len(transition_calls), 1)
-        self.assertEqual(transition_calls[0].args[1], "approved_to_human")
+        self.assertEqual(result.trigger, "approved_to_human")
 
 
 if __name__ == "__main__":

--- a/tests/test_merge_non_bot_branch.py
+++ b/tests/test_merge_non_bot_branch.py
@@ -4,9 +4,9 @@ Issue #1013: when a human-authored PR carrying ``pr:approved`` (admin
 applied the label hoping for auto-merge) sat on a non-``auto-improve/``
 branch, ``handle_merge`` logged ``result=not_bot_branch`` and returned
 0 without changing state, so the dispatcher re-routed the same PR to
-``handle_merge`` on every drain tick. The fix applies the
-``approved_to_human`` PR transition so the PR parks at
-``PR_HUMAN_NEEDED``.
+``handle_merge`` on every drain tick. The fix returns a
+:class:`HandlerResult` carrying the ``approved_to_human`` transition so
+the dispatcher's ``_driver_fire`` parks the PR at ``PR_HUMAN_NEEDED``.
 """
 import os
 import sys
@@ -16,6 +16,7 @@ from unittest.mock import patch, MagicMock
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from cai_lib.actions import merge as merge_mod
+from cai_lib.dispatcher import HandlerResult
 
 
 def _pr_non_bot(number: int = 945) -> dict:
@@ -44,19 +45,16 @@ class TestHandleMergeNonBotBranch(unittest.TestCase):
         run_mock.return_value.returncode = 0
         run_mock.return_value.stdout = ""
         run_mock.return_value.stderr = ""
-        transition_mock = MagicMock(return_value=True)
         log_mock = MagicMock()
 
         with patch.object(merge_mod, "_run", run_mock), \
-             patch.object(merge_mod, "fire_trigger", transition_mock), \
              patch.object(merge_mod, "log_run", log_mock):
-            rc = merge_mod.handle_merge(pr)
+            result = merge_mod.handle_merge(pr)
 
-        self.assertEqual(rc, 0)
-        transition_mock.assert_called_once()
-        args, kwargs = transition_mock.call_args
-        self.assertEqual(args[0], 945)
-        self.assertEqual(args[1], "approved_to_human")
+        self.assertIsInstance(result, HandlerResult)
+        self.assertEqual(result.trigger, "approved_to_human")
+        self.assertIn("feat/audit-modules-loader-886",
+                      result.divert_reason or "")
 
         # A single comment is posted explaining the park.
         gh_comment_calls = [
@@ -75,7 +73,7 @@ class TestHandleMergeNonBotBranch(unittest.TestCase):
         self.assertEqual(log_call_kwargs.get("exit"), 0)
 
     def test_non_bot_branch_does_not_call_merge_agent(self):
-        """Park must fire *before* any _run_claude_p invocation."""
+        """Park must return *before* any _run_claude_p invocation."""
         pr = _pr_non_bot()
         run_mock = MagicMock()
         run_mock.return_value.returncode = 0
@@ -83,8 +81,6 @@ class TestHandleMergeNonBotBranch(unittest.TestCase):
 
         with patch.object(merge_mod, "_run", run_mock), \
              patch.object(merge_mod, "_run_claude_p", claude_mock), \
-             patch.object(merge_mod, "fire_trigger",
-                          MagicMock(return_value=True)), \
              patch.object(merge_mod, "log_run", MagicMock()):
             merge_mod.handle_merge(pr)
 

--- a/tests/test_merge_workflow_review_label.py
+++ b/tests/test_merge_workflow_review_label.py
@@ -156,9 +156,10 @@ class TestHandleMergeWorkflowReviewLabel(unittest.TestCase):
              patch.object(merge_mod, "_git",
                           MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))), \
              patch.object(merge_mod, "log_run", log_mock):
-            rc = merge_mod.handle_merge(pr)
+            result = merge_mod.handle_merge(pr)
 
-        self.assertEqual(rc, 0)
+        from cai_lib.dispatcher import HandlerResult
+        self.assertIsInstance(result, HandlerResult)
         return run_mock, log_mock
 
     def _label_add_calls(self, run_mock: MagicMock) -> list:

--- a/tests/test_open_pr_non_bot_branch.py
+++ b/tests/test_open_pr_non_bot_branch.py
@@ -2,13 +2,17 @@
 
 Issue #1065: when a human-authored PR is opened on a non-
 ``auto-improve/<N>-…`` branch, ``handle_open_to_review`` must
-immediately apply the ``open_to_human`` transition so the PR parks
+immediately request the ``open_to_human`` transition so the PR parks
 at ``pr:human-needed`` **before** any review / rebase / docs cycle
 is spent. The prior behaviour tagged every fresh PR
 ``pr:reviewing-code`` and only parked at merge time via
 ``not_bot_branch`` in ``handle_merge``, wasting agent time and
 polluting the audit log with downstream pipeline transitions for
 a PR that would never auto-merge.
+
+``handle_open_to_review`` returns a :class:`HandlerResult` that the
+dispatcher converts to the corresponding ``fire_trigger`` call via
+``_driver_fire``.
 """
 import os
 import sys
@@ -18,6 +22,7 @@ from unittest.mock import patch, MagicMock
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from cai_lib.actions import open_pr as open_pr_mod
+from cai_lib.dispatcher import HandlerResult
 
 
 def _pr(number: int, branch: str) -> dict:
@@ -45,19 +50,16 @@ class TestHandleOpenToReviewNonBotBranch(unittest.TestCase):
         run_mock.return_value.returncode = 0
         run_mock.return_value.stdout = ""
         run_mock.return_value.stderr = ""
-        transition_mock = MagicMock(return_value=(True, False))
         log_mock = MagicMock()
 
         with patch.object(open_pr_mod, "_run", run_mock), \
-             patch.object(open_pr_mod, "fire_trigger", transition_mock), \
              patch.object(open_pr_mod, "log_run", log_mock):
-            rc = open_pr_mod.handle_open_to_review(pr)
+            result = open_pr_mod.handle_open_to_review(pr)
 
-        self.assertEqual(rc, 0)
-        transition_mock.assert_called_once()
-        args, _ = transition_mock.call_args
-        self.assertEqual(args[0], 945)
-        self.assertEqual(args[1], "open_to_human")
+        self.assertIsInstance(result, HandlerResult)
+        self.assertEqual(result.trigger, "open_to_human")
+        self.assertIn("feat/audit-modules-loader-886",
+                      result.divert_reason or "")
 
         gh_comment_calls = [
             call for call in run_mock.call_args_list
@@ -77,19 +79,14 @@ class TestHandleOpenToReviewNonBotBranch(unittest.TestCase):
         pr = _pr(946, "auto-improve/945-some-slug")
         run_mock = MagicMock()
         run_mock.return_value.returncode = 0
-        transition_mock = MagicMock(return_value=(True, False))
         log_mock = MagicMock()
 
         with patch.object(open_pr_mod, "_run", run_mock), \
-             patch.object(open_pr_mod, "fire_trigger", transition_mock), \
              patch.object(open_pr_mod, "log_run", log_mock):
-            rc = open_pr_mod.handle_open_to_review(pr)
+            result = open_pr_mod.handle_open_to_review(pr)
 
-        self.assertEqual(rc, 0)
-        transition_mock.assert_called_once()
-        args, _ = transition_mock.call_args
-        self.assertEqual(args[0], 946)
-        self.assertEqual(args[1], "open_to_reviewing_code")
+        self.assertIsInstance(result, HandlerResult)
+        self.assertEqual(result.trigger, "open_to_reviewing_code")
 
         gh_comment_calls = [
             call for call in run_mock.call_args_list
@@ -102,19 +99,14 @@ class TestHandleOpenToReviewNonBotBranch(unittest.TestCase):
         pr = _pr(947, "")
         run_mock = MagicMock()
         run_mock.return_value.returncode = 0
-        transition_mock = MagicMock(return_value=(True, False))
         log_mock = MagicMock()
 
         with patch.object(open_pr_mod, "_run", run_mock), \
-             patch.object(open_pr_mod, "fire_trigger", transition_mock), \
              patch.object(open_pr_mod, "log_run", log_mock):
-            rc = open_pr_mod.handle_open_to_review(pr)
+            result = open_pr_mod.handle_open_to_review(pr)
 
-        self.assertEqual(rc, 0)
-        transition_mock.assert_called_once()
-        args, _ = transition_mock.call_args
-        self.assertEqual(args[0], 947)
-        self.assertEqual(args[1], "open_to_human")
+        self.assertIsInstance(result, HandlerResult)
+        self.assertEqual(result.trigger, "open_to_human")
 
 
 if __name__ == "__main__":

--- a/tests/test_pr_bounce.py
+++ b/tests/test_pr_bounce.py
@@ -1,10 +1,11 @@
 """Tests for cai_lib.actions.pr_bounce.handle_pr_bounce.
 
-Covers the three branches:
-  1. Open linked PR exists → calls dispatch_pr.
-  2. No open PR + closed-merged PR found → applies pr_to_merged.
-  3. No open PR + closed-unmerged PR found → applies pr_to_refined.
-  4. No PR found at all → applies pr_to_human_needed.
+Covers the four branches of the recovery decision tree:
+  1. Open linked PR exists → calls dispatch_pr (and returns its int rc).
+  2. No open PR + closed-merged PR found → HandlerResult(pr_to_merged).
+  3. No open PR + closed-unmerged PR found (bot vs human closer) →
+     HandlerResult(pr_to_refined) or HandlerResult(pr_to_human_needed).
+  4. No PR found at all → HandlerResult(pr_to_human_needed).
 """
 import os
 import sys
@@ -14,6 +15,7 @@ from unittest.mock import patch
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from cai_lib.actions import pr_bounce
+from cai_lib.dispatcher import HandlerResult
 
 
 def _issue(number: int, label: str = "auto-improve:pr-open") -> dict:
@@ -33,13 +35,11 @@ class TestHandlePrBounce(unittest.TestCase):
         open_pr = {"number": 643, "headRefName": "auto-improve/620-foo"}
         with patch.object(pr_bounce, "_find_open_linked_pr", return_value=open_pr), \
              patch.object(pr_bounce, "_find_recent_closed_linked_pr") as closed_lookup, \
-             patch.object(pr_bounce, "fire_trigger") as apply_t, \
              patch("cai_lib.dispatcher.dispatch_pr", return_value=0) as dpr:
             rc = pr_bounce.handle_pr_bounce(issue)
         self.assertEqual(rc, 0)
         dpr.assert_called_once_with(643)
         closed_lookup.assert_not_called()
-        apply_t.assert_not_called()
 
     def test_closed_merged_pr_advances_to_merged(self):
         issue = _issue(620)
@@ -51,15 +51,11 @@ class TestHandlePrBounce(unittest.TestCase):
         with patch.object(pr_bounce, "_find_open_linked_pr", return_value=None), \
              patch.object(pr_bounce, "_find_recent_closed_linked_pr",
                           return_value=closed_pr), \
-             patch.object(pr_bounce, "fire_trigger", return_value=(True, False)) as apply_t, \
              patch("cai_lib.dispatcher.dispatch_pr") as dpr:
             rc = pr_bounce.handle_pr_bounce(issue)
-        self.assertEqual(rc, 0)
+        self.assertIsInstance(rc, HandlerResult)
+        self.assertEqual(rc.trigger, "pr_to_merged")
         dpr.assert_not_called()
-        apply_t.assert_called_once()
-        args, kwargs = apply_t.call_args
-        self.assertEqual(args[0], 620)
-        self.assertEqual(args[1], "pr_to_merged")
 
     def test_closed_unmerged_by_bot_reverts_to_refined(self):
         issue = _issue(644)
@@ -73,13 +69,11 @@ class TestHandlePrBounce(unittest.TestCase):
                           return_value=closed_pr), \
              patch.object(pr_bounce, "_pr_close_actor", return_value="cai-bot"), \
              patch.object(pr_bounce, "_our_gh_login", return_value="cai-bot"), \
-             patch.object(pr_bounce, "fire_trigger", return_value=(True, False)) as apply_t, \
              patch("cai_lib.dispatcher.dispatch_pr") as dpr:
             rc = pr_bounce.handle_pr_bounce(issue)
-        self.assertEqual(rc, 0)
+        self.assertIsInstance(rc, HandlerResult)
+        self.assertEqual(rc.trigger, "pr_to_refined")
         dpr.assert_not_called()
-        apply_t.assert_called_once()
-        self.assertEqual(apply_t.call_args[0][1], "pr_to_refined")
 
     def test_closed_unmerged_by_human_diverts_to_human_needed(self):
         issue = _issue(644)
@@ -94,13 +88,12 @@ class TestHandlePrBounce(unittest.TestCase):
              patch.object(pr_bounce, "_pr_close_actor",
                           return_value="damien-robotsix"), \
              patch.object(pr_bounce, "_our_gh_login", return_value="cai-bot"), \
-             patch.object(pr_bounce, "fire_trigger", return_value=(True, False)) as apply_t, \
              patch("cai_lib.dispatcher.dispatch_pr") as dpr:
             rc = pr_bounce.handle_pr_bounce(issue)
-        self.assertEqual(rc, 0)
+        self.assertIsInstance(rc, HandlerResult)
+        self.assertEqual(rc.trigger, "pr_to_human_needed")
+        self.assertTrue(rc.divert_reason)
         dpr.assert_not_called()
-        apply_t.assert_called_once()
-        self.assertEqual(apply_t.call_args[0][1], "pr_to_human_needed")
 
     def test_closed_unmerged_unknown_actor_diverts_to_human_needed(self):
         """When timeline lookup fails, default to human-needed (safer)."""
@@ -115,33 +108,22 @@ class TestHandlePrBounce(unittest.TestCase):
                           return_value=closed_pr), \
              patch.object(pr_bounce, "_pr_close_actor", return_value=None), \
              patch.object(pr_bounce, "_our_gh_login", return_value="cai-bot"), \
-             patch.object(pr_bounce, "fire_trigger", return_value=(True, False)) as apply_t, \
              patch("cai_lib.dispatcher.dispatch_pr") as dpr:
             rc = pr_bounce.handle_pr_bounce(issue)
-        self.assertEqual(rc, 0)
-        self.assertEqual(apply_t.call_args[0][1], "pr_to_human_needed")
+        self.assertIsInstance(rc, HandlerResult)
+        self.assertEqual(rc.trigger, "pr_to_human_needed")
 
     def test_no_pr_diverts_to_human_needed(self):
         issue = _issue(700)
         with patch.object(pr_bounce, "_find_open_linked_pr", return_value=None), \
              patch.object(pr_bounce, "_find_recent_closed_linked_pr",
                           return_value=None), \
-             patch.object(pr_bounce, "fire_trigger", return_value=(True, False)) as apply_t, \
              patch("cai_lib.dispatcher.dispatch_pr") as dpr:
             rc = pr_bounce.handle_pr_bounce(issue)
-        self.assertEqual(rc, 0)
+        self.assertIsInstance(rc, HandlerResult)
+        self.assertEqual(rc.trigger, "pr_to_human_needed")
+        self.assertTrue(rc.divert_reason)
         dpr.assert_not_called()
-        apply_t.assert_called_once()
-        self.assertEqual(apply_t.call_args[0][1], "pr_to_human_needed")
-
-    def test_apply_transition_failure_returns_one(self):
-        issue = _issue(700)
-        with patch.object(pr_bounce, "_find_open_linked_pr", return_value=None), \
-             patch.object(pr_bounce, "_find_recent_closed_linked_pr",
-                          return_value=None), \
-             patch.object(pr_bounce, "fire_trigger", return_value=(False, False)):
-            rc = pr_bounce.handle_pr_bounce(issue)
-        self.assertEqual(rc, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #1137. Step 2 of 3 under parent #1124.

- Migrates all 8 PR-side action handlers (`open_pr`, `review_pr`, `revise`, `review_docs`, `merge`, `rebase`, `fix_ci`, and `handle_pr_bounce` in `pr_bounce.py`) from `(pr: dict) -> int` to `-> HandlerResult`, using the mechanical patterns (B/C/D) catalogued in parent #1124.
- Drops the `isinstance(rc, HandlerResult)` compat shim in `dispatch_pr` so `_driver_fire` runs on every PR-handler return. The shim in `dispatch_issue` stays because the issue-side migration (#1141) was closed NOT_PLANNED — other issue handlers still return `int`.
- Updates the 7 test files that drove PR-side handlers directly so they assert on the returned `HandlerResult` (trigger / divert_reason) instead of mocking `fire_trigger` and asserting `rc == 0`.

### Preserved per the scope guardrails

- Pattern A entry-transition blocks in `handle_fix_ci` (lines 293-307) and `handle_revise` (lines 945-960) are untouched — Step 3 (#1138) removes those when `drive_pr` takes over entry-transition firing.
- The cross-entity Pattern C fire in `handle_merge` (line 1383, approach_mismatch close → `pr_to_plan_approved` on the linked issue) remains an explicit `fire_trigger` — `_driver_fire` only translates the handler's own PR-side return.
- `handle_review_pr` keeps the OPEN→REVIEWING_CODE normalization `fire_trigger` explicit so the subsequent REVIEWING_CODE→* transition can ride on the returned `HandlerResult` in the same handler invocation.
- Dispatcher registries (`ISSUE_STATE_ACTIONS`, `PR_STATE_ACTIONS`) keep all their current entries — registry collapse is Step 3.
- `handle_pr_bounce` keeps its int return on the bounce path (`return dispatch_pr(open_pr["number"])`); the recovery branches return `HandlerResult`. The `dispatch_issue` compat shim handles both.
- Behavioral invariants preserved: approach-mismatch routing (`merge-hold-approach-mismatch-routing.md`), LOW+hold fixable-bug routing (`merge-low-hold-fixable-bug-routing.md`), and pipeline co-edit exemption.

### Dispatcher co-edits

- `dispatch_pr` no longer branches on `isinstance(rc, HandlerResult)`; it always captures the result and calls `_driver_fire(pr_number, result, is_pr=True, current_pr=pr)`.
- The rebase-divert branch in `dispatch_pr` now captures `handle_rebase`'s `HandlerResult` and routes it through `_driver_fire` before returning its int exit code.
- `PRHandler` type alias narrowed to `Callable[[dict], HandlerResult]`.

## Test plan

- [x] `python -m unittest discover tests` — 675 tests, all passing.
- [x] `python -c "from cai_lib.dispatcher import dispatch_issue, dispatch_pr, HandlerResult, _driver_fire"` — succeeds.
- [x] Grep verifies PR-side `fire_trigger` usage is limited to Pattern A entry blocks (`fix_ci.py`, `revise.py`, `review_pr.py` normalization) and the single cross-entity fire in `merge.py`.
- [x] All 8 target handlers carry `-> HandlerResult` annotations.
- [x] `isinstance.*HandlerResult` appears only once in `dispatcher.py` — in `dispatch_issue`, as expected while Step 1b stays unmerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)