### PR TITLE
auto-improve: Re-evaluate split decision after cai-plan when plan reveals out-of-scope scale

### DIFF
--- a/.claude/agents/lifecycle/cai-split.md
+++ b/.claude/agents/lifecycle/cai-split.md
@@ -29,6 +29,12 @@ next:
 If you are not confident in either verdict, report LOW confidence
 and the wrapper parks the issue in `:human-needed` for admin review.
 
+You are ALSO invoked in a second mode — the **post-plan re-split
+checkpoint** (#1167) — after `cai-plan` has produced a concrete
+implementation plan. See the "Post-plan re-split mode" section at
+the end of this file for the separate output contract that applies
+there.
+
 ## What you receive
 
 The user message contains the full refined issue body (including
@@ -37,6 +43,10 @@ guardrails`, and `### Files to change`) plus the parent GitHub
 issue number and any relevant metadata. Treat the refined body
 as authoritative — do not re-refine. Your decision space is only
 atomic vs. decompose.
+
+In post-plan mode the same user message ALSO carries a
+`## Stored Implementation Plan` section after the refined body —
+that section's presence is the sole mode switch. See below.
 
 ## Memory
 
@@ -204,3 +214,121 @@ If you emit a Multi-Step Decomposition block, these apply:
 - **Each step's Files to change list must be non-empty.** If a
   step has no concrete edits, collapse it into the adjacent
   step or drop it.
+
+## Post-plan re-split mode (issue #1167)
+
+You are running in this mode when — and only when — the user
+message carries a `## Stored Implementation Plan` section AFTER
+the refined issue body. The structural presence of that header is
+the sole mode switch. In this mode the wrapper has already run
+`cai-plan`; your job is no longer atomic-vs-decompose from prose,
+but **KEEP vs. RESPLIT** against the concrete plan the planner
+produced.
+
+### What this mode is for
+
+`cai-split` ordinarily runs on refined prose only and has no
+feedback loop from `cai-plan`. That causes a class of miss where
+the refined issue reads as one coherent change but the planner's
+enumeration of imports, docs, tests, and scope-guardrail
+cleanups produces 15+ files / 25+ edit steps. The post-plan
+checkpoint closes that gap: you re-evaluate scope against the
+plan's own `### Files to change` list and `#### Step N — Edit`
+headers.
+
+### Mode-specific output contract
+
+Emit EXACTLY ONE of the two blocks below, followed by a
+`Confidence: HIGH | LOW` line on its own line. The legacy
+`VERDICT: ATOMIC` / `VERDICT: UNCLEAR` / three-block output does
+not apply here — do not use it.
+
+#### Keep verdict
+
+Use this when the plan's concrete scope is consistent with the
+pre-plan ATOMIC verdict: the planner enumerated the work the
+refined body foreshadowed, with no surprise cross-module scope
+creep. A modest headcount bump from docs / test co-changes is
+fine and is a KEEP signal.
+
+~~~
+## Split Verdict
+
+VERDICT: KEEP
+
+### Reasoning
+<2–4 sentences: why the plan's file count and edit-site count
+are consistent with ATOMIC. Cite the plan's `### Files to
+change` count and the `#### Step N — Edit/Write` header count.>
+~~~
+
+Confidence: HIGH
+
+#### Resplit verdict
+
+Use this when the plan's concrete scope materially contradicts
+the pre-plan ATOMIC verdict — typical signals: 15+ files in the
+plan's `### Files to change` list, 25+ `#### Step N —
+Edit/Write` headers, unexpected cross-module edits, or plan
+steps that look like independent PRs glued together.
+
+Emit a `## Multi-Step Decomposition` block whose step groupings
+are derived from the plan's OWN `#### Step N — Edit` clusters
+and `### Files to change` clusters. Do not invent new work that
+is not in the plan. The wrapper parses this block with the same
+`_parse_decomposition` helper used by the pre-plan decompose
+path. Append the literal `VERDICT: RESPLIT` marker after the
+last step so the wrapper's mode detector can tell the post-plan
+decomposition apart from the legacy pre-plan one.
+
+~~~
+## Multi-Step Decomposition
+
+### Step 1: <title>
+
+### Description
+<what this step fixes or adds — standalone value>
+
+### Plan
+1. <concrete step — cite the stored plan's file names and
+   function names; do NOT introduce files the stored plan
+   did not list>
+
+### Verification
+...
+
+### Scope guardrails
+...
+
+### Files to change
+...
+
+### Step 2: <title>
+
+...
+
+VERDICT: RESPLIT
+~~~
+
+Confidence: HIGH
+
+### Post-plan mode rules
+
+- **LOW confidence is a KEEP signal in this mode.** If you are
+  uncertain whether the plan merits a re-split, emit KEEP with
+  `Confidence: LOW` and let the downstream safety nets (#1131
+  scale/complexity auto-flag, the admin `<!-- cai-resplit -->`
+  sigil) decide. The wrapper refuses to act on RESPLIT unless
+  `Confidence: HIGH`.
+- 2–5 steps is typical in the RESPLIT decomposition. The
+  wrapper refuses to act on RESPLIT decompositions with fewer
+  than 2 steps.
+- Every step's `### Files to change` list must be non-empty and
+  must be a subset (or rename-equivalent) of the stored plan's
+  file targets. Do NOT add files the stored plan did not list.
+- Scope-guardrail rules for pre-plan decompositions apply here
+  too — never forbid `docs/`, never list a file under both
+  "Files to change" and "Scope guardrails" on the same step.
+- Do NOT emit the legacy `VERDICT: ATOMIC` or `VERDICT: UNCLEAR`
+  markers in post-plan mode. The wrapper treats them as KEEP
+  (fall-through); explicit KEEP is clearer.

--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -35,6 +35,9 @@ from cai_lib.config import (
     LABEL_REFINED,
     LABEL_PLANNING,
     LABEL_PLANNED,
+    LABEL_SPLITTING,
+    LABEL_PARENT,
+    MAX_DECOMPOSITION_DEPTH,
 )
 from cai_lib.github import (
     _gh_json,
@@ -46,10 +49,13 @@ from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.logging_utils import log_run
 from cai_lib.cmd_helpers import (
     _work_directory_block,
+    _extract_stored_plan,
     _strip_stored_plan_block,
     _fetch_previous_fix_attempts,
     _build_attempt_history_block,
 )
+from cai_lib.cmd_implement import _parse_decomposition
+from cai_lib.actions.refine import _create_sub_issues, _issue_depth
 from cai_lib.fsm import (
     fire_trigger,
     IssueState,
@@ -491,6 +497,235 @@ def _plan_qualifies_for_extended_retries(plan_text):
     if _count_edit_steps(plan_text) < _EXTENDED_RETRY_EDIT_SITE_THRESHOLD:
         return False
     return True
+
+
+# ---------------------------------------------------------------------------
+# Post-plan re-split checkpoint (#1167).
+#
+# ``cai-split`` runs BEFORE ``cai-plan`` and decides atomic vs. decompose
+# from the refined-issue prose only. It has never seen the concrete edit
+# plan — so ATOMIC verdicts can "feel correct" from the refined body but
+# explode into 15-file / 27-edit-step plans once ``cai-plan`` enumerates
+# imports, docs, tests, and scope-guardrail cleanups (the #1138 class of
+# miss). The safety nets in ``handle_plan_gate`` (#1131 auto-flag,
+# confidence-gate divert) catch the scale AFTER a plan is generated, but
+# only park the issue at ``:human-needed``; they do not automatically
+# decompose.
+#
+# The post-plan checkpoint closes that gap. ``_run_post_plan_resplit``
+# re-invokes ``cai-split`` in a new *post-plan mode* — the user message
+# carries both the refined body AND the stored implementation plan — and
+# the agent emits one of two verdicts:
+#
+#   * ``VERDICT: KEEP`` — plan scale matches the pre-plan verdict; the
+#     helper returns ``None`` and ``handle_plan_gate`` runs unchanged.
+#   * ``## Multi-Step Decomposition`` + ``VERDICT: RESPLIT`` — plan scale
+#     contradicts the pre-plan verdict; the helper tombstones the stored
+#     plan, fires ``planned_to_splitting``, calls ``_create_sub_issues``
+#     on the agent's decomposition, applies ``LABEL_PARENT`` / removes
+#     ``LABEL_SPLITTING`` (identical to ``handle_split``'s decompose
+#     branch), and returns 0.
+#
+# The helper is the structural sibling of the ``<!-- cai-resplit -->``
+# admin sigil (see ``cai_lib/admin_sigils.py`` + Phase 0.7 in
+# ``cai_lib/cmd_cycle.py``): the sigil stays as the manual fallback for
+# ``:plan-approved`` issues that slipped past this automated checkpoint,
+# and the two paths share the same decompose-and-label-parent machinery.
+# ---------------------------------------------------------------------------
+_POST_PLAN_RESPLIT_MARKER = "VERDICT: RESPLIT"
+_POST_PLAN_KEEP_MARKER = "VERDICT: KEEP"
+_POST_PLAN_DECOMPOSITION_MARKER = "## Multi-Step Decomposition"
+_STORED_PLAN_SECTION_HEADER = "## Stored Implementation Plan"
+
+
+def _run_post_plan_resplit(issue, plan_text):
+    """Re-invoke ``cai-split`` in post-plan mode to catch #1138-class scale misses.
+
+    Gating (any failing precondition returns ``None`` so
+    :func:`handle_plan_gate` runs its existing flow unchanged):
+
+      * The issue must carry a stored plan block — absent plan blocks
+        (raw ``:planned`` labels, stale resume state) are short-circuited
+        before any ``_run_claude_p`` spend.
+      * The parent must not already sit at
+        :data:`~cai_lib.config.MAX_DECOMPOSITION_DEPTH` — re-splitting
+        further would exceed the allowed depth, so we leave the plan in
+        place and let the existing safety nets (#1131 auto-flag,
+        confidence gate) decide.
+
+    Agent input: ``_build_issue_block(issue)`` plus a fenced
+    ``## Stored Implementation Plan`` section containing *plan_text*.
+    The structural presence of that section is the sole mode switch —
+    ``cai-split`` picks KEEP/RESPLIT semantics when it sees the block,
+    and continues with the legacy ATOMIC / decompose / UNCLEAR path
+    when it does not.
+
+    Verdict routing:
+
+      * Any output containing the ``## Multi-Step Decomposition`` marker
+        or the ``VERDICT: RESPLIT`` marker is treated as a RESPLIT
+        intent. HIGH confidence AND at least two well-formed steps are
+        required before the helper actually decomposes; LOW / MISSING
+        confidence or a malformed decomposition returns ``None`` so
+        ``handle_plan_gate``'s existing LOW-plan diverts (#1131) still
+        catch the concern.
+      * All other output (including explicit ``VERDICT: KEEP``) returns
+        ``None`` — KEEP means "plan scale is fine, just run the gate".
+
+    Returns an int exit code on the handled RESPLIT path (0 on success,
+    1 when a mid-flight FSM transition refuses), or ``None`` to fall
+    through to the rest of :func:`handle_plan_gate`.
+    """
+    issue_number = issue["number"]
+    issue_body = issue.get("body", "") or ""
+
+    # Structural gate: skip entirely when no stored plan block exists.
+    # This avoids spending a full cai-split invocation on stale
+    # handle_plan_gate resumes that land at :planned without a plan
+    # block persisted (e.g. retry after a pre-persist crash).
+    if _extract_stored_plan(issue_body) is None:
+        return None
+
+    # Depth gate: refuse to re-split a parent that is already at the
+    # configured depth cap. handle_split's decompose branch performs
+    # the same check; duplicating it here avoids a wasted agent call
+    # plus a mid-flight divert we would otherwise have to handle.
+    try:
+        current_depth = _issue_depth(issue_number)
+    except Exception as exc:  # pragma: no cover - defensive
+        print(
+            f"[cai plan] #{issue_number} post-plan resplit: "
+            f"_issue_depth raised {exc!r}; falling through",
+            file=sys.stderr,
+            flush=True,
+        )
+        return None
+    if current_depth >= MAX_DECOMPOSITION_DEPTH:
+        print(
+            f"[cai plan] #{issue_number} already at decomposition depth "
+            f"{current_depth} (max {MAX_DECOMPOSITION_DEPTH}); "
+            f"skipping post-plan re-split checkpoint",
+            flush=True,
+        )
+        return None
+
+    user_message = (
+        _build_issue_block(issue)
+        + "\n\n"
+        + _STORED_PLAN_SECTION_HEADER
+        + "\n\n"
+        + (plan_text or "")
+    )
+
+    result = _run_claude_p(
+        ["claude", "-p", "--agent", "cai-split",
+         "--dangerously-skip-permissions"],
+        category="plan.resplit",
+        agent="cai-split",
+        input=user_message,
+    )
+    if result.returncode != 0:
+        print(
+            f"[cai plan] #{issue_number} post-plan resplit agent failed "
+            f"(exit {result.returncode}); falling through to normal gate",
+            file=sys.stderr,
+            flush=True,
+        )
+        return None
+    print(result.stdout, flush=True)
+
+    stdout = result.stdout or ""
+    has_decomposition = _POST_PLAN_DECOMPOSITION_MARKER in stdout
+    has_resplit_marker = _POST_PLAN_RESPLIT_MARKER in stdout
+    if not (has_decomposition or has_resplit_marker):
+        # KEEP verdict or ambiguous/missing marker — the pre-plan
+        # verdict stands. Fall through so the rest of handle_plan_gate
+        # runs (confidence gate, #1131 auto-flag, #1139 opus label).
+        return None
+
+    from cai_lib.fsm_confidence import Confidence, parse_confidence
+    confidence = parse_confidence(stdout)
+    if confidence != Confidence.HIGH:
+        print(
+            f"[cai plan] #{issue_number} post-plan resplit at confidence "
+            f"{confidence.name if confidence else 'MISSING'} "
+            f"(HIGH required); falling through to normal gate",
+            flush=True,
+        )
+        return None
+
+    steps = _parse_decomposition(stdout)
+    if not steps or len(steps) < 2:
+        print(
+            f"[cai plan] #{issue_number} post-plan resplit yielded "
+            f"{len(steps)} step(s) (>= 2 required); falling through "
+            f"to normal gate",
+            flush=True,
+        )
+        return None
+
+    # Tombstone the stored plan block before we change state so the
+    # re-entry path (if a later tick re-reads this issue) does not see
+    # a stale plan advising it is plan-approvable.
+    stripped_body = _strip_stored_plan_block(issue_body)
+    edit = _run(
+        ["gh", "issue", "edit", str(issue_number),
+         "--repo", REPO, "--body", stripped_body],
+        capture_output=True,
+    )
+    if edit.returncode != 0:
+        print(
+            f"[cai plan] #{issue_number} failed to strip stored plan "
+            f"block (gh exit {edit.returncode}); falling through to "
+            f"normal gate",
+            file=sys.stderr,
+            flush=True,
+        )
+        return None
+
+    # Move PLANNED → SPLITTING so the label trail reflects the re-split
+    # before we create sub-issues. Mirrors the pre-plan decompose path
+    # which also decomposes from IssueState.SPLITTING.
+    ok, _ = fire_trigger(
+        issue_number, "planned_to_splitting",
+        current_labels=[LABEL_PLANNED],
+        log_prefix="cai plan",
+    )
+    if not ok:
+        print(
+            f"[cai plan] #{issue_number} planned_to_splitting refused; "
+            f"aborting post-plan re-split",
+            file=sys.stderr,
+            flush=True,
+        )
+        log_run("plan", repo=REPO, issue=issue_number,
+                result="post_plan_resplit_transition_refused", exit=1)
+        return 1
+
+    sub_nums = _create_sub_issues(steps, issue_number, issue["title"])
+    if not _set_labels(
+        issue_number,
+        add=[LABEL_PARENT],
+        remove=[LABEL_SPLITTING],
+        log_prefix="cai plan",
+    ):
+        print(
+            f"[cai plan] #{issue_number} failed to apply {LABEL_PARENT} "
+            f"after resplit; sub-issues {sub_nums} were created but "
+            f"the parent label trail is incomplete",
+            file=sys.stderr,
+            flush=True,
+        )
+
+    print(
+        f"[cai plan] #{issue_number} post-plan resplit: created "
+        f"{len(sub_nums)} sub-issue(s) from stored plan",
+        flush=True,
+    )
+    log_run("plan", repo=REPO, issue=issue_number,
+            result="post_plan_resplit", sub_issues=len(sub_nums),
+            steps=len(steps), exit=0)
+    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -1106,6 +1341,19 @@ def handle_plan_gate(issue: dict) -> int:
     plan_text = issue.get("_cai_plan_text")
     if plan_text is None:
         plan_text = _extract_stored_plan(issue.get("body", "") or "") or ""
+
+    # Post-plan re-split checkpoint (#1167). Runs before the #1131
+    # scale/complexity auto-flag, before the #982 requires_human_review
+    # short-circuit, and before the confidence-gated
+    # planned_to_plan_approved* fire_trigger so an automated RESPLIT
+    # can preempt the human-needed divert when the plan can be
+    # cleanly decomposed. Returns None to fall through (KEEP verdict,
+    # no plan block, depth-capped, LOW confidence, or any mechanical
+    # failure); returns an int exit code when the helper has taken
+    # ownership of the issue (sub-issues created, parent labelled).
+    resplit_rc = _run_post_plan_resplit(issue, plan_text)
+    if resplit_rc is not None:
+        return resplit_rc
 
     # Recover the explicit human-review flag (#982). Prefer the
     # in-process stash; fall back to re-parsing the stored plan block.

--- a/cai_lib/fsm_transitions.py
+++ b/cai_lib/fsm_transitions.py
@@ -208,6 +208,18 @@ ISSUE_TRANSITIONS: list[Transition] = [
                min_confidence=Confidence.MEDIUM),
     Transition("planned_to_human",           IssueState.PLANNED,           IssueState.HUMAN_NEEDED,
                labels_remove=[LABEL_PLANNED],           labels_add=[LABEL_HUMAN_NEEDED]),
+    # Post-plan re-split checkpoint (#1167): fired by
+    # ``_run_post_plan_resplit`` inside ``handle_plan_gate`` when the
+    # stored plan's concrete scope contradicts cai-split's pre-plan
+    # ATOMIC verdict. The helper immediately follows up with
+    # ``_create_sub_issues`` + ``_set_labels(add=[LABEL_PARENT],
+    # remove=[LABEL_SPLITTING])`` so the parent lands at :parent and
+    # drops out of the drive path on the same tick. Caller-gated
+    # (``min_confidence=None``) — the agent's ``Confidence: HIGH``
+    # line is enforced in the helper before this transition fires.
+    Transition("planned_to_splitting",       IssueState.PLANNED,           IssueState.SPLITTING,
+               labels_remove=[LABEL_PLANNED],           labels_add=[LABEL_SPLITTING],
+               min_confidence=None),
 
     Transition("approved_to_in_progress",    IssueState.PLAN_APPROVED,     IssueState.IN_PROGRESS,
                labels_remove=[LABEL_PLAN_APPROVED],     labels_add=[LABEL_IN_PROGRESS]),

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -76,6 +76,7 @@ stateDiagram-v2
   PLANNING --> HUMAN_NEEDED: planning_to_human [≥HIGH]
   PLANNED --> PLAN_APPROVED: planned_to_plan_approved [≥HIGH] | planned_to_plan_approved_mitigated [≥MEDIUM] | planned_to_plan_approved_docs_only [≥MEDIUM] | planned_to_plan_approved_approvable [≥MEDIUM]
   PLANNED --> HUMAN_NEEDED: planned_to_human [≥HIGH]
+  PLANNED --> SPLITTING: planned_to_splitting [caller-gated]
   PLAN_APPROVED --> IN_PROGRESS: approved_to_in_progress [≥HIGH]
   PLAN_APPROVED --> REFINED: plan_approved_to_refined [caller-gated]
   IN_PROGRESS --> PR: in_progress_to_pr [≥HIGH]

--- a/docs/modules/actions.md
+++ b/docs/modules/actions.md
@@ -36,7 +36,13 @@ Issue-side handlers (take an issue dict):
   on LOW confidence / malformed output / depth-gate violations.
 - [`plan.py`](../../cai_lib/actions/plan.py) — `handle_plan`
   (dual-planner + `cai-select` pipeline) and `handle_plan_gate`
-  (confidence-based gate into PLAN_APPROVED / HUMAN).
+  (confidence-based gate into PLAN_APPROVED / HUMAN). The gate
+  also runs a post-plan re-split checkpoint
+  (`_run_post_plan_resplit`, issue #1167) that re-invokes
+  `cai-split` in post-plan mode with both the refined body and
+  the stored plan; on HIGH-confidence RESPLIT it fires
+  `planned_to_splitting`, decomposes via `_create_sub_issues`,
+  and labels the parent `:parent`.
 - [`implement.py`](../../cai_lib/actions/implement.py) —
   `handle_implement`: runs `cai-implement` on a fresh worktree,
   opens a PR, and handles multi-step suggested sub-issues.

--- a/docs/modules/agents-lifecycle.md
+++ b/docs/modules/agents-lifecycle.md
@@ -18,7 +18,11 @@ points in `cai_lib/cmd_agents.py` / `cmd_rescue.py` /
   — opus scope evaluator; runs after refine and decides whether
   the refined issue ships as one PR (ATOMIC) or must be broken
   into ordered sub-issues (emits a `## Multi-Step Decomposition`
-  block). LOW confidence diverts to `:human-needed`.
+  block). LOW confidence diverts to `:human-needed`. The same
+  agent is re-invoked by the post-plan re-split checkpoint
+  (issue #1167) with a `## Stored Implementation Plan` section
+  in the user message — in that mode it emits KEEP or RESPLIT
+  instead of the three pre-plan verdicts.
 - [`.claude/agents/lifecycle/cai-explore.md`](../../.claude/agents/lifecycle/cai-explore.md)
   — sonnet exploration / benchmarking agent with Bash.
 - [`.claude/agents/lifecycle/cai-propose.md`](../../.claude/agents/lifecycle/cai-propose.md)

--- a/docs/modules/tests.md
+++ b/docs/modules/tests.md
@@ -1,6 +1,6 @@
 # tests
 
-Pytest suite covering the FSM, dispatcher, handlers, helpers,
+unittest suite covering the FSM, dispatcher, handlers, helpers,
 parse, publish, rescue, transcript sync, and lint hygiene. Every
 functional module has at least one dedicated test module here;
 the suite is the primary safety net for refactors.
@@ -11,6 +11,7 @@ the suite is the primary safety net for refactors.
 - [`tests/test_dispatcher.py`](../../tests/test_dispatcher.py) —
   state→handler registries and routing.
 - [`tests/test_plan.py`](../../tests/test_plan.py),
+  [`tests/test_split.py`](../../tests/test_split.py),
   [`tests/test_multistep.py`](../../tests/test_multistep.py),
   [`tests/test_implement_consecutive_failures.py`](../../tests/test_implement_consecutive_failures.py),
   [`tests/test_implement_helper_extract.py`](../../tests/test_implement_helper_extract.py),
@@ -47,7 +48,7 @@ the suite is the primary safety net for refactors.
   **audit**, **transcripts**, **github-glue** — the suite covers
   every functional module.
 - Run by **cli** — `cmd_test` (`cai test`) is the wrapper that
-  installs deps and runs pytest + ruff.
+  installs deps and runs unittest + ruff.
 - Run by **installer** — `entrypoint.sh` runs `cai test` on fresh
   container starts in some deployment modes.
 - No reverse imports — nothing in the pipeline imports `tests/`.

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -715,13 +715,14 @@ class TestTransientStatesShape(unittest.TestCase):
         self.assertIn(IssueState.HUMAN_NEEDED, dests)
 
     def test_planned_can_fall_back_to_human(self):
-        """PLANNED → PLAN_APPROVED is confidence-gated; explicit human path too."""
+        """PLANNED → PLAN_APPROVED is confidence-gated; explicit human path too.
+        Post-plan re-split (#1167) adds PLANNED → SPLITTING via planned_to_splitting."""
         dests = {
             t.to_state
             for t in ISSUE_TRANSITIONS
             if t.from_state == IssueState.PLANNED
         }
-        self.assertEqual(dests, {IssueState.PLAN_APPROVED, IssueState.HUMAN_NEEDED})
+        self.assertEqual(dests, {IssueState.PLAN_APPROVED, IssueState.HUMAN_NEEDED, IssueState.SPLITTING})
 
     def test_refined_advances_to_splitting_or_planning(self):
         """REFINED is a waypoint — next stop is either SPLITTING

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1699,5 +1699,96 @@ class TestHandlePlanGateAppliesOpusLabel(unittest.TestCase):
         mock_post.assert_not_called()
 
 
+class TestHandlePlanGatePostPlanResplit(unittest.TestCase):
+    """#1167 — the post-plan re-split checkpoint runs before every
+    other branch of handle_plan_gate. Tests here assert:
+
+      (a) a RESPLIT-handled response short-circuits the rest of the
+          gate (including the #1131 auto-flag);
+      (b) a KEEP-handled response (helper returns None) falls
+          through to the confidence gate unchanged;
+      (c) an issue whose body lacks a stored plan block skips the
+          helper entirely so no agent call is spent.
+    """
+
+    def _issue(self, *, body="", confidence=Confidence.LOW, comments=None):
+        return {
+            "number": 1167,
+            "title": "t",
+            "body": body,
+            "labels": [{"name": "auto-improve:planned"}],
+            "comments": comments or [],
+            "_cai_plan_confidence": confidence,
+            "_cai_plan_confidence_reason": "",
+            "_cai_plan_text": body,
+            "_cai_plan_requires_human_review": False,
+            "_cai_plan_approvable_at_medium": False,
+        }
+
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan._run_post_plan_resplit", return_value=0)
+    @patch("cai_lib.actions.plan.log_run")
+    def test_resplit_preempts_1131_auto_flag(
+        self, _mock_log, mock_resplit, mock_fire, mock_set_labels,
+    ):
+        """When the same issue would also trip the #1131 15-files
+        auto-flag, RESPLIT wins: fire_trigger must NOT see
+        planned_to_human and _set_labels must NOT be asked to apply
+        LABEL_PLAN_NEEDS_REVIEW."""
+        from cai_lib.actions.plan import handle_plan_gate
+        body = "### Files to change\n" + "\n".join(
+            f"- `pkg/file{i}.py`" for i in range(20)
+        ) + "\n"
+        rc = handle_plan_gate(self._issue(body=body))
+        self.assertEqual(rc, 0)
+        mock_resplit.assert_called_once()
+        # No divert, no label stamp.
+        mock_fire.assert_not_called()
+        mock_set_labels.assert_not_called()
+
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan._run_post_plan_resplit", return_value=None)
+    @patch("cai_lib.actions.plan.log_run")
+    def test_keep_falls_through_to_confidence_gate(
+        self, _mock_log, mock_resplit, mock_fire, _mock_set_labels,
+    ):
+        """When the helper returns None (KEEP verdict), the default
+        confidence gate must still fire with the default transition."""
+        from cai_lib.actions.plan import handle_plan_gate
+        mock_fire.return_value = (True, False)
+        issue = self._issue(
+            body="", confidence=Confidence.HIGH,
+        )
+        rc = handle_plan_gate(issue)
+        self.assertEqual(rc, 0)
+        mock_resplit.assert_called_once()
+        # Default confidence-gated transition must have fired.
+        gated_calls = [
+            c for c in mock_fire.call_args_list
+            if c.kwargs.get("_confidence_gated")
+        ]
+        self.assertEqual(len(gated_calls), 1)
+        self.assertEqual(gated_calls[0].args[1], "planned_to_plan_approved")
+
+    @patch("cai_lib.actions.plan._run_claude_p")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan.log_run")
+    def test_no_plan_block_skips_claude_invocation(
+        self, _mock_log, mock_fire, mock_claude,
+    ):
+        """An issue whose body carries no stored plan block must
+        short-circuit the post-plan helper without spending a
+        cai-split call — guards against stale :planned resumes."""
+        from cai_lib.actions.plan import handle_plan_gate
+        mock_fire.return_value = (True, False)
+        issue = self._issue(body="", confidence=Confidence.HIGH)
+        rc = handle_plan_gate(issue)
+        self.assertEqual(rc, 0)
+        # _run_claude_p must not have been called inside the helper.
+        mock_claude.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -22,6 +22,21 @@ from unittest.mock import patch, MagicMock
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from cai_lib.actions.split import handle_split
+from cai_lib.actions.plan import _run_post_plan_resplit
+
+
+_POST_PLAN_RESPLIT_FIXTURE_PLAN = (
+    "<!-- cai-plan-start -->\n"
+    "## Selected Implementation Plan\n\n"
+    "### Files to change\n"
+    + "".join(f"- `pkg/f{i}.py`: change it\n" for i in range(15))
+    + "\n### Detailed steps\n\n"
+    + "".join(
+        f"#### Step {i+1} — Edit `pkg/f{i}.py`\nbody\n\n" for i in range(15)
+    )
+    + "Confidence: HIGH\n"
+    "<!-- cai-plan-end -->"
+)
 
 
 def _refined_issue(number: int = 1) -> dict:
@@ -275,6 +290,202 @@ class TestSplitUnclearAndMalformed(unittest.TestCase):
         handle_split(_splitting_issue())
         fired = [c.args[1] for c in mock_fire.call_args_list]
         self.assertIn("splitting_to_human", fired)
+
+
+class TestPostPlanResplit(unittest.TestCase):
+    """#1167 — post-plan re-split checkpoint driven by _run_post_plan_resplit.
+
+    The helper lives in ``cai_lib.actions.plan`` but the tests live
+    here because the agent driven by the checkpoint is ``cai-split``
+    and the behaviour mirrors ``handle_split``'s decompose branch
+    (create sub-issues, label the parent :parent). The pre-plan
+    ``handle_split`` path is exercised by the TestSplit* suites above
+    and is NOT affected by these tests — the post-plan helper is
+    strictly additive.
+    """
+
+    def _planned_issue(self, number: int = 1167, body=None) -> dict:
+        return {
+            "number": number,
+            "title": "post-plan resplit fixture",
+            "body": body if body is not None else _POST_PLAN_RESPLIT_FIXTURE_PLAN,
+            "labels": [
+                {"name": "auto-improve"},
+                {"name": "auto-improve:planned"},
+            ],
+        }
+
+    @patch("cai_lib.actions.plan._run_claude_p")
+    @patch("cai_lib.actions.plan._issue_depth", return_value=0)
+    def test_no_stored_plan_block_short_circuits(
+        self, mock_depth, mock_claude,
+    ):
+        """Without a ``<!-- cai-plan-start -->`` block the helper must
+        return None without invoking the agent — guards against
+        wasted spend on stale :planned labels."""
+        issue = self._planned_issue(body="no plan block here")
+        self.assertIsNone(_run_post_plan_resplit(issue, "ignored"))
+        mock_claude.assert_not_called()
+        mock_depth.assert_not_called()
+
+    @patch("cai_lib.actions.plan._run_claude_p")
+    @patch("cai_lib.actions.plan._issue_depth", return_value=0)
+    def test_keep_verdict_returns_none(self, _mock_depth, mock_claude):
+        """A ``VERDICT: KEEP`` response must fall through so the
+        normal confidence gate runs unchanged."""
+        mock_claude.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "## Split Verdict\n\nVERDICT: KEEP\n\n"
+                "### Reasoning\nPlan scale matches ATOMIC.\n\n"
+                "Confidence: HIGH\n"
+            ),
+            stderr="",
+        )
+        self.assertIsNone(
+            _run_post_plan_resplit(
+                self._planned_issue(), "plan text",
+            )
+        )
+
+    @patch("cai_lib.actions.plan._run_claude_p")
+    @patch("cai_lib.actions.plan._issue_depth", return_value=0)
+    def test_agent_failure_returns_none(self, _mock_depth, mock_claude):
+        """A non-zero agent exit must fall through so the gate's
+        existing safety nets still fire."""
+        mock_claude.return_value = MagicMock(
+            returncode=2, stdout="", stderr="boom",
+        )
+        self.assertIsNone(
+            _run_post_plan_resplit(
+                self._planned_issue(), "plan text",
+            )
+        )
+
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan._create_sub_issues", return_value=[200, 201])
+    @patch("cai_lib.actions.plan.fire_trigger", return_value=(True, False))
+    @patch("cai_lib.actions.plan._run")
+    @patch("cai_lib.actions.plan._run_claude_p")
+    @patch("cai_lib.actions.plan._issue_depth", return_value=0)
+    def test_resplit_high_creates_sub_issues(
+        self, _mock_depth, mock_claude, mock_run, mock_fire,
+        mock_create_subs, mock_set_labels,
+    ):
+        """RESPLIT + HIGH + well-formed decomposition must fire
+        planned_to_splitting, create sub-issues, and apply
+        LABEL_PARENT / remove LABEL_SPLITTING."""
+        mock_claude.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "## Multi-Step Decomposition\n\n"
+                "### Step 1: First slice\nBody one.\n\n"
+                "### Step 2: Second slice\nBody two.\n\n"
+                "VERDICT: RESPLIT\n\n"
+                "Confidence: HIGH\n"
+            ),
+            stderr="",
+        )
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        mock_set_labels.return_value = True
+
+        rc = _run_post_plan_resplit(
+            self._planned_issue(), "plan text",
+        )
+
+        self.assertEqual(rc, 0)
+        # fire_trigger must be called with planned_to_splitting.
+        fired = [c.args[1] for c in mock_fire.call_args_list]
+        self.assertIn("planned_to_splitting", fired)
+        # Sub-issues were requested.
+        mock_create_subs.assert_called_once()
+        subs_args = mock_create_subs.call_args.args
+        self.assertEqual(subs_args[1], 1167)  # parent number
+        self.assertEqual(len(subs_args[0]), 2)  # two steps
+        # Parent labelled :parent, splitting removed.
+        mock_set_labels.assert_called_once()
+        set_kwargs = mock_set_labels.call_args.kwargs
+        from cai_lib.config import LABEL_PARENT, LABEL_SPLITTING
+        self.assertEqual(set_kwargs.get("add"), [LABEL_PARENT])
+        self.assertEqual(set_kwargs.get("remove"), [LABEL_SPLITTING])
+
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan._create_sub_issues")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan._run")
+    @patch("cai_lib.actions.plan._run_claude_p")
+    @patch("cai_lib.actions.plan._issue_depth", return_value=0)
+    def test_resplit_low_confidence_falls_through(
+        self, _mock_depth, mock_claude, mock_run, mock_fire,
+        mock_create_subs, mock_set_labels,
+    ):
+        """RESPLIT + LOW confidence must NOT act; the helper returns
+        None so handle_plan_gate's #1131 safety net still fires."""
+        mock_claude.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "## Multi-Step Decomposition\n\n"
+                "### Step 1: First\nA.\n\n"
+                "### Step 2: Second\nB.\n\n"
+                "VERDICT: RESPLIT\n\n"
+                "Confidence: LOW\n"
+            ),
+            stderr="",
+        )
+        self.assertIsNone(
+            _run_post_plan_resplit(
+                self._planned_issue(), "plan text",
+            )
+        )
+        mock_run.assert_not_called()
+        mock_fire.assert_not_called()
+        mock_create_subs.assert_not_called()
+        mock_set_labels.assert_not_called()
+
+    @patch("cai_lib.actions.plan._set_labels")
+    @patch("cai_lib.actions.plan._create_sub_issues")
+    @patch("cai_lib.actions.plan.fire_trigger")
+    @patch("cai_lib.actions.plan._run")
+    @patch("cai_lib.actions.plan._run_claude_p")
+    @patch("cai_lib.actions.plan._issue_depth", return_value=0)
+    def test_resplit_single_step_is_malformed(
+        self, _mock_depth, mock_claude, mock_run, mock_fire,
+        mock_create_subs, mock_set_labels,
+    ):
+        """A decomposition with fewer than 2 steps must not act."""
+        mock_claude.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "## Multi-Step Decomposition\n\n"
+                "### Step 1: Only step\nA.\n\n"
+                "VERDICT: RESPLIT\n\n"
+                "Confidence: HIGH\n"
+            ),
+            stderr="",
+        )
+        self.assertIsNone(
+            _run_post_plan_resplit(
+                self._planned_issue(), "plan text",
+            )
+        )
+        mock_run.assert_not_called()
+        mock_fire.assert_not_called()
+        mock_create_subs.assert_not_called()
+        mock_set_labels.assert_not_called()
+
+    @patch("cai_lib.actions.plan._run_claude_p")
+    @patch("cai_lib.actions.plan._issue_depth", return_value=5)
+    def test_depth_cap_short_circuits(self, _mock_depth, mock_claude):
+        """An issue already at MAX_DECOMPOSITION_DEPTH must not
+        re-split; the helper returns None without invoking the
+        agent."""
+        with patch("cai_lib.actions.plan.MAX_DECOMPOSITION_DEPTH", 5):
+            self.assertIsNone(
+                _run_post_plan_resplit(
+                    self._planned_issue(), "plan text",
+                )
+            )
+        mock_claude.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1167

**Issue:** #1167 — Re-evaluate split decision after cai-plan when plan reveals out-of-scope scale

## PR Summary

### What this fixes
`cai-split` decides ATOMIC vs. DECOMPOSE from refined-issue prose only, before `cai-plan` runs, and has no feedback loop from the planner. This means a plan can pass the pre-plan split check but explode in scale once the planner enumerates imports, docs, tests, and guardrail cleanups (#1138 class of miss) — at which point the only recourse was a manual `<!-- cai-resplit -->` admin sigil or a `:human-needed` park via the #1131 auto-flag.

### What was changed
- **`cai_lib/fsm_transitions.py`**: Added new caller-gated `planned_to_splitting` transition (PLANNED → SPLITTING, `min_confidence=None`) for the post-plan RESPLIT path.
- **`cai_lib/actions/plan.py`**: Added top-level imports for `LABEL_SPLITTING`, `LABEL_PARENT`, `MAX_DECOMPOSITION_DEPTH`, `_extract_stored_plan`, `_parse_decomposition`, `_create_sub_issues`, `_issue_depth`. Added `_run_post_plan_resplit` helper (re-invokes `cai-split` in post-plan mode with both the refined body and stored plan; on HIGH-confidence RESPLIT with ≥2 steps, tombstones the plan, fires `planned_to_splitting`, creates sub-issues, labels the parent `:parent`). Wired the helper into `handle_plan_gate` before the #1131 auto-flag and confidence gate.
- **`.claude/agents/lifecycle/cai-split.md`** (via staging): Added "Post-plan re-split mode" section documenting the `## Stored Implementation Plan` mode switch, KEEP/RESPLIT output contract, and post-plan mode rules.
- **`tests/test_split.py`**: Added `TestPostPlanResplit` suite (7 cases: no-plan-block short-circuit, KEEP fall-through, agent failure, RESPLIT+HIGH sub-issue creation, RESPLIT+LOW fall-through, malformed single-step, depth cap).
- **`tests/test_plan.py`**: Added `TestHandlePlanGatePostPlanResplit` suite (3 cases: RESPLIT preempts #1131 auto-flag, KEEP falls through to confidence gate, no-plan-block skips agent call).
- **`tests/test_fsm.py`**: Updated `test_planned_can_fall_back_to_human` to include `SPLITTING` as a valid PLANNED destination.
- **`docs/modules/actions.md`** and **`docs/modules/agents-lifecycle.md`**: Extended relevant bullets to document the post-plan checkpoint.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
