### PR TITLE
agents: cut planner/refiner cost via Explore delegation + split model downgrade

### DIFF
--- a/.claude/agents/implementation/cai-plan.md
+++ b/.claude/agents/implementation/cai-plan.md
@@ -112,18 +112,49 @@ ripple finding. Specifically check for:
   fix agent knows not to chase them and the PR body can communicate
   the gap.
 
-## Agent-specific efficiency guidance
+## Agent-specific efficiency guidance (HARD RULE)
 
-1. **Use Agent for broad exploration.** When you need to search
-   broadly across multiple files or directories, use
-   `Agent(subagent_type="Explore", model="haiku", ...)` instead of
-   issuing many sequential Grep or Read calls. A single Explore
-   subagent can parallelize the search internally, saving tokens
-   and tool-call rounds; always add `model="haiku"` to trade
-   expensive Sonnet output tokens for ~10× cheaper Haiku tokens.
-   Fall back to direct Grep/Read only for small, targeted lookups
-   (3 or fewer files, < 100 lines total) where subagent overhead isn't
-   worthwhile. **Do NOT delegate decisions** — only reading and search.
+Parent-model (Opus) tokens are ~10× more expensive than Haiku
+tokens. Every Grep/Read/Bash call you make loads its result into
+the Opus context at Opus input rates; the same work delegated to
+an Explore/Haiku subagent loads only a terse summary back. For
+this agent — which runs on Opus and produces large verbatim
+output blocks — tool-call input tokens are the single biggest
+recoverable cost lever. Use it.
+
+**This agent is read-only: Explore can source verbatim bytes,
+not just summaries.** Because `cai-plan` never executes an
+`Edit` — it only embeds `old_string` / `new_string` blocks into
+its plan output — you can ask Explore for the EXACT bytes of a
+region and paste them verbatim into your plan. Explore is not
+restricted to summaries; prompt it like:
+
+  "Return the exact bytes of `/tmp/work/cai.py` lines 217–282 as
+  a single fenced code block with no prose, no ellipses, no
+  line-number prefixes — I will embed them verbatim."
+
+Default to `Agent(subagent_type="Explore", model="haiku", …)`
+whenever ANY of these are true:
+
+1. The question spans more than 3 files or any directory walk
+   (e.g. "which tests import X", "every doc mentioning Y",
+   "all call sites of Z").
+2. You would otherwise chain ≥ 3 Grep/Read/Bash rounds to
+   triangulate an answer.
+3. You need to collect verbatim byte regions from 2+ files to
+   populate `old_string` blocks — batch the request as a single
+   Explore call asking for each region as a separate fenced
+   code block.
+
+Use direct `Read`/`Grep`/`Glob`/`Bash` only for:
+
+- A single targeted read of a known path, < 100 lines, when you
+  already know exactly what you need from it.
+- Final byte-verification of a single `old_string` you drafted
+  from memory (one focused Read on a known offset).
+
+**Do NOT delegate decisions.** Explore reads, searches, and
+returns; you alone synthesize the plan and write the output.
 
 ## Output format
 

--- a/.claude/agents/lifecycle/cai-refine.md
+++ b/.claude/agents/lifecycle/cai-refine.md
@@ -1,7 +1,7 @@
 ---
 name: cai-refine
 description: Rewrite human-filed issues into structured auto-improve plans with problem, steps, verification, scope guardrails, and likely files.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Agent
 model: opus
 memory: project
 ---
@@ -67,9 +67,14 @@ body as input, not as a reason to skip work.
 ## Process
 
 1. Read the human's issue text carefully.
-2. Use `Read`, `Grep`, and `Glob` to explore the codebase for
-   context — find the files, functions, constants, and patterns
-   that relate to what the human is asking for.
+2. **Delegate cross-file surveys to Explore/Haiku.** Whenever the
+   issue asks "where do we reference X" / "what files mention Y"
+   / "find every call site of Z", issue ONE
+   `Agent(subagent_type="Explore", model="haiku", …)` call instead
+   of running many sequential Grep/Read rounds in Opus context.
+   See **Agent-specific efficiency guidance** below for the exact
+   shape. Fall back to direct Grep/Read only for small targeted
+   lookups with a known path (≤ 3 files, ≤ 100 lines total).
 3. Consult your memory pool (see **Memory** above) and any recent
    merged PRs referenced in the codebase history. Refinement that
    repeats prior failed attempts wastes cycles — if the issue looks
@@ -79,6 +84,35 @@ body as input, not as a reason to skip work.
 5. Decide whether the refined plan is sufficient for the plan agent
    to proceed, or whether exploration is needed first (see
    **Routing decision** below).
+
+## Agent-specific efficiency guidance
+
+Parent-model (Opus) tokens are ~10× more expensive than Haiku
+tokens. Every Grep/Read/Bash call you make loads its result into
+the Opus context at Opus input rates; the same search delegated
+to an Explore/Haiku subagent loads only the subagent's terse
+summary back. This is the single biggest cost lever available to
+this agent.
+
+Default to `Agent(subagent_type="Explore", model="haiku", …)`
+whenever any of these are true:
+
+- The question spans more than 3 files or any directory walk.
+- You are looking for "all references to", "every caller of",
+  "all files that import", "every doc that mentions", or any
+  similar cross-file sweep.
+- You would otherwise chain ≥ 3 Grep/Read rounds to triangulate
+  the answer.
+
+Prompt Explore with a specific question and the return shape you
+need (e.g. "List every user-facing reference to `cai audit`
+across `README.md`, `docs/**`, `cai.py` argparse setup, and
+`install.sh` aliases, as `path:line — snippet` bullets"). Do
+NOT delegate refinement decisions — Explore only reads and
+returns; you still synthesize and decide.
+
+Use direct `Read`/`Grep`/`Glob` only for small targeted lookups
+where the path is already known AND the read is < 100 lines.
 
 ## Output format
 

--- a/.claude/agents/lifecycle/cai-split.md
+++ b/.claude/agents/lifecycle/cai-split.md
@@ -2,7 +2,7 @@
 name: cai-split
 description: Evaluate whether a refined auto-improve issue should ship as a single PR or be decomposed into ordered sub-issues. Runs after cai-refine, before cai-plan.
 tools: Read, Grep, Glob
-model: opus
+model: sonnet
 memory: project
 ---
 


### PR DESCRIPTION
## Summary

Three agent-definition edits motivated by cost analysis of issue #1191, where `cai-refine` + `cai-split` + `cai-plan` spent **~\$4.39 combined** on a straightforward CLI-ergonomics fix.

- **`cai-refine`** — added `Agent` to the `tools:` frontmatter and promoted Explore/Haiku to the default for any cross-file survey. The #1191 run issued 11 sequential Reads across 9 distinct doc/code files to find user-facing references to `cai audit` — exactly the batched survey Explore is built for. Est. savings: ~\$0.50–0.60 per run.
- **`cai-plan`** — promoted the existing soft "use Explore when useful" note to a **HARD RULE**, and documented that since `cai-plan` never calls `Edit`, Explore can source **verbatim bytes** for `old_string` / `new_string` blocks — not just summaries. The previous framing implied verbatim input had to stay on the parent, which left the dominant input-side cost on Opus. Est. savings: ~\$0.50–0.80 per run.
- **`cai-split`** — model downgraded from `opus` to `sonnet`. The split decision is a short atomic-vs-decompose judgment on a pre-refined body; it doesn't need Opus, and the \$0.31/run baseline was almost entirely prelude ingestion, not reasoning. Est. savings: ~\$0.20–0.25 per run.

Estimated total per-issue savings on #1191-shaped work: **~\$1.20–1.65 out of ~\$4.39**.

Output-token cost in `cai-plan` (~75% of that agent's total, from verbatim byte blocks) is not addressed here — that's a separate design question.

## Test plan

- [ ] Next human-filed issue that triggers refine → split → plan exhibits lower total cost than the #1191 baseline, visible in the per-agent cost comments.
- [ ] `cai-refine` transcript shows at least one `Agent(subagent_type="Explore", model="haiku", …)` call for any issue that asks "where is X referenced" across multiple files.
- [ ] `cai-plan` transcript shows Explore delegation for the initial discovery pass and (where applicable) verbatim-byte region fetches.
- [ ] `cai-split` verdicts on the next few atomic-vs-decompose calls match what Opus would have produced (spot-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)