### PR TITLE
auto-improve: cost log: stamp fix_attempt_count to measure retry spend

### DIFF
--- a/cai_lib/actions/fix_ci.py
+++ b/cai_lib/actions/fix_ci.py
@@ -34,6 +34,7 @@ from cai_lib.cmd_helpers import (
     _apply_agent_edit_staging,
     _parse_iso_ts,
     _fetch_review_comments,
+    _fetch_previous_fix_attempts,
 )
 from cai_lib.actions.revise import _filter_comments_with_haiku
 
@@ -393,6 +394,7 @@ def handle_fix_ci(pr: dict) -> HandlerResult:
             cwd="/app",
             target_kind="pr",
             target_number=pr_number,
+            fix_attempt_count=len(_fetch_previous_fix_attempts(issue_number)),
         )
         if agent.stdout:
             print(agent.stdout, flush=True)

--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -1243,6 +1243,7 @@ def handle_implement(issue: dict) -> int:
             target_number=issue_number,
             scope_files=_plan_scope_files,
             fingerprint_payload=user_message,
+            fix_attempt_count=len(attempts),
         )
         if agent.stdout:
             print(agent.stdout, flush=True)

--- a/cai_lib/actions/revise.py
+++ b/cai_lib/actions/revise.py
@@ -32,6 +32,7 @@ from cai_lib.cmd_helpers import (
     _git,
     _gh_user_identity,
     _fetch_review_comments,
+    _fetch_previous_fix_attempts,
     _parse_iso_ts,
     _apply_agent_edit_staging,
     _is_bot_comment,
@@ -798,6 +799,7 @@ def handle_revise(pr: dict) -> HandlerResult:
                 target_number=pr_number,
                 extra_target_kind="issue",
                 extra_target_number=issue_number,
+                fix_attempt_count=len(_fetch_previous_fix_attempts(issue_number)),
             )
             if agent.stdout:
                 print(agent.stdout, flush=True)

--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -498,6 +498,7 @@ def _run_claude_p(
     module: str | None = None,
     scope_files: list[str] | None = None,
     fingerprint_payload: str | None = None,
+    fix_attempt_count: int | None = None,
     **kwargs,
 ) -> subprocess.CompletedProcess:
     """Run a ``claude -p`` command via the Claude Agent SDK and record its cost.
@@ -529,12 +530,16 @@ def _run_claude_p(
     (dispatcher funnel position, issue #1203), ``cache_hit_rate`` (pre-computed
     aggregate hit rate, issue #1205), ``prompt_fingerprint`` (16-char SHA256
     hash for cache-rate regression detection, issue #1207), ``target_kind``
-    (``"issue"`` or ``"pr"``, issue #1210), and ``target_number`` (numeric
-    issue/PR ID, issue #1210). Rows from non-handler call sites (rescue,
-    unblock, dup-check, audit, init) typically omit ``fsm_state`` and other
-    optional fields, preserving back-compat for legacy rows. ``parent_cost_usd``
-    is intentionally dropped — the CLI format emits exactly one result event so
-    there is nothing to attribute.
+    (``"issue"`` or ``"pr"``, issue #1210), ``target_number`` (numeric
+    issue/PR ID, issue #1210), and ``fix_attempt_count`` (count of prior
+    closed-unmerged PRs for the linked issue — matches the ``_log_outcome``
+    semantic in ``cai-outcomes.jsonl`` so the two logs can be joined; stamped
+    only by fix-retry flows: ``implement`` / ``revise`` / ``fix-ci``,
+    issue #1204). Rows from non-handler call sites (rescue, unblock, dup-check,
+    audit, init) typically omit ``fsm_state`` and other optional fields,
+    preserving back-compat for legacy rows. ``parent_cost_usd`` is intentionally
+    dropped — the CLI format emits exactly one result event so there is nothing
+    to attribute.
     """
     if len(cmd) < 2 or cmd[0] != "claude" or cmd[1] != "-p":
         raise ValueError("_run_claude_p requires cmd[:2] == ['claude', '-p']")
@@ -687,6 +692,15 @@ def _run_claude_p(
         row["target_kind"] = target_kind
     if target_number is not None:
         row["target_number"] = target_number
+    # Issue #1204: stamp the linked issue's prior-fix-attempt count so
+    # cost-log readers can join cai-cost.jsonl to cai-outcomes.jsonl
+    # (which already carries the same key via _log_outcome). Only
+    # fix-retry flows (implement / revise / fix-ci) pass the kwarg;
+    # every other call site leaves it None and the key is omitted,
+    # preserving pre-#1204 row shape. Zero must be stamped (first
+    # attempt) — use ``is not None``, not truthiness.
+    if fix_attempt_count is not None:
+        row["fix_attempt_count"] = fix_attempt_count
     log_cost(row)
 
     # Post a per-target cost-attribution comment on the issue/PR the

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -666,5 +666,69 @@ class TestCacheHitRateAnnotation(unittest.TestCase):
         self.assertNotIn("cacheHitRate", haiku)
 
 
+class TestFixAttemptCountStamping(unittest.TestCase):
+    """Issue #1204: ``_run_claude_p`` must stamp the caller-provided
+    ``fix_attempt_count`` onto each cost-log row under the optional
+    ``fix_attempt_count`` key, and omit the key entirely when the
+    kwarg is unset (default) so pre-#1204 rows stay byte-identical.
+
+    Mirrors the conditional-stamp pattern used by ``TestFsmStateStamping``
+    above (issue #1203). Explicitly covers the ``fix_attempt_count=0``
+    first-attempt case to guard against a future ``if fix_attempt_count:``
+    truthiness-check regression — zero must be stamped.
+    """
+
+    def test_omitting_fix_attempt_count_leaves_row_unchanged(self):
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        captured: list[dict] = []
+
+        def _fake_log_cost(row: dict) -> None:
+            captured.append(dict(row))
+
+        msg = _mk_result(result="ok", total_cost_usd=0.05)
+        with patch.object(subprocess_utils, "query", _mock_query(msg)), \
+             patch.object(subprocess_utils, "log_cost", _fake_log_cost):
+            _run_claude_p(
+                ["claude", "-p", "--agent", "cai-plan"],
+                category="plan.plan", agent="cai-plan",
+            )
+
+        self.assertEqual(len(captured), 1)
+        self.assertNotIn("fix_attempt_count", captured[0])
+
+    def test_passing_fix_attempt_count_stamps_row(self):
+        from cai_lib import subprocess_utils
+        from cai_lib.subprocess_utils import _run_claude_p
+
+        captured: list[dict] = []
+
+        def _fake_log_cost(row: dict) -> None:
+            captured.append(dict(row))
+
+        msg = _mk_result(result="ok", total_cost_usd=0.05)
+        with patch.object(subprocess_utils, "query", _mock_query(msg)), \
+             patch.object(subprocess_utils, "log_cost", _fake_log_cost):
+            # First attempt: zero must land in the row (is-not-None check).
+            _run_claude_p(
+                ["claude", "-p", "--agent", "cai-implement"],
+                category="implement", agent="cai-implement",
+                fix_attempt_count=0,
+            )
+            # Retry: non-zero stamped as-is.
+            _run_claude_p(
+                ["claude", "-p", "--agent", "cai-implement"],
+                category="implement", agent="cai-implement",
+                fix_attempt_count=2,
+            )
+
+        self.assertEqual(len(captured), 2)
+        self.assertIn("fix_attempt_count", captured[0])
+        self.assertEqual(captured[0]["fix_attempt_count"], 0)
+        self.assertIn("fix_attempt_count", captured[1])
+        self.assertEqual(captured[1]["fix_attempt_count"], 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1204

**Issue:** #1204 — cost log: stamp fix_attempt_count to measure retry spend

## PR Summary

### What this fixes
The cost log (`cai-cost.jsonl`) was missing a `fix_attempt_count` field that `cai-outcomes.jsonl` already carries, making it impossible to join the two logs and answer questions like "how much did retries cost this week" or "what fraction of `cai-implement` spend goes to attempts 2+".

### What was changed
- **`cai_lib/subprocess_utils.py`**: Added `fix_attempt_count: int | None = None` keyword parameter to `_run_claude_p`; updated docstring; added conditional `is not None` stamp onto the cost-log row before `log_cost(row)` (mirrors the `fsm_state`/`parent_model`/`subagents` pattern).
- **`cai_lib/actions/implement.py`**: Passes `fix_attempt_count=len(attempts)` at the main `cai-implement` subagent call (line 1239); `attempts` was already computed at line 1158.
- **`cai_lib/actions/revise.py`**: Added `_fetch_previous_fix_attempts` import; passes `fix_attempt_count=len(_fetch_previous_fix_attempts(issue_number))` at the main agent call.
- **`cai_lib/actions/fix_ci.py`**: Added `_fetch_previous_fix_attempts` import; passes `fix_attempt_count=len(_fetch_previous_fix_attempts(issue_number))` at the main agent call.
- **`tests/test_subprocess_utils.py`**: Added `TestFixAttemptCountStamping` class with two tests: one confirming the key is absent when the kwarg is not passed, one confirming both zero and non-zero values are stamped correctly.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
