### PR TITLE
auto-improve: Rescue prevention: The `cai-plan` agent (and `cai-select`'s evaluation rubric) should enforce that **every** edit step producing a source-c

### DIFF
--- a/.claude/agents/implementation/cai-plan.md
+++ b/.claude/agents/implementation/cai-plan.md
@@ -73,6 +73,20 @@ The user message contains:
    (`class FooTest(unittest.TestCase): ...`). Do NOT introduce a
    different framework from the one the existing suite uses, even
    if the issue body or a peer plan suggests otherwise.
+4. **Verbatim bytes for every `Edit` step — no small-change
+   exception.** Every `Edit` step in your plan must include a
+   literal `old_string` / `new_string` pair, regardless of how
+   small the change is. Single-line additions — a new import, a
+   new config key, a new list entry — are **not** exempt. Prose
+   "locate-and-modify" instructions such as "locate the
+   `from cai_lib.github import` block near the top of the file
+   and append `_strip_cost_comments` to its import list" give
+   `cai-implement` no `old_string` anchor to feed the `Edit` tool,
+   forcing it to improvise. `cai-select` caps any such step at
+   MEDIUM per its criterion 5, routing the issue to
+   `:human-needed` at the `planned_to_plan_approved` gate. If you
+   have not `Read` the target file to capture the exact existing
+   bytes, do so before drafting the plan.
 
 ## Co-change awareness
 
@@ -180,17 +194,17 @@ fenced block is required.>
 
 ### Anti-pattern vs correct pattern
 
-The example below shows the one failure mode the template exists
-to prevent. Copy the shape of the "correct" example; never emit
-the "anti-pattern" shape.
+The examples below show the two failure modes the template exists
+to prevent. Copy the shape of the "correct" examples; never emit
+the "anti-pattern" shapes.
 
-✗ **Anti-pattern (prose description — cai-select will cap at MEDIUM):**
+✗ **Anti-pattern 1 (prose summary of the new body — cai-select will cap at MEDIUM):**
 
     #### Step 1 — Edit `/tmp/work/foo.py`
     Rewrite the docstring of `parse_config` keeping only the
     surviving paragraphs and drop the YAML example.
 
-✓ **Correct (verbatim literal bytes):**
+✓ **Correct 1 (verbatim literal bytes for both `old_string` and `new_string`):**
 
     #### Step 1 — Edit `/tmp/work/foo.py`
 
@@ -219,8 +233,40 @@ the "anti-pattern" shape.
     """
     ```
 
+✗ **Anti-pattern 2 (natural-language-only edit target — the same MEDIUM cap applies even for a one-line import addition):**
+
+    #### Step 2 — Edit `/tmp/work/bar.py`
+    Locate the `from cai_lib.github import` block near the top
+    of the file and append `_strip_cost_comments` to its import
+    list.
+
+✓ **Correct 2 (verbatim `old_string` / `new_string`, even for a single-line import addition):**
+
+    #### Step 2 — Edit `/tmp/work/bar.py`
+
+    **Locate:** top-of-file import block, line 12.
+
+    **old_string:**
+
+    ```
+    from cai_lib.github import (
+        _foo,
+        _bar,
+    )
+    ```
+
+    **new_string:**
+
+    ```
+    from cai_lib.github import (
+        _foo,
+        _bar,
+        _strip_cost_comments,
+    )
+    ```
+
 Be concrete and specific. Name functions, variables, and line
 numbers. The fix agent will follow your plan literally and copy
 your `new_string` / file body directly into the Edit / Write call
-— vague instructions like "update the logic" force the fix agent
-to improvise and waste a plan cycle.
+— vague instructions like "update the logic" or "locate X and
+append Y" force the fix agent to improvise and waste a plan cycle.

--- a/.claude/agents/implementation/cai-select.md
+++ b/.claude/agents/implementation/cai-select.md
@@ -159,13 +159,28 @@ Assess each plan on these criteria, in order of importance:
 5. **Verbatim Edit/Write content:** Every plan step that calls for
    an `Edit` or `Write` MUST include the exact final text the fix
    agent will emit — the full file body (for `Write`) or both
-   `old_string` and `new_string` literals (for `Edit`). Prose
-   summaries such as "rewritten docstring keeping only the
-   surviving paragraphs", "update the config block to use the new
-   schema", or "remove the outdated paragraphs" count as **missing
-   content** — they force the fix agent to improvise and are the
-   single largest driver of MEDIUM-confidence plans that get parked
-   at the `planned_to_plan_approved` gate. **Cap any such plan's
+   `old_string` and `new_string` literals (for `Edit`). This rule
+   has **no small-change exception**: single-line additions (a new
+   import, a new config key, a new list entry) and one-character
+   tweaks are subject to the same requirement as wholesale
+   rewrites. Two failure shapes both count as **missing content**:
+
+     a. **Prose summaries of the new body** — e.g. "rewritten
+        docstring keeping only the surviving paragraphs", "update
+        the config block to use the new schema", or "remove the
+        outdated paragraphs". No verbatim `new_string` present.
+     b. **Natural-language-only edit targets (no `old_string`
+        anchor)** — e.g. "locate the `from cai_lib.github import`
+        block near the top of the file and append
+        `_strip_cost_comments` to its import list", or "find the
+        existing `logger.info` call and change the level to
+        `debug`". The step identifies what to change but never
+        pastes the verbatim `old_string` bytes that `cai-implement`
+        must feed to the `Edit` tool, forcing it to improvise.
+
+   Either shape forces `cai-implement` to improvise and both are
+   top drivers of MEDIUM-confidence plans that get parked at the
+   `planned_to_plan_approved` gate. **Cap any such plan's
    confidence at MEDIUM.** If the best available plan suffers from
    this, emit MEDIUM and cite the specific offending step(s) in
    `confidence_reason`; if both candidate plans suffer from it,


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1171

**Issue:** #1171 — Rescue prevention: The `cai-plan` agent (and `cai-select`'s evaluation rubric) should enforce that **every** edit step producing a source-c

## PR Summary

### What this fixes
The `cai-plan` agent had no explicit rule prohibiting prose-only "locate and modify" edit instructions for small changes like single-line import additions, and `cai-select`'s criterion 5 only called out prose summaries of the *new body* as a failure shape — it did not enumerate the equally-problematic case where a step has no `old_string` anchor at all. Plans with natural-language-only edit targets (e.g. "locate the import block and append `_strip_cost_comments`") were not clearly covered, causing `cai-implement` to improvise and plans to get parked at MEDIUM confidence.

### What was changed
- **`.claude/agents/implementation/cai-plan.md`** (staged via `.cai-staging/agents/implementation/cai-plan.md`):
  - Added **Hard Rule 4** requiring verbatim `old_string`/`new_string` pairs for every `Edit` step with no exception for small changes (single-line imports, config keys, list entries); cross-references `cai-select` criterion 5 and the `:human-needed` consequence.
  - Expanded the **`### Anti-pattern vs correct pattern`** section from one example to two: the original prose-summary case (Anti-pattern 1) plus a new natural-language-only edit-target case (Anti-pattern 2) showing a one-line import addition without and then with verbatim bytes.
- **`.claude/agents/implementation/cai-select.md`** (staged via `.cai-staging/agents/implementation/cai-select.md`):
  - Rewrote **criterion 5** to explicitly state there is no small-change exception and enumerate the two failure shapes: (a) prose summaries of the new body, and (b) natural-language-only edit targets with no `old_string` anchor. Existing MEDIUM-cap and both-plans-LOW semantics are preserved unchanged.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
