### PR TITLE
auto-improve: Remove efficiency rules in cai-implement.md that duplicate CLAUDE.md

### DIFF
--- a/.claude/agents/implementation/cai-implement.md
+++ b/.claude/agents/implementation/cai-implement.md
@@ -105,33 +105,15 @@ and label transitions — so you only need to focus on the code.
    a unique comment. Never use an `old_string` composed entirely of
    generic lines (blank lines, closing braces, common keywords) that
    could match multiple locations.
-3. **Grep before Read.** Use Grep to locate the relevant file(s)
-   and line numbers before opening them with Read. Do not
-   sequentially Read files to search for content — reserve Read for
-   files whose paths and relevance are already known.
-4. **Verify paths with Glob before Read.** When a file path is
-   constructed or inferred (not hard-coded), confirm the file exists
-   using Glob before attempting to Read it. If a Read fails, do not
-   retry the same path — use Glob to find the correct filename
-   first.
-5. **Batch independent Read calls.** When you need to read multiple
-   files and the reads are independent, issue all Read calls in a
-   single turn rather than one at a time.
-6. **Batch edits to the same file.** Combine multiple changes into
+3. **Batch edits to the same file.** Combine multiple changes into
    as few Edit calls as possible by using larger `old_string` spans.
    Avoid single-line edits when a multi-line replacement achieves
    the same result in one call.
-7. **Minimize Write calls.** Before creating multiple new files,
+4. **Minimize Write calls.** Before creating multiple new files,
    consider whether the content could fit in a single file or fewer
    files. When several files are genuinely needed, plan the full set
    first, then issue all independent Write calls in one turn rather
    than creating them one at a time.
-8. **Batch Grep calls.** When searching for multiple patterns or
-   across multiple paths, combine them into a single Grep call using
-   regex alternation (`pat1|pat2`) or issue independent Grep calls
-   in parallel rather than sequentially. Use Glob first to narrow
-   the file set, then Grep the results, instead of running
-   exploratory Grep calls one at a time.
 
 ## Consult your memory first
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1250

**Issue:** #1250 — Remove efficiency rules in cai-implement.md that duplicate CLAUDE.md

## PR Summary

### What this fixes
`cai-implement.md` duplicated four efficiency rules byte-for-byte from `CLAUDE.md`, which is already loaded into every subagent's context — wasting ~18 lines of prompt tokens on every invocation.

### What was changed
- `.claude/agents/implementation/cai-implement.md` (via staging): deleted the four duplicate rules from `## Efficiency guidance` — "Grep before Read" (old rule 3), "Verify paths with Glob before Read" (old rule 4), "Batch independent Read calls" (old rule 5), and "Batch Grep calls" (old rule 8) — and renumbered the two surviving implement-specific rules from 6→3 ("Batch edits to the same file") and 7→4 ("Minimize Write calls").

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
