### PR TITLE
auto-improve: Remove ~30 dead imports from cai.py

### DIFF
--- a/cai.py
+++ b/cai.py
@@ -152,62 +152,20 @@ the cai_home volume.
 No third-party Python dependencies — only stdlib.
 """
 import argparse
-import json
-import os
-import re
-import shutil
-import subprocess
 import sys
-import uuid
 
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
+from cai_lib.publish import ensure_all_labels
+from cai_lib.config import *  # noqa: F403
 
-from cai_lib.publish import (  # noqa: E402
-    ensure_all_labels, AUDIT_CATEGORIES,
-    create_issue, issue_exists, ensure_labels,
-)
-from cai_lib.dup_check import check_duplicate_or_resolved  # noqa: E402
-
-
-from cai_lib.config import *  # noqa: E402,F403
-from cai_lib.config import (  # noqa: E402
-    _STALE_MERGED_DAYS,
-)
-
-from cai_lib.logging_utils import (  # noqa: E402
-    log_cost,  # noqa: F401
-    _get_issue_category, _log_outcome, _load_outcome_stats,
-)
-from cai_lib.audit.cost import (  # noqa: E402
-    _load_outcome_counts, _load_cost_log, _row_ts, _build_cost_summary,
-)
-
-
-# ---------------------------------------------------------------------------
-# Common helpers
-# ---------------------------------------------------------------------------
-
-from cai_lib.subprocess_utils import _run, _run_claude_p  # noqa: E402
-
-
-from cai_lib.github import (  # noqa: E402
-    check_gh_auth, check_claude_auth,
-    _set_pr_labels, _issue_has_label, _build_issue_block,
-    _build_implement_user_message, _fetch_linked_issue_block,
-    close_issue_not_planned, _recover_stale_pr_open,
-)
-from cai_lib.cmd_helpers import _work_directory_block  # noqa: E402
-from cai_lib.cmd_unblock import cmd_unblock  # noqa: E402
-from cai_lib.cmd_rescue import cmd_rescue  # noqa: E402
-from cai_lib.cmd_misc import (  # noqa: E402
+from cai_lib.github import check_gh_auth, check_claude_auth
+from cai_lib.cmd_unblock import cmd_unblock
+from cai_lib.cmd_rescue import cmd_rescue
+from cai_lib.cmd_misc import (
     cmd_init, cmd_verify, cmd_test, cmd_cost_report,
 )
-from cai_lib.cmd_agents import cmd_audit_module, cmd_audit_health  # noqa: E402
-from cai_lib.cmd_cycle import cmd_cycle, cmd_dispatch  # noqa: E402
-from cai_lib.transcript_sync import cmd_transcript_sync  # noqa: E402
-
-
+from cai_lib.cmd_agents import cmd_audit_module, cmd_audit_health
+from cai_lib.cmd_cycle import cmd_cycle, cmd_dispatch
+from cai_lib.transcript_sync import cmd_transcript_sync
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1234

**Issue:** #1234 — Remove ~30 dead imports from cai.py

## PR Summary

### What this fixes
After extraction refactors reduced `cai.py` to a 374-line subcommand dispatcher, ~30 imports were left behind that are no longer referenced anywhere in the file. This PR removes them.

### What was changed
- **`cai.py`** (import block, lines 154–210): replaced ~55-line import block with a 15-line clean block:
  - Removed unused stdlib imports: `json`, `os`, `re`, `shutil`, `subprocess`, `uuid`, `datetime`, `timedelta`, `timezone`, `Path`
  - Shrunk `cai_lib.publish` import to just `ensure_all_labels` (removed `AUDIT_CATEGORIES`, `create_issue`, `issue_exists`, `ensure_labels`)
  - Shrunk `cai_lib.github` import to just `check_gh_auth, check_claude_auth` (removed 6 unused symbols)
  - Deleted entire import lines for `cai_lib.dup_check`, `cai_lib.subprocess_utils`, `cai_lib.audit.cost`, `cai_lib.logging_utils`, `cai_lib.cmd_helpers`
  - Deleted the redundant explicit `from cai_lib.config import (_STALE_MERGED_DAYS,)` (covered by the preceding star import)
  - Removed all `# noqa: E402` and `# noqa: F401` suppressions that became unnecessary
  - Removed the now-empty `# Common helpers` comment block

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
