### PR TITLE
auto-improve: Inline single-caller `_extract_verdict_block` in split.py

### DIFF
--- a/cai_lib/actions/split.py
+++ b/cai_lib/actions/split.py
@@ -53,14 +53,6 @@ _UNCLEAR_MARKER = "VERDICT: UNCLEAR"
 _DECOMPOSITION_MARKER = "## Multi-Step Decomposition"
 
 
-def _extract_verdict_block(stdout: str, marker: str) -> str:
-    """Return the slice starting at *marker* (trimmed), or empty string."""
-    pos = stdout.find(marker)
-    if pos == -1:
-        return ""
-    return stdout[pos:].strip()
-
-
 def handle_split(issue: dict) -> int:
     """Evaluate scope of a refined issue via cai-split.
 
@@ -265,7 +257,7 @@ def handle_split(issue: dict) -> int:
 
     # 3c. Unclear verdict or missing marker — divert to human.
     if has_unclear:
-        verdict_block = _extract_verdict_block(stdout, _UNCLEAR_MARKER)
+        verdict_block = (stdout[stdout.find(_UNCLEAR_MARKER):].strip() if _UNCLEAR_MARKER in stdout else "")
         divert_reason = (
             "cai-split returned VERDICT: UNCLEAR — the agent was not "
             "confident enough to decide atomic vs. decompose. Admin "


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1245

**Issue:** #1245 — Inline single-caller `_extract_verdict_block` in split.py

## PR Summary

### What this fixes
`_extract_verdict_block` in `cai_lib/actions/split.py` was a 6-line helper with exactly one call site in the same file. The helper added indirection without reuse value.

### What was changed
- **`cai_lib/actions/split.py`**: Deleted the `_extract_verdict_block` function definition (lines 56–62, ~7 lines including blank separator). Replaced the single call site at the former line 268 with an inline one-liner: `(stdout[stdout.find(_UNCLEAR_MARKER):].strip() if _UNCLEAR_MARKER in stdout else "")`. Net reduction: ~5–6 lines.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
