### PR TITLE
cost-comment: tag parent agent's model, not the first subagent

### DIFF
--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -149,28 +149,41 @@ def _argv_to_options(
 async def _collect_results(
     prompt: str,
     options: ClaudeAgentOptions,
-) -> tuple[list[ResultMessage], str]:
+) -> tuple[list[ResultMessage], str, str | None]:
     """Drive ``query()`` to completion.
 
-    Returns ``(result_messages, last_non_empty_assistant_text)``. Collects
-    every ResultMessage (forward-compat: today the CLI emits exactly one)
-    and records the final non-empty ``AssistantMessage`` TextBlock so the
-    priority-4 stdout-salvage path can fall back to it when ``result`` is
-    absent (e.g. ``subtype == "error_max_budget_usd"``).
+    Returns ``(result_messages, last_non_empty_assistant_text,
+    parent_model)``. Collects every ResultMessage (forward-compat: today
+    the CLI emits exactly one) and records the final non-empty
+    ``AssistantMessage`` TextBlock so the priority-4 stdout-salvage path
+    can fall back to it when ``result`` is absent (e.g. ``subtype ==
+    "error_max_budget_usd"``).
+
+    ``parent_model`` is the model of the first ``AssistantMessage`` whose
+    ``parent_tool_use_id is None`` — i.e. the top-level agent. The SDK's
+    ``ResultMessage.model_usage`` aggregates every model a run touched
+    (parent + any Task subagents + Claude Code's own haiku-backed helpers
+    like the memory-project loader), so a bare ``next(iter(model_usage))``
+    can mislabel the run with a subagent's haiku instead of the parent's
+    opus. ``parent_model`` lets the cost-comment renderer pick the right
+    one deterministically.
     """
     results: list[ResultMessage] = []
     last_assistant = ""
+    parent_model: str | None = None
     async for msg in query(prompt=prompt, options=options):
         if isinstance(msg, ResultMessage):
             results.append(msg)
         elif isinstance(msg, AssistantMessage):
+            if parent_model is None and msg.parent_tool_use_id is None:
+                parent_model = msg.model or None
             parts = [
                 b.text for b in msg.content
                 if isinstance(b, TextBlock) and b.text.strip()
             ]
             if parts:
                 last_assistant = "".join(parts).strip()
-    return results, last_assistant
+    return results, last_assistant, parent_model
 
 
 def _sdk_error_summary(result) -> str:
@@ -259,22 +272,44 @@ def _post_cost_comment(
         category = str(row.get("category") or "")
         ts = str(row.get("ts") or "")
         models_field = row.get("models") or {}
-        primary_model = ""
-        if isinstance(models_field, dict) and models_field:
+        # Prefer the parent/top-level agent's model (captured from the
+        # first ``AssistantMessage`` with ``parent_tool_use_id is None``)
+        # over ``next(iter(model_usage))``. The SDK's ``model_usage``
+        # aggregates parent + subagents + built-in helpers (e.g. the
+        # haiku-backed ``memory: project`` loader), so picking the first
+        # key would mislabel opus-configured agents like ``cai-refine``
+        # / ``cai-split`` / ``cai-plan`` with whichever haiku subagent
+        # fired first.
+        parent_model = str(row.get("parent_model") or "")
+        primary_model = parent_model
+        if not primary_model and isinstance(models_field, dict) \
+                and models_field:
             primary_model = next(iter(models_field.keys()))
+        subagent_models: list[str] = []
+        if isinstance(models_field, dict) and models_field:
+            subagent_models = sorted(
+                m for m in models_field.keys() if m and m != primary_model
+            )
+        subagents_field = ",".join(subagent_models)
         marker = (
             f"<!-- cai-cost agent={agent} category={category} "
             f"model={primary_model} cost_usd={cost_usd:.4f} "
             f"turns={turns} duration_ms={duration_ms} "
             f"input_tokens={in_tokens} output_tokens={out_tokens} "
-            f"is_error={is_error} ts={ts} -->"
+            f"is_error={is_error} ts={ts}"
         )
+        if subagents_field:
+            marker += f" subagent_models={subagents_field}"
+        marker += " -->"
         if len(marker) > _COST_COMMENT_MAX_CHARS:
             marker = marker[: _COST_COMMENT_MAX_CHARS - 4] + " -->"
         seconds = duration_ms / 1000.0
+        model_label = primary_model or "unknown"
+        if subagent_models:
+            model_label += f" (+{len(subagent_models)} subagent model(s))"
         summary = (
             f"**Agent cost:** `{agent or '(no agent)'}` on "
-            f"`{primary_model or 'unknown'}` — "
+            f"`{model_label}` — "
             f"${cost_usd:.4f} / {turns} turn(s) / {seconds:.1f}s "
             f"(category=`{category}`)"
         )
@@ -364,13 +399,13 @@ def _run_claude_p(
 
     try:
         if timeout is not None:
-            results, last_assistant = asyncio.run(
+            results, last_assistant, parent_model = asyncio.run(
                 asyncio.wait_for(
                     _collect_results(prompt, options), timeout=timeout,
                 )
             )
         else:
-            results, last_assistant = asyncio.run(
+            results, last_assistant, parent_model = asyncio.run(
                 _collect_results(prompt, options)
             )
     except Exception as exc:  # noqa: BLE001
@@ -440,6 +475,8 @@ def _run_claude_p(
     row.update(flat)
     if models:
         row["models"] = models
+    if parent_model:
+        row["parent_model"] = parent_model
     log_cost(row)
 
     # Post a per-target cost-attribution comment on the issue/PR the

--- a/tests/test_cost_comment.py
+++ b/tests/test_cost_comment.py
@@ -23,7 +23,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from claude_agent_sdk.types import ResultMessage
+from claude_agent_sdk.types import AssistantMessage, ResultMessage, TextBlock
 
 from cai_lib.config import CAI_COST_COMMENT_RE
 from cai_lib.github import _strip_cost_comments
@@ -42,6 +42,15 @@ def _mk_result(**fields) -> ResultMessage:
         result=fields.pop("result", "ok"),
         structured_output=fields.pop("structured_output", None),
         model_usage=fields.pop("model_usage", {"claude-sonnet-4": {}}),
+    )
+
+
+def _mk_assistant(model: str, *, parent_tool_use_id: str | None = None,
+                  text: str = "hi") -> AssistantMessage:
+    return AssistantMessage(
+        content=[TextBlock(text=text)],
+        model=model,
+        parent_tool_use_id=parent_tool_use_id,
     )
 
 
@@ -244,6 +253,99 @@ class TestRunClaudePPostsCostComment(unittest.TestCase):
         self.assertEqual(mock_issue.call_count, 1)
         (_num, body), _kwargs = mock_issue.call_args
         self.assertIn("is_error=True", body)
+
+
+class TestCostCommentParentModel(unittest.TestCase):
+    """Parent model picked from the first parent-level ``AssistantMessage``,
+    not ``next(iter(model_usage))`` — which otherwise mislabels opus-
+    configured agents with whichever haiku subagent/helper fired first."""
+
+    @patch("cai_lib.subprocess_utils.log_cost")
+    def test_parent_model_wins_over_first_model_usage_key(self, _mock_log):
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        # model_usage dict orders haiku first (a subagent / memory helper
+        # that ran before the parent's first assistant turn). The parent
+        # AssistantMessage carries opus.
+        msg_result = _mk_result(
+            model_usage={
+                "claude-haiku-4-5-20251001": {},
+                "claude-opus-4-7": {},
+            }
+        )
+        msg_sub = _mk_assistant(
+            "claude-haiku-4-5-20251001", parent_tool_use_id="tool_abc",
+        )
+        msg_parent = _mk_assistant(
+            "claude-opus-4-7", parent_tool_use_id=None,
+        )
+        with patch.object(subprocess_utils, "query",
+                          _mock_query(msg_sub, msg_parent, msg_result)), \
+             patch("cai_lib.github._post_issue_comment",
+                   return_value=True) as mock_issue:
+            _run_claude_p(
+                ["claude", "-p", "--agent", "cai-refine"],
+                category="refine",
+                agent="cai-refine",
+                target_kind="issue",
+                target_number=1,
+            )
+        (_num, body), _kwargs = mock_issue.call_args
+        self.assertIn("model=claude-opus-4-7", body)
+        self.assertIn("subagent_models=claude-haiku-4-5-20251001", body)
+        self.assertIn("on `claude-opus-4-7", body)
+        # and definitely NOT the haiku-first mislabel
+        self.assertNotIn("model=claude-haiku-4-5-20251001", body)
+
+    @patch("cai_lib.subprocess_utils.log_cost")
+    def test_falls_back_to_model_usage_when_no_parent_message(
+        self, _mock_log,
+    ):
+        """When the run has no parent-level AssistantMessage (unusual —
+        happens on very-early crash paths), the old ``next(iter(...))``
+        heuristic still applies so the comment is never blank."""
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        msg_result = _mk_result(model_usage={"claude-sonnet-4-6": {}})
+        with patch.object(subprocess_utils, "query", _mock_query(msg_result)), \
+             patch("cai_lib.github._post_issue_comment",
+                   return_value=True) as mock_issue:
+            _run_claude_p(
+                ["claude", "-p", "--agent", "cai-merge"],
+                category="merge",
+                agent="cai-merge",
+                target_kind="issue",
+                target_number=2,
+            )
+        (_num, body), _kwargs = mock_issue.call_args
+        self.assertIn("model=claude-sonnet-4-6", body)
+        # no subagents when only one model was used
+        self.assertNotIn("subagent_models=", body)
+
+    @patch("cai_lib.subprocess_utils.log_cost")
+    def test_single_model_run_has_no_subagent_field(self, _mock_log):
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        msg_result = _mk_result(model_usage={"claude-opus-4-7": {}})
+        msg_parent = _mk_assistant("claude-opus-4-7")
+        with patch.object(subprocess_utils, "query",
+                          _mock_query(msg_parent, msg_result)), \
+             patch("cai_lib.github._post_issue_comment",
+                   return_value=True) as mock_issue:
+            _run_claude_p(
+                ["claude", "-p", "--agent", "cai-plan"],
+                category="plan.plan",
+                agent="cai-plan",
+                target_kind="issue",
+                target_number=3,
+            )
+        (_num, body), _kwargs = mock_issue.call_args
+        self.assertIn("model=claude-opus-4-7", body)
+        self.assertNotIn("subagent_models=", body)
+        self.assertNotIn("subagent model(s)", body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The per-target `<!-- cai-cost ... -->` attribution comment was mislabeling every opus-configured agent with `claude-haiku-4-5-20251001`. Visible on #1185 where `cai-refine` / `cai-split` / `cai-plan` all show up as haiku despite their frontmatter declaring `model: opus` and the bills ($0.19 / $0.30 / $3.86 for tiny turn counts) being clearly opus-shaped.

Root cause: `_post_cost_comment` picked the model via `next(iter(ResultMessage.model_usage.keys()))`. `model_usage` aggregates the parent agent **plus** any Task subagents **plus** Claude Code's own haiku-backed helpers (the `memory: project` loader, transcript helpers), so whichever model fired first — almost always a haiku helper — got labeled as the primary.

## Fix

- `_collect_results` now also captures the first `AssistantMessage` with `parent_tool_use_id is None` (the SDK's marker for the top-level agent) and returns its `model`.
- `_run_claude_p` stores it on the cost row as `parent_model` and hands it to `_post_cost_comment`.
- `_post_cost_comment` prefers `parent_model` over the `next(iter(...))` heuristic, and surfaces any remaining models from `model_usage` as `subagent_models=...` in the marker + `(+N subagent model(s))` in the human summary. Falls back to the old behaviour if no parent AssistantMessage was seen (early-crash paths).

## Test plan

- [x] New `TestCostCommentParentModel` covers: parent-model-wins-over-first-key, fallback when no parent message, single-model-run has no subagent field.
- [x] Full test suite: `python -m unittest discover tests` → 704 passed (1 skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)