### PR TITLE
auto-improve: add jq to the docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update \
         wget \
         gnupg \
         git \
+        jq \
         rsync \
         openssh-client \
     && mkdir -p -m 755 /etc/apt/keyrings \


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1192

**Issue:** #1192 — add jq to the docker

## PR Summary

### What this fixes
The container image lacked a standalone `jq` binary on `$PATH`, making ad-hoc JSON processing of `findings.json`, audit logs, and session transcripts impossible inside the container.

### What was changed
- **`Dockerfile`**: added `jq \` to the existing `apt-get install -y --no-install-recommends` list (line 36), inserted alphabetically between `git` and `rsync`. No new RUN layer, no version pin, no smoke-test command — strictly a one-line addition to the existing combined-install block.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
