### PR TITLE
auto-improve: Delete unused marker constants in cmd_helpers_github.py

### DIFF
--- a/cai_lib/cmd_helpers.py
+++ b/cai_lib/cmd_helpers.py
@@ -12,8 +12,6 @@ from cai_lib.cmd_helpers_git import (
 )
 from cai_lib.cmd_helpers_github import (
     _BOT_COMMENT_MARKERS,
-    _NO_ADDITIONAL_CHANGES_MARKER,
-    _REBASE_FAILED_MARKER,
     _gh_user_identity,
     _is_bot_comment,
     _parse_iso_ts,
@@ -41,8 +39,6 @@ __all__ = [
     "_apply_agent_edit_staging",
     # GitHub API helpers
     "_BOT_COMMENT_MARKERS",
-    "_NO_ADDITIONAL_CHANGES_MARKER",
-    "_REBASE_FAILED_MARKER",
     "_gh_user_identity",
     "_is_bot_comment",
     "_parse_iso_ts",

--- a/cai_lib/cmd_helpers_github.py
+++ b/cai_lib/cmd_helpers_github.py
@@ -32,13 +32,6 @@ _BOT_COMMENT_MARKERS = (
 )
 
 
-# Duplicates of module-level markers in cai.py. Kept in sync with the
-# cai.py definitions; these copies exist so cmd_helpers is importable
-# without a circular dependency on cai.py.
-_NO_ADDITIONAL_CHANGES_MARKER = "## Revise subagent: no additional changes"
-_REBASE_FAILED_MARKER = "## Revise subagent: rebase resolution failed"
-
-
 def _gh_user_identity() -> tuple[str, str]:
     """Resolve the gh-token owner's git name and email."""
     user = _gh_json(["api", "user"])


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1238

**Issue:** #1238 — Delete unused marker constants in cmd_helpers_github.py

## PR Summary

### What this fixes
Two marker constants (`_NO_ADDITIONAL_CHANGES_MARKER` and `_REBASE_FAILED_MARKER`) were defined in `cai_lib/cmd_helpers_github.py` with a stale comment claiming they mirror definitions in `cai.py` (which no longer defines them), and re-exported through `cai_lib/cmd_helpers.py`, but no external consumer ever imported them — `cai_lib/actions/revise.py` carries its own independent local copies.

### What was changed
- **`cai_lib/cmd_helpers_github.py`**: Deleted the 5-line block (stale comment + `_NO_ADDITIONAL_CHANGES_MARKER` + `_REBASE_FAILED_MARKER` definitions).
- **`cai_lib/cmd_helpers.py`**: Removed the two import statements for those constants (lines 15–16) and their two entries in `__all__` (lines 44–45). Net: 9 lines removed, no behavior change.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
