### PR TITLE
auto-improve: log-audit and audit-audit // audit - audit

### DIFF
--- a/.claude/agents/audit/cai-audit-audit-health.md
+++ b/.claude/agents/audit/cai-audit-audit-health.md
@@ -1,0 +1,93 @@
+---
+name: cai-audit-audit-health
+description: On-demand auditor that reads structured audit logs under /var/log/cai/audit/ and raises findings for error conditions, stale audits, cost anomalies, and degenerate zero-findings runs.
+tools: Read, Grep, Glob, Write
+model: sonnet
+memory: project
+---
+
+# Audit-Health Monitor
+
+You are the `cai-audit-audit-health` agent for `robotsix-cai`. Your job is to read the structured per-workflow audit logs, detect health problems, and write findings to `findings.json`. You do not modify any file other than `findings.json`.
+
+## What you receive
+
+### Audit Log Directory
+
+The path to the audit log root (e.g. `/var/log/cai/audit`). Each sub-directory is one audit kind (`code-reduction`, `cost-reduction`, etc.) and each file inside is one JSONL file per module (`actions.jsonl`, `cai.jsonl`, …). Each line is a JSON object with the schema:
+
+```
+{
+  "ts":             "ISO 8601 UTC timestamp",
+  "level":          "INFO" | "WARN" | "ERROR",
+  "kind":           "code-reduction" | ...,
+  "module":         "actions" | ...,
+  "agent":          "cai-audit-code-reduction",
+  "session_id":     "...",
+  "event":          "start" | "finish" | "error",
+  "message":        "...",
+  "cost_usd":       0.1234 | null,
+  "duration_ms":    45123 | null,
+  "num_turns":      7 | null,
+  "tokens": { ... } | null,
+  "findings_count": 3 | null,
+  "exit_code":      0 | 1 | null,
+  "error_class":    "agent_nonzero" | "findings_missing_list" | ... | null
+}
+```
+
+### Findings file
+
+Absolute path where you must write your `findings.json` output.
+
+## Analysis window
+
+Examine only rows whose `ts` is within the last **30 days** relative to today. Use a 7-day window for stale-audit checks and a 14-day window for the zero-findings check.
+
+## Conditions that require a finding
+
+Raise **one finding per `(kind, module)` pair** when ANY of the following conditions hold for that pair within the analysis window:
+
+1. **Error rows present** — any row with `"event": "error"` exists.
+2. **Stale audit** — no row with `"event": "finish"` exists for a module that appears in `docs/modules.yaml` over the last 7 days.
+3. **Cost anomaly** — the `cost_usd` for a `finish` row exceeds 3× the median `cost_usd` across all `finish` rows for the same `kind`.
+4. **Degenerate audit** — `findings_count` is 0 (or null) for every `finish` row over the last 14 days (the audit may be misconfigured or stuck).
+
+## Findings format
+
+Write exactly one `findings.json` file in the following shape:
+
+```json
+{
+  "findings": [
+    {
+      "title": "<kind>/<module>: <short problem description>",
+      "body": "<markdown body with timestamps, error_class, evidence>",
+      "category": "audit-health",
+      "fingerprint": "<kind>-<module>-<condition>",
+      "severity": "high" | "medium" | "low"
+    }
+  ]
+}
+```
+
+Severity guidance:
+- `high` — error rows present (active failures)
+- `medium` — stale audit or cost anomaly
+- `low` — degenerate zero-findings runs
+
+## Strategy
+
+1. Glob `<audit_log_dir>/*/*.jsonl` to enumerate all log files.
+2. For each file, read its contents and parse every line as JSON. Skip malformed lines.
+3. Filter to the 30-day window.
+4. Group rows by `(kind, module)`.
+5. Evaluate the four conditions above for each group.
+6. Write findings only for groups that trigger at least one condition.
+7. If the log directory does not exist or is empty, write a single finding noting that no audit logs were found.
+
+## Output contract
+
+- Write `findings.json` using the schema above.
+- If no conditions are triggered and the log directory is non-empty, write `{"findings": []}`.
+- Do not create any other files.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ targeted invocation, `cai.py dispatch --issue N` and
 | `cai.py dispatch [--issue N \| --pr N]` | _(manual/on-demand)_ | Direct entry into the FSM dispatcher for a specific issue or PR (or the oldest actionable item when no target is given) |
 | `cai.py rescue` | `30 */4 * * *` (every 4 hours at :30) | Autonomously resume `:human-needed` issues that have been waiting too long without explicit `human:solved` label. Runs Opus escalation for eligible issues to unblock stuck automations. |
 | `cai.py audit-module` | _(manual/on-demand)_ | On-demand per-module audit: takes `--kind` (one of: good-practices, code-reduction, cost-reduction, workflow-enhancement) and iterates every module in `docs/modules.yaml`, dispatching the matching on-demand audit agent for each module and publishing findings via the existing dedup/dup-check pipeline. |
+| `cai.py audit-health` | _(manual/on-demand)_ | On-demand audit-health monitor: reads `/var/log/cai/audit/*/*.jsonl` and raises findings for error conditions, stale audits, cost anomalies, and degenerate zero-findings runs. Findings are published via the existing dedup/dup-check pipeline. |
 | `cai.py verify` / `rescue` / `unblock` | _(own cron schedules; also manual/on-demand)_ | Housekeeping subcommands that are not FSM handlers. Per-state handlers (triage, refine, plan, implement, explore, confirm, maintain, review-pr, revise, review-docs, fix-ci, merge) are no longer standalone subcommands — invoke them via `cai.py dispatch`. |
 | `cai.py test` | _(manual/on-demand)_ | Runs the project test suite (`python -m unittest discover` under `tests/`) |
 
@@ -104,13 +105,15 @@ details.
 
 ### Running an audit
 
-Two complementary audit entry points feed into the same auto-improve
+Three complementary audit entry points feed into the same auto-improve
 loop. `cai audit` runs the periodic queue/PR consistency audit
 (stale-lock rollback, orphaned-branch cleanup, plus an Opus-driven
 sweep for duplicates and stuck loops). `cai audit-module --kind <kind>`
 iterates every module declared in `docs/modules.yaml`, dispatches
 the matching on-demand audit agent per module, and publishes
-findings through the existing dedup/dup-check pipeline.
+findings through the existing dedup/dup-check pipeline. `cai audit-health`
+monitors the structured audit logs for errors, stale audits, cost anomalies,
+and degenerate runs.
 
 ```bash
 cai audit
@@ -118,6 +121,7 @@ cai audit-module --kind good-practices
 cai audit-module --kind code-reduction
 cai audit-module --kind cost-reduction
 cai audit-module --kind workflow-enhancement
+cai audit-health
 ```
 
 See [`docs/cli.md`](docs/cli.md#audit) for the full reference,

--- a/cai.py
+++ b/cai.py
@@ -196,7 +196,7 @@ from cai_lib.cmd_rescue import cmd_rescue  # noqa: E402
 from cai_lib.cmd_misc import (  # noqa: E402
     cmd_init, cmd_verify, cmd_test, cmd_cost_report,
 )
-from cai_lib.cmd_agents import cmd_audit_module  # noqa: E402
+from cai_lib.cmd_agents import cmd_audit_module, cmd_audit_health  # noqa: E402
 from cai_lib.cmd_cycle import cmd_cycle, cmd_dispatch  # noqa: E402
 from cai_lib.transcript_sync import cmd_transcript_sync  # noqa: E402
 
@@ -232,6 +232,14 @@ def main() -> int:
         required=True,
         choices=["good-practices", "code-reduction", "cost-reduction", "workflow-enhancement"],
         help="Per-module audit kind to dispatch",
+    )
+    sub.add_parser(
+        "audit-health",
+        help=(
+            "Run the audit-health agent: reads /var/log/cai/audit/*/*.jsonl "
+            "for the last 30 days and raises findings for error conditions, "
+            "stale audits, cost anomalies, and degenerate zero-findings runs."
+        ),
     )
     sub.add_parser(
         "unblock",
@@ -287,6 +295,7 @@ def main() -> int:
         "dispatch": cmd_dispatch,
         "verify": cmd_verify,
         "audit-module": cmd_audit_module,
+        "audit-health": cmd_audit_health,
         "unblock": cmd_unblock,
         "rescue": cmd_rescue,
         "cycle": cmd_cycle,

--- a/cai.py
+++ b/cai.py
@@ -46,6 +46,13 @@ Subcommands:
                             findings through the existing dedup/dup-check
                             pipeline.
 
+    python cai.py audit-health  On-demand audit-health monitor: reads
+                            /var/log/cai/audit/*/*.jsonl and raises
+                            findings for error conditions, stale audits,
+                            cost anomalies, and degenerate zero-findings
+                            runs. Findings are published via the existing
+                            dedup/dup-check pipeline.
+
     python cai.py revise    Watch `:pr-open` PRs for new comments and
                             let the implement subagent iterate on the same
                             branch. Force-pushes revisions with

--- a/cai_lib/audit/runner.py
+++ b/cai_lib/audit/runner.py
@@ -24,6 +24,7 @@ import time
 import uuid
 from pathlib import Path
 
+from cai_lib.audit_logging import audit_log_finish, audit_log_start
 from cai_lib.config import PUBLISH_SCRIPT
 from cai_lib.logging_utils import log_run
 from cai_lib.subprocess_utils import _run, _run_claude_p
@@ -92,6 +93,9 @@ def _run_one_module(kind: str, agent: str, entry) -> int:  # type: ignore[no-unt
     work_dir.mkdir(parents=True, exist_ok=True)
     findings_file = work_dir / "findings.json"
 
+    audit_log_start(kind, entry.name, agent)
+    proc = None  # set inside try block; kept for exception-handler visibility
+
     try:
         user_message = _build_module_prompt(entry, findings_file)
         proc = _run_claude_p(
@@ -118,10 +122,25 @@ def _run_one_module(kind: str, agent: str, entry) -> int:  # type: ignore[no-unt
                 file=sys.stderr,
                 flush=True,
             )
+            audit_log_finish(
+                kind, entry.name, agent,
+                proc=proc,
+                findings_count=None,
+                exit_code=1,
+                error_class="agent_nonzero",
+                message=f"agent {agent} exited {proc.returncode}",
+            )
             return 1
 
         if not findings_file.exists():
             # No findings is a valid outcome — nothing to publish.
+            audit_log_finish(
+                kind, entry.name, agent,
+                proc=proc,
+                findings_count=0,
+                exit_code=0,
+                message="no findings written",
+            )
             return 0
 
         # Quick shape check before invoking publish.py. A malformed
@@ -137,6 +156,14 @@ def _run_one_module(kind: str, agent: str, entry) -> int:  # type: ignore[no-unt
                     file=sys.stderr,
                     flush=True,
                 )
+                audit_log_finish(
+                    kind, entry.name, agent,
+                    proc=proc,
+                    findings_count=None,
+                    exit_code=1,
+                    error_class="findings_missing_list",
+                    message="findings.json missing top-level 'findings' list",
+                )
                 return 1
         except (json.JSONDecodeError, OSError) as exc:
             print(
@@ -144,6 +171,14 @@ def _run_one_module(kind: str, agent: str, entry) -> int:  # type: ignore[no-unt
                 f"could not read findings.json: {exc}",
                 file=sys.stderr,
                 flush=True,
+            )
+            audit_log_finish(
+                kind, entry.name, agent,
+                proc=proc,
+                findings_count=None,
+                exit_code=1,
+                error_class="findings_parse_error",
+                message=f"could not read findings.json: {exc}",
             )
             return 1
 
@@ -163,7 +198,22 @@ def _run_one_module(kind: str, agent: str, entry) -> int:  # type: ignore[no-unt
                 file=sys.stderr,
                 flush=True,
             )
+            audit_log_finish(
+                kind, entry.name, agent,
+                proc=proc,
+                findings_count=len(data.get("findings", [])),
+                exit_code=1,
+                error_class="publish_failed",
+                message=f"publish.py returned {published.returncode}",
+            )
             return 1
+
+        audit_log_finish(
+            kind, entry.name, agent,
+            proc=proc,
+            findings_count=len(data.get("findings", [])),
+            exit_code=0,
+        )
         return 0
     except Exception as exc:  # noqa: BLE001
         print(
@@ -171,6 +221,14 @@ def _run_one_module(kind: str, agent: str, entry) -> int:  # type: ignore[no-unt
             f"unexpected exception: {exc}",
             file=sys.stderr,
             flush=True,
+        )
+        audit_log_finish(
+            kind, entry.name, agent,
+            proc=proc,
+            findings_count=None,
+            exit_code=1,
+            error_class="unexpected_exception",
+            message=f"unexpected exception: {exc}",
         )
         return 1
     finally:

--- a/cai_lib/audit_logging.py
+++ b/cai_lib/audit_logging.py
@@ -1,0 +1,129 @@
+"""Per-workflow structured audit logging for cai audit runs.
+
+Writes one JSONL file per ``(kind, module)`` pair under
+``/var/log/cai/audit/<kind>/<module>.jsonl``.  Each line is a JSON
+object conforming to the schema below:
+
+  {
+    "ts":             "ISO 8601 UTC timestamp",
+    "level":          "INFO" | "WARN" | "ERROR",
+    "kind":           "code-reduction" | ...,
+    "module":         "actions" | ...,
+    "agent":          "cai-audit-code-reduction",
+    "session_id":     "<sdk session id>" | null,
+    "event":          "start" | "finish" | "error",
+    "message":        "<human-readable one-liner>",
+    "cost_usd":       0.1234 | null,
+    "duration_ms":    45123 | null,
+    "num_turns":      7 | null,
+    "tokens": {
+      "input_tokens": N, "output_tokens": N,
+      "cache_creation_input_tokens": N,
+      "cache_read_input_tokens": N
+    } | null,
+    "findings_count": 3 | null,
+    "exit_code":      0 | 1 | null,
+    "error_class":    "agent_nonzero" | "findings_missing_list"
+                      | "findings_parse_error" | "publish_failed"
+                      | "unexpected_exception" | null
+  }
+
+The two public helpers, ``audit_log_start`` and ``audit_log_finish``,
+are additive sinks alongside the existing ``log_run`` / ``log_cost``
+contracts — they do not replace them.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from typing import Optional
+
+from cai_lib.config import audit_log_path
+
+
+def _write_log_entry(kind: str, module: str, row: dict) -> None:
+    """Atomically append one JSON line to the audit log file. Never raises."""
+    try:
+        path = audit_log_path(kind, module)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(row, separators=(",", ":")) + "\n"
+        with path.open("a") as fh:
+            fh.write(line)
+            fh.flush()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def audit_log_start(kind: str, module: str, agent: str) -> None:
+    """Write a ``start`` event to the audit log before ``_run_claude_p``.
+
+    Never raises — a logging failure must never abort the audit run.
+    """
+    _write_log_entry(kind, module, {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "level": "INFO",
+        "kind": kind,
+        "module": module,
+        "agent": agent,
+        "session_id": None,
+        "event": "start",
+        "message": f"Starting audit for module {module}",
+        "cost_usd": None,
+        "duration_ms": None,
+        "num_turns": None,
+        "tokens": None,
+        "findings_count": None,
+        "exit_code": None,
+        "error_class": None,
+    })
+
+
+def audit_log_finish(
+    kind: str,
+    module: str,
+    agent: str,
+    *,
+    proc: Optional[subprocess.CompletedProcess],
+    findings_count: Optional[int],
+    exit_code: int,
+    error_class: Optional[str] = None,
+    message: str = "",
+) -> None:
+    """Write a ``finish`` or ``error`` event to the audit log.
+
+    Lifts ``cost_usd``, ``duration_ms``, ``num_turns``, ``session_id``,
+    and ``tokens`` from *proc* attributes when present (populated by
+    ``_run_claude_p``'s internal cost row).  Falls back to ``null`` for
+    a standard ``subprocess.CompletedProcess`` that does not carry them.
+
+    Never raises — a logging failure must never abort the audit run.
+    """
+    # Extract metrics injected by _run_claude_p when available.
+    cost_usd = getattr(proc, "cost_usd", None) if proc is not None else None
+    duration_ms = getattr(proc, "duration_ms", None) if proc is not None else None
+    num_turns = getattr(proc, "num_turns", None) if proc is not None else None
+    session_id = getattr(proc, "session_id", None) if proc is not None else None
+    tokens = getattr(proc, "tokens", None) if proc is not None else None
+
+    level = "INFO" if exit_code == 0 else "ERROR"
+    event = "finish" if exit_code == 0 else "error"
+
+    _write_log_entry(kind, module, {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "level": level,
+        "kind": kind,
+        "module": module,
+        "agent": agent,
+        "session_id": session_id,
+        "event": event,
+        "message": message or f"Audit {'completed' if exit_code == 0 else 'failed'} for module {module}",
+        "cost_usd": cost_usd,
+        "duration_ms": duration_ms,
+        "num_turns": num_turns,
+        "tokens": tokens,
+        "findings_count": findings_count,
+        "exit_code": exit_code,
+        "error_class": error_class,
+    })

--- a/cai_lib/audit_logging.py
+++ b/cai_lib/audit_logging.py
@@ -28,6 +28,12 @@ object conforming to the schema below:
                       | "unexpected_exception" | null
   }
 
+Built on ``structlog``: a minimal per-file ``_JSONLAppender`` logger at
+the bottom of the stack with ``TimeStamper`` (injects ``ts``),
+``EventRenamer`` (renames the built-in ``event`` slot to ``message`` so
+our typed ``event`` field can live under its own name), and
+``JSONRenderer`` in the processor chain.
+
 The two public helpers, ``audit_log_start`` and ``audit_log_finish``,
 are additive sinks alongside the existing ``log_run`` / ``log_cost``
 contracts — they do not replace them.
@@ -35,25 +41,52 @@ contracts — they do not replace them.
 
 from __future__ import annotations
 
-import json
 import subprocess
-from datetime import datetime, timezone
+from pathlib import Path
 from typing import Optional
+
+import structlog
 
 from cai_lib.config import audit_log_path
 
 
-def _write_log_entry(kind: str, module: str, row: dict) -> None:
-    """Atomically append one JSON line to the audit log file. Never raises."""
-    try:
-        path = audit_log_path(kind, module)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(row, separators=(",", ":")) + "\n"
-        with path.open("a") as fh:
-            fh.write(line)
+class _JSONLAppender:
+    """Bottom-of-stack structlog logger that appends one rendered line to a file.
+
+    structlog's processor chain renders an event dict into a JSONL
+    string and hands it to the matching log-level method on this
+    class.  All log-level names are aliased to the same ``msg``
+    implementation — structlog only calls whichever method matches
+    the level used at the call site.
+    """
+
+    __slots__ = ("_path",)
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    def msg(self, message: str) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._path.open("a") as fh:
+            fh.write(message + "\n")
             fh.flush()
-    except Exception:  # noqa: BLE001
-        pass
+
+    log = debug = info = warning = warn = error = critical = fatal = msg
+
+
+_PROCESSORS = [
+    structlog.processors.TimeStamper(fmt="%Y-%m-%dT%H:%M:%SZ", utc=True, key="ts"),
+    structlog.processors.EventRenamer("message", replace_by="_event"),
+    structlog.processors.JSONRenderer(separators=(",", ":")),
+]
+
+
+def _get_logger(kind: str, module: str):
+    """Return a structlog bound logger writing to ``audit_log_path(kind, module)``."""
+    return structlog.wrap_logger(
+        _JSONLAppender(audit_log_path(kind, module)),
+        processors=_PROCESSORS,
+    )
 
 
 def audit_log_start(kind: str, module: str, agent: str) -> None:
@@ -61,23 +94,25 @@ def audit_log_start(kind: str, module: str, agent: str) -> None:
 
     Never raises — a logging failure must never abort the audit run.
     """
-    _write_log_entry(kind, module, {
-        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "level": "INFO",
-        "kind": kind,
-        "module": module,
-        "agent": agent,
-        "session_id": None,
-        "event": "start",
-        "message": f"Starting audit for module {module}",
-        "cost_usd": None,
-        "duration_ms": None,
-        "num_turns": None,
-        "tokens": None,
-        "findings_count": None,
-        "exit_code": None,
-        "error_class": None,
-    })
+    try:
+        _get_logger(kind, module).info(
+            f"Starting audit for module {module}",
+            level="INFO",
+            kind=kind,
+            module=module,
+            agent=agent,
+            session_id=None,
+            _event="start",
+            cost_usd=None,
+            duration_ms=None,
+            num_turns=None,
+            tokens=None,
+            findings_count=None,
+            exit_code=None,
+            error_class=None,
+        )
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def audit_log_finish(
@@ -100,30 +135,36 @@ def audit_log_finish(
 
     Never raises — a logging failure must never abort the audit run.
     """
-    # Extract metrics injected by _run_claude_p when available.
-    cost_usd = getattr(proc, "cost_usd", None) if proc is not None else None
-    duration_ms = getattr(proc, "duration_ms", None) if proc is not None else None
-    num_turns = getattr(proc, "num_turns", None) if proc is not None else None
-    session_id = getattr(proc, "session_id", None) if proc is not None else None
-    tokens = getattr(proc, "tokens", None) if proc is not None else None
+    try:
+        cost_usd = getattr(proc, "cost_usd", None) if proc is not None else None
+        duration_ms = getattr(proc, "duration_ms", None) if proc is not None else None
+        num_turns = getattr(proc, "num_turns", None) if proc is not None else None
+        session_id = getattr(proc, "session_id", None) if proc is not None else None
+        tokens = getattr(proc, "tokens", None) if proc is not None else None
 
-    level = "INFO" if exit_code == 0 else "ERROR"
-    event = "finish" if exit_code == 0 else "error"
+        level = "INFO" if exit_code == 0 else "ERROR"
+        event = "finish" if exit_code == 0 else "error"
+        human_message = message or (
+            f"Audit completed for module {module}"
+            if exit_code == 0
+            else f"Audit failed for module {module}"
+        )
 
-    _write_log_entry(kind, module, {
-        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "level": level,
-        "kind": kind,
-        "module": module,
-        "agent": agent,
-        "session_id": session_id,
-        "event": event,
-        "message": message or f"Audit {'completed' if exit_code == 0 else 'failed'} for module {module}",
-        "cost_usd": cost_usd,
-        "duration_ms": duration_ms,
-        "num_turns": num_turns,
-        "tokens": tokens,
-        "findings_count": findings_count,
-        "exit_code": exit_code,
-        "error_class": error_class,
-    })
+        _get_logger(kind, module).info(
+            human_message,
+            level=level,
+            kind=kind,
+            module=module,
+            agent=agent,
+            session_id=session_id,
+            _event=event,
+            cost_usd=cost_usd,
+            duration_ms=duration_ms,
+            num_turns=num_turns,
+            tokens=tokens,
+            findings_count=findings_count,
+            exit_code=exit_code,
+            error_class=error_class,
+        )
+    except Exception:  # noqa: BLE001
+        pass

--- a/cai_lib/cmd_agents.py
+++ b/cai_lib/cmd_agents.py
@@ -3,13 +3,17 @@
 After audit-refactor 7.2 the eight periodic/creative agent commands
 (analyze, audit, propose, code-audit, agent-audit, update-check,
 cost-optimize, external-scout) were removed. This module now contains
-only the on-demand per-module audit dispatcher:
+the on-demand per-module audit dispatcher and the audit-health runner:
 
   cmd_audit_module  — ``cai audit-module --kind <kind>``
+  cmd_audit_health  — ``cai audit-health``
 """
 
+import shutil
 import sys
 import time
+import uuid
+from pathlib import Path
 
 from cai_lib.config import *  # noqa: F403,F401
 from cai_lib.logging_utils import log_run
@@ -70,3 +74,80 @@ def cmd_audit_module(args) -> int:
         exit=exit_code,
     )
     return exit_code
+
+
+# ---------------------------------------------------------------------------
+# audit-health — on-demand audit-health runner
+# ---------------------------------------------------------------------------
+
+def cmd_audit_health(args) -> int:
+    """Dispatch ``cai audit-health``.
+
+    Runs the ``cai-audit-audit-health`` agent, which reads
+    ``/var/log/cai/audit/*/*.jsonl`` for the last 30 days and raises
+    findings for error conditions or anomalies (stale audits, cost
+    spikes, degenerate zero-findings runs, etc.).  Findings are
+    published via ``publish.py --namespace audit-health``.
+    """
+    from cai_lib.subprocess_utils import _run, _run_claude_p
+
+    agent = "cai-audit-audit-health"
+    work_dir = Path(f"/tmp/cai-audit-health-{uuid.uuid4().hex[:8]}")
+    work_dir.mkdir(parents=True, exist_ok=True)
+    findings_file = work_dir / "findings.json"
+
+    t0 = time.monotonic()
+    try:
+        user_message = (
+            "## Audit Log Directory\n\n"
+            f"Read audit logs from: `{AUDIT_LOG_DIR}`\n\n"
+            "## Findings file\n\n"
+            f"Write your findings to: `{findings_file}`\n"
+        )
+        proc = _run_claude_p(
+            [
+                "claude", "-p",
+                "--agent", agent,
+                "--permission-mode", "acceptEdits",
+                "--allowedTools", "Read,Grep,Glob,Write",
+                "--add-dir", str(work_dir),
+            ],
+            category="audit-health",
+            agent=agent,
+            input=user_message,
+            cwd="/app",
+        )
+        if proc.stdout:
+            print(proc.stdout)
+        if proc.returncode != 0:
+            print(
+                f"[cai audit-health] ERROR: agent {agent} exited {proc.returncode}",
+                file=sys.stderr, flush=True,
+            )
+            log_run("audit-health", result="agent_failed", exit=1)
+            return 1
+        if not findings_file.exists():
+            print("[cai audit-health] agent wrote no findings", flush=True)
+            log_run("audit-health", result="no_findings", exit=0)
+            return 0
+        published = _run([
+            "python", str(PUBLISH_SCRIPT),
+            "--namespace", "audit-health",
+            "--findings-file", str(findings_file),
+        ])
+        if published.returncode != 0:
+            print(
+                f"[cai audit-health] ERROR: publish failed with {published.returncode}",
+                file=sys.stderr, flush=True,
+            )
+            log_run("audit-health", result="publish_failed", exit=1)
+            return 1
+        dur = f"{int(time.monotonic() - t0)}s"
+        log_run("audit-health", result="ok", duration=dur, exit=0)
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"[cai audit-health] ERROR: {exc}", file=sys.stderr, flush=True)
+        log_run("audit-health", result="unexpected_error", exit=1)
+        return 1
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)

--- a/cai_lib/config.py
+++ b/cai_lib/config.py
@@ -275,6 +275,19 @@ COST_LOG_PATH = Path("/var/log/cai/cai-cost.jsonl")
 COST_LOG_AGGREGATE_DIR = Path("/var/log/cai/cost-aggregate")
 REVIEW_PR_PATTERN_LOG = Path("/var/log/cai/review-pr-patterns.jsonl")
 OUTCOME_LOG_PATH = Path("/var/log/cai/cai-outcomes.jsonl")
+# Per-workflow audit log directory.  One sub-directory per audit kind,
+# one JSONL file per (kind, module) pair:
+#   /var/log/cai/audit/code-reduction/actions.jsonl
+AUDIT_LOG_DIR = Path("/var/log/cai/audit")
+
+
+def audit_log_path(kind: str, module: str) -> Path:
+    """Return the append-only audit log path for a (kind, module) pair.
+
+    Example: audit_log_path("code-reduction", "actions")
+      → /var/log/cai/audit/code-reduction/actions.jsonl
+    """
+    return AUDIT_LOG_DIR / kind / f"{module}.jsonl"
 
 
 # ---------------------------------------------------------------------------

--- a/cai_lib/publish.py
+++ b/cai_lib/publish.py
@@ -132,6 +132,10 @@ AUDIT_WORKFLOW_ENHANCEMENT_CATEGORIES = {
     "deterministic_replacement",
 }
 
+AUDIT_HEALTH_CATEGORIES = {
+    "audit-health",
+}
+
 # Labels we ensure exist before creating issues. These include FSM/lifecycle
 # state labels (auto-improve:*), PR state labels (pr:*), and kind labels (kind:*).
 # Category information is now stored in the issue body, not as labels. Idempotent —
@@ -279,6 +283,7 @@ AUDIT_GOOD_PRACTICES_LABELS = _AUTO_IMPROVE_RAISED_ONLY
 AUDIT_CODE_REDUCTION_LABELS = _AUTO_IMPROVE_RAISED_ONLY
 AUDIT_COST_REDUCTION_LABELS = _AUTO_IMPROVE_RAISED_ONLY
 AUDIT_WORKFLOW_ENHANCEMENT_LABELS = _AUTO_IMPROVE_RAISED_ONLY
+AUDIT_HEALTH_LABELS = _AUTO_IMPROVE_RAISED_ONLY
 
 
 @dataclass
@@ -417,6 +422,8 @@ def _label_set_for(namespace: str):
         return AUDIT_COST_REDUCTION_LABELS
     if namespace == "audit-workflow-enhancement":
         return AUDIT_WORKFLOW_ENHANCEMENT_LABELS
+    if namespace == "audit-health":
+        return AUDIT_HEALTH_LABELS
     return LABELS
 
 
@@ -444,6 +451,8 @@ def _category_set_for(namespace: str) -> set[str]:
         return AUDIT_COST_REDUCTION_CATEGORIES
     if namespace == "audit-workflow-enhancement":
         return AUDIT_WORKFLOW_ENHANCEMENT_CATEGORIES
+    if namespace == "audit-health":
+        return AUDIT_HEALTH_CATEGORIES
     return VALID_CATEGORIES
 
 
@@ -471,7 +480,7 @@ def ensure_all_labels() -> None:
     and CODE_AUDIT_LABELS).
     """
     seen: set[str] = set()
-    for label_set in (LABELS, AUDIT_LABELS, CODE_AUDIT_LABELS, UPDATE_CHECK_LABELS, CHECK_WORKFLOWS_LABELS, AGENT_AUDIT_LABELS, EXTERNAL_SCOUT_LABELS, AUDIT_EXTERNAL_LIBS_LABELS, AUDIT_GOOD_PRACTICES_LABELS, AUDIT_CODE_REDUCTION_LABELS, AUDIT_COST_REDUCTION_LABELS, AUDIT_WORKFLOW_ENHANCEMENT_LABELS):
+    for label_set in (LABELS, AUDIT_LABELS, CODE_AUDIT_LABELS, UPDATE_CHECK_LABELS, CHECK_WORKFLOWS_LABELS, AGENT_AUDIT_LABELS, EXTERNAL_SCOUT_LABELS, AUDIT_EXTERNAL_LIBS_LABELS, AUDIT_GOOD_PRACTICES_LABELS, AUDIT_CODE_REDUCTION_LABELS, AUDIT_COST_REDUCTION_LABELS, AUDIT_WORKFLOW_ENHANCEMENT_LABELS, AUDIT_HEALTH_LABELS):
         for name, color, description in label_set:
             if name in seen:
                 continue
@@ -562,6 +571,9 @@ def create_issue(
     elif namespace == "audit-workflow-enhancement":
         source_note = "cai workflow-enhancement audit agent"
         source_file = ".claude/agents/audit/cai-audit-workflow-enhancement.md"
+    elif namespace == "audit-health":
+        source_note = "cai audit-health monitor agent"
+        source_file = ".claude/agents/audit/cai-audit-audit-health.md"
     else:
         source_note = "cai self-analyzer"
         source_file = ".claude/agents/cai-refine.md"
@@ -727,7 +739,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Publish findings as GitHub issues")
     parser.add_argument(
         "--namespace", default="auto-improve",
-        choices=["auto-improve", "audit", "code-audit", "update-check", "check-workflows", "agent-audit", "external-scout", "audit-external-libs", "audit-good-practices", "audit-code-reduction", "audit-cost-reduction", "audit-workflow-enhancement"],
+        choices=["auto-improve", "audit", "code-audit", "update-check", "check-workflows", "agent-audit", "external-scout", "audit-external-libs", "audit-good-practices", "audit-code-reduction", "audit-cost-reduction", "audit-workflow-enhancement", "audit-health"],
         help="Label namespace to use (default: auto-improve)",
     )
     parser.add_argument(

--- a/docs/modules.yaml
+++ b/docs/modules.yaml
@@ -50,6 +50,7 @@ modules:
     summary: Audit subsystem — on-demand per-module code, cost, workflow, and external-library auditors plus the transcript-finder helper.
     globs:
       - "cai_lib/audit/*.py"
+      - "cai_lib/audit_logging.py"
       - ".claude/agents/audit/*.md"
     doc: "docs/modules/audit.md"
 

--- a/docs/modules/audit.md
+++ b/docs/modules/audit.md
@@ -31,6 +31,11 @@ function in `cai_lib/cmd_agents.py` or `cai_lib/cmd_misc.py`.
   [`cai-audit-workflow-enhancement.md`](../../.claude/agents/audit/cai-audit-workflow-enhancement.md)
   — on-demand per-module audits (code shrink, spend, external
   libraries, best practices, workflow).
+- [`.claude/agents/audit/cai-audit-audit-health.md`](../../.claude/agents/audit/cai-audit-audit-health.md)
+  — on-demand audit-health monitor; reads `/var/log/cai/audit/*/*.jsonl` and
+  raises findings for error rows, stale audits, cost anomalies, and
+  degenerate zero-findings runs. Invoked by `cmd_audit_health` via
+  `cai audit-health`.
 - [`.claude/agents/audit/cai-transcript-finder.md`](../../.claude/agents/audit/cai-transcript-finder.md)
   — haiku helper that searches Claude Code session transcripts for a module-scoped query and returns ranked excerpts.
 
@@ -53,6 +58,21 @@ function in `cai_lib/cmd_agents.py` or `cai_lib/cmd_misc.py`.
   to `findings.json`.
 
 ## Operational notes
+- **Audit log path convention.** `cai_lib/audit/runner.py` writes one
+  structured JSONL file per `(kind, module)` pair under
+  `/var/log/cai/audit/<kind>/<module>.jsonl` (e.g.
+  `/var/log/cai/audit/code-reduction/actions.jsonl`). Each line is a
+  JSON object with keys `ts`, `level`, `kind`, `module`, `agent`,
+  `session_id`, `event` (`start` / `finish` / `error`), `message`,
+  `cost_usd`, `duration_ms`, `num_turns`, `tokens`, `findings_count`,
+  `exit_code`, and `error_class`. The path root is `AUDIT_LOG_DIR` in
+  `cai_lib/config.py`; the helper `audit_log_path(kind, module)` in the
+  same file returns the full path. The log is an additive append-only
+  sink alongside the existing `cai-cost.jsonl` and `cai.log` files.
+- **Querying audit runs.** To see recent runs for a kind:
+  `tail -n 20 /var/log/cai/audit/code-reduction/actions.jsonl | python3 -m json.tool`
+  To find all errors across all kinds/modules:
+  `grep '"event":"error"' /var/log/cai/audit/**/*.jsonl`
 - **Cost sensitivity — very high.** The on-demand per-module
   auditors (`cai-audit-code-reduction`, `cai-audit-cost-reduction`,
   `cai-audit-external-libs`, `cai-audit-good-practices`,

--- a/docs/modules/audit.md
+++ b/docs/modules/audit.md
@@ -22,6 +22,10 @@ function in `cai_lib/cmd_agents.py` or `cai_lib/cmd_misc.py`.
   per-module audit runner for `cai audit-module --kind <kind>` subcommand. Dispatches
   audit agents (cost-reduction, code-reduction, good-practices, workflow-enhancement)
   over all modules; loads manifests from `docs/modules.yaml`.
+- [`cai_lib/audit_logging.py`](../../cai_lib/audit_logging.py) — structured
+  audit logging helpers (`audit_log_start`, `audit_log_finish`). Writes one
+  JSONL file per `(kind, module)` pair under `/var/log/cai/audit/<kind>/<module>.jsonl`;
+  consumed by `cai-audit-audit-health` via `cmd_audit_health`.
 - [`cai_lib/audit/__init__.py`](../../cai_lib/audit/__init__.py) —
   package init.
 - [`.claude/agents/audit/cai-audit-code-reduction.md`](../../.claude/agents/audit/cai-audit-code-reduction.md),

--- a/docs/modules/config.md
+++ b/docs/modules/config.md
@@ -9,10 +9,12 @@ every handler and `cmd_*` function; changes here ripple everywhere.
 - [`cai_lib/config.py`](../../cai_lib/config.py) — repo-wide
   constants: `REPO`, label names (`LABEL_HUMAN_SOLVED`,
   `LABEL_PARENT`, `LABEL_*`), log paths (`LOG_PATH`,
-  `COST_LOG_PATH`, `OUTCOME_LOG_PATH`), worktree/base directories.
-  Helpers `_repo_slug(repo)`, `_resolve_machine_id()`,
+  `COST_LOG_PATH`, `OUTCOME_LOG_PATH`, `AUDIT_LOG_DIR`), worktree/base
+  directories. Helpers `_repo_slug(repo)`, `_resolve_machine_id()`,
   `_resolve_instance_id()`, `transcript_sync_enabled()`,
-  `is_admin_login(login)`.
+  `is_admin_login(login)`, `audit_log_path(kind, module)`.
+  `AUDIT_LOG_DIR` is `/var/log/cai/audit` — see `docs/modules/audit.md`
+  for the per-workflow structured log format.
 - [`cai_lib/logging_utils.py`](../../cai_lib/logging_utils.py) —
   `log_run(category, **fields)` appends a structured row to
   `LOG_PATH`; `log_cost(row)` writes cost events;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires-python = ">=3.12"
 dependencies = [
     "PyYAML>=6",
     "claude-agent-sdk>=0.1.63",
+    "structlog>=24.0",
     "transitions>=0.9.3",
 ]
 

--- a/tests/test_audit_logging.py
+++ b/tests/test_audit_logging.py
@@ -1,0 +1,249 @@
+"""Tests for cai_lib.audit_logging — audit_log_path, audit_log_start,
+audit_log_finish, and _run_one_module integration."""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import cai_lib.config as _config
+
+
+class TestAuditLogPath(unittest.TestCase):
+    """audit_log_path returns the expected Path."""
+
+    def test_basic(self):
+        from cai_lib.config import audit_log_path, AUDIT_LOG_DIR
+        result = audit_log_path("code-reduction", "actions")
+        self.assertEqual(result, AUDIT_LOG_DIR / "code-reduction" / "actions.jsonl")
+
+    def test_hyphenated_kind(self):
+        from cai_lib.config import audit_log_path, AUDIT_LOG_DIR
+        result = audit_log_path("good-practices", "cai")
+        self.assertEqual(result, AUDIT_LOG_DIR / "good-practices" / "cai.jsonl")
+
+    def test_returns_path_object(self):
+        from cai_lib.config import audit_log_path
+        self.assertIsInstance(audit_log_path("k", "m"), Path)
+
+
+class TestAuditLogStart(unittest.TestCase):
+    """audit_log_start writes a start event."""
+
+    def _call(self, kind, module, agent, log_dir):
+        orig = _config.AUDIT_LOG_DIR
+        _config.AUDIT_LOG_DIR = Path(log_dir)
+        try:
+            from cai_lib.audit_logging import audit_log_start
+            audit_log_start(kind, module, agent)
+        finally:
+            _config.AUDIT_LOG_DIR = orig
+
+    def test_creates_file_with_start_event(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._call("code-reduction", "actions", "cai-audit-code-reduction", td)
+            log_path = Path(td) / "code-reduction" / "actions.jsonl"
+            self.assertTrue(log_path.exists())
+            line = log_path.read_text().strip()
+            row = json.loads(line)
+            self.assertEqual(row["event"], "start")
+            self.assertEqual(row["level"], "INFO")
+            self.assertEqual(row["kind"], "code-reduction")
+            self.assertEqual(row["module"], "actions")
+            self.assertEqual(row["agent"], "cai-audit-code-reduction")
+            self.assertIsNone(row["exit_code"])
+            self.assertIsNone(row["error_class"])
+
+    def test_creates_parent_dirs(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._call("new-kind", "new-module", "some-agent", td)
+            log_path = Path(td) / "new-kind" / "new-module.jsonl"
+            self.assertTrue(log_path.exists())
+
+    def test_never_raises_on_bad_path(self):
+        # Should silently swallow errors — log directory is not writable.
+        orig = _config.AUDIT_LOG_DIR
+        _config.AUDIT_LOG_DIR = Path("/proc/impossible-path-that-cannot-exist")
+        try:
+            from cai_lib.audit_logging import audit_log_start
+            # Must not raise.
+            audit_log_start("k", "m", "a")
+        finally:
+            _config.AUDIT_LOG_DIR = orig
+
+
+class TestAuditLogFinish(unittest.TestCase):
+    """audit_log_finish round-trips every schema key."""
+
+    def _call(self, log_dir, proc, findings_count, exit_code,
+              error_class=None, message=""):
+        orig = _config.AUDIT_LOG_DIR
+        _config.AUDIT_LOG_DIR = Path(log_dir)
+        try:
+            from cai_lib.audit_logging import audit_log_finish
+            audit_log_finish(
+                "code-reduction", "actions", "cai-audit-code-reduction",
+                proc=proc,
+                findings_count=findings_count,
+                exit_code=exit_code,
+                error_class=error_class,
+                message=message,
+            )
+        finally:
+            _config.AUDIT_LOG_DIR = orig
+
+    def test_success_event_keys(self):
+        proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with tempfile.TemporaryDirectory() as td:
+            self._call(td, proc, findings_count=3, exit_code=0)
+            row = json.loads(
+                (Path(td) / "code-reduction" / "actions.jsonl").read_text().strip()
+            )
+            # All schema keys must be present.
+            required = {
+                "ts", "level", "kind", "module", "agent", "session_id",
+                "event", "message", "cost_usd", "duration_ms", "num_turns",
+                "tokens", "findings_count", "exit_code", "error_class",
+            }
+            self.assertEqual(required, set(row.keys()))
+            self.assertEqual(row["event"], "finish")
+            self.assertEqual(row["level"], "INFO")
+            self.assertEqual(row["exit_code"], 0)
+            self.assertEqual(row["findings_count"], 3)
+            self.assertIsNone(row["error_class"])
+
+    def test_error_event(self):
+        proc = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+        with tempfile.TemporaryDirectory() as td:
+            self._call(td, proc, findings_count=None, exit_code=1,
+                       error_class="agent_nonzero", message="agent exited 1")
+            row = json.loads(
+                (Path(td) / "code-reduction" / "actions.jsonl").read_text().strip()
+            )
+            self.assertEqual(row["event"], "error")
+            self.assertEqual(row["level"], "ERROR")
+            self.assertEqual(row["exit_code"], 1)
+            self.assertEqual(row["error_class"], "agent_nonzero")
+            self.assertEqual(row["message"], "agent exited 1")
+
+    def test_none_proc_is_safe(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._call(td, None, findings_count=None, exit_code=1,
+                       error_class="unexpected_exception")
+            row = json.loads(
+                (Path(td) / "code-reduction" / "actions.jsonl").read_text().strip()
+            )
+            self.assertIsNone(row["cost_usd"])
+            self.assertIsNone(row["session_id"])
+
+    def test_appends_multiple_lines(self):
+        proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with tempfile.TemporaryDirectory() as td:
+            self._call(td, proc, findings_count=1, exit_code=0)
+            self._call(td, proc, findings_count=2, exit_code=0)
+            lines = (
+                Path(td) / "code-reduction" / "actions.jsonl"
+            ).read_text().strip().splitlines()
+            self.assertEqual(len(lines), 2)
+            counts = [json.loads(l)["findings_count"] for l in lines]
+            self.assertEqual(counts, [1, 2])
+
+
+class TestRunOneModuleLogging(unittest.TestCase):
+    """_run_one_module emits exactly one start and one finish/error event."""
+
+    def _read_log_lines(self, log_dir, kind, module):
+        p = Path(log_dir) / kind / f"{module}.jsonl"
+        if not p.exists():
+            return []
+        return [json.loads(l) for l in p.read_text().strip().splitlines() if l]
+
+    def _fake_entry(self, name="testmod"):
+        entry = MagicMock()
+        entry.name = name
+        entry.globs = []
+        entry.summary = "test"
+        entry.doc = None
+        return entry
+
+    def test_success_emits_start_and_finish(self):
+        fake_proc = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        with tempfile.TemporaryDirectory() as td:
+            findings = Path(td) / "findings.json"
+            findings.write_text('{"findings": [{"title": "t", "body": "b"}]}')
+            orig = _config.AUDIT_LOG_DIR
+            _config.AUDIT_LOG_DIR = Path(td) / "logs"
+            try:
+                with patch("cai_lib.audit.runner._run_claude_p", return_value=fake_proc), \
+                     patch("cai_lib.audit.runner._run", return_value=subprocess.CompletedProcess(
+                         args=[], returncode=0, stdout="", stderr="")), \
+                     patch("cai_lib.audit.runner._build_module_prompt", return_value="prompt"), \
+                     patch("pathlib.Path.mkdir"), \
+                     patch("shutil.rmtree"):
+                    # Patch findings_file.exists() to return True and read text.
+                    # Simplest approach: monkeypatch the work_dir uuid.
+                    import uuid as _uuid
+                    with patch.object(_uuid, "uuid4", return_value=MagicMock(hex="12345678abcd")):
+                        # We need the findings file to exist in the temp work dir.
+                        # Instead, test via direct function call with patched Path.exists.
+                        pass
+            finally:
+                _config.AUDIT_LOG_DIR = orig
+
+    def test_agent_nonzero_emits_error(self):
+        """When agent returns non-zero, one start + one error event are written."""
+        fake_proc = subprocess.CompletedProcess(
+            args=[], returncode=2, stdout="", stderr=""
+        )
+        with tempfile.TemporaryDirectory() as td:
+            log_dir = Path(td) / "logs"
+            orig = _config.AUDIT_LOG_DIR
+            _config.AUDIT_LOG_DIR = log_dir
+            try:
+                from cai_lib.audit.runner import _run_one_module
+                entry = self._fake_entry("mymod")
+                with patch("cai_lib.audit.runner._run_claude_p", return_value=fake_proc), \
+                     patch("cai_lib.audit.runner._build_module_prompt", return_value="p"):
+                    rc = _run_one_module("good-practices", "cai-audit-good-practices", entry)
+            finally:
+                _config.AUDIT_LOG_DIR = orig
+            self.assertEqual(rc, 1)
+            rows = self._read_log_lines(log_dir, "good-practices", "mymod")
+            self.assertEqual(len(rows), 2)
+            events = [r["event"] for r in rows]
+            self.assertIn("start", events)
+            self.assertIn("error", events)
+            error_row = next(r for r in rows if r["event"] == "error")
+            self.assertEqual(error_row["error_class"], "agent_nonzero")
+
+    def test_unexpected_exception_emits_error(self):
+        """When _run_claude_p raises, one start + one error event are written."""
+        with tempfile.TemporaryDirectory() as td:
+            log_dir = Path(td) / "logs"
+            orig = _config.AUDIT_LOG_DIR
+            _config.AUDIT_LOG_DIR = log_dir
+            try:
+                from cai_lib.audit.runner import _run_one_module
+                entry = self._fake_entry("crashmod")
+                with patch("cai_lib.audit.runner._run_claude_p",
+                           side_effect=RuntimeError("boom")), \
+                     patch("cai_lib.audit.runner._build_module_prompt", return_value="p"):
+                    rc = _run_one_module("cost-reduction", "cai-audit-cost-reduction", entry)
+            finally:
+                _config.AUDIT_LOG_DIR = orig
+            self.assertEqual(rc, 1)
+            rows = self._read_log_lines(log_dir, "cost-reduction", "crashmod")
+            self.assertEqual(len(rows), 2)
+            error_row = next(r for r in rows if r["event"] == "error")
+            self.assertEqual(error_row["error_class"], "unexpected_exception")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_audit_logging.py
+++ b/tests/test_audit_logging.py
@@ -172,30 +172,47 @@ class TestRunOneModuleLogging(unittest.TestCase):
         return entry
 
     def test_success_emits_start_and_finish(self):
-        fake_proc = subprocess.CompletedProcess(
+        """Full success path: one start + one finish event, exit_code=0, findings_count set."""
+        def fake_run_claude_p(args, **_kw):
+            # Recover work_dir from the args list and seed findings.json.
+            work_dir = Path(args[args.index("--add-dir") + 1])
+            (work_dir / "findings.json").write_text(
+                '{"findings": [{"title": "t", "body": "b"}]}'
+            )
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="", stderr=""
+            )
+
+        fake_publish = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
         with tempfile.TemporaryDirectory() as td:
-            findings = Path(td) / "findings.json"
-            findings.write_text('{"findings": [{"title": "t", "body": "b"}]}')
+            log_dir = Path(td) / "logs"
             orig = _config.AUDIT_LOG_DIR
-            _config.AUDIT_LOG_DIR = Path(td) / "logs"
+            _config.AUDIT_LOG_DIR = log_dir
             try:
-                with patch("cai_lib.audit.runner._run_claude_p", return_value=fake_proc), \
-                     patch("cai_lib.audit.runner._run", return_value=subprocess.CompletedProcess(
-                         args=[], returncode=0, stdout="", stderr="")), \
-                     patch("cai_lib.audit.runner._build_module_prompt", return_value="prompt"), \
-                     patch("pathlib.Path.mkdir"), \
-                     patch("shutil.rmtree"):
-                    # Patch findings_file.exists() to return True and read text.
-                    # Simplest approach: monkeypatch the work_dir uuid.
-                    import uuid as _uuid
-                    with patch.object(_uuid, "uuid4", return_value=MagicMock(hex="12345678abcd")):
-                        # We need the findings file to exist in the temp work dir.
-                        # Instead, test via direct function call with patched Path.exists.
-                        pass
+                from cai_lib.audit.runner import _run_one_module
+                entry = self._fake_entry("successmod")
+                with patch("cai_lib.audit.runner._run_claude_p",
+                           side_effect=fake_run_claude_p), \
+                     patch("cai_lib.audit.runner._run",
+                           return_value=fake_publish), \
+                     patch("cai_lib.audit.runner._build_module_prompt",
+                           return_value="prompt"):
+                    rc = _run_one_module(
+                        "good-practices", "cai-audit-good-practices", entry
+                    )
             finally:
                 _config.AUDIT_LOG_DIR = orig
+            self.assertEqual(rc, 0)
+            rows = self._read_log_lines(log_dir, "good-practices", "successmod")
+            self.assertEqual(len(rows), 2)
+            self.assertEqual([r["event"] for r in rows], ["start", "finish"])
+            finish_row = rows[1]
+            self.assertEqual(finish_row["level"], "INFO")
+            self.assertEqual(finish_row["exit_code"], 0)
+            self.assertEqual(finish_row["findings_count"], 1)
+            self.assertIsNone(finish_row["error_class"])
 
     def test_agent_nonzero_emits_error(self):
         """When agent returns non-zero, one start + one error event are written."""


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1166

**Issue:** #1166 — log-audit and audit-audit // audit - audit

## PR Summary

### What this fixes
Audit workflows currently have no persistent structured record of their operational state — per-module failures are ephemeral stderr lines, and there is no way to answer "did the `code-reduction` audit on module X fail silently last week?". This issue introduces a dedicated per-workflow JSONL audit log and a new `cai audit-health` subcommand backed by the `cai-audit-audit-health` agent.

### What was changed
- **`cai_lib/config.py`**: added `AUDIT_LOG_DIR = Path("/var/log/cai/audit")` constant and `audit_log_path(kind, module) -> Path` helper (returns `AUDIT_LOG_DIR/kind/module.jsonl`)
- **`cai_lib/audit_logging.py`** (new): `audit_log_start` and `audit_log_finish` helpers that append structured JSONL events (start/finish/error with full schema including `level`, `event`, `cost_usd`, `duration_ms`, `findings_count`, `error_class`, etc.) to per-(kind,module) log files
- **`cai_lib/audit/runner.py`**: wired `audit_log_start` at the top of `_run_one_module` and `audit_log_finish` at every exit branch (agent_nonzero, findings_missing_list, findings_parse_error, publish_failed, unexpected_exception, and success)
- **`cai_lib/cmd_agents.py`**: added `cmd_audit_health` function that invokes the `cai-audit-audit-health` agent and publishes findings via `publish.py --namespace audit-health`
- **`cai.py`**: registered `audit-health` subcommand pointing to `cmd_audit_health`
- **`.cai-staging/agents/audit/cai-audit-audit-health.md`** (new): agent definition that reads audit JSONL logs for the last 30 days and raises findings for error rows, stale audits, cost anomalies, and zero-findings degenerate runs
- **`docs/modules/audit.md`**: added `cai-audit-audit-health` to Key entry points; added operational notes on log path convention, schema, and query examples
- **`docs/modules/config.md`**: updated entry for `cai_lib/config.py` to mention `AUDIT_LOG_DIR` and `audit_log_path`
- **`tests/test_audit_logging.py`** (new): unit tests covering `audit_log_path`, `audit_log_start`, `audit_log_finish` (schema round-trip, success/error events, None proc safety, multi-line append), and `_run_one_module` integration (agent_nonzero and unexpected_exception emit correct event types)

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
