### PR TITLE
auto-improve: [#1208 Step 1/2] Wire cost pre-load — enrich log fields, rewrite summary, wire into runner

### DIFF
--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -1228,6 +1228,11 @@ def handle_implement(issue: dict) -> int:
         claude_cmd += ["--dangerously-skip-permissions",
                        "--add-dir", str(work_dir)]
         print(f"[cai implement] running cai-implement subagent for {work_dir}", flush=True)
+        _plan_scope_files: list[str] | None = None
+        if selected_plan:
+            _sec = _FILES_TO_CHANGE_SECTION_RE.search(selected_plan)
+            if _sec:
+                _plan_scope_files = _FILES_TO_CHANGE_PATH_RE.findall(_sec.group(1))
         agent = _run_claude_p(
             claude_cmd,
             category="implement",
@@ -1236,6 +1241,8 @@ def handle_implement(issue: dict) -> int:
             cwd="/app",
             target_kind="issue",
             target_number=issue_number,
+            scope_files=_plan_scope_files,
+            fingerprint_payload=user_message,
         )
         if agent.stdout:
             print(agent.stdout, flush=True)

--- a/cai_lib/audit/cost.py
+++ b/cai_lib/audit/cost.py
@@ -1,7 +1,9 @@
 """Audit-side cost/outcome helpers (moved from cai_lib/logging_utils.py)."""
 
+import fnmatch
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 
 from cai_lib.config import COST_LOG_AGGREGATE_DIR, COST_LOG_PATH, OUTCOME_LOG_PATH
 
@@ -125,108 +127,341 @@ def _primary_model(row: dict) -> str:
     return best[0] if best else ""
 
 
-def _build_cost_summary(days: int = 7, top_n: int = 10) -> str:
-    """Build a markdown cost summary for the on-demand
-    cost-reduction audit user message.
+def _load_outcome_index(days: int = 90) -> dict[int, dict]:
+    """Return a mapping of issue_number -> {outcome, fix_attempt_count}
+    from the outcome log. Used by _build_cost_summary for §3 and §4 joins.
 
-    Returns an empty string if no cost rows exist for the window.
-    Otherwise emits a section with per-category aggregates, per-FSM-state
-    aggregates (when rows carry the optional #1203 ``fsm_state`` field),
-    and the top-N most expensive individual invocations, so the audit
-    agent can spot cost outliers (a single invocation that dwarfs the
-    median, or a funnel stage that dominates total spend).
+    Returns {} when the file is absent, the required fields are missing,
+    or any read failure occurs — all section joins degrade gracefully.
+    """
+    if not OUTCOME_LOG_PATH.exists():
+        return {}
+    cutoff_ts = datetime.now(timezone.utc).timestamp() - days * 86400
+    result: dict[int, dict] = {}
+    try:
+        with OUTCOME_LOG_PATH.open("r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                issue_num = row.get("issue_number")
+                if not isinstance(issue_num, int):
+                    continue
+                ts = row.get("ts", "")
+                try:
+                    row_ts = datetime.strptime(
+                        ts, "%Y-%m-%dT%H:%M:%SZ",
+                    ).replace(tzinfo=timezone.utc).timestamp()
+                except ValueError:
+                    continue
+                if row_ts < cutoff_ts:
+                    continue
+                result[issue_num] = {
+                    "outcome": row.get("outcome"),
+                    "fix_attempt_count": row.get("fix_attempt_count"),
+                }
+    except OSError:
+        return {}
+    return result
+
+
+def _build_module_index() -> list[tuple[str, str]]:
+    """Return a list of (glob_pattern, module_name) from docs/modules.yaml.
+
+    Used by _build_cost_summary §5 to infer module name from scope_files.
+    Returns [] when the manifest is absent, unreadable, or raises.
+    """
+    try:
+        from cai_lib.audit.modules import load_modules  # noqa: PLC0415
+        manifest = Path(__file__).resolve().parents[2] / "docs" / "modules.yaml"
+        modules = load_modules(manifest)
+        return [(g, m.name) for m in modules for g in m.globs]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _infer_module_from_files(
+    scope_files: list[str],
+    module_index: list[tuple[str, str]],
+) -> str | None:
+    """Return the most-matched module name for a list of scope_files.
+
+    Counts how many files in scope_files match each module's globs; returns
+    the module with the most matches. Returns None when no match is found.
+    """
+    module_counts: dict[str, int] = {}
+    for f in scope_files:
+        for g, name in module_index:
+            if fnmatch.fnmatch(f, g):
+                module_counts[name] = module_counts.get(name, 0) + 1
+    if not module_counts:
+        return None
+    return max(module_counts.items(), key=lambda kv: kv[1])[0]
+
+
+def _build_cost_summary(days: int = 7, top_n: int = 10, cluster_n: int = 10) -> str:
+    """Build a rich 7-section cost-analysis markdown summary for the
+    on-demand cost-reduction audit user message and operator banner.
+
+    Returns an empty string when no cost rows exist for the window.
+    Each section degrades gracefully when its required fields are absent
+    from the data — sections with no content are omitted.
+
+    Sections:
+      §1 Window headline
+      §2 Recent vs prior Δ by agent (skip agents < 2*cluster_n invocations)
+      §3 Top-N expensive targets (skip when no rows have target_number)
+      §4 Phase breakdown by fsm_state (always shown)
+      §5 Per-module cost (skip when no module/scope_files data available)
+      §6 Cache-health regressions (skip when no regressions detected)
+      §7 Host anomalies (always shown when rows have host field)
     """
     rows = _load_cost_log(days=days)
     if not rows:
         return ""
 
-    # Per-category aggregates: total cost, call count, mean cost.
-    cats: dict[str, dict] = {}
-    grand_total = 0.0
-    for r in rows:
-        cat = r.get("category") or "(unknown)"
-        cost = r.get("cost_usd") or 0.0
+    def _cost(r: dict) -> float:
         try:
-            cost = float(cost)
+            return float(r.get("cost_usd") or 0.0)
         except (TypeError, ValueError):
-            cost = 0.0
-        bucket = cats.setdefault(cat, {"calls": 0, "cost": 0.0})
-        bucket["calls"] += 1
-        bucket["cost"] += cost
-        grand_total += cost
+            return 0.0
 
-    cat_lines = []
-    for cat, b in sorted(cats.items(), key=lambda kv: -kv[1]["cost"]):
-        share = (b["cost"] / grand_total * 100.0) if grand_total else 0.0
-        mean = b["cost"] / b["calls"] if b["calls"] else 0.0
-        cat_lines.append(
-            f"| {cat} | {b['calls']} | ${b['cost']:.4f} "
-            f"({share:.1f}%) | ${mean:.4f} |"
+    rows_sorted = sorted(rows, key=_row_ts)
+    grand_total = sum(_cost(r) for r in rows)
+    target_numbers = {r["target_number"] for r in rows if isinstance(r.get("target_number"), int)}
+    hosts = {r["host"] for r in rows if r.get("host")}
+
+    # Precompute shared indices (outcome join for §3+§4, module globs for §5).
+    outcome_index = _load_outcome_index()
+    module_index = _build_module_index()
+
+    sections: list[str] = []
+
+    # ── §1 Window headline ─────────────────────────────────────────────
+    sections.append(
+        f"## Cost summary (last {days}d, ${grand_total:.4f} across "
+        f"{len(rows)} invocations, {len(target_numbers)} unique target(s), "
+        f"{len(hosts)} host(s), cluster_n={cluster_n})\n"
+    )
+
+    # ── §2 Recent vs prior Δ by agent ──────────────────────────────────
+    # Group rows by agent in chronological order; compare most-recent
+    # cluster_n vs the prior cluster_n; skip agents with < 2*cluster_n calls.
+    by_agent: dict[str, list[dict]] = {}
+    for r in rows_sorted:
+        a = r.get("agent") or "(no-agent)"
+        by_agent.setdefault(a, []).append(r)
+
+    delta_lines: list[str] = []
+    for agent_name in sorted(by_agent.keys()):
+        agent_rows = by_agent[agent_name]
+        if len(agent_rows) < cluster_n * 2:
+            continue
+        recent = agent_rows[-cluster_n:]
+        prior = agent_rows[-(cluster_n * 2):-cluster_n]
+        recent_mean = sum(_cost(r) for r in recent) / cluster_n
+        prior_mean = sum(_cost(r) for r in prior) / cluster_n
+        delta_pct = ((recent_mean - prior_mean) / prior_mean * 100.0) if prior_mean else 0.0
+        flag = " ⚠️" if delta_pct > 10.0 else ""
+        delta_lines.append(
+            f"| {agent_name} | {len(agent_rows)} | ${prior_mean:.4f} | "
+            f"${recent_mean:.4f} | {delta_pct:+.1f}%{flag} |"
         )
 
-    # Per-FSM-state aggregates (issue #1203). Rows written by non-FSM
-    # call sites omit ``fsm_state``; those land in the ``(none)`` bucket
-    # so the section stays faithful to the data.
-    fsm_states: dict[str, dict] = {}
+    if delta_lines:
+        sections.append(
+            f"### §2 Recent vs prior Δ by agent "
+            f"(recent/prior = last {cluster_n}/{cluster_n} calls, "
+            f"skip < {cluster_n * 2} invocations)\n\n"
+            "| agent | total calls | prior mean | recent mean | Δ% |\n"
+            "|---|---|---|---|---|\n"
+            + "\n".join(delta_lines) + "\n"
+        )
+
+    # ── §3 Top-N expensive targets ─────────────────────────────────────
+    # Group by target_number, join with outcome log for outcome +
+    # fix_attempt_count. Rows without target_number are excluded here.
+    by_target: dict[int, list[dict]] = {}
+    for r in rows:
+        tn = r.get("target_number")
+        if isinstance(tn, int):
+            by_target.setdefault(tn, []).append(r)
+
+    if by_target:
+        top_targets = sorted(
+            by_target.items(),
+            key=lambda kv: sum(_cost(r) for r in kv[1]),
+            reverse=True,
+        )[:top_n]
+        target_lines = []
+        for tn, tn_rows in top_targets:
+            total = sum(_cost(r) for r in tn_rows)
+            oi = outcome_index.get(tn, {})
+            outcome = oi.get("outcome") or "-"
+            fa = oi.get("fix_attempt_count")
+            attempts_str = str(int(fa)) if isinstance(fa, (int, float)) else "-"
+            target_lines.append(
+                f"| #{tn} | {len(tn_rows)} | ${total:.4f} | {outcome} | {attempts_str} |"
+            )
+        sections.append(
+            f"### §3 Top-{len(target_lines)} expensive target(s)\n\n"
+            "| target | calls | total cost | outcome | fix_attempts |\n"
+            "|---|---|---|---|---|\n"
+            + "\n".join(target_lines) + "\n"
+        )
+
+    # ── §4 Phase breakdown ─────────────────────────────────────────────
+    # Group all rows by fsm_state. For rows with target_number, join the
+    # outcome log to split first-attempt (fix_attempt_count ≤ 1) vs retry.
+    fsm_buckets: dict[str, dict] = {}
     for r in rows:
         fs = r.get("fsm_state") or "(none)"
-        cost = r.get("cost_usd") or 0.0
-        try:
-            cost = float(cost)
-        except (TypeError, ValueError):
-            cost = 0.0
-        bucket = fsm_states.setdefault(fs, {"calls": 0, "cost": 0.0})
-        bucket["calls"] += 1
-        bucket["cost"] += cost
+        tn = r.get("target_number")
+        oi = outcome_index.get(tn, {}) if isinstance(tn, int) else {}
+        fa = oi.get("fix_attempt_count")
+        is_first = not isinstance(fa, (int, float)) or fa <= 1
+        bucket = fsm_buckets.setdefault(fs, {"first": [], "retry": []})
+        if is_first:
+            bucket["first"].append(r)
+        else:
+            bucket["retry"].append(r)
 
-    fsm_lines = []
-    for fs, b in sorted(fsm_states.items(), key=lambda kv: -kv[1]["cost"]):
-        share = (b["cost"] / grand_total * 100.0) if grand_total else 0.0
-        mean = b["cost"] / b["calls"] if b["calls"] else 0.0
-        fsm_lines.append(
-            f"| {fs} | {b['calls']} | ${b['cost']:.4f} "
-            f"({share:.1f}%) | ${mean:.4f} |"
+    phase_lines = []
+    for fs in sorted(
+        fsm_buckets.keys(),
+        key=lambda k: -(
+            sum(_cost(r) for r in fsm_buckets[k]["first"])
+            + sum(_cost(r) for r in fsm_buckets[k]["retry"])
+        ),
+    ):
+        b = fsm_buckets[fs]
+        first_cost = sum(_cost(r) for r in b["first"])
+        retry_cost = sum(_cost(r) for r in b["retry"])
+        phase_lines.append(
+            f"| {fs} | {len(b['first'])} | ${first_cost:.4f} | "
+            f"{len(b['retry'])} | ${retry_cost:.4f} | "
+            f"${first_cost + retry_cost:.4f} |"
         )
 
-    # Top-N most expensive individual invocations.
-    top = sorted(
-        rows,
-        key=lambda r: float(r.get("cost_usd") or 0.0),
-        reverse=True,
-    )[:top_n]
-    top_lines = []
-    for r in top:
-        cost = float(r.get("cost_usd") or 0.0)
-        # Issue #1205: cite the pre-computed ``cache_hit_rate`` field
-        # written by ``_run_claude_p`` (aggregate rate over
-        # cache_read + cache_creation + input tokens). Rows predating
-        # the change legitimately omit the field and render as ``-``.
-        hit = r.get("cache_hit_rate")
-        hit_str = f"{hit * 100:.1f}%" if isinstance(hit, (int, float)) else "-"
-        top_lines.append(
-            f"| {r.get('ts', '')} | {r.get('category', '')} | "
-            f"{r.get('agent', '')} | {_primary_model(r)} | ${cost:.4f} | "
-            f"{r.get('num_turns', '')} | "
-            f"{(r.get('input_tokens') or 0) + (r.get('output_tokens') or 0)} | "
-            f"{hit_str} |"
-        )
-
-    return (
-        f"## Cost summary (last {days}d, total ${grand_total:.4f} "
-        f"across {len(rows)} invocations)\n\n"
-        "### Per-category totals\n\n"
-        "| category | calls | total cost (share) | mean cost |\n"
-        "|---|---|---|---|\n"
-        + "\n".join(cat_lines)
-        + "\n\n"
-        "### By FSM state\n\n"
-        "| fsm_state | calls | total cost (share) | mean cost |\n"
-        "|---|---|---|---|\n"
-        + "\n".join(fsm_lines)
-        + "\n\n"
-        f"### Top {len(top_lines)} most expensive individual invocations\n\n"
-        "| ts | category | agent | model | cost | turns | tokens | hit% |\n"
-        "|---|---|---|---|---|---|---|---|\n"
-        + "\n".join(top_lines)
-        + "\n"
+    sections.append(
+        "### §4 Phase breakdown (first-attempt vs retry, by fsm_state)\n\n"
+        "| fsm_state | first calls | first cost | retry calls | "
+        "retry cost | total cost |\n"
+        "|---|---|---|---|---|---|\n"
+        + "\n".join(phase_lines) + "\n"
     )
+
+    # ── §5 Per-module cost ─────────────────────────────────────────────
+    # Group by the ``module`` field. For rows missing ``module`` but having
+    # ``scope_files``, infer module via fnmatch against docs/modules.yaml.
+    module_buckets: dict[str, list[dict]] = {}
+    for r in rows:
+        mod = r.get("module") or ""
+        if not mod:
+            sf = r.get("scope_files")
+            if isinstance(sf, list) and sf and module_index:
+                mod = _infer_module_from_files(sf, module_index) or ""
+        if mod:
+            module_buckets.setdefault(mod, []).append(r)
+
+    if module_buckets:
+        module_lines = []
+        for mod in sorted(
+            module_buckets.keys(),
+            key=lambda k: -sum(_cost(r) for r in module_buckets[k]),
+        ):
+            mod_rows = module_buckets[mod]
+            total = sum(_cost(r) for r in mod_rows)
+            module_lines.append(f"| {mod} | {len(mod_rows)} | ${total:.4f} |")
+        sections.append(
+            "### §5 Per-module cost\n\n"
+            "| module | calls | total cost |\n"
+            "|---|---|---|\n"
+            + "\n".join(module_lines) + "\n"
+        )
+
+    # ── §6 Cache-health regressions ────────────────────────────────────
+    # Group by (agent, prompt_fingerprint). Compare most-recent cluster_n
+    # vs prior cluster_n cache_hit_rate. Flag ≥10pp drops.
+    # Skip pairs with < 2*cluster_n invocations.
+    fp_buckets: dict[tuple, list[dict]] = {}
+    for r in rows_sorted:
+        a = r.get("agent") or "(no-agent)"
+        fp = r.get("prompt_fingerprint")
+        if fp is not None:
+            fp_buckets.setdefault((a, fp), []).append(r)
+
+    regression_lines = []
+    for (a, fp), fp_rows in sorted(fp_buckets.items()):
+        if len(fp_rows) < cluster_n * 2:
+            continue
+        recent = fp_rows[-cluster_n:]
+        prior = fp_rows[-(cluster_n * 2):-cluster_n]
+        recent_vals = [
+            r["cache_hit_rate"] for r in recent
+            if isinstance(r.get("cache_hit_rate"), (int, float))
+        ]
+        prior_vals = [
+            r["cache_hit_rate"] for r in prior
+            if isinstance(r.get("cache_hit_rate"), (int, float))
+        ]
+        if not recent_vals or not prior_vals:
+            continue
+        recent_mean = sum(recent_vals) / len(recent_vals)
+        prior_mean = sum(prior_vals) / len(prior_vals)
+        drop_pp = (prior_mean - recent_mean) * 100.0
+        if drop_pp >= 10.0:
+            regression_lines.append(
+                f"| {a} | `{fp}` | {prior_mean * 100:.1f}% | "
+                f"{recent_mean * 100:.1f}% | -{drop_pp:.1f}pp ⚠️ |"
+            )
+
+    if regression_lines:
+        sections.append(
+            f"### §6 Cache-health regressions "
+            f"(≥10pp drop, ≥{cluster_n * 2} invocations)\n\n"
+            "| agent | fingerprint | prior hit% | recent hit% | drop |\n"
+            "|---|---|---|---|---|\n"
+            + "\n".join(regression_lines) + "\n"
+        )
+
+    # ── §7 Host anomalies ──────────────────────────────────────────────
+    # Per-host totals; flag hosts whose mean $/call is ≥ 2× the median.
+    host_buckets: dict[str, list[dict]] = {}
+    for r in rows:
+        h = r.get("host")
+        if h:
+            host_buckets.setdefault(h, []).append(r)
+
+    if host_buckets:
+        host_means = {
+            h: sum(_cost(r) for r in hrs) / len(hrs)
+            for h, hrs in host_buckets.items()
+        }
+        sorted_means = sorted(host_means.values())
+        n = len(sorted_means)
+        if n % 2 == 1:
+            median_mean = sorted_means[n // 2]
+        else:
+            median_mean = (sorted_means[n // 2 - 1] + sorted_means[n // 2]) / 2.0
+
+        host_lines = []
+        for h in sorted(host_buckets.keys(), key=lambda k: -host_means[k]):
+            total = sum(_cost(r) for r in host_buckets[h])
+            mean = host_means[h]
+            flag = " ⚠️" if median_mean > 0 and mean >= 2.0 * median_mean else ""
+            host_lines.append(
+                f"| {h} | {len(host_buckets[h])} | ${total:.4f} | ${mean:.4f}{flag} |"
+            )
+        sections.append(
+            "### §7 Host anomalies (flag mean $/call ≥ 2× median)\n\n"
+            "| host | calls | total cost | mean cost |\n"
+            "|---|---|---|---|\n"
+            + "\n".join(host_lines) + "\n"
+        )
+
+    return "\n".join(sections)

--- a/cai_lib/audit/runner.py
+++ b/cai_lib/audit/runner.py
@@ -24,6 +24,7 @@ import time
 import uuid
 from pathlib import Path
 
+from cai_lib.audit.cost import _build_cost_summary
 from cai_lib.audit_logging import audit_log_finish, audit_log_start
 from cai_lib.config import PUBLISH_SCRIPT
 from cai_lib.logging_utils import log_run
@@ -59,7 +60,16 @@ def _build_module_prompt(entry, findings_file: Path) -> str:  # type: ignore[no-
     expect a ``## Module`` section (name, summary, globs, optional doc
     snippet) followed by a ``## Findings file`` section pointing at
     the absolute path where they must write ``findings.json``.
+
+    Also pulls fresh cost data (no-op when sync is disabled) and appends
+    a ``## Cost summary`` block so the audit agent receives spend context.
     """
+    try:
+        from cai_lib.transcript_sync import pull_cost  # noqa: PLC0415
+        pull_cost()
+    except Exception:  # noqa: BLE001
+        pass
+
     globs_block = "\n".join(f"- `{g}`" for g in entry.globs) if entry.globs else "- (none)"
     parts = [
         "## Module",
@@ -78,6 +88,14 @@ def _build_module_prompt(entry, findings_file: Path) -> str:  # type: ignore[no-
         f"Write your findings to: `{findings_file}`",
         "",
     ]
+    cost_summary = _build_cost_summary()
+    if cost_summary:
+        parts += [
+            "",
+            "## Cost summary",
+            "",
+            cost_summary,
+        ]
     return "\n".join(parts)
 
 
@@ -98,6 +116,16 @@ def _run_one_module(kind: str, agent: str, entry) -> int:  # type: ignore[no-unt
 
     try:
         user_message = _build_module_prompt(entry, findings_file)
+        if sys.stderr.isatty():
+            _banner = _build_cost_summary()
+            if _banner:
+                print(
+                    f"\n--- cost summary (module={entry.name}) ---\n"
+                    f"{_banner}"
+                    f"--- end cost summary ---\n",
+                    file=sys.stderr,
+                    flush=True,
+                )
         proc = _run_claude_p(
             [
                 "claude", "-p",
@@ -110,6 +138,7 @@ def _run_one_module(kind: str, agent: str, entry) -> int:  # type: ignore[no-unt
             agent=agent,
             input=user_message,
             cwd="/app",
+            module=entry.name,
         )
 
         if proc.stdout:

--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -495,6 +495,9 @@ def _run_claude_p(
     target_number: int | None = None,
     extra_target_kind: str | None = None,
     extra_target_number: int | None = None,
+    module: str | None = None,
+    scope_files: list[str] | None = None,
+    fingerprint_payload: str | None = None,
     **kwargs,
 ) -> subprocess.CompletedProcess:
     """Run a ``claude -p`` command via the Claude Agent SDK and record its cost.
@@ -666,14 +669,18 @@ def _run_claude_p(
     fsm_state = _CURRENT_FSM_STATE.get()
     if fsm_state:
         row["fsm_state"] = fsm_state
-    # Issue #1207: stamp a short SHA256 fingerprint of the system + user
-    # prompts so cost-optimize can detect cache-rate regressions caused by
-    # prompt changes.  16 hex chars is sufficient for grouping; the actual
-    # prompt text lives in the versioned agent definition file.
+    # Issue #1207: stamp a short SHA256 fingerprint. When ``fingerprint_payload``
+    # is provided, use it as-is (stable caller-controlled key); otherwise
+    # fall back to the system + user prompt concatenation.
     fp_src = (
-        (options.system_prompt or "") + "\n---\n" + (prompt or "")
+        fingerprint_payload if fingerprint_payload is not None
+        else (options.system_prompt or "") + "\n---\n" + (prompt or "")
     )
     row["prompt_fingerprint"] = hashlib.sha256(fp_src.encode()).hexdigest()[:16]
+    if module:
+        row["module"] = module
+    if scope_files is not None:
+        row["scope_files"] = list(scope_files)
     if target_kind is not None and target_number is not None:
         row["target_kind"] = target_kind
         row["target_number"] = target_number

--- a/docs/modules/audit.md
+++ b/docs/modules/audit.md
@@ -10,9 +10,10 @@ function in `cai_lib/cmd_agents.py` or `cai_lib/cmd_misc.py`.
 
 ## Key entry points
 - [`cai_lib/audit/cost.py`](../../cai_lib/audit/cost.py) — `_load_outcome_counts`,
-  `_load_cost_log`, `_row_ts`, `_primary_model`,
-  `_build_cost_summary`; token/cost helpers consumed by
-  `cmd_cost_report` and `cmd_cost_optimize`.
+  `_load_cost_log`, `_load_outcome_index`, `_row_ts`, `_primary_model`,
+  `_build_module_index`, `_infer_module_from_files`, `_build_cost_summary`; 
+  token/cost helpers consumed by `cmd_cost_report`, `cmd_cost_optimize`, 
+  and `runner.py` for per-module audit context.
 - [`cai_lib/audit/modules.py`](../../cai_lib/audit/modules.py) —
   `ModuleEntry` dataclass; `load_modules(path, check_doc_exists)`
   and `coverage_check(modules, files)`. Drives
@@ -62,6 +63,15 @@ function in `cai_lib/cmd_agents.py` or `cai_lib/cmd_misc.py`.
   to `findings.json`.
 
 ## Operational notes
+- **Cost summary pre-load.** `_build_module_prompt` in `runner.py` now
+  calls `pull_cost()` (if sync is configured) to fetch fresh cost data 
+  before invoking each audit agent. `_build_cost_summary()` generates a 
+  rich 7-section markdown block (cost by agent, top targets, phase breakdown, 
+  per-module spend, cache-health regressions, host anomalies) and appends 
+  it as a `## Cost summary` section in the agent's user message. This 
+  provides spend context per module without the agent needing to parse 
+  log files. The cost summary is also printed to stderr when running 
+  interactively (TTY).
 - **Audit log path convention.** `cai_lib/audit/runner.py` writes one
   structured JSONL file per `(kind, module)` pair under
   `/var/log/cai/audit/<kind>/<module>.jsonl` (e.g.

--- a/tests/test_audit_cost.py
+++ b/tests/test_audit_cost.py
@@ -160,9 +160,9 @@ class TestLoadCostLogAggregation(unittest.TestCase):
 
 
 class TestBuildCostSummaryFsmState(unittest.TestCase):
-    """Issue #1203: ``_build_cost_summary`` must emit a ``### By FSM state``
-    section that aggregates rows by the optional ``fsm_state`` field and
-    handles rows missing the field by bucketing them under ``(none)``."""
+    """Issue #1203: ``_build_cost_summary`` §4 phase breakdown aggregates
+    rows by the optional ``fsm_state`` field and handles rows missing the
+    field by bucketing them under ``(none)``."""
 
     _RECENT_TS_A = "2099-01-01T00:00:00Z"
     _RECENT_TS_B = "2099-01-02T00:00:00Z"
@@ -191,16 +191,16 @@ class TestBuildCostSummaryFsmState(unittest.TestCase):
             ):
                 summary = _build_cost_summary(days=3650, top_n=3)
 
-        self.assertIn("### By FSM state", summary)
-        self.assertIn("| fsm_state | calls | total cost (share) | mean cost |",
-                      summary)
-        # The three distinct buckets must all appear.
+        # §4 Phase breakdown replaces the old "### By FSM state" section.
+        self.assertIn("§4 Phase breakdown", summary)
+        self.assertIn("| fsm_state |", summary)
+        # The three distinct buckets must all appear in the §4 table.
         self.assertIn("| REFINING | 1 |", summary)
         self.assertIn("| PLANNING | 1 |", summary)
         self.assertIn("| (none) | 1 |", summary)
 
     def test_summary_empty_when_no_rows(self):
-        """Back-compat: no rows → empty string (no FSM section emitted)."""
+        """Back-compat: no rows → empty string (no sections emitted)."""
         from cai_lib.audit.cost import _build_cost_summary
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -213,6 +213,345 @@ class TestBuildCostSummaryFsmState(unittest.TestCase):
                 summary = _build_cost_summary(days=7, top_n=3)
 
         self.assertEqual(summary, "")
+
+
+class TestBuildCostSummaryAllSections(unittest.TestCase):
+    """Verify all 7 §-sections of the rewritten _build_cost_summary.
+
+    Uses cluster_n=2 so §2 and §6 trigger with small fixtures.
+    """
+
+    _TS = [
+        "2099-01-01T00:00:00Z",
+        "2099-01-02T00:00:00Z",
+        "2099-01-03T00:00:00Z",
+        "2099-01-04T00:00:00Z",
+        "2099-01-05T00:00:00Z",
+    ]
+
+    def _write_rows(self, path: Path, rows: list[dict]) -> None:
+        path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+    def _base_row(self, i: int, **extra) -> dict:
+        r = {
+            "ts": self._TS[i % len(self._TS)],
+            "category": "implement",
+            "agent": "cai-implement",
+            "cost_usd": 0.10 * (i + 1),
+            "host": "host-a",
+        }
+        r.update(extra)
+        return r
+
+    def test_section1_headline(self):
+        """§1 headline shows grand total and invocation count."""
+        from cai_lib.audit.cost import _build_cost_summary
+
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            self._write_rows(local, [self._base_row(0), self._base_row(1)])
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                summary = _build_cost_summary(days=3650, top_n=5, cluster_n=2)
+
+        self.assertIn("## Cost summary (last 3650d,", summary)
+        self.assertIn("2 invocations", summary)
+
+    def test_section2_delta_by_agent(self):
+        """§2 shows agent delta when agent has >= 2*cluster_n rows."""
+        from cai_lib.audit.cost import _build_cost_summary
+
+        # Need >= 4 rows (cluster_n=2 → skip < 4)
+        rows = [self._base_row(i, ts=self._TS[i % len(self._TS)]) for i in range(4)]
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            self._write_rows(local, rows)
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                summary = _build_cost_summary(days=3650, top_n=5, cluster_n=2)
+
+        self.assertIn("§2 Recent vs prior", summary)
+        self.assertIn("cai-implement", summary)
+
+    def test_section2_skipped_when_not_enough_rows(self):
+        """§2 is omitted when no agent has >= 2*cluster_n rows."""
+        from cai_lib.audit.cost import _build_cost_summary
+
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            self._write_rows(local, [self._base_row(0)])  # only 1 row
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                summary = _build_cost_summary(days=3650, top_n=5, cluster_n=2)
+
+        self.assertNotIn("§2", summary)
+
+    def test_section3_expensive_targets(self):
+        """§3 shows top targets grouped by target_number."""
+        from cai_lib.audit.cost import _build_cost_summary
+
+        rows = [
+            self._base_row(0, target_number=42, cost_usd=0.50),
+            self._base_row(1, target_number=99, cost_usd=0.10),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            self._write_rows(local, rows)
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                summary = _build_cost_summary(days=3650, top_n=5, cluster_n=2)
+
+        self.assertIn("§3 Top-", summary)
+        self.assertIn("| #42 |", summary)
+        self.assertIn("| #99 |", summary)
+
+    def test_section3_outcome_join(self):
+        """§3 joins outcome log to show outcome and fix_attempt_count."""
+        from cai_lib.audit.cost import _build_cost_summary
+
+        cost_rows = [self._base_row(0, target_number=42, cost_usd=1.00)]
+        outcome_row = json.dumps({
+            "ts": "2099-01-01T00:00:00Z",
+            "issue_number": 42,
+            "outcome": "solved",
+            "fix_attempt_count": 3,
+        })
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            outcome = Path(tmp) / "cai-outcome.jsonl"
+            self._write_rows(local, cost_rows)
+            outcome.write_text(outcome_row + "\n")
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+                mock.patch.object(_cost_module, "OUTCOME_LOG_PATH", outcome),
+            ):
+                summary = _build_cost_summary(days=3650, top_n=5, cluster_n=2)
+
+        self.assertIn("| #42 |", summary)
+        self.assertIn("solved", summary)
+        self.assertIn("3", summary)
+
+    def test_section3_skipped_when_no_target_numbers(self):
+        """§3 is omitted when no rows have target_number."""
+        from cai_lib.audit.cost import _build_cost_summary
+
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            self._write_rows(local, [self._base_row(0)])  # no target_number
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                summary = _build_cost_summary(days=3650, top_n=5, cluster_n=2)
+
+        self.assertNotIn("§3", summary)
+
+    def test_section4_phase_breakdown_always_present(self):
+        """§4 is always shown, even with a single row."""
+        from cai_lib.audit.cost import _build_cost_summary
+
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            self._write_rows(local, [self._base_row(0, fsm_state="IN_PROGRESS")])
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                summary = _build_cost_summary(days=3650, top_n=5, cluster_n=2)
+
+        self.assertIn("§4 Phase breakdown", summary)
+        self.assertIn("| IN_PROGRESS |", summary)
+
+    def test_section4_retry_split(self):
+        """§4 correctly splits first-attempt vs retry via outcome join."""
+        from cai_lib.audit.cost import _build_cost_summary
+
+        cost_rows = [
+            self._base_row(0, target_number=10, fsm_state="IN_PROGRESS", cost_usd=0.20),
+        ]
+        # fix_attempt_count=3 → retry
+        outcome_row = json.dumps({
+            "ts": "2099-01-01T00:00:00Z",
+            "issue_number": 10,
+            "outcome": "solved",
+            "fix_attempt_count": 3,
+        })
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            outcome = Path(tmp) / "cai-outcome.jsonl"
+            self._write_rows(local, cost_rows)
+            outcome.write_text(outcome_row + "\n")
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+                mock.patch.object(_cost_module, "OUTCOME_LOG_PATH", outcome),
+            ):
+                summary = _build_cost_summary(days=3650, top_n=5, cluster_n=2)
+
+        # The IN_PROGRESS row should be in the retry column (0 first, 1 retry)
+        self.assertIn("| IN_PROGRESS | 0 |", summary)
+
+    def test_section5_module_field(self):
+        """§5 groups by module field when present."""
+        from cai_lib.audit.cost import _build_cost_summary
+
+        rows = [
+            self._base_row(0, module="fsm", cost_usd=0.30),
+            self._base_row(1, module="fsm", cost_usd=0.10),
+            self._base_row(2, module="audit", cost_usd=0.50),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            self._write_rows(local, rows)
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                summary = _build_cost_summary(days=3650, top_n=5, cluster_n=2)
+
+        self.assertIn("§5 Per-module", summary)
+        self.assertIn("| fsm |", summary)
+        self.assertIn("| audit |", summary)
+        # audit > fsm by total cost, so audit should appear first
+        self.assertLess(summary.index("| audit |"), summary.index("| fsm |"))
+
+    def test_section5_skipped_when_no_module_data(self):
+        """§5 is omitted when no rows have module or scope_files."""
+        from cai_lib.audit.cost import _build_cost_summary
+
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            self._write_rows(local, [self._base_row(0)])  # no module
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                summary = _build_cost_summary(days=3650, top_n=5, cluster_n=2)
+
+        self.assertNotIn("§5", summary)
+
+    def test_section6_cache_regression(self):
+        """§6 flags a ≥10pp cache-hit-rate drop for the same fingerprint."""
+        from cai_lib.audit.cost import _build_cost_summary
+
+        # cluster_n=2: need >= 4 rows per (agent, fingerprint)
+        # prior 2: high cache hit; recent 2: low cache hit
+        rows = [
+            self._base_row(0, prompt_fingerprint="abc123", cache_hit_rate=0.80),
+            self._base_row(1, prompt_fingerprint="abc123", cache_hit_rate=0.80),
+            self._base_row(2, prompt_fingerprint="abc123", cache_hit_rate=0.50),
+            self._base_row(3, prompt_fingerprint="abc123", cache_hit_rate=0.50),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            self._write_rows(local, rows)
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                summary = _build_cost_summary(days=3650, top_n=5, cluster_n=2)
+
+        self.assertIn("§6 Cache-health regressions", summary)
+        self.assertIn("abc123", summary)
+        self.assertIn("⚠️", summary)
+
+    def test_section6_skipped_when_no_regression(self):
+        """§6 is omitted when cache hit rate is stable (< 10pp drop)."""
+        from cai_lib.audit.cost import _build_cost_summary
+
+        rows = [
+            self._base_row(0, prompt_fingerprint="fp1", cache_hit_rate=0.80),
+            self._base_row(1, prompt_fingerprint="fp1", cache_hit_rate=0.80),
+            self._base_row(2, prompt_fingerprint="fp1", cache_hit_rate=0.79),
+            self._base_row(3, prompt_fingerprint="fp1", cache_hit_rate=0.79),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            self._write_rows(local, rows)
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                summary = _build_cost_summary(days=3650, top_n=5, cluster_n=2)
+
+        self.assertNotIn("§6", summary)
+
+    def test_section7_host_anomalies(self):
+        """§7 flags hosts with mean $/call ≥ 2× median.
+
+        Use 3 hosts so the odd-index median is the middle value and the
+        expensive host clearly exceeds 2× it.
+        """
+        from cai_lib.audit.cost import _build_cost_summary
+
+        # host-a and host-b have mean 0.10; host-c has mean 1.00.
+        # sorted_means=[0.10, 0.10, 1.00], median=0.10; host-c: 1.00 >= 2*0.10 ✓
+        rows = [
+            self._base_row(0, host="host-a", cost_usd=0.10),
+            self._base_row(1, host="host-b", cost_usd=0.10),
+            self._base_row(2, host="host-c", cost_usd=1.00),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            self._write_rows(local, rows)
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                summary = _build_cost_summary(days=3650, top_n=5, cluster_n=2)
+
+        self.assertIn("§7 Host anomalies", summary)
+        self.assertIn("| host-a |", summary)
+        self.assertIn("| host-c |", summary)
+        # host-c has mean 1.00 vs median 0.10; 1.00 >= 2*0.10 so flagged
+        idx_c = summary.index("| host-c |")
+        self.assertIn("⚠️", summary[idx_c:idx_c + 80])
+
+    def test_scope_files_field_in_row(self):
+        """Rows can carry scope_files and prompt_fingerprint fields."""
+        from cai_lib.audit.cost import _build_cost_summary
+
+        rows = [
+            self._base_row(
+                0,
+                scope_files=["cai_lib/audit/cost.py", "tests/test_audit_cost.py"],
+                prompt_fingerprint="deadbeef",
+            )
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / "cai-cost.jsonl"
+            self._write_rows(local, rows)
+            missing_agg = Path(tmp) / "nope"
+            with (
+                mock.patch.object(_cost_module, "COST_LOG_PATH", local),
+                mock.patch.object(_cost_module, "COST_LOG_AGGREGATE_DIR", missing_agg),
+            ):
+                # Confirm the summary is non-empty (rows present)
+                summary = _build_cost_summary(days=3650, top_n=5, cluster_n=2)
+
+        self.assertNotEqual(summary, "")
 
 
 if __name__ == "__main__":

--- a/tests/test_cmd_helpers_git.py
+++ b/tests/test_cmd_helpers_git.py
@@ -122,13 +122,20 @@ class TestReadPrefetchedFiles(unittest.TestCase):
     def test_issue_body_without_files_to_change_section(self):
         tmp = self._make_tmp()
         issue_body = "Some issue body without any files section."
-        result = _work_directory_block(tmp, issue_body)
+        # Suppress shared-memory injection (implement-plan-scope-gate.md
+        # contains the literal phrase "## Pre-loaded file contents" which
+        # would cause false-positive assertNotIn failures — same pattern
+        # as PR#1204 / PR#1226).
+        with patch("cai_lib.cmd_helpers_git._read_shared_memory", return_value=""):
+            result = _work_directory_block(tmp, issue_body)
         # Should fall back to current behavior — no preload section.
         self.assertNotIn("## Pre-loaded file contents", result)
 
     def test_no_issue_body_no_preload(self):
         tmp = self._make_tmp()
-        result = _work_directory_block(tmp)
+        # Same shared-memory isolation as test_issue_body_without_files_to_change_section.
+        with patch("cai_lib.cmd_helpers_git._read_shared_memory", return_value=""):
+            result = _work_directory_block(tmp)
         self.assertNotIn("## Pre-loaded file contents", result)
 
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1224

**Issue:** #1224 — [#1208 Step 1/2] Wire cost pre-load — enrich log fields, rewrite summary, wire into runner

## PR Summary

### What this fixes
Issue #1224 delivers the core cost pre-load infrastructure: enriches cost-log rows with `module`, `scope_files`, and `fingerprint_payload` fields; rewrites `_build_cost_summary` with 7 graceful-degrading analysis sections; wires the summary into the audit module prompt; and adds a developer stderr banner.

### What was changed
- **`cai_lib/subprocess_utils.py`**: Added `module`, `scope_files`, and `fingerprint_payload` optional kwargs to `_run_claude_p`. When provided, `module` and `scope_files` are stamped on the cost-log row; `fingerprint_payload` overrides the default system+user-prompt fingerprint computation.
- **`cai_lib/actions/implement.py`**: At the main implement subagent call site, extracts the `### Files to change` path list from `selected_plan` and passes it as `scope_files`, plus `fingerprint_payload=user_message`.
- **`cai_lib/audit/runner.py`**: `_run_one_module` passes `module=entry.name` to `_run_claude_p` and prints a `_build_cost_summary` stderr banner when `sys.stderr.isatty()`. `_build_module_prompt` calls `pull_cost()` (sync no-op when disabled) and appends a `## Cost summary` block to the agent prompt.
- **`cai_lib/audit/cost.py`**: Added three new helpers (`_load_outcome_index`, `_build_module_index`, `_infer_module_from_files`). Rewrote `_build_cost_summary` with 7 sections: §1 window headline, §2 recent vs prior Δ by agent, §3 top-N expensive targets (joined with outcome log), §4 phase breakdown by fsm_state, §5 per-module cost, §6 cache-health regressions, §7 host anomalies. New `cluster_n=10` parameter controls cluster windows.
- **`tests/test_audit_cost.py`**: Updated `TestBuildCostSummaryFsmState` for the new §4 section header; added `TestBuildCostSummaryAllSections` with 13 new tests covering all 7 sections, graceful-skip behavior, and the outcome-log join.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
