### PR TITLE
install: add cai-audit and cai-audit-health shell aliases

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,6 +90,8 @@ configure_aliases() {
   echo "    cai                       # interactive claude session"
   echo "    cai -p 'fix the bug'      # one-shot prompt"
   echo "    cai-cycle                  # run one fix-pipeline cycle"
+  echo "    cai-audit <kind>           # on-demand per-module audit (e.g. cost-reduction)"
+  echo "    cai-audit-health           # run the audit-health monitor"
   echo "    cai-logs                   # tail container logs"
   echo "    cai-exec <cmd>             # run any command in the container"
   echo
@@ -114,6 +116,8 @@ alias cai-dispatch='${DC} exec --user cai cai python /app/cai.py dispatch'
 alias cai-verify='${DC} exec --user cai cai python /app/cai.py verify'
 alias cai-cost='${DC} exec --user cai cai python /app/cai.py cost-report'
 alias cai-health='${DC} exec --user cai cai python /app/cai.py health-report --dry-run'
+alias cai-audit='${DC} exec --user cai cai python /app/cai.py audit-module --kind'
+alias cai-audit-health='${DC} exec --user cai cai python /app/cai.py audit-health'
 alias cai-logs='${DC} logs -f cai'
 alias cai-exec='${DC} exec --user cai cai'
 ALIASES


### PR DESCRIPTION
## Summary
- Adds `cai-audit <kind>` alias that appends a positional kind to `cai audit-module --kind` (e.g. `cai-audit cost-reduction`).
- Adds `cai-audit-health` alias for the standalone `cai audit-health` subcommand.
- Updates the help text printed above the alias-prompt to mention both.

## Test plan
- [ ] Fresh `bash install.sh` with `y` at the alias prompt writes a block containing `alias cai-audit=...` and `alias cai-audit-health=...`.
- [ ] Re-running `install.sh` on an rc file that already has the old block replaces it cleanly (the sed range `# robotsix-cai aliases` → `alias cai-exec=` still brackets the new block).
- [ ] `cai-audit cost-reduction` expands to `docker compose exec --user cai cai python /app/cai.py audit-module --kind cost-reduction`.
- [ ] `cai-audit-health` expands to `docker compose exec --user cai cai python /app/cai.py audit-health`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)