### PR TITLE
auto-improve: Inline single-caller `_linked_open_pr_number`

### DIFF
--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -1179,12 +1179,6 @@ def _pr_ci_pending(pr: dict) -> bool:
     return False
 
 
-def _linked_open_pr_number(issue_number: int) -> Optional[int]:
-    """Return the open ``auto-improve/<N>-...`` PR number for this issue, or None."""
-    pr = _find_open_linked_pr(issue_number)
-    return pr["number"] if pr else None
-
-
 def _issue_number_from_pr_branch(pr: dict) -> Optional[int]:
     """Parse the issue number from an ``auto-improve/<N>-...`` branch."""
     head = pr.get("headRefName", "") or ""
@@ -1282,7 +1276,8 @@ def _drive_target_to_completion(
                     return worst_rc
                 # Issue→PR hop: issue advanced to PR state — drive the linked PR.
                 if post_state == IssueState.PR:
-                    linked = _linked_open_pr_number(number)
+                    linked_pr = _find_open_linked_pr(number)
+                    linked = linked_pr["number"] if linked_pr else None
                     if linked is not None and ("pr", linked) not in touched:
                         print(f"[cai dispatch] issue #{number} advanced to PR — "
                               f"following PR #{linked}", flush=True)


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1237

**Issue:** #1237 — Inline single-caller `_linked_open_pr_number`

## PR Summary

### What this fixes
`_linked_open_pr_number` was a trivial 4-line pass-through wrapper around `_find_open_linked_pr` with no additional logic and only one call site, adding unnecessary indirection.

### What was changed
- **`cai_lib/dispatcher.py`**: Deleted the `_linked_open_pr_number` function definition (lines 1182–1185). At the single call site (formerly line 1285), replaced `linked = _linked_open_pr_number(number)` with a direct two-line inline: `linked_pr = _find_open_linked_pr(number)` / `linked = linked_pr["number"] if linked_pr else None`. Net: -3 lines, identical runtime behavior.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
