### PR TITLE
perf: run cai-select on sonnet

### DIFF
--- a/.claude/agents/implementation/cai-select.md
+++ b/.claude/agents/implementation/cai-select.md
@@ -2,7 +2,7 @@
 name: cai-select
 description: INTERNAL — Evaluate multiple fix plans for an auto-improve issue and select the best one. Plans arrive in the user message; may run targeted Read/Grep/Glob on the clone to verify narrow structural claims before downgrading confidence.
 tools: Read, Grep, Glob
-model: opus
+model: sonnet
 ---
 
 # Plan Selector


### PR DESCRIPTION
Switches the cai-select agent's model from opus to sonnet to reduce cost on plan selection — a structured evaluation task that doesn't require opus-tier reasoning.

## Test plan
- [ ] Observe a subsequent auto-improve run that invokes cai-select and confirm plan selection quality remains acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)