### PR TITLE
refine: post refined body before guardrail-contradiction divert

### DIFF
--- a/cai_lib/actions/refine.py
+++ b/cai_lib/actions/refine.py
@@ -322,6 +322,36 @@ def handle_refine(issue: dict) -> int:
 
     refined_body = stdout[marker_pos:].strip()
 
+    # Build the new issue body: refined content + original text quoted.
+    # Post it BEFORE the contradiction lint so an admin handling the
+    # :human-needed divert can see the agent's proposed Files-to-change
+    # and Scope guardrails sections when deciding how to resolve the
+    # contradiction.
+    next_step = _parse_refine_next_step(stdout)
+    original_body = _strip_stored_plan_block(issue.get("body") or "(no body)")
+    quoted_original = "\n".join(f"> {line}" for line in original_body.splitlines())
+    new_body = (
+        f"{refined_body}\n\n"
+        f"---\n\n"
+        f"> **Original issue text:**\n>\n"
+        f"{quoted_original}\n"
+    )
+
+    update = _run(
+        ["gh", "issue", "edit", str(issue_number),
+         "--repo", REPO, "--body", new_body],
+        capture_output=True,
+    )
+    if update.returncode != 0:
+        print(
+            f"[cai refine] gh issue edit failed:\n{update.stderr}",
+            file=sys.stderr,
+        )
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run("refine", repo=REPO, issue=issue_number,
+                duration=dur, result="edit_failed", exit=1)
+        return 1
+
     # Scope-guardrail contradiction lint (issue #919).
     contradictions = _detect_guardrail_contradictions(refined_body)
     if contradictions:
@@ -354,33 +384,6 @@ def handle_refine(issue: dict) -> int:
             contradictions=",".join(contradictions), exit=0,
         )
         return 0
-
-    # Build the new issue body: refined content + original text quoted.
-    next_step = _parse_refine_next_step(stdout)
-    original_body = _strip_stored_plan_block(issue.get("body") or "(no body)")
-    quoted_original = "\n".join(f"> {line}" for line in original_body.splitlines())
-    new_body = (
-        f"{refined_body}\n\n"
-        f"---\n\n"
-        f"> **Original issue text:**\n>\n"
-        f"{quoted_original}\n"
-    )
-
-    # Update the issue body.
-    update = _run(
-        ["gh", "issue", "edit", str(issue_number),
-         "--repo", REPO, "--body", new_body],
-        capture_output=True,
-    )
-    if update.returncode != 0:
-        print(
-            f"[cai refine] gh issue edit failed:\n{update.stderr}",
-            file=sys.stderr,
-        )
-        dur = f"{int(time.monotonic() - t0)}s"
-        log_run("refine", repo=REPO, issue=issue_number,
-                duration=dur, result="edit_failed", exit=1)
-        return 1
 
     # Transition out of :refining. NextStep: EXPLORE routes the
     # issue to :needs-exploration; anything else advances to :refined

--- a/tests/test_multistep.py
+++ b/tests/test_multistep.py
@@ -295,6 +295,59 @@ class TestGuardrailContradictionLint(unittest.TestCase):
         self.assertEqual(_detect_guardrail_contradictions(body), [])
 
 
+class TestHandleRefinePostsBodyBeforeContradictionDivert(unittest.TestCase):
+    """Regression for #1161: when the guardrail-contradiction lint trips,
+    handle_refine must still post the refined body to the issue so the
+    admin handling the :human-needed divert can see the proposed Files
+    to change / Scope guardrails sections.
+    """
+
+    @patch("cai_lib.actions.refine.log_run")
+    @patch("cai_lib.actions.refine.fire_trigger")
+    @patch("cai_lib.actions.refine._run")
+    @patch("cai_lib.actions.refine._run_claude_p")
+    def test_issue_body_is_updated_before_divert(
+        self, mock_claude, mock_run, mock_fire, mock_log,
+    ):
+        stdout = (
+            "## Refined Issue\n\n"
+            "### Problem\n\nSomething.\n\n"
+            "### Files to change\n"
+            "- `cai_lib/publish.py`\n\n"
+            "### Scope guardrails\n"
+            "- Do not modify `cai_lib/publish.py`\n"
+        )
+        mock_claude.return_value = MagicMock(
+            returncode=0, stdout=stdout, stderr="",
+        )
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        issue = {
+            "number": 1161,
+            "title": "Test",
+            "body": "original text",
+            "labels": [{"name": "auto-improve:refining"}],
+        }
+        handle_refine(issue)
+
+        edit_calls = [
+            c for c in mock_run.call_args_list
+            if c.args and c.args[0][:3] == ["gh", "issue", "edit"]
+        ]
+        self.assertEqual(len(edit_calls), 1,
+                         "handle_refine must post the refined body before diverting")
+        body_arg = edit_calls[0].args[0][-1]
+        self.assertIn("### Files to change", body_arg)
+        self.assertIn("### Scope guardrails", body_arg)
+        self.assertIn("`cai_lib/publish.py`", body_arg)
+        self.assertIn("> original text", body_arg)
+
+        divert_calls = [
+            c for c in mock_fire.call_args_list
+            if c.args and c.args[1] == "refining_to_human"
+        ]
+        self.assertEqual(len(divert_calls), 1)
+
+
 class TestExtractPathsHelper(unittest.TestCase):
     """Tests for the _extract_paths pre-strips (clone-prefix + leading ./).
 


### PR DESCRIPTION
## Summary
- When the guardrail-contradiction lint trips, `handle_refine` diverts to `:human-needed` without writing the refined body to the issue, so the admin can't see the `Files to change` and `Scope guardrails` sections that caused the contradiction.
- Move the `gh issue edit` call in `cai_lib/actions/refine.py` above the contradiction check so the refined body is always posted — then divert with the full proposed scope already visible in the issue body.
- Add a regression test in `tests/test_multistep.py` covering the divert path.

Fixes #1161.

## Test plan
- [x] `python -m pytest tests/test_multistep.py` — 29 passed
- [x] `python -m pytest tests/` — 648 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)