### PR TITLE
auto-improve: Derive `Confidence` ordering via `functools.total_ordering`

### DIFF
--- a/cai_lib/fsm_confidence.py
+++ b/cai_lib/fsm_confidence.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 import re
 from enum import Enum
+from functools import total_ordering
 from typing import Optional
 
 
+@total_ordering
 class Confidence(Enum):
     """Qualitative confidence level emitted by agents.
 
@@ -25,21 +27,6 @@ class Confidence(Enum):
         if not isinstance(other, Confidence):
             return NotImplemented
         return self.value < other.value
-
-    def __le__(self, other: "Confidence") -> bool:
-        if not isinstance(other, Confidence):
-            return NotImplemented
-        return self.value <= other.value
-
-    def __gt__(self, other: "Confidence") -> bool:
-        if not isinstance(other, Confidence):
-            return NotImplemented
-        return self.value > other.value
-
-    def __ge__(self, other: "Confidence") -> bool:
-        if not isinstance(other, Confidence):
-            return NotImplemented
-        return self.value >= other.value
 
 
 _CONFIDENCE_RE = re.compile(


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1241

**Issue:** #1241 — Derive `Confidence` ordering via `functools.total_ordering`

## PR Summary

### What this fixes
`cai_lib/fsm_confidence.py` hand-rolled all four ordering dunders (`__lt__`, `__le__`, `__gt__`, `__ge__`) on the `Confidence` enum, producing 19 lines of near-identical boilerplate. Since `__le__` and `__gt__` have zero call sites in production or tests, and `__ge__` can be derived automatically, three of the four methods were redundant.

### What was changed
- **`cai_lib/fsm_confidence.py`**: added `from functools import total_ordering` to the import block, added `@total_ordering` decorator to `class Confidence(Enum):`, and removed the `__le__`, `__gt__`, and `__ge__` method bodies. `__lt__` is kept unchanged as the single ordering primitive that `total_ordering` builds from. Net: +2 lines, −17 lines (−15 net). All 771 tests pass.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
