### PR TITLE
auto-improve: cost log: pre-compute cache_hit_rate once at write time

### DIFF
--- a/.claude/agents/utility/cai-cost-optimize.md
+++ b/.claude/agents/utility/cai-cost-optimize.md
@@ -20,15 +20,20 @@ The user message contains:
 - `## Cost data` — 14-day cost summary with per-category totals, an
   optional **By FSM state** section (issue #1203: funnel-position
   totals derived from the optional `fsm_state` row field stamped by
-  the dispatcher on every handler-produced cost row), top invocations,
-  and a per-agent WoW breakdown table (last 7d vs prior 7d, WoW Δ%,
-  cache hit %). Prefer the **By FSM state** section over re-parsing
-  the free-form `category` field when you need to reason about
-  funnel-stage spend — the `fsm_state` value is the `.name` of an
-  `IssueState` or `PRState` enum member (e.g. `REFINING`,
-  `PLANNING`, `IN_PROGRESS`, `REVIEWING_CODE`). Rows produced
-  outside a dispatched handler (rescue, unblock, dup-check, audit,
-  init) omit `fsm_state` and land in the `(none)` bucket.
+  the dispatcher on every handler-produced cost row), top invocations
+  with a `hit%` column populated from each row's pre-computed
+  `cache_hit_rate` field (a fraction in `[0.0, 1.0]`, issue #1205:
+  `cache_read / (cache_read + cache_create + input_tokens)` —
+  aggregate across all models invoked for that row; rows predating
+  the change legitimately render as `-`), and a per-agent WoW
+  breakdown table (last 7d vs prior 7d, WoW Δ%). Prefer the
+  **By FSM state** section over re-parsing the free-form `category`
+  field when you need to reason about funnel-stage spend — the
+  `fsm_state` value is the `.name` of an `IssueState` or `PRState`
+  enum member (e.g. `REFINING`, `PLANNING`, `IN_PROGRESS`,
+  `REVIEWING_CODE`). Rows produced outside a dispatched handler
+  (rescue, unblock, dup-check, audit, init) omit `fsm_state` and
+  land in the `(none)` bucket.
 - `## Previous proposals` — memory from prior runs (proposals made,
   their statuses, and any evaluations)
 

--- a/cai_lib/audit/cost.py
+++ b/cai_lib/audit/cost.py
@@ -197,11 +197,18 @@ def _build_cost_summary(days: int = 7, top_n: int = 10) -> str:
     top_lines = []
     for r in top:
         cost = float(r.get("cost_usd") or 0.0)
+        # Issue #1205: cite the pre-computed ``cache_hit_rate`` field
+        # written by ``_run_claude_p`` (aggregate rate over
+        # cache_read + cache_creation + input tokens). Rows predating
+        # the change legitimately omit the field and render as ``-``.
+        hit = r.get("cache_hit_rate")
+        hit_str = f"{hit * 100:.1f}%" if isinstance(hit, (int, float)) else "-"
         top_lines.append(
             f"| {r.get('ts', '')} | {r.get('category', '')} | "
             f"{r.get('agent', '')} | {_primary_model(r)} | ${cost:.4f} | "
             f"{r.get('num_turns', '')} | "
-            f"{(r.get('input_tokens') or 0) + (r.get('output_tokens') or 0)} |"
+            f"{(r.get('input_tokens') or 0) + (r.get('output_tokens') or 0)} | "
+            f"{hit_str} |"
         )
 
     return (
@@ -218,8 +225,8 @@ def _build_cost_summary(days: int = 7, top_n: int = 10) -> str:
         + "\n".join(fsm_lines)
         + "\n\n"
         f"### Top {len(top_lines)} most expensive individual invocations\n\n"
-        "| ts | category | agent | model | cost | turns | tokens |\n"
-        "|---|---|---|---|---|---|---|\n"
+        "| ts | category | agent | model | cost | turns | tokens | hit% |\n"
+        "|---|---|---|---|---|---|---|---|\n"
         + "\n".join(top_lines)
         + "\n"
     )

--- a/cai_lib/cmd_misc.py
+++ b/cai_lib/cmd_misc.py
@@ -304,6 +304,8 @@ def cmd_cost_report(args) -> int:
     grand_total = 0.0
     grand_in = 0
     grand_out = 0
+    grand_cr = 0
+    grand_cc = 0
     for r in rows:
         key = group_key(r)
         try:
@@ -312,16 +314,26 @@ def cmd_cost_report(args) -> int:
             cost = 0.0
         in_t = int(r.get("input_tokens") or 0)
         out_t = int(r.get("output_tokens") or 0)
+        # Issue #1205: sum the cache-read / cache-creation token fields
+        # per group so we can render a weighted hit% column without
+        # re-deriving it from individual rows.
+        cr_t = int(r.get("cache_read_input_tokens") or 0)
+        cc_t = int(r.get("cache_creation_input_tokens") or 0)
         bucket = groups.setdefault(
-            key, {"calls": 0, "cost": 0.0, "in": 0, "out": 0},
+            key, {"calls": 0, "cost": 0.0, "in": 0, "out": 0,
+                  "cr": 0, "cc": 0},
         )
         bucket["calls"] += 1
         bucket["cost"] += cost
         bucket["in"] += in_t
         bucket["out"] += out_t
+        bucket["cr"] += cr_t
+        bucket["cc"] += cc_t
         grand_total += cost
         grand_in += in_t
         grand_out += out_t
+        grand_cr += cr_t
+        grand_cc += cc_t
 
     # Header.
     print(
@@ -337,22 +349,34 @@ def cmd_cost_report(args) -> int:
     key_width = max(key_width, 12)
     header = (
         f"{args.by:<{key_width}}  {'calls':>6}  {'cost':>10}  "
-        f"{'share':>7}  {'mean':>10}  {'in_tok':>10}  {'out_tok':>10}"
+        f"{'share':>7}  {'mean':>10}  {'in_tok':>10}  {'out_tok':>10}  "
+        f"{'hit%':>6}"
     )
     print(header)
     print("-" * len(header))
     for key, b in sorted_groups:
         share = (b["cost"] / grand_total * 100.0) if grand_total else 0.0
         mean = b["cost"] / b["calls"] if b["calls"] else 0.0
+        # Issue #1205: weighted hit% over the group's summed cache-read,
+        # cache-creation and input tokens. Prints ``-`` when no cache or
+        # input tokens were observed (avoids a misleading 0.0% for
+        # groups that never touched the cache path).
+        denom = b["cr"] + b["cc"] + b["in"]
+        hit_str = f"{b['cr'] / denom * 100:.1f}%" if denom else "-"
         print(
             f"{key:<{key_width}}  {b['calls']:>6}  ${b['cost']:>9.4f}  "
-            f"{share:>6.1f}%  ${mean:>9.4f}  {b['in']:>10}  {b['out']:>10}"
+            f"{share:>6.1f}%  ${mean:>9.4f}  {b['in']:>10}  {b['out']:>10}  "
+            f"{hit_str:>6}"
         )
+    grand_denom = grand_cr + grand_cc + grand_in
+    grand_hit_str = (
+        f"{grand_cr / grand_denom * 100:.1f}%" if grand_denom else "-"
+    )
     print(
         f"{'TOTAL':<{key_width}}  {len(rows):>6}  ${grand_total:>9.4f}  "
         f"{100.0:>6.1f}%  "
         f"${(grand_total / len(rows) if rows else 0):>9.4f}  "
-        f"{grand_in:>10}  {grand_out:>10}"
+        f"{grand_in:>10}  {grand_out:>10}  {grand_hit_str:>6}"
     )
 
     # Top-N most expensive invocations.
@@ -364,7 +388,8 @@ def cmd_cost_report(args) -> int:
     print(f"\n--- Top {len(top)} most expensive invocations ---\n")
     top_header = (
         f"{'ts':<20}  {'category':<14}  {'agent':<20}  "
-        f"{'cost':>10}  {'turns':>5}  {'in_tok':>10}  {'out_tok':>10}"
+        f"{'cost':>10}  {'turns':>5}  {'in_tok':>10}  {'out_tok':>10}  "
+        f"{'hit%':>6}"
     )
     print(top_header)
     print("-" * len(top_header))
@@ -379,9 +404,16 @@ def cmd_cost_report(args) -> int:
         turns = r.get("num_turns") or 0
         in_t = int(r.get("input_tokens") or 0)
         out_t = int(r.get("output_tokens") or 0)
+        # Issue #1205: cite the pre-computed ``cache_hit_rate`` field
+        # written by ``_run_claude_p``. Rows predating the change omit
+        # the field and render as ``-``.
+        hit = r.get("cache_hit_rate")
+        hit_str = (
+            f"{hit * 100:.1f}%" if isinstance(hit, (int, float)) else "-"
+        )
         print(
             f"{ts:<20}  {cat:<14}  {ag:<20}  ${cost:>9.4f}  "
-            f"{turns:>5}  {in_t:>10}  {out_t:>10}"
+            f"{turns:>5}  {in_t:>10}  {out_t:>10}  {hit_str:>6}"
         )
 
     # Last-hour snapshot — cost per agent. Useful for spotting a

--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -616,7 +616,35 @@ def _run_claude_p(
         "is_error": bool(result.is_error),
     }
     row.update(flat)
+    # Issue #1205: pre-compute aggregate cache hit rate once at write
+    # time so every downstream reader (cost-report, cost-optimize, the
+    # audit/cost.py summary) cites a single authoritative number instead
+    # of re-deriving it (and getting the formula subtly wrong — e.g.
+    # forgetting ``cache_creation_input_tokens`` or including
+    # ``output_tokens`` in the denominator). Rows whose denominator is
+    # zero (no cache tokens and no input tokens observed) omit the
+    # field entirely so legacy/empty-usage rows stay byte-identical to
+    # the pre-#1205 shape.
+    cr = flat.get("cache_read_input_tokens") or 0
+    cc = flat.get("cache_creation_input_tokens") or 0
+    it = flat.get("input_tokens") or 0
+    denom = cr + cc + it
+    if denom > 0:
+        row["cache_hit_rate"] = round(cr / denom, 4)
     if models:
+        # Per-model hit rate using the camelCase keys the SDK emits
+        # inside ``model_usage``. Mutates ``models`` in place; skips
+        # entries whose denominator is zero (same omission rule as the
+        # aggregate field). A non-dict ``mu`` is defensively ignored.
+        for _m, mu in models.items():
+            if not isinstance(mu, dict):
+                continue
+            m_cr = mu.get("cacheReadInputTokens") or 0
+            m_cc = mu.get("cacheCreationInputTokens") or 0
+            m_it = mu.get("inputTokens") or 0
+            m_denom = m_cr + m_cc + m_it
+            if m_denom > 0:
+                mu["cacheHitRate"] = round(m_cr / m_denom, 4)
         row["models"] = models
     if parent_model:
         row["parent_model"] = parent_model

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -482,5 +482,131 @@ class TestFsmStateStamping(unittest.TestCase):
         self.assertNotIn("fsm_state", captured[1])
 
 
+class TestCacheHitRateAnnotation(unittest.TestCase):
+    """Issue #1205: ``_run_claude_p`` must pre-compute a single
+    authoritative ``cache_hit_rate`` value on each cost-log row
+    (aggregate) and a ``cacheHitRate`` value inside each ``models[m]``
+    entry (per-model). Rows with no cache/input tokens observed must
+    omit the field so legacy rows stay byte-identical."""
+
+    def test_cache_hit_rate_set_when_tokens_present(self):
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        captured: list[dict] = []
+
+        def _fake_log_cost(row: dict) -> None:
+            captured.append(dict(row))
+
+        # 50 cache_read + 25 cache_create + 25 input → denom=100, hit=0.5.
+        usage = {
+            "input_tokens": 25,
+            "output_tokens": 10,
+            "cache_creation_input_tokens": 25,
+            "cache_read_input_tokens": 50,
+        }
+        msg = _mk_result(
+            usage=usage, result="ok", total_cost_usd=0.01,
+        )
+        with patch.object(subprocess_utils, "query", _mock_query(msg)), \
+             patch.object(subprocess_utils, "log_cost", _fake_log_cost):
+            _run_claude_p(
+                ["claude", "-p", "--agent", "cai-plan"],
+                category="plan.plan", agent="cai-plan",
+            )
+
+        self.assertEqual(len(captured), 1)
+        self.assertIn("cache_hit_rate", captured[0])
+        self.assertAlmostEqual(captured[0]["cache_hit_rate"], 0.5, places=4)
+
+    def test_cache_hit_rate_omitted_when_denominator_zero(self):
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        captured: list[dict] = []
+
+        def _fake_log_cost(row: dict) -> None:
+            captured.append(dict(row))
+
+        # No input_tokens, no cache_* tokens — denom=0 → key must be
+        # absent so legacy callers (audit/cost.py, cost-report) can
+        # still rely on ``r.get("cache_hit_rate") is None`` as the
+        # "missing" signal.
+        usage = {"output_tokens": 5}
+        msg = _mk_result(
+            usage=usage, result="ok", total_cost_usd=0.01,
+        )
+        with patch.object(subprocess_utils, "query", _mock_query(msg)), \
+             patch.object(subprocess_utils, "log_cost", _fake_log_cost):
+            _run_claude_p(
+                ["claude", "-p", "--agent", "cai-plan"],
+                category="plan.plan", agent="cai-plan",
+            )
+
+        self.assertEqual(len(captured), 1)
+        self.assertNotIn("cache_hit_rate", captured[0])
+
+    def test_per_model_cache_hit_rate_stamped(self):
+        """Each ``models[m]`` entry gets a ``cacheHitRate`` when its
+        per-model cache/input tokens are non-zero. Entries whose
+        denominator is zero are skipped (no key written)."""
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        captured: list[dict] = []
+
+        def _fake_log_cost(row: dict) -> None:
+            captured.append(dict(row))
+
+        usage = {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cache_read_input_tokens": 30,
+            "cache_creation_input_tokens": 10,
+        }
+        msg = _mk_result(
+            usage=usage, result="ok", total_cost_usd=0.01,
+        )
+
+        # Patch ``query`` to yield a message whose ResultMessage.model_usage
+        # carries two model entries: one with tokens, one with zero
+        # denom so we can assert the per-model skip rule.
+        async def _gen(*, prompt, options=None, transport=None):
+            # Attach model_usage on the instance so the parser picks
+            # it up (ResultMessage may not accept it via constructor).
+            msg.model_usage = {
+                "claude-sonnet-4-6": {
+                    "inputTokens": 10,
+                    "cacheReadInputTokens": 30,
+                    "cacheCreationInputTokens": 10,
+                    "outputTokens": 5,
+                },
+                "claude-haiku-4-5-20251001": {
+                    "inputTokens": 0,
+                    "cacheReadInputTokens": 0,
+                    "cacheCreationInputTokens": 0,
+                    "outputTokens": 0,
+                },
+            }
+            yield msg
+
+        with patch.object(subprocess_utils, "query", _gen), \
+             patch.object(subprocess_utils, "log_cost", _fake_log_cost):
+            _run_claude_p(
+                ["claude", "-p", "--agent", "cai-plan"],
+                category="plan.plan", agent="cai-plan",
+            )
+
+        self.assertEqual(len(captured), 1)
+        models = captured[0].get("models") or {}
+        sonnet = models.get("claude-sonnet-4-6") or {}
+        haiku = models.get("claude-haiku-4-5-20251001") or {}
+        # 30 / (30 + 10 + 10) = 0.6
+        self.assertIn("cacheHitRate", sonnet)
+        self.assertAlmostEqual(sonnet["cacheHitRate"], 0.6, places=4)
+        # Zero-denom model must be skipped (no key added).
+        self.assertNotIn("cacheHitRate", haiku)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1205

**Issue:** #1205 — cost log: pre-compute cache_hit_rate once at write time

## PR Summary

### What this fixes
Cost-log rows in `cai-cost.jsonl` had no pre-computed cache hit rate field, requiring every downstream reader to re-derive it from four token fields — with the risk of formula divergence (wrong denominator, forgotten `cache_creation_input_tokens`, etc.). This change adds a single authoritative `cache_hit_rate` field written once at log time, and surfaces it as a `hit%` column in all cost-reporting surfaces.

### What was changed
- **`cai_lib/subprocess_utils.py`**: In `_run_claude_p`, after `row.update(flat)`, computes `cache_hit_rate = round(cache_read / (cache_read + cache_create + input_tokens), 4)` and writes it to the row when the denominator is non-zero. Also stamps `cacheHitRate` into each `models[m]` dict entry using camelCase SDK keys. Rows with no token data omit both fields (legacy rows stay byte-identical).
- **`cai_lib/audit/cost.py`**: Adds a `hit%` column to the Top-N invocations table in `_build_cost_summary`, rendering the pre-computed `cache_hit_rate` as `"42.3%"` or `"-"` when absent.
- **`cai_lib/cmd_misc.py`**: Adds `grand_cr`/`grand_cc` accumulators and per-bucket `cr`/`cc` fields to `cmd_cost_report`'s grouping loop, then appends a `hit%` column to the per-group table (including the TOTAL row) and the Top-N invocations table.
- **`tests/test_subprocess_utils.py`**: New `TestCacheHitRateAnnotation` class with three tests: non-zero denominator sets `cache_hit_rate` to the expected ratio; zero denominator omits the field; per-model `cacheHitRate` is stamped into `models[m]` entries when tokens exist (with zero-denom model skipped).
- **`.claude/agents/utility/cai-cost-optimize.md`** (via staging): Updated the `## What you receive` bullet to describe the `cache_hit_rate` field precisely (fraction in `[0.0, 1.0]`, formula, legacy `-` rendering) instead of the vague "cache hit %".

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
