### PR TITLE
auto-improve: Inline single-caller `_ops_source_is_inferred` in maintain.py

### DIFF
--- a/cai_lib/actions/maintain.py
+++ b/cai_lib/actions/maintain.py
@@ -46,13 +46,6 @@ _OPS_SOURCE_INFERRED_RE = re.compile(
 )
 
 
-def _ops_source_is_inferred(text: str) -> bool:
-    """Return True iff *text* contains a well-formed ``Ops-source: inferred`` line."""
-    if not text:
-        return False
-    return _OPS_SOURCE_INFERRED_RE.search(text) is not None
-
-
 def handle_maintain(issue: dict) -> int:
     """Dispatcher handler for ``IssueState.APPLYING``.
 
@@ -131,7 +124,7 @@ def handle_maintain(issue: dict) -> int:
     # sibling's only difference from the default is its MEDIUM confidence
     # gate — labels move identically. Plans with an explicit ``Ops:``
     # header stay on the default HIGH-threshold transition.
-    ops_inferred = _ops_source_is_inferred(result.stdout)
+    ops_inferred = bool(result.stdout and _OPS_SOURCE_INFERRED_RE.search(result.stdout))
     transition_name = (
         "applying_to_applied_inferred_ops" if ops_inferred
         else "applying_to_applied"


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1246

**Issue:** #1246 — Inline single-caller `_ops_source_is_inferred` in maintain.py

## PR Summary

### What this fixes
`cai_lib/actions/maintain.py` contained a trivial 5-line helper `_ops_source_is_inferred` that wrapped a single compiled-regex call and had exactly one call site in the same file. This unnecessary abstraction added indirection without reuse value.

### What was changed
- **`cai_lib/actions/maintain.py`**: Deleted the `_ops_source_is_inferred` helper function (lines 49–53 plus blank separator, net −6 lines). At the sole call site replaced `_ops_source_is_inferred(result.stdout)` with the equivalent inline expression `bool(result.stdout and _OPS_SOURCE_INFERRED_RE.search(result.stdout))`. The module-level `_OPS_SOURCE_INFERRED_RE` regex is unchanged.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
