### PR TITLE
auto-improve: cost log: split 'category' into structured phase / sub_phase (or add fsm_state)

### DIFF
--- a/.claude/agents/audit/cai-audit-cost-reduction.md
+++ b/.claude/agents/audit/cai-audit-cost-reduction.md
@@ -49,7 +49,12 @@ helper's own agent file for its full input/output contract.
 A table or JSON excerpt of cost rows from `/var/log/cai/cai-cost.jsonl`,
 pre-filtered to only the agents declared in this module. Columns:
 `timestamp`, `agent`, `model`, `input_tokens`, `output_tokens`,
-`cache_creation_tokens`, `cache_read_tokens`, `cost_usd`.
+`cache_creation_tokens`, `cache_read_tokens`, `cost_usd`, and an optional
+`fsm_state` (issue #1203: `.name` of an `IssueState` or `PRState` enum member
+stamped by the dispatcher on every handler-produced row; non-FSM call sites
+— rescue, unblock, dup-check, audit, init — omit this field). When the
+summary includes a **By FSM state** section, prefer it over re-parsing the
+free-form `category` field to reason about funnel-stage spend.
 
 Use this section as your primary cost signal. Every finding you raise must
 cite one or more rows from this table as motivation.

--- a/.claude/agents/utility/cai-cost-optimize.md
+++ b/.claude/agents/utility/cai-cost-optimize.md
@@ -17,9 +17,18 @@ actually reduced costs.
 
 The user message contains:
 
-- `## Cost data` — 14-day cost summary with per-category totals, top
-  invocations, and a per-agent WoW breakdown table (last 7d vs prior
-  7d, WoW Δ%, cache hit %)
+- `## Cost data` — 14-day cost summary with per-category totals, an
+  optional **By FSM state** section (issue #1203: funnel-position
+  totals derived from the optional `fsm_state` row field stamped by
+  the dispatcher on every handler-produced cost row), top invocations,
+  and a per-agent WoW breakdown table (last 7d vs prior 7d, WoW Δ%,
+  cache hit %). Prefer the **By FSM state** section over re-parsing
+  the free-form `category` field when you need to reason about
+  funnel-stage spend — the `fsm_state` value is the `.name` of an
+  `IssueState` or `PRState` enum member (e.g. `REFINING`,
+  `PLANNING`, `IN_PROGRESS`, `REVIEWING_CODE`). Rows produced
+  outside a dispatched handler (rescue, unblock, dup-check, audit,
+  init) omit `fsm_state` and land in the `(none)` bucket.
 - `## Previous proposals` — memory from prior runs (proposals made,
   their statuses, and any evaluations)
 

--- a/cai.py
+++ b/cai.py
@@ -312,7 +312,8 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Number of most-expensive invocations to list (default: 10)",
     )
     cost_parser.add_argument(
-        "--by", choices=["category", "agent", "day"], default="category",
+        "--by", choices=["category", "agent", "day", "fsm_state"],
+        default="category",
         help="Aggregation grouping (default: category)",
     )
 

--- a/cai_lib/audit/cost.py
+++ b/cai_lib/audit/cost.py
@@ -130,10 +130,11 @@ def _build_cost_summary(days: int = 7, top_n: int = 10) -> str:
     cost-reduction audit user message.
 
     Returns an empty string if no cost rows exist for the window.
-    Otherwise emits a section with per-category aggregates and the
-    top-N most expensive individual invocations, so the audit agent
-    can spot cost outliers (a single invocation that dwarfs the
-    median, or a category that dominates total spend).
+    Otherwise emits a section with per-category aggregates, per-FSM-state
+    aggregates (when rows carry the optional #1203 ``fsm_state`` field),
+    and the top-N most expensive individual invocations, so the audit
+    agent can spot cost outliers (a single invocation that dwarfs the
+    median, or a funnel stage that dominates total spend).
     """
     rows = _load_cost_log(days=days)
     if not rows:
@@ -163,6 +164,30 @@ def _build_cost_summary(days: int = 7, top_n: int = 10) -> str:
             f"({share:.1f}%) | ${mean:.4f} |"
         )
 
+    # Per-FSM-state aggregates (issue #1203). Rows written by non-FSM
+    # call sites omit ``fsm_state``; those land in the ``(none)`` bucket
+    # so the section stays faithful to the data.
+    fsm_states: dict[str, dict] = {}
+    for r in rows:
+        fs = r.get("fsm_state") or "(none)"
+        cost = r.get("cost_usd") or 0.0
+        try:
+            cost = float(cost)
+        except (TypeError, ValueError):
+            cost = 0.0
+        bucket = fsm_states.setdefault(fs, {"calls": 0, "cost": 0.0})
+        bucket["calls"] += 1
+        bucket["cost"] += cost
+
+    fsm_lines = []
+    for fs, b in sorted(fsm_states.items(), key=lambda kv: -kv[1]["cost"]):
+        share = (b["cost"] / grand_total * 100.0) if grand_total else 0.0
+        mean = b["cost"] / b["calls"] if b["calls"] else 0.0
+        fsm_lines.append(
+            f"| {fs} | {b['calls']} | ${b['cost']:.4f} "
+            f"({share:.1f}%) | ${mean:.4f} |"
+        )
+
     # Top-N most expensive individual invocations.
     top = sorted(
         rows,
@@ -186,6 +211,11 @@ def _build_cost_summary(days: int = 7, top_n: int = 10) -> str:
         "| category | calls | total cost (share) | mean cost |\n"
         "|---|---|---|---|\n"
         + "\n".join(cat_lines)
+        + "\n\n"
+        "### By FSM state\n\n"
+        "| fsm_state | calls | total cost (share) | mean cost |\n"
+        "|---|---|---|---|\n"
+        + "\n".join(fsm_lines)
         + "\n\n"
         f"### Top {len(top_lines)} most expensive individual invocations\n\n"
         "| ts | category | agent | model | cost | turns | tokens |\n"

--- a/cai_lib/cmd_misc.py
+++ b/cai_lib/cmd_misc.py
@@ -293,6 +293,11 @@ def cmd_cost_report(args) -> int:
         if args.by == "day":
             ts = r.get("ts") or ""
             return ts.split("T", 1)[0] or "(unknown)"
+        if args.by == "fsm_state":
+            # Issue #1203: non-FSM call sites omit ``fsm_state``; they
+            # land in ``(none)`` so grouping stays honest about which
+            # rows were produced inside vs outside a dispatched handler.
+            return r.get("fsm_state") or "(none)"
         return "(unknown)"
 
     groups: dict[str, dict] = {}

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -52,6 +52,7 @@ from cai_lib.github import (
     open_blockers,
 )
 from cai_lib.issues import list_sub_issues
+from cai_lib.subprocess_utils import set_current_fsm_state
 
 
 # ---------------------------------------------------------------------------
@@ -756,7 +757,11 @@ def drive_issue(issue: dict) -> int:
         f"[cai dispatch] issue #{issue_number} at {state.name} → "
         f"{handler.__name__}", flush=True,
     )
-    rc = handler(issue)
+    # Issue #1203: stamp the FSM state on every cost-log row produced by
+    # the handler (via _run_claude_p) so downstream readers can group by
+    # funnel position without parsing the free-form ``category`` field.
+    with set_current_fsm_state(state.name):
+        rc = handler(issue)
     if isinstance(rc, HandlerResult):
         ok, _ = _driver_fire(
             issue_number, rc,
@@ -809,7 +814,11 @@ def drive_pr(pr: dict) -> int:
         f"[cai dispatch] PR #{pr_number} at {state.name} → "
         f"{handler.__name__}", flush=True,
     )
-    result = handler(pr)
+    # Issue #1203: stamp the FSM state on every cost-log row produced by
+    # the handler (via _run_claude_p) so downstream readers can group by
+    # funnel position without parsing the free-form ``category`` field.
+    with set_current_fsm_state(state.name):
+        result = handler(pr)
     ok, _ = _driver_fire(
         pr_number, result,
         is_pr=True, current_pr=pr,
@@ -870,7 +879,12 @@ def dispatch_issue(issue_number: int) -> int:
               flush=True)
         return 0
     try:
-        rc = handler(issue)
+        # Issue #1203: stamp the FSM state on every cost-log row the
+        # handler produces so downstream readers can group by funnel
+        # position without parsing the free-form ``category`` field.
+        # Covers MERGED / HUMAN_NEEDED handlers that bypass ``drive_issue``.
+        with set_current_fsm_state(state.name):
+            rc = handler(issue)
         if isinstance(rc, HandlerResult):
             ok, _ = _driver_fire(
                 issue_number, rc,
@@ -952,7 +966,12 @@ def dispatch_pr(pr_number: int) -> int:
               flush=True)
         return 0
     try:
-        result = handler(pr)
+        # Issue #1203: stamp the FSM state on every cost-log row the
+        # handler produces so downstream readers can group by funnel
+        # position without parsing the free-form ``category`` field.
+        # Covers PR_HUMAN_NEEDED handlers that bypass ``drive_pr``.
+        with set_current_fsm_state(state.name):
+            result = handler(pr)
         if isinstance(result, HandlerResult):
             ok, _ = _driver_fire(
                 pr_number, result,

--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import json
 import shutil
 import socket
 import subprocess
 import sys
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -40,6 +42,44 @@ _CLI_PATH = shutil.which("claude")
 # placeholder "Check stderr output for details".
 _CAPTURED_STDERR_MAX_LINES = 200
 _CAPTURED_STDERR_MAX_CHARS = 4000
+
+
+# Issue #1203: per-invocation FSM state stamp for cost-log rows.
+#
+# The dispatcher (``cai_lib/dispatcher.py``) wraps each handler call with
+# ``set_current_fsm_state(state.name)`` so that any ``_run_claude_p`` call
+# made inside the handler records the funnel position (e.g. ``"REFINING"``,
+# ``"PLANNING"``, ``"IN_PROGRESS"``, ``"REVIEWING_CODE"``) into the row's
+# optional ``fsm_state`` key. Non-FSM call sites (``cmd_rescue``,
+# ``cmd_unblock``, ``dup_check``, ``audit/runner.py``, ``cmd_misc.init``)
+# leave the contextvar unset; those rows simply omit the key, preserving
+# back-compat for readers that only know ``category``.
+_CURRENT_FSM_STATE: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "cai_current_fsm_state", default=None,
+)
+
+
+@contextmanager
+def set_current_fsm_state(name: str | None):
+    """Set the FSM state stamp for every ``_run_claude_p`` call in the block.
+
+    ``name`` should be the ``.name`` of an :class:`IssueState` or
+    :class:`PRState` enum member (e.g. ``"REFINING"``). Passing ``None``
+    explicitly clears the stamp for the scoped block.
+
+    Usage::
+
+        with set_current_fsm_state(state.name):
+            handler(issue)
+
+    The stamp is scoped by ``contextvars.Token`` so nested wraps restore
+    the previous value cleanly on exit.
+    """
+    token = _CURRENT_FSM_STATE.set(name)
+    try:
+        yield
+    finally:
+        _CURRENT_FSM_STATE.reset(token)
 
 
 def _make_stderr_sink(buf: list[str]):
@@ -582,6 +622,13 @@ def _run_claude_p(
         row["parent_model"] = parent_model
     if subagent_counts:
         row["subagents"] = dict(subagent_counts)
+    # Issue #1203: stamp the FSM funnel position when the dispatcher has
+    # set it. Non-FSM call sites (cmd_rescue, cmd_unblock, dup_check,
+    # audit/runner.py, cmd_misc.init) leave the contextvar unset; the
+    # key is omitted in that case, preserving pre-#1203 row shape.
+    fsm_state = _CURRENT_FSM_STATE.get()
+    if fsm_state:
+        row["fsm_state"] = fsm_state
     log_cost(row)
 
     # Post a per-target cost-attribution comment on the issue/PR the

--- a/tests/test_audit_cost.py
+++ b/tests/test_audit_cost.py
@@ -159,5 +159,61 @@ class TestLoadCostLogAggregation(unittest.TestCase):
             self.assertEqual(rows, [])
 
 
+class TestBuildCostSummaryFsmState(unittest.TestCase):
+    """Issue #1203: ``_build_cost_summary`` must emit a ``### By FSM state``
+    section that aggregates rows by the optional ``fsm_state`` field and
+    handles rows missing the field by bucketing them under ``(none)``."""
+
+    _RECENT_TS_A = "2099-01-01T00:00:00Z"
+    _RECENT_TS_B = "2099-01-02T00:00:00Z"
+    _RECENT_TS_C = "2099-01-03T00:00:00Z"
+
+    def _write_rows(self, path: Path, rows: list[dict]) -> None:
+        path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+    def test_summary_groups_by_fsm_state_with_none_bucket(self):
+        from cai_lib.audit.cost import _build_cost_summary
+
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            self._write_rows(local, [
+                {"ts": self._RECENT_TS_A, "category": "refine",
+                 "cost_usd": 0.10, "fsm_state": "REFINING"},
+                {"ts": self._RECENT_TS_B, "category": "plan.plan",
+                 "cost_usd": 0.20, "fsm_state": "PLANNING"},
+                {"ts": self._RECENT_TS_C, "category": "rescue",
+                 "cost_usd": 0.05},  # no fsm_state — non-FSM call site
+            ])
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                summary = _build_cost_summary(days=3650, top_n=3)
+
+        self.assertIn("### By FSM state", summary)
+        self.assertIn("| fsm_state | calls | total cost (share) | mean cost |",
+                      summary)
+        # The three distinct buckets must all appear.
+        self.assertIn("| REFINING | 1 |", summary)
+        self.assertIn("| PLANNING | 1 |", summary)
+        self.assertIn("| (none) | 1 |", summary)
+
+    def test_summary_empty_when_no_rows(self):
+        """Back-compat: no rows → empty string (no FSM section emitted)."""
+        from cai_lib.audit.cost import _build_cost_summary
+
+        with tempfile.TemporaryDirectory() as tmp:
+            missing_local = Path(tmp) / "missing.jsonl"
+            missing_agg = Path(tmp) / "missing-agg"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", missing_local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                summary = _build_cost_summary(days=7, top_n=3)
+
+        self.assertEqual(summary, "")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -402,5 +402,85 @@ class TestCostCommentKwargsBackwardsCompat(unittest.TestCase):
         self.assertEqual(proc2.returncode, 0)
 
 
+class TestFsmStateStamping(unittest.TestCase):
+    """Issue #1203: ``_run_claude_p`` must stamp the current FSM state
+    (set by the dispatcher via ``set_current_fsm_state``) onto each
+    cost-log row under the optional ``fsm_state`` key, and omit the
+    key entirely when the contextvar is unset."""
+
+    def test_fsm_state_stamped_when_contextvar_set(self):
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import (
+            _run_claude_p, set_current_fsm_state,
+        )
+
+        captured: list[dict] = []
+
+        def _fake_log_cost(row: dict) -> None:
+            captured.append(dict(row))
+
+        msg = _mk_result(result="ok", total_cost_usd=0.05)
+        with patch.object(subprocess_utils, "query", _mock_query(msg)), \
+             patch.object(subprocess_utils, "log_cost", _fake_log_cost):
+            with set_current_fsm_state("REFINING"):
+                _run_claude_p(
+                    ["claude", "-p", "--agent", "cai-refine"],
+                    category="refine", agent="cai-refine",
+                )
+
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(captured[0].get("fsm_state"), "REFINING")
+
+    def test_fsm_state_omitted_when_contextvar_unset(self):
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        captured: list[dict] = []
+
+        def _fake_log_cost(row: dict) -> None:
+            captured.append(dict(row))
+
+        msg = _mk_result(result="ok", total_cost_usd=0.05)
+        with patch.object(subprocess_utils, "query", _mock_query(msg)), \
+             patch.object(subprocess_utils, "log_cost", _fake_log_cost):
+            _run_claude_p(
+                ["claude", "-p", "--agent", "cai-audit-health"],
+                category="audit", agent="cai-audit-health",
+            )
+
+        self.assertEqual(len(captured), 1)
+        self.assertNotIn("fsm_state", captured[0])
+
+    def test_fsm_state_reset_after_block_exits(self):
+        """Nested/sequential blocks must restore the prior value on exit."""
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import (
+            _run_claude_p, set_current_fsm_state,
+        )
+
+        captured: list[dict] = []
+
+        def _fake_log_cost(row: dict) -> None:
+            captured.append(dict(row))
+
+        msg = _mk_result(result="ok", total_cost_usd=0.01)
+        with patch.object(subprocess_utils, "query", _mock_query(msg)), \
+             patch.object(subprocess_utils, "log_cost", _fake_log_cost):
+            with set_current_fsm_state("PLANNING"):
+                _run_claude_p(
+                    ["claude", "-p", "--agent", "cai-plan"],
+                    category="plan.plan", agent="cai-plan",
+                )
+            # Outside the block, the stamp must be cleared.
+            _run_claude_p(
+                ["claude", "-p", "--agent", "cai-plan"],
+                category="plan.plan", agent="cai-plan",
+            )
+
+        self.assertEqual(len(captured), 2)
+        self.assertEqual(captured[0].get("fsm_state"), "PLANNING")
+        self.assertNotIn("fsm_state", captured[1])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1203

**Issue:** #1203 — cost log: split 'category' into structured phase / sub_phase (or add fsm_state)

## PR Summary

### What this fixes
Cost-log rows had no structured FSM funnel position — only a free-form `category` string — making it impossible to reliably group spend by pipeline stage (refining, planning, implement, review) without string parsing. Issue #1203 requested adding a `fsm_state` field using Option B (contextvar stamping) so downstream readers can slice by funnel position.

### What was changed
- **`cai_lib/subprocess_utils.py`**: Added `contextvars` + `contextmanager` imports; added `_CURRENT_FSM_STATE` contextvar and `set_current_fsm_state` context-manager helper; stamped `row["fsm_state"]` in `_run_claude_p` (omitted when contextvar is unset, preserving back-compat)
- **`cai_lib/dispatcher.py`**: Imported `set_current_fsm_state`; wrapped `handler(issue/pr)` calls in all 4 dispatcher entry points (`drive_issue`, `drive_pr`, `dispatch_issue`, `dispatch_pr`) with `set_current_fsm_state(state.name)`
- **`cai_lib/audit/cost.py`**: Extended `_build_cost_summary` to include a `### By FSM state` aggregation table alongside the existing per-category table
- **`cai_lib/cmd_misc.py`**: Added `fsm_state` branch to `group_key` in `cmd_cost_report`
- **`cai.py`**: Added `"fsm_state"` to `--by` choices on the `cost-report` subparser
- **`.cai-staging/agents/utility/cai-cost-optimize.md`**: Documented the optional `fsm_state` field and the "By FSM state" summary section
- **`.cai-staging/agents/audit/cai-audit-cost-reduction.md`**: Documented the optional `fsm_state` field
- **`tests/test_subprocess_utils.py`**: Added `TestFsmStateStamping` (3 tests verifying stamping, omission, and reset)
- **`tests/test_audit_cost.py`**: Added `TestBuildCostSummaryFsmState` (2 tests verifying FSM grouping and empty-rows back-compat)

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
