### PR TITLE
auto-improve: audit: cost-summary banner printed for all audit kinds (noise outside cost-reduction)

### DIFF
--- a/cai_lib/audit/runner.py
+++ b/cai_lib/audit/runner.py
@@ -116,7 +116,7 @@ def _run_one_module(kind: str, agent: str, entry) -> int:  # type: ignore[no-unt
 
     try:
         user_message = _build_module_prompt(entry, findings_file)
-        if sys.stderr.isatty():
+        if kind == "cost-reduction" and sys.stderr.isatty():
             _banner = _build_cost_summary()
             if _banner:
                 print(

--- a/docs/modules/audit.md
+++ b/docs/modules/audit.md
@@ -71,7 +71,8 @@ function in `cai_lib/cmd_agents.py` or `cai_lib/cmd_misc.py`.
   it as a `## Cost summary` section in the agent's user message. This 
   provides spend context per module without the agent needing to parse 
   log files. The cost summary is also printed to stderr when running 
-  interactively (TTY).
+  `cai audit cost-reduction` interactively (TTY) to provide real-time 
+  spend visibility for the cost-reduction audit only.
 - **Audit log path convention.** `cai_lib/audit/runner.py` writes one
   structured JSONL file per `(kind, module)` pair under
   `/var/log/cai/audit/<kind>/<module>.jsonl` (e.g.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1236

**Issue:** #1236 — audit: cost-summary banner printed for all audit kinds (noise outside cost-reduction)

## PR Summary

### What this fixes
The cost-summary banner (token/dollar spend, per-agent deltas) was being printed to stderr before every audit agent run, regardless of audit kind. This was noise for `good-practices`, `code-reduction`, and `workflow-enhancement` audits — the cost data is only relevant when running a `cost-reduction` audit.

### What was changed
- **`cai_lib/audit/runner.py` line 119** — changed `if sys.stderr.isatty():` to `if kind == "cost-reduction" and sys.stderr.isatty():`, gating the banner so it only prints during cost-reduction audits; the existing isatty check (suppresses output in non-interactive contexts) is preserved.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
