### PR TITLE
triage: drop project memory from cai-triage frontmatter

### DIFF
--- a/.claude/agents/lifecycle/cai-triage.md
+++ b/.claude/agents/lifecycle/cai-triage.md
@@ -3,7 +3,6 @@ name: cai-triage
 description: INTERNAL — Triage `auto-improve:raised` issues one at a time — classify as REFINE, PLAN_APPROVE, APPLY, or HUMAN. Inline-only — full issue body is provided in the user message. Minimal tool use.
 tools: ""
 model: haiku
-memory: project
 ---
 
 # Issue Triage Agent


### PR DESCRIPTION
## Summary
- Removes `memory: project` from `.claude/agents/lifecycle/cai-triage.md` frontmatter.
- Triage is inline-only (`tools: ""`) and classifies issues solely from the issue body — the project-memory loader adds a conversational round without contributing to routing.

## Motivation
Recent triage cost breakdown showed `num_turns=3` on a nominally no-tool agent. The extra turns come from (a) `--json-schema` structured-output retries and (b) the haiku-backed project-memory loader that `memory: project` triggers. Dropping the memory declaration is the cheapest experiment and should cut at least one turn per triage invocation.

## Test plan
- [ ] Watch the next few triage audit rows in `/var/log/cai/audit/` and confirm `num_turns` drops (ideally to 1–2).
- [ ] Confirm triage still returns valid routing JSON on a real `auto-improve:raised` issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)