### PR TITLE
auto-improve: Pre-load "Files to change" contents into downstream agents to eliminate redundant Reads

### DIFF
--- a/.claude/agents/implementation/cai-implement.md
+++ b/.claude/agents/implementation/cai-implement.md
@@ -148,6 +148,11 @@ persisted after other issues were solved and its entries override your
 per-agent notes when they conflict. **Do NOT attempt to read from
 disk** — the shared memory is already included in that section.
 
+Similarly, the `## Pre-loaded file contents` section (if present) contains
+files from the issue's `### Files to change` list — **do not read these
+files from disk.** They are already included in the Work directory block.
+Grep for symbol lookups is still encouraged.
+
 If the issue you're working on overlaps with something in your
 memory — e.g., the issue is asking you to do something your memory
 says was already considered and rejected — do not make the change.

--- a/.claude/agents/implementation/cai-plan.md
+++ b/.claude/agents/implementation/cai-plan.md
@@ -32,12 +32,15 @@ The user message contains:
 
 1. **Understand the issue.** Read the issue carefully. Identify
    what needs to change and why.
-2. **Consult shared memory.** Refer to the `## Shared agent memory
-   (pre-loaded)` section in the Work directory block — the shared
-   pool records cross-cutting design decisions from prior issues and
-   may already answer your question. **Do NOT attempt to read from
-   disk** — the shared memory is already included in that section.
-   Then use Grep, Glob, and Read to find the relevant files,
+2. **Consult shared memory and pre-loaded files.** Refer to the
+   `## Shared agent memory (pre-loaded)` section in the Work directory
+   block — the shared pool records cross-cutting design decisions from
+   prior issues and may already answer your question. **Do NOT attempt
+   to read from disk** — the shared memory is already included in that
+   section. Similarly, the `## Pre-loaded file contents` section (if
+   present) contains files from the issue's `### Files to change` list
+   — do not read these files from disk. Grep for symbol lookups is still
+   encouraged. Then use Grep, Glob, and Read to find the relevant files,
    functions, and code paths. Understand the current state before
    proposing changes.
 3. **Identify the minimal change set.** Determine exactly which

--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -1182,13 +1182,13 @@ def handle_implement(issue: dict) -> int:
 
         # 5. Run the cai-implement declarative subagent.
         user_message = (
-            _work_directory_block(work_dir)
+            _work_directory_block(work_dir, issue.get("body") or "")
             + "\n"
             + _build_implement_user_message(issue, attempt_history_block)
         )
         if selected_plan:
             user_message = (
-                _work_directory_block(work_dir)
+                _work_directory_block(work_dir, issue.get("body") or "")
                 + "\n"
                 + "## Selected Implementation Plan\n\n"
                 + "The following plan was pre-computed by `cai plan` and "

--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -53,6 +53,7 @@ from cai_lib.cmd_helpers import (
     _fetch_review_comments,
     _extract_stored_plan,
     _git,
+    _work_directory_block,
 )
 from cai_lib.actions.plan import (
     _FILES_TO_CHANGE_SECTION_RE,
@@ -1042,6 +1043,11 @@ def handle_merge(pr: dict) -> HandlerResult:
             _git(work_dir, "fetch", "origin", branch)
             _git(work_dir, "checkout", branch)
             add_dir_argv: list[str] = ["--add-dir", str(work_dir)]
+            user_message = (
+                _work_directory_block(work_dir, issue_full.get("body") or "")
+                + "\n"
+                + user_message
+            )
         else:
             print(
                 f"[cai merge] PR #{pr_number}: clone failed (non-fatal); "

--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -54,6 +54,10 @@ from cai_lib.cmd_helpers import (
     _fetch_previous_fix_attempts,
     _build_attempt_history_block,
 )
+from cai_lib.cmd_helpers_issues import (
+    _FILES_TO_CHANGE_SECTION_RE,
+    _FILES_TO_CHANGE_PATH_RE,
+)
 from cai_lib.cmd_implement import _parse_decomposition
 from cai_lib.actions.refine import _create_sub_issues, _issue_depth
 from cai_lib.fsm import (
@@ -138,17 +142,6 @@ def _plan_has_anchor_mitigation(plan_text: str | None) -> bool:
 #   * Have every such path begin with ``docs/`` (strict prefix — any
 #     non-``docs/`` path disqualifies the plan).
 # ---------------------------------------------------------------------------
-_FILES_TO_CHANGE_SECTION_RE = re.compile(
-    r"^###\s+Files\s+to\s+change\s*$\n(.*?)(?=^###\s|\Z)",
-    re.IGNORECASE | re.DOTALL | re.MULTILINE,
-)
-
-# Match backticked path tokens of the form ``path/with.ext`` — requires
-# at least one ``/`` and an extension, so free-standing symbol names
-# (e.g. ``parse_config``) and extensionless bare names are ignored.
-_FILES_TO_CHANGE_PATH_RE = re.compile(
-    r"`([^`\s]+/[^`\s]*\.[A-Za-z0-9]+)`"
-)
 
 
 def _plan_targets_only_docs(plan_text: str | None) -> bool:
@@ -798,7 +791,7 @@ def _run_plan_agent(issue: dict, plan_index: int, work_dir: Path, attempt_histor
     operating on the clone via absolute paths (#342).
     """
     user_message = (
-        _work_directory_block(work_dir)
+        _work_directory_block(work_dir, issue.get("body") or "")
         + "\n"
         + _build_issue_block(issue)
         + attempt_history_block
@@ -922,7 +915,7 @@ def _run_select_agent(
 
     from cai_lib.fsm import Confidence
 
-    user_message = _work_directory_block(work_dir) + "\n"
+    user_message = _work_directory_block(work_dir, issue.get("body") or "") + "\n"
     user_message += _build_issue_block(issue)
     user_message += "\n---\n\n# Candidate Plans\n\n"
     for i, plan in enumerate(plans, 1):

--- a/cai_lib/actions/rebase.py
+++ b/cai_lib/actions/rebase.py
@@ -34,6 +34,7 @@ from cai_lib.config import REPO
 from cai_lib.dispatcher import HandlerResult
 from cai_lib.subprocess_utils import _run, _run_claude_p
 from cai_lib.cmd_helpers import _git, _gh_user_identity, _work_directory_block
+from cai_lib.github import _fetch_linked_issue_block
 from cai_lib.logging_utils import log_run
 
 
@@ -159,8 +160,9 @@ def handle_rebase(pr: dict) -> HandlerResult:
 
         # Conflicts exist (or rebase aborted). Hand to cai-rebase agent.
         conflict_files = _rebase_conflict_files(work_dir)
+        _linked_issue_block = _fetch_linked_issue_block(pr.get("body", ""))
         user_message = (
-            _work_directory_block(work_dir)
+            _work_directory_block(work_dir, _linked_issue_block)
             + "\n"
             + "## Rebase conflict\n\n"
             + f"PR #{pr_number} (`{branch}`) cannot be merged onto `origin/main` "

--- a/cai_lib/actions/review_docs.py
+++ b/cai_lib/actions/review_docs.py
@@ -295,7 +295,7 @@ def handle_review_docs(pr: dict) -> HandlerResult:
         author_login = pr.get("author", {}).get("login", "unknown")
         issue_block = _fetch_linked_issue_block(pr.get("body", ""))
         user_message = (
-            _work_directory_block(work_dir)
+            _work_directory_block(work_dir, issue_block)
             + "\n"
             + "## PR metadata\n\n"
             + f"- **Number:** #{pr_number}\n"

--- a/cai_lib/actions/review_pr.py
+++ b/cai_lib/actions/review_pr.py
@@ -193,7 +193,7 @@ def handle_review_pr(pr: dict) -> HandlerResult:
         author_login = pr.get("author", {}).get("login", "unknown")
         issue_block = _fetch_linked_issue_block(pr.get("body", ""))
         user_message = (
-            _work_directory_block(work_dir)
+            _work_directory_block(work_dir, issue_block)
             + "\n"
             + "## PR metadata\n\n"
             + f"- **Number:** #{pr_number}\n"

--- a/cai_lib/actions/revise.py
+++ b/cai_lib/actions/revise.py
@@ -734,7 +734,7 @@ def handle_revise(pr: dict) -> HandlerResult:
             _issue_body = _extract_revise_context(_issue_body_raw)
 
             user_message = (
-                _work_directory_block(work_dir)
+                _work_directory_block(work_dir, issue_data.get("body") or "")
                 + "\n"
                 + f"{rebase_state_block}\n"
                 + "## Original issue\n\n"

--- a/cai_lib/cmd_helpers_git.py
+++ b/cai_lib/cmd_helpers_git.py
@@ -6,6 +6,8 @@ import sys
 
 from pathlib import Path
 
+from cai_lib.cmd_helpers_issues import _parse_files_to_change
+
 
 def _read_shared_memory() -> str:
     """Read all shared agent memory files and return them as a formatted
@@ -62,7 +64,87 @@ def _git(work_dir: Path, *args: str, check: bool = True) -> subprocess.Completed
     return subprocess.run(cmd, text=True, check=check, capture_output=True)
 
 
-def _work_directory_block(work_dir: Path) -> str:
+def _read_prefetched_files(
+    work_dir: Path,
+    paths: list[str],
+    per_file_token_cap: int = 15000,
+    total_token_cap: int = 40000,
+) -> str:
+    """Read a list of relative *paths* from *work_dir* and return them
+    formatted as a ``## Pre-loaded file contents`` section.
+
+    Each file is wrapped in a fenced code block preceded by a
+    ``### <relpath>`` heading.  Files are skipped when:
+
+    - the path does not exist under *work_dir* (logged as "missing");
+    - the estimated token count (``len(text) // 4``) exceeds
+      *per_file_token_cap* (logged as "too large");
+    - the accumulated total would exceed *total_token_cap* (logged as
+      "total cap exceeded"; stops accumulation early).
+
+    Returns an empty string when *paths* is empty or no file qualifies.
+    All skip events are emitted as ``[cai refine-preload]`` lines on
+    stderr so pipeline operators can inspect the behavior.
+    """
+    if not paths:
+        return ""
+
+    parts: list[str] = []
+    total_tokens = 0
+
+    for rel in paths:
+        target = work_dir / rel
+        if not target.is_file():
+            print(
+                f"[cai refine-preload] skipping {rel}: missing",
+                file=sys.stderr,
+            )
+            continue
+
+        try:
+            text = target.read_text(errors="replace")
+        except OSError as exc:
+            print(
+                f"[cai refine-preload] skipping {rel}: read error: {exc}",
+                file=sys.stderr,
+            )
+            continue
+
+        file_tokens = len(text) // 4
+        if file_tokens > per_file_token_cap:
+            print(
+                f"[cai refine-preload] skipping {rel}: too large "
+                f"(~{file_tokens} tokens > {per_file_token_cap} cap)",
+                file=sys.stderr,
+            )
+            continue
+
+        if total_tokens + file_tokens > total_token_cap:
+            print(
+                f"[cai refine-preload] skipping {rel}: total cap exceeded "
+                f"(accumulated ~{total_tokens} tokens, cap {total_token_cap})",
+                file=sys.stderr,
+            )
+            continue
+
+        total_tokens += file_tokens
+        parts.append(f"### {rel}\n\n```\n{text}\n```")
+
+    if not parts:
+        return ""
+
+    return (
+        "\n\n## Pre-loaded file contents\n\n"
+        "The following files were pre-loaded from the `### Files to change` "
+        "section of the linked issue. **Do NOT attempt to read these files "
+        "from disk — they are already included below.** Grep for symbol "
+        "lookups is still encouraged.\n\n"
+        + "\n\n".join(parts)
+        + "\n"
+    )
+
+
+def _work_directory_block(work_dir: Path, issue_body: str | None = None) -> str:
     """Return the standard "## Work directory" user-message section
     that informs a cloned-worktree subagent where its actual work
     happens, and how to update protected `.claude/agents/*.md`
@@ -227,7 +309,11 @@ def _work_directory_block(work_dir: Path) -> str:
         "\"<full new file content>\")`\n"
         f"  - BAD:  `Edit(\"{work_dir}/CLAUDE.md\", ...)`  "
         "(blocked by claude-code)\n"
-    ) + _read_shared_memory()
+    ) + _read_shared_memory() + (
+        _read_prefetched_files(work_dir, _parse_files_to_change(issue_body))
+        if issue_body
+        else ""
+    )
 
 
 def _setup_agent_edit_staging(work_dir: Path) -> Path:

--- a/cai_lib/cmd_helpers_issues.py
+++ b/cai_lib/cmd_helpers_issues.py
@@ -9,6 +9,41 @@ from cai_lib.github import _gh_json, _strip_cost_comments
 from cai_lib.subprocess_utils import _run
 
 
+# ---------------------------------------------------------------------------
+# Files-to-change section parser (shared with plan.py, implement.py,
+# merge.py, and cmd_helpers_git.py).
+# ---------------------------------------------------------------------------
+
+# Case-insensitive "### Files to change" header; section body captured in
+# group 1, bounded by the next "### " heading or end of text.
+_FILES_TO_CHANGE_SECTION_RE = re.compile(
+    r"^###\s+Files\s+to\s+change\s*$\n(.*?)(?=^###\s|\Z)",
+    re.IGNORECASE | re.DOTALL | re.MULTILINE,
+)
+
+# Match backticked path tokens of the form ``path/with.ext`` — requires
+# at least one ``/`` and an extension, so free-standing symbol names
+# (e.g. ``parse_config``) and extensionless bare names are ignored.
+_FILES_TO_CHANGE_PATH_RE = re.compile(
+    r"`([^`\s]+/[^`\s]*\.[A-Za-z0-9]+)`"
+)
+
+
+def _parse_files_to_change(issue_body: str) -> list[str]:
+    """Return the list of relative file paths declared in the issue body's
+    ``### Files to change`` section.
+
+    Paths are extracted from backtick-quoted ``path/with.ext`` tokens.
+    Returns an empty list when the section is absent or contains no paths.
+    """
+    if not issue_body:
+        return []
+    section = _FILES_TO_CHANGE_SECTION_RE.search(issue_body)
+    if not section:
+        return []
+    return _FILES_TO_CHANGE_PATH_RE.findall(section.group(1))
+
+
 def _parse_oob_issues(agent_output: str) -> list[dict]:
     """Extract out-of-scope issue blocks from a review agent's output.
 

--- a/tests/test_cmd_helpers_git.py
+++ b/tests/test_cmd_helpers_git.py
@@ -1,0 +1,155 @@
+"""Tests for the _read_prefetched_files helper and the
+issue_body extension to _work_directory_block in
+cai_lib.cmd_helpers_git."""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cai_lib.cmd_helpers_git import (  # noqa: E402
+    _read_prefetched_files,
+    _work_directory_block,
+)
+from cai_lib.cmd_helpers_issues import _parse_files_to_change  # noqa: E402
+
+
+class TestReadPrefetchedFiles(unittest.TestCase):
+
+    def _make_tmp(self) -> Path:
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(tmp, ignore_errors=True))
+        return tmp
+
+    def test_empty_paths_returns_empty_string(self):
+        tmp = self._make_tmp()
+        result = _read_prefetched_files(tmp, [])
+        self.assertEqual(result, "")
+
+    def test_missing_file_skipped_with_log(self):
+        tmp = self._make_tmp()
+        # Create one real file and reference one missing file.
+        real = tmp / "real.py"
+        real.write_text("# real content\n")
+        stderr_lines = []
+        with patch("sys.stderr") as mock_err:
+            mock_err.write = lambda s: stderr_lines.append(s)
+            result = _read_prefetched_files(tmp, ["missing.py", "real.py"])
+        # The real file's content must appear.
+        self.assertIn("### real.py", result)
+        self.assertIn("# real content", result)
+        # The preload section header must appear.
+        self.assertIn("## Pre-loaded file contents", result)
+
+    def test_per_file_cap_skips_large_file(self):
+        tmp = self._make_tmp()
+        # A file whose estimated token count (len//4) exceeds per_file_token_cap.
+        big = tmp / "big.py"
+        big.write_text("x" * 1000)  # 1000 chars → ~250 tokens
+        small = tmp / "small.py"
+        small.write_text("# small\n")
+
+        stderr_output = []
+        original_stderr = sys.stderr
+        class CapturingStderr:
+            def write(self, s):
+                stderr_output.append(s)
+            def flush(self):
+                pass
+        sys.stderr = CapturingStderr()
+        try:
+            result = _read_prefetched_files(
+                tmp, ["big.py", "small.py"], per_file_token_cap=100
+            )
+        finally:
+            sys.stderr = original_stderr
+
+        # big.py should be skipped; small.py should appear.
+        self.assertNotIn("big.py", result)
+        self.assertIn("### small.py", result)
+        combined = "".join(stderr_output)
+        self.assertIn("too large", combined)
+
+    def test_total_cap_stops_accumulation(self):
+        tmp = self._make_tmp()
+        # Two files each ~100 tokens; total cap of 150 should include first
+        # but skip the second.
+        f1 = tmp / "file1.py"
+        f1.write_text("a" * 400)  # ~100 tokens
+        f2 = tmp / "file2.py"
+        f2.write_text("b" * 400)  # ~100 tokens
+
+        stderr_output = []
+        original_stderr = sys.stderr
+        class CapturingStderr:
+            def write(self, s):
+                stderr_output.append(s)
+            def flush(self):
+                pass
+        sys.stderr = CapturingStderr()
+        try:
+            result = _read_prefetched_files(
+                tmp, ["file1.py", "file2.py"],
+                per_file_token_cap=200, total_token_cap=150,
+            )
+        finally:
+            sys.stderr = original_stderr
+
+        self.assertIn("### file1.py", result)
+        self.assertNotIn("### file2.py", result)
+        combined = "".join(stderr_output)
+        self.assertIn("total cap exceeded", combined)
+
+    def test_issue_body_with_files_to_change_section(self):
+        tmp = self._make_tmp()
+        target = tmp / "cai_lib" / "foo.py"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("def foo(): pass\n")
+
+        issue_body = (
+            "### Files to change\n\n"
+            "- `cai_lib/foo.py`: add bar function\n"
+        )
+        result = _work_directory_block(tmp, issue_body)
+        self.assertIn("## Pre-loaded file contents", result)
+        self.assertIn("### cai_lib/foo.py", result)
+        self.assertIn("def foo(): pass", result)
+
+    def test_issue_body_without_files_to_change_section(self):
+        tmp = self._make_tmp()
+        issue_body = "Some issue body without any files section."
+        result = _work_directory_block(tmp, issue_body)
+        # Should fall back to current behavior — no preload section.
+        self.assertNotIn("## Pre-loaded file contents", result)
+
+    def test_no_issue_body_no_preload(self):
+        tmp = self._make_tmp()
+        result = _work_directory_block(tmp)
+        self.assertNotIn("## Pre-loaded file contents", result)
+
+
+class TestParseFilesToChange(unittest.TestCase):
+
+    def test_parses_paths_from_section(self):
+        body = (
+            "### Files to change\n\n"
+            "- `cai_lib/foo.py`: add thing\n"
+            "- `cai_lib/bar.md`: update docs\n"
+        )
+        paths = _parse_files_to_change(body)
+        self.assertIn("cai_lib/foo.py", paths)
+        self.assertIn("cai_lib/bar.md", paths)
+
+    def test_returns_empty_for_missing_section(self):
+        self.assertEqual(_parse_files_to_change("No section here"), [])
+
+    def test_returns_empty_for_empty_input(self):
+        self.assertEqual(_parse_files_to_change(""), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1196

**Issue:** #1196 — Pre-load "Files to change" contents into downstream agents to eliminate redundant Reads

## PR Summary

### What this fixes
Every auto-improve agent downstream of `cai-refine` was redundantly re-Reading the same source files listed in `### Files to change`, wasting input tokens and adding latency. This PR extends the existing `## Work directory` pre-load mechanism to also embed those file contents in the agent's user message.

### What was changed
- **`cai_lib/cmd_helpers_issues.py`**: Added `_FILES_TO_CHANGE_SECTION_RE`, `_FILES_TO_CHANGE_PATH_RE` regex constants and `_parse_files_to_change(issue_body)` function that parses the `### Files to change` section and returns a list of relative file paths
- **`cai_lib/cmd_helpers_git.py`**: Added `_read_prefetched_files(work_dir, paths, per_file_token_cap=15000, total_token_cap=40000)` that reads paths from a work directory, formats them with `### <relpath>` headers and fenced code blocks, and enforces soft token caps (logs skips to stderr); extended `_work_directory_block(work_dir, issue_body=None)` to append a `## Pre-loaded file contents` section when an issue body is provided
- **`cai_lib/actions/plan.py`**: Moved regex constants to import from `cmd_helpers_issues` (backward compat preserved); updated both `_work_directory_block()` calls to pass `issue.get("body") or ""`
- **`cai_lib/actions/implement.py`**: Updated two `_work_directory_block()` calls to pass issue body
- **`cai_lib/actions/revise.py`**: Updated `_work_directory_block()` call to pass `issue_data.get("body") or ""`
- **`cai_lib/actions/rebase.py`**: Added `_fetch_linked_issue_block` import; passes linked issue block to `_work_directory_block()`
- **`cai_lib/actions/review_pr.py`**: Updated `_work_directory_block()` call to pass `issue_block`
- **`cai_lib/actions/review_docs.py`**: Updated `_work_directory_block()` call to pass `issue_block`
- **`cai_lib/actions/merge.py`**: Added `_work_directory_block` import; prepends work directory block (with preloaded files) to `user_message` after clone succeeds
- **`tests/test_cmd_helpers_git.py`** (new): Unit tests for `_read_prefetched_files` covering empty paths, missing files, per-file cap, total cap, and `_work_directory_block` with/without issue body

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
