### PR TITLE
auto-improve: Rescue prevention: **False-positive in `_extract_files_to_change` (cai_lib/actions/refine.py):** `_PATH_RE.finditer()` extracts ALL file-pa

### DIFF
--- a/cai_lib/actions/refine.py
+++ b/cai_lib/actions/refine.py
@@ -127,7 +127,18 @@ def _extract_paths(section_text: str) -> set[str]:
 
 
 def _extract_files_to_change(refined_body: str) -> set[str]:
-    return _extract_paths(_extract_section(refined_body, _FILES_TO_CHANGE_HEADER))
+    section = _extract_section(refined_body, _FILES_TO_CHANGE_HEADER)
+    paths: set[str] = set()
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            continue
+        # Restrict extraction to the primary subject of each bullet — the portion
+        # before the " — " description separator — to avoid picking up incidental
+        # file-path tokens embedded in the change description.
+        subject = stripped[2:].split(" — ", 1)[0]
+        paths |= _extract_paths(subject)
+    return paths
 
 
 def _extract_scope_guardrails_paths(refined_body: str) -> set[str]:


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1181

**Issue:** #1181 — Rescue prevention: **False-positive in `_extract_files_to_change` (cai_lib/actions/refine.py):** `_PATH_RE.finditer()` extracts ALL file-pa

## PR Summary

### What this fixes
`_extract_files_to_change` in `cai_lib/actions/refine.py` called `_extract_paths()` on the entire "### Files to change" section, extracting every path-like token anywhere in the text — including paths that appear only as incidental content within a bullet's description (e.g., `- docs/modules.yaml — add \`cai_lib/audit_logging.py\` to the globs list` incorrectly extracted both paths).

### What was changed
- **`cai_lib/actions/refine.py`**: Rewrote `_extract_files_to_change` from a one-liner into a per-bullet parser. For each `- ` bullet line in the section, the function now splits on ` — ` and passes only the subject portion (before the separator) to `_extract_paths`, so incidental path tokens in descriptions are never extracted. All 688 existing tests pass.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
