### PR TITLE
fix: mirror cai revise / cai merge cost comments onto linked issue

### DIFF
--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -1067,6 +1067,8 @@ def handle_merge(pr: dict) -> HandlerResult:
             input=user_message,
             target_kind="pr",
             target_number=pr_number,
+            extra_target_kind="issue",
+            extra_target_number=issue_number,
         )
     finally:
         if work_dir.exists():

--- a/cai_lib/actions/revise.py
+++ b/cai_lib/actions/revise.py
@@ -165,6 +165,7 @@ _FILTER_DIFF_MAX_CHARS = 20000
 def _filter_comments_with_haiku(
     all_comments: list[dict],
     pr_number: int,
+    issue_number: int,
 ) -> list[dict]:
     """Filter PR comments using the cai-comment-filter haiku agent.
 
@@ -172,6 +173,10 @@ def _filter_comments_with_haiku(
     the agent judges to be genuinely unresolved. On agent failure,
     returns all non-bot comments (conservative fallback — better to
     over-process than silently drop human requests).
+
+    ``issue_number`` is the linked ``auto-improve/<N>-*`` issue; the
+    cost-attribution comment is mirrored onto it so humans scanning
+    the issue see every agent invocation's spend, not just the PR's.
     """
     if not all_comments:
         return []
@@ -214,6 +219,8 @@ def _filter_comments_with_haiku(
         cwd="/app",
         target_kind="pr",
         target_number=pr_number,
+        extra_target_kind="issue",
+        extra_target_number=issue_number,
     )
 
     if result.returncode != 0 or not (result.stdout or "").strip():
@@ -441,7 +448,9 @@ def handle_revise(pr: dict) -> HandlerResult:
     line_comments = _fetch_review_comments(pr_detail["number"])
     all_comments = issue_comments + line_comments
     # Filter to genuinely unresolved comments using the haiku agent.
-    unaddressed = _filter_comments_with_haiku(all_comments, pr_detail["number"])
+    unaddressed = _filter_comments_with_haiku(
+        all_comments, pr_detail["number"], issue_number,
+    )
     needs_rebase = pr_detail.get("mergeable") == "CONFLICTING" or \
         pr_detail.get("mergeStateStatus") == "DIRTY"
     targets = [{
@@ -787,6 +796,8 @@ def handle_revise(pr: dict) -> HandlerResult:
                 cwd="/app",
                 target_kind="pr",
                 target_number=pr_number,
+                extra_target_kind="issue",
+                extra_target_number=issue_number,
             )
             if agent.stdout:
                 print(agent.stdout, flush=True)

--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -492,6 +492,8 @@ def _run_claude_p(
     cwd: str | None = None,
     target_kind: str | None = None,
     target_number: int | None = None,
+    extra_target_kind: str | None = None,
+    extra_target_number: int | None = None,
     **kwargs,
 ) -> subprocess.CompletedProcess:
     """Run a ``claude -p`` command via the Claude Agent SDK and record its cost.
@@ -638,8 +640,15 @@ def _run_claude_p(
     # it never pollutes downstream prompts, while remaining visible
     # to humans and audit tools that read comments via ``gh``.
     # Best-effort — ``_post_cost_comment`` swallows all exceptions.
+    #
+    # ``extra_target_kind`` / ``extra_target_number`` let a caller mirror
+    # the cost comment onto a second object — used by ``cai revise`` and
+    # ``cai merge`` to surface spend on both the PR and the linked issue
+    # (the issue is the unit humans track; the PR is the work product).
     if target_kind is not None and target_number is not None:
         _post_cost_comment(target_kind, target_number, row, agent)
+    if extra_target_kind is not None and extra_target_number is not None:
+        _post_cost_comment(extra_target_kind, extra_target_number, row, agent)
 
     # Priority: structured_output → error_max_structured_output_retries →
     # result text → last-assistant salvage.

--- a/tests/test_revise_filter.py
+++ b/tests/test_revise_filter.py
@@ -92,21 +92,21 @@ class TestFilterCommentsWithHaiku(unittest.TestCase):
         """Human comment not covered by any resolved marker should come back."""
         run_p, claude_p = self._patch_run({"unresolved": [{"id": "0", "reason": "needs docstrings"}]})
         with run_p, claude_p:
-            result = _filter_comments_with_haiku([HUMAN_COMMENT], pr_number=42)
+            result = _filter_comments_with_haiku([HUMAN_COMMENT], pr_number=42, issue_number=100)
         self.assertEqual(result, [HUMAN_COMMENT])
 
     def test_bot_comment_not_in_unresolved(self):
         """If the haiku returns no unresolved items, the filter returns nothing."""
         run_p, claude_p = self._patch_run({"unresolved": []})
         with run_p, claude_p:
-            result = _filter_comments_with_haiku([BOT_COMMENT], pr_number=42)
+            result = _filter_comments_with_haiku([BOT_COMMENT], pr_number=42, issue_number=100)
         self.assertEqual(result, [])
 
     def test_resolved_thread_excluded(self):
         """A comment the haiku marks as resolved is excluded."""
         run_p, claude_p = self._patch_run({"unresolved": []})
         with run_p, claude_p:
-            result = _filter_comments_with_haiku([RESOLVED_THREAD], pr_number=42)
+            result = _filter_comments_with_haiku([RESOLVED_THREAD], pr_number=42, issue_number=100)
         self.assertEqual(result, [])
 
     def test_no_additional_changes_marker_covers_earlier(self):
@@ -115,7 +115,7 @@ class TestFilterCommentsWithHaiku(unittest.TestCase):
         run_p, claude_p = self._patch_run({"unresolved": []})
         with run_p, claude_p:
             result = _filter_comments_with_haiku(
-                [COVERED_COMMENT, NO_CHANGES_MARKER], pr_number=42,
+                [COVERED_COMMENT, NO_CHANGES_MARKER], pr_number=42, issue_number=100,
             )
         self.assertEqual(result, [])
 
@@ -128,7 +128,7 @@ class TestFilterCommentsWithHaiku(unittest.TestCase):
         run_p, claude_p = self._patch_run({"unresolved": []})
         with run_p, claude_p:
             result = _filter_comments_with_haiku(
-                [PREMERGE_FINDING, PREMERGE_CLEAN], pr_number=42,
+                [PREMERGE_FINDING, PREMERGE_CLEAN], pr_number=42, issue_number=100,
             )
         self.assertEqual(result, [])
 
@@ -138,7 +138,7 @@ class TestFilterCommentsWithHaiku(unittest.TestCase):
         # Haiku says only idx 0 (HUMAN_COMMENT) is unresolved.
         run_p, claude_p = self._patch_run({"unresolved": [{"id": "0", "reason": "docstrings missing"}]})
         with run_p, claude_p:
-            result = _filter_comments_with_haiku(all_comments, pr_number=42)
+            result = _filter_comments_with_haiku(all_comments, pr_number=42, issue_number=100)
         self.assertEqual(result, [HUMAN_COMMENT])
 
     def test_fallback_on_haiku_failure(self):
@@ -154,7 +154,7 @@ class TestFilterCommentsWithHaiku(unittest.TestCase):
         all_comments = [HUMAN_COMMENT, BOT_COMMENT]
         with patch("cai_lib.actions.revise._run", return_value=diff_proc):
             with patch("cai_lib.actions.revise._run_claude_p", return_value=fail_proc):
-                result = _filter_comments_with_haiku(all_comments, pr_number=42)
+                result = _filter_comments_with_haiku(all_comments, pr_number=42, issue_number=100)
 
         # BOT_COMMENT starts with "## Revise subagent:" so it is a bot comment.
         self.assertIn(HUMAN_COMMENT, result)
@@ -173,7 +173,7 @@ class TestFilterCommentsWithHaiku(unittest.TestCase):
         all_comments = [HUMAN_COMMENT, BOT_COMMENT]
         with patch("cai_lib.actions.revise._run", return_value=diff_proc):
             with patch("cai_lib.actions.revise._run_claude_p", return_value=bad_proc):
-                result = _filter_comments_with_haiku(all_comments, pr_number=42)
+                result = _filter_comments_with_haiku(all_comments, pr_number=42, issue_number=100)
 
         self.assertIn(HUMAN_COMMENT, result)
         self.assertNotIn(BOT_COMMENT, result)
@@ -181,7 +181,7 @@ class TestFilterCommentsWithHaiku(unittest.TestCase):
     def test_empty_comments_returns_empty(self):
         """Empty input yields empty output without calling the haiku."""
         with patch("cai_lib.actions.revise._run_claude_p") as mock_claude:
-            result = _filter_comments_with_haiku([], pr_number=42)
+            result = _filter_comments_with_haiku([], pr_number=42, issue_number=100)
         self.assertEqual(result, [])
         mock_claude.assert_not_called()
 
@@ -196,7 +196,7 @@ class TestFilterCommentsWithHaiku(unittest.TestCase):
             ],
         })
         with run_p, claude_p:
-            result = _filter_comments_with_haiku([c1, c2], pr_number=99)
+            result = _filter_comments_with_haiku([c1, c2], pr_number=99, issue_number=199)
         self.assertEqual(result, [c1, c2])
 
 

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -402,6 +402,64 @@ class TestCostCommentKwargsBackwardsCompat(unittest.TestCase):
         self.assertEqual(proc2.returncode, 0)
 
 
+class TestExtraTargetCostComment(unittest.TestCase):
+    """``cai revise`` / ``cai merge`` mirror their cost-attribution
+    comment onto the linked issue so humans scanning the issue see
+    every agent's spend, not just the PR's. ``extra_target_kind`` /
+    ``extra_target_number`` drive that second post.
+    """
+
+    @patch("cai_lib.subprocess_utils.log_cost")
+    def test_extra_target_posts_to_both_pr_and_issue(self, _mock_log):
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        msg = _mk_result(result="ok", total_cost_usd=0.02)
+        with patch.object(subprocess_utils, "query", _mock_query(msg)), \
+             patch(
+                "cai_lib.github._post_issue_comment", return_value=True,
+             ) as mock_issue_post, \
+             patch(
+                "cai_lib.github._post_pr_comment", return_value=True,
+             ) as mock_pr_post:
+            proc = _run_claude_p(
+                ["claude", "-p", "--agent", "cai-merge"],
+                category="merge", agent="cai-merge",
+                target_kind="pr", target_number=42,
+                extra_target_kind="issue", extra_target_number=99,
+            )
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(mock_pr_post.call_count, 1)
+        self.assertEqual(mock_issue_post.call_count, 1)
+        # Targets mirror the kwargs (PR #42 and issue #99).
+        pr_args, _ = mock_pr_post.call_args
+        issue_args, _ = mock_issue_post.call_args
+        self.assertEqual(pr_args[0], 42)
+        self.assertEqual(issue_args[0], 99)
+
+    @patch("cai_lib.subprocess_utils.log_cost")
+    def test_extra_target_omitted_posts_only_to_primary(self, _mock_log):
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        msg = _mk_result(result="ok", total_cost_usd=0.02)
+        with patch.object(subprocess_utils, "query", _mock_query(msg)), \
+             patch(
+                "cai_lib.github._post_issue_comment", return_value=True,
+             ) as mock_issue_post, \
+             patch(
+                "cai_lib.github._post_pr_comment", return_value=True,
+             ) as mock_pr_post:
+            proc = _run_claude_p(
+                ["claude", "-p", "--agent", "cai-plan"],
+                category="plan.plan", agent="cai-plan",
+                target_kind="issue", target_number=7,
+            )
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(mock_pr_post.call_count, 0)
+        self.assertEqual(mock_issue_post.call_count, 1)
+
+
 class TestFsmStateStamping(unittest.TestCase):
     """Issue #1203: ``_run_claude_p`` must stamp the current FSM state
     (set by the dispatcher via ``set_current_fsm_state``) onto each


### PR DESCRIPTION
## Summary

- `_run_claude_p` only posted its cost-attribution comment to a single target, so `cai revise` and `cai merge` (both pass `target_kind=\"pr\"`) surfaced spend only on the PR — never on the linked `auto-improve/<N>-*` issue, which is the unit humans actually track.
- Add optional `extra_target_kind` / `extra_target_number` kwargs to `_run_claude_p` that post a second mirrored cost comment.
- Wire `cai revise` (both the `cai-comment-filter` haiku call and the main `cai-revise` / `cai-rebase` call) and `cai merge` to pass the linked issue number through.

## Test plan

- [x] New unit tests in `tests/test_subprocess_utils.py` cover the dual-post case and confirm the single-target path is unchanged when `extra_target_*` is omitted.
- [x] `tests/test_revise_filter.py` updated for the new `issue_number` parameter on `_filter_comments_with_haiku`.
- [x] `python -m pytest` — 721 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)