### PR TITLE
fix: pass issue_number to _filter_comments_with_haiku in handle_merge

### DIFF
--- a/cai_lib/actions/merge.py
+++ b/cai_lib/actions/merge.py
@@ -831,7 +831,7 @@ def handle_merge(pr: dict) -> HandlerResult:
     except Exception:
         pass
 
-    unaddressed = _filter_comments_with_haiku(all_comments, pr_number)
+    unaddressed = _filter_comments_with_haiku(all_comments, pr_number, issue_number)
     has_unaddressed = bool(unaddressed)
 
     if has_unaddressed:


### PR DESCRIPTION
## Summary
- `handle_merge` in `cai_lib/actions/merge.py:834` was still calling `_filter_comments_with_haiku(all_comments, pr_number)` after commit 8409200 made `issue_number` a required parameter on that helper.
- Every APPROVED PR crashed with `TypeError: _filter_comments_with_haiku() missing 1 required positional argument: 'issue_number'`, which aborted the drive for that PR (seen on PR #1209 in the cron logs).
- `issue_number` is already parsed from the branch name at `merge.py:762`, so the fix is a one-line thread-through.

## Root cause
Commit `8409200` ("mirror cai revise / cai merge cost comments onto linked issue") added a required `issue_number` parameter to `_filter_comments_with_haiku` in `revise.py` (for cost-comment mirroring) and updated the in-file call site, but missed the second call site in `merge.py`.

## Test plan
- [ ] Next `cai cycle` drives an APPROVED PR through `handle_merge` without raising `TypeError`.
- [ ] Confirm cost-attribution comment for the haiku filter is mirrored onto the linked issue as well as the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)