### PR TITLE
auto-improve: cost log: stamp host on every row (survive multi-host aggregation)

### DIFF
--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import shutil
+import socket
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -570,6 +571,7 @@ def _run_claude_p(
         "duration_api_ms": result.duration_api_ms,
         "num_turns": result.num_turns,
         "session_id": result.session_id,
+        "host": socket.gethostname(),
         "exit": returncode,
         "is_error": bool(result.is_error),
     }

--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -475,7 +475,7 @@ def _run_claude_p(
 
     Cost rows carry exactly the same keys as the pre-SDK version (``ts``,
     ``category``, ``agent``, ``cost_usd``, ``duration_ms``,
-    ``duration_api_ms``, ``num_turns``, ``session_id``, ``exit``,
+    ``duration_api_ms``, ``num_turns``, ``session_id``, ``host``, ``exit``,
     ``is_error``, the four flat token keys, and an optional ``models``
     per-model rollup). ``subagents`` / ``parent_cost_usd`` are
     intentionally dropped — the CLI format emits exactly one result event


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1201

**Issue:** #1201 — cost log: stamp host on every row (survive multi-host aggregation)

## PR Summary

### What this fixes
Cost rows written to `cai-cost.jsonl` carried no host identifier — once `_load_cost_log` read the union of per-host aggregate files into a flat list, the originating host was lost, making per-host attribution and anomaly detection impossible.

### What was changed
- **`cai_lib/subprocess_utils.py`**: added `import socket` to the stdlib import block (alphabetically between `shutil` and `subprocess`), and added `"host": socket.gethostname(),` to the `row = {…}` literal in the post-run cost-logging path (after `"session_id"`). No other files changed.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
