### PR TITLE
cost-comment: per-category dollar breakdown in the detail line

### DIFF
--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -244,6 +244,51 @@ def _sdk_error_summary(result) -> str:
 _COST_COMMENT_MAX_CHARS = 800
 
 
+# Claude 4.x pricing ratios relative to the input-token rate. These
+# hold across Opus / Sonnet / Haiku and across 200k / 1M context
+# windows because Anthropic scales all four rates uniformly per model.
+# Used to split a known ``costUSD`` into per-category dollars without
+# having to hardcode per-model prices (which drift with new model
+# releases). The breakdown is informational — the authoritative total
+# is still ``costUSD`` as reported by the SDK.
+_TOKEN_COST_RATIOS = {
+    "input": 1.0,
+    "output": 5.0,
+    "cache_read": 0.1,
+    "cache_write": 1.25,
+}
+
+
+def _split_cost_by_category(
+    total_cost: float,
+    in_tokens: int,
+    out_tokens: int,
+    cache_read_tokens: int,
+    cache_write_tokens: int,
+) -> dict[str, float]:
+    """Split ``total_cost`` across the four token-category buckets.
+
+    Uses the fixed Claude 4.x pricing ratios (see ``_TOKEN_COST_RATIOS``).
+    Returns zeros everywhere when the weighted-token denominator is zero
+    — the only case the caller needs to guard.
+    """
+    weighted = (
+        in_tokens          * _TOKEN_COST_RATIOS["input"]
+        + out_tokens       * _TOKEN_COST_RATIOS["output"]
+        + cache_read_tokens  * _TOKEN_COST_RATIOS["cache_read"]
+        + cache_write_tokens * _TOKEN_COST_RATIOS["cache_write"]
+    )
+    if weighted <= 0 or total_cost <= 0:
+        return {"input": 0.0, "output": 0.0, "cache_read": 0.0, "cache_write": 0.0}
+    scale = total_cost / weighted
+    return {
+        "input":       in_tokens          * _TOKEN_COST_RATIOS["input"]       * scale,
+        "output":      out_tokens         * _TOKEN_COST_RATIOS["output"]      * scale,
+        "cache_read":  cache_read_tokens  * _TOKEN_COST_RATIOS["cache_read"]  * scale,
+        "cache_write": cache_write_tokens * _TOKEN_COST_RATIOS["cache_write"] * scale,
+    }
+
+
 def _post_cost_comment(
     target_kind: str,
     target_number: int,
@@ -350,11 +395,15 @@ def _post_cost_comment(
                     mu.get("cacheCreationInputTokens") or 0
                 )
                 role = "parent" if m == primary_model else "subagent"
+                split = _split_cost_by_category(
+                    m_cost, m_in, m_out, m_cache_read, m_cache_create,
+                )
                 detail_lines.append(
                     f"- `{m}` ({role}): ${m_cost:.4f} — "
-                    f"in={m_in} / out={m_out} / "
-                    f"cache_read={m_cache_read} / "
-                    f"cache_create={m_cache_create}"
+                    f"in={m_in} (${split['input']:.4f}) / "
+                    f"out={m_out} (${split['output']:.4f}) / "
+                    f"cache_read={m_cache_read} (${split['cache_read']:.4f}) / "
+                    f"cache_create={m_cache_create} (${split['cache_write']:.4f})"
                 )
         if subagents_invoked:
             inv_parts = ", ".join(

--- a/tests/test_cost_comment.py
+++ b/tests/test_cost_comment.py
@@ -395,10 +395,73 @@ class TestCostCommentPerModelDetail(unittest.TestCase):
         self.assertIn("`claude-opus-4-7` (parent): $1.0267", body)
         self.assertIn("`claude-haiku-4-5-20251001` (subagent): $0.0009",
                       body)
-        self.assertIn("in=32 / out=8288", body)
+        self.assertIn("in=32 ", body)
+        self.assertIn("out=8288 ", body)
         self.assertIn("cache_read=1029092", body)
         # parent comes before subagent in the body
         self.assertLess(body.index("(parent)"), body.index("(subagent)"))
+
+    @patch("cai_lib.subprocess_utils.log_cost")
+    def test_per_category_cost_split_rendered(self, _mock_log):
+        """Each per-model line carries an inline $X.XXXX split for
+        each of in / out / cache_read / cache_create, derived from
+        the fixed Claude 4.x pricing ratios."""
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        # Canonical #1191-plan figures: in=34, out=34394,
+        # cache_read=3_267_345, cache_create=127_540, total=$3.2908.
+        # Expected split via ratios 1:5:0.1:1.25:
+        #   weighted = 34 + 5*34394 + 0.1*3267345 + 1.25*127540
+        #            = 658163.5
+        #   scale    = 3.2908 / 658163.5 ≈ 5.0e-6
+        #   in_cost       ≈ $0.0002
+        #   out_cost      ≈ $0.8599
+        #   cache_read    ≈ $1.6337
+        #   cache_write   ≈ $0.7971
+        msg_result = _mk_result(
+            model_usage={
+                "claude-opus-4-7": {
+                    "inputTokens": 34,
+                    "outputTokens": 34394,
+                    "cacheReadInputTokens": 3267345,
+                    "cacheCreationInputTokens": 127540,
+                    "costUSD": 3.2908,
+                },
+            },
+        )
+        msg_parent = _mk_assistant("claude-opus-4-7")
+        with patch.object(subprocess_utils, "query",
+                          _mock_query(msg_parent, msg_result)), \
+             patch("cai_lib.github._post_issue_comment",
+                   return_value=True) as mock_issue:
+            _run_claude_p(
+                ["claude", "-p", "--agent", "cai-plan"],
+                category="plan.plan",
+                agent="cai-plan",
+                target_kind="issue",
+                target_number=1191,
+            )
+        (_num, body), _kwargs = mock_issue.call_args
+        # Tokens kept verbatim, dollar splits from the 1:5:0.1:1.25
+        # ratios. The four splits must sum to the total $3.2908.
+        self.assertIn("in=34 ($0.0002)", body)
+        self.assertIn("out=34394 ($0.8598)", body)
+        self.assertIn("cache_read=3267345 ($1.6337)", body)
+        self.assertIn("cache_create=127540 ($0.7971)", body)
+
+    def test_split_cost_by_category_zero_tokens(self):
+        """Zero tokens yields zero split, no DivisionByZero."""
+        from cai_lib.subprocess_utils import _split_cost_by_category
+
+        self.assertEqual(
+            _split_cost_by_category(0.0, 0, 0, 0, 0),
+            {"input": 0.0, "output": 0.0, "cache_read": 0.0, "cache_write": 0.0},
+        )
+        self.assertEqual(
+            _split_cost_by_category(1.0, 0, 0, 0, 0),
+            {"input": 0.0, "output": 0.0, "cache_read": 0.0, "cache_write": 0.0},
+        )
 
 
 class TestCostCommentSubagentInvocations(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds an inline \`(\$X.XXXX)\` next to each token count in the per-model cost comment detail line, derived from the fixed Claude 4.x pricing ratios (\`in : out : cache_read : cache_write = 1 : 5 : 0.1 : 1.25\`). The four splits sum to the reported \`costUSD\`.

**Before:**

\`\`\`
- \`claude-opus-4-7\` (parent): \$3.2908 — in=34 / out=34394 / cache_read=3267345 / cache_create=127540
\`\`\`

**After:**

\`\`\`
- \`claude-opus-4-7\` (parent): \$3.2908 — in=34 (\$0.0002) / out=34394 (\$0.8598) / cache_read=3267345 (\$1.6337) / cache_create=127540 (\$0.7971)
\`\`\`

## Why it matters

Today's comment only shows token counts, which makes it hard to tell which bucket actually drove the spend. The common intuition that "output tokens dominate" happens to be wrong for long-running Opus agents: on cai-plan's #1191 run, `cache_read` was ~50% of the cost and output only ~26%. Opposite conclusions lead to opposite optimizations (fewer turns vs. shorter output), so surfacing the split directly in the comment prevents misdirected tuning. This also directly informed PR #1193 (promoting Explore delegation from soft guidance to a hard rule — fewer turns is the cache-read lever).

## Implementation notes

- No per-model pricing table is hardcoded. The pricing ratios are scale-free — they're the same for Opus / Sonnet / Haiku and for 200k / 1M context windows because Anthropic scales all four rates uniformly per model. Adding new models requires no code change.
- Falls back to zeros when weighted-token denominator is zero (first-turn edge case).
- The authoritative total is still \`costUSD\` as reported by the SDK; the split is informational.

## Test plan

- [x] New unit test \`test_per_category_cost_split_rendered\` pins the format against the canonical #1191-plan figures.
- [x] New unit test \`test_split_cost_by_category_zero_tokens\` covers the zero-token edge case.
- [x] Updated \`test_per_model_lines_rendered\` to tolerate the new inline \`(\$X.XXXX)\` suffixes.
- [x] \`python -m unittest discover tests\` — all 710 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)