### PR TITLE
auto-improve: [#1265 Step 1/2] Foundation — strip repo couplings from `subagent/`, relocate `cost.py`/`fsm_state.py`, add `CaiSubAgent`/`CaiCostTracker`

### DIFF
--- a/cai_lib/actions/confirm.py
+++ b/cai_lib/actions/confirm.py
@@ -37,7 +37,7 @@ from cai_lib.utils.log import (
 )
 from claude_agent_sdk import ClaudeAgentOptions
 
-from cai_lib.subagent import run_subagent
+from cai_lib.cai_subagent import run_subagent
 from cai_lib.subprocess_utils import _run
 
 

--- a/cai_lib/cai_subagent.py
+++ b/cai_lib/cai_subagent.py
@@ -1,0 +1,133 @@
+"""Cai-specific subagent layer — repo-coupled subclasses of SubAgent/CostTracker.
+
+This module owns all robotsix-cai repository specifics that have been
+stripped from :mod:`cai_lib.subagent.core` and
+:mod:`cai_lib.subagent.cost_tracker`:
+
+* :class:`CaiCostTracker` — overrides :meth:`~CostTracker._emit` to stamp
+  the FSM-state contextvar, call :func:`cai_lib.utils.log.log_cost`, and
+  mirror the cost row as a GH comment via
+  :func:`cai_lib.cost_comment._post_cost_comment`.
+* :class:`CaiSubAgent` — overrides :meth:`~SubAgent._prepare_options` to
+  pin the npm-installed ``claude`` CLI path and auto-inject the
+  ``cai-skills`` plugin when present.
+* :func:`run_subagent` — one-shot shim that constructs a
+  :class:`CaiSubAgent` backed by a :class:`CaiCostTracker`.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from claude_agent_sdk import ClaudeAgentOptions
+
+from cai_lib.subagent.core import SubAgent
+from cai_lib.subagent.cost_tracker import CostTracker
+from cai_lib.cost_comment import _post_cost_comment
+from cai_lib.fsm_state import _CURRENT_FSM_STATE
+from cai_lib.utils.log import log_cost
+
+
+class CaiCostTracker(CostTracker):
+    """CostTracker subclass that logs to disk and mirrors GH comments.
+
+    Overrides :meth:`_emit` to stamp the FSM state contextvar onto the
+    row, call :func:`~cai_lib.utils.log.log_cost`, and post the
+    cost-attribution comment on the issue/PR target (and optional extra
+    target) via :func:`~cai_lib.cost_comment._post_cost_comment`.
+    """
+
+    def _emit(self, row: dict, agent: str) -> None:
+        """Stamp FSM state, log cost row, and post GH cost-attribution comment."""
+        fsm_state = _CURRENT_FSM_STATE.get()
+        if fsm_state:
+            row["fsm_state"] = fsm_state
+        log_cost(row)
+        if self.target_kind is not None and self.target_number is not None:
+            _post_cost_comment(
+                self.target_kind, self.target_number, row, agent,
+            )
+        if (
+            self.extra_target_kind is not None
+            and self.extra_target_number is not None
+        ):
+            _post_cost_comment(
+                self.extra_target_kind, self.extra_target_number,
+                row, agent,
+            )
+
+
+class CaiSubAgent(SubAgent):
+    """SubAgent subclass that pins the CLI path and injects the cai-skills plugin.
+
+    Overrides :meth:`_prepare_options` to call the parent's stderr-sink
+    setup, then additionally:
+
+    * Pin ``options.cli_path`` to the npm-installed ``claude`` binary so
+      the SDK reuses the binary audited in the Dockerfile.
+    * Inject the ``cai-skills`` local plugin when
+      ``.claude/plugins/cai-skills`` exists at the caller's cwd.
+    """
+
+    def _prepare_options(self) -> None:
+        """Pin cli_path, auto-inject cai-skills plugin, attach stderr sink."""
+        # Base: reset captured stderr and attach fresh stderr sink.
+        super()._prepare_options()
+
+        _cli_path = shutil.which("claude")
+        if _cli_path and not getattr(self.options, "cli_path", None):
+            self.options.cli_path = _cli_path
+
+        skills_plugin = Path(".claude/plugins/cai-skills")
+        if skills_plugin.is_dir():
+            if self.options.plugins is None:
+                self.options.plugins = []
+            already = any(
+                isinstance(p, dict) and p.get("path") == str(skills_plugin)
+                for p in self.options.plugins
+            )
+            if not already:
+                self.options.plugins.append(
+                    {"type": "local", "path": str(skills_plugin)}
+                )
+
+
+def run_subagent(
+    prompt: str,
+    options: ClaudeAgentOptions,
+    *,
+    category: str,
+    agent: str,
+    target_kind: str | None = None,
+    target_number: int | None = None,
+    extra_target_kind: str | None = None,
+    extra_target_number: int | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess:
+    """Cai-specific one-shot subagent invocation over :class:`CaiSubAgent`.
+
+    Constructs a :class:`CaiSubAgent` (with a :class:`CaiCostTracker` built
+    from the optional target metadata), calls ``.run(prompt)`` once, and
+    returns the :class:`subprocess.CompletedProcess`.
+
+    This is the cai-repository-specific counterpart to
+    :func:`cai_lib.subagent.core.run_subagent`. Callers that need CLI-pin,
+    plugin-inject, cost-log, and GH-comment behaviors should use this
+    function; the base :func:`cai_lib.subagent.run_subagent` is a stripped
+    version without those behaviors.
+    """
+    tracker = CaiCostTracker(
+        target_kind=target_kind,
+        target_number=target_number,
+        extra_target_kind=extra_target_kind,
+        extra_target_number=extra_target_number,
+    )
+    return CaiSubAgent(
+        options=options,
+        category=category,
+        agent=agent,
+        timeout=timeout,
+        cost_tracker=tracker,
+    ).run(prompt)

--- a/cai_lib/cost_comment.py
+++ b/cai_lib/cost_comment.py
@@ -5,6 +5,10 @@ format, and the best-effort issue/PR comment post that fires after
 ``log_cost(row)`` when ``_run_claude_p``/``run_subagent`` are called
 with a target kind and number. See ``cai_lib.config.CAI_COST_COMMENT_RE``
 and ``_strip_cost_comments`` for the matching reader side.
+
+Previously located at :mod:`cai_lib.subagent.cost`; moved here to
+decouple the base :mod:`cai_lib.subagent` package from repo-specific
+dependencies (issue #1269).
 """
 
 from __future__ import annotations

--- a/cai_lib/cost_summary.py
+++ b/cai_lib/cost_summary.py
@@ -1,7 +1,7 @@
 """Close-time per-issue cost-summary comment.
 
 Sits on top of the per-invocation ``<!-- cai-cost ... -->`` markers
-posted by :func:`cai_lib.subagent.cost._post_cost_comment`. When an
+posted by :func:`cai_lib.cost_comment._post_cost_comment`. When an
 auto-improve issue reaches the merged path,
 :func:`post_final_cost_summary` aggregates every cost row tagged
 against that issue or its linked PR and posts a single
@@ -266,7 +266,7 @@ def post_final_cost_summary(
 ) -> None:
     """Best-effort: aggregate + post the close-time cost summary.
 
-    Contract mirrors :func:`cai_lib.subagent.cost._post_cost_comment`:
+    Contract mirrors :func:`cai_lib.cost_comment._post_cost_comment`:
     every exception is caught and logged to stderr; the caller (merge
     handler) must remain unaffected by failures here.
     """

--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -52,7 +52,7 @@ from cai_lib.github import (
     open_blockers,
 )
 from cai_lib.issues import list_sub_issues
-from cai_lib.subagent import set_current_fsm_state
+from cai_lib.fsm_state import set_current_fsm_state
 
 
 # ---------------------------------------------------------------------------

--- a/cai_lib/fsm_state.py
+++ b/cai_lib/fsm_state.py
@@ -1,0 +1,50 @@
+"""Per-invocation FSM state stamp for cost-log rows (issue #1203).
+
+The dispatcher (``cai_lib/dispatcher.py``) wraps each handler call with
+``set_current_fsm_state(state.name)`` so that any ``_run_claude_p`` or
+``run_subagent`` call made inside the handler records the funnel position
+(e.g. ``"REFINING"``, ``"PLANNING"``, ``"IN_PROGRESS"``,
+``"REVIEWING_CODE"``) into the row's optional ``fsm_state`` key. Non-FSM
+call sites (``cmd_rescue``, ``cmd_unblock``, ``dup_check``,
+``audit/runner.py``, ``cmd_misc.init``) leave the contextvar unset; those
+rows simply omit the key, preserving back-compat for readers that only
+know ``category``.
+
+Previously located at :mod:`cai_lib.subagent.fsm_state`; moved here to
+decouple the base :mod:`cai_lib.subagent` package from repo-specific
+dependencies (issue #1269). :mod:`cai_lib.subagent.fsm_state` is kept as
+a thin re-export shim for backwards-compatibility.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from contextlib import contextmanager
+
+
+_CURRENT_FSM_STATE: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "cai_current_fsm_state", default=None,
+)
+
+
+@contextmanager
+def set_current_fsm_state(name: str | None):
+    """Set the FSM state stamp for every ``_run_claude_p`` or ``run_subagent`` call in the block.
+
+    ``name`` should be the ``.name`` of an :class:`IssueState` or
+    :class:`PRState` enum member (e.g. ``"REFINING"``). Passing ``None``
+    explicitly clears the stamp for the scoped block.
+
+    Usage::
+
+        with set_current_fsm_state(state.name):
+            handler(issue)
+
+    The stamp is scoped by ``contextvars.Token`` so nested wraps restore
+    the previous value cleanly on exit.
+    """
+    token = _CURRENT_FSM_STATE.set(name)
+    try:
+        yield
+    finally:
+        _CURRENT_FSM_STATE.reset(token)

--- a/cai_lib/subagent/core.py
+++ b/cai_lib/subagent/core.py
@@ -19,10 +19,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-import shutil
+import logging
 import subprocess
-import sys
-from pathlib import Path
 
 from claude_agent_sdk import ClaudeAgentOptions, query
 from claude_agent_sdk.types import (
@@ -36,12 +34,6 @@ from pydantic import BaseModel, ConfigDict, Field
 from .cost_tracker import CostTracker
 from .errors import _sdk_error_summary
 from .stderr_sink import _captured_stderr_text, _make_stderr_sink
-
-
-# Resolve the CLI path once at import time so the SDK reuses the
-# npm-installed `claude` binary audited in Dockerfile instead of the
-# copy bundled with the SDK wheel.
-_CLI_PATH = shutil.which("claude")
 
 
 async def _collect_results(
@@ -189,31 +181,13 @@ class SubAgent(BaseModel):
         return self._to_completed_process(result, stdout)
 
     def _prepare_options(self) -> None:
-        """Pin cli_path, auto-inject cai-skills plugin, attach a fresh stderr sink.
+        """Attach a fresh stderr sink and reset :attr:`last_captured_stderr`.
 
-        Preserves the implicit ``cai-skills`` injection that
-        ``_argv_to_options`` (legacy.py:102-104) does for the argv path
-        and the ``cli_path`` pin that every call path needs to reuse
-        the npm-installed ``claude`` binary. Resets
-        :attr:`last_captured_stderr` to a fresh list each run so a
-        reused instance does not leak stderr lines across runs.
+        Resets :attr:`last_captured_stderr` to a fresh list each run so a
+        reused instance does not leak stderr lines across runs. Subclasses
+        (e.g. :class:`cai_lib.cai_subagent.CaiSubAgent`) call ``super()``
+        first and then add repo-specific setup (CLI path pin, plugin inject).
         """
-        if _CLI_PATH and not getattr(self.options, "cli_path", None):
-            self.options.cli_path = _CLI_PATH
-
-        skills_plugin = Path(".claude/plugins/cai-skills")
-        if skills_plugin.is_dir():
-            if self.options.plugins is None:
-                self.options.plugins = []
-            already = any(
-                isinstance(p, dict) and p.get("path") == str(skills_plugin)
-                for p in self.options.plugins
-            )
-            if not already:
-                self.options.plugins.append(
-                    {"type": "local", "path": str(skills_plugin)}
-                )
-
         self.last_captured_stderr = []
         self.options.stderr = _make_stderr_sink(self.last_captured_stderr)
 
@@ -238,10 +212,10 @@ class SubAgent(BaseModel):
         if result.structured_output is not None:
             return json.dumps(result.structured_output)
         if result.subtype == "error_max_structured_output_retries":
-            print(
-                f"[cai cost] structured output retries exhausted "
-                f"({self.category}/{self.agent}); schema was not satisfied",
-                file=sys.stderr, flush=True,
+            logging.getLogger(__name__).warning(
+                "[cai cost] structured output retries exhausted "
+                "(%s/%s); schema was not satisfied",
+                self.category, self.agent,
             )
             return ""
         if isinstance(result.result, str):
@@ -272,7 +246,7 @@ class SubAgent(BaseModel):
         )
         if cli_stderr_preview:
             msg += f" | cli_stderr={cli_stderr_preview!r}"
-        print(msg, file=sys.stderr, flush=True)
+        logging.getLogger(__name__).warning(msg)
         combined = str(exc)
         if cli_stderr:
             combined = f"{combined}\n--- cli stderr ---\n{cli_stderr}"
@@ -295,7 +269,7 @@ class SubAgent(BaseModel):
         )
         if cli_stderr_preview:
             msg += f" | cli_stderr={cli_stderr_preview!r}"
-        print(msg, file=sys.stderr, flush=True)
+        logging.getLogger(__name__).warning(msg)
         combined = f"no_ResultMessage last_assistant={preview!r}"
         if cli_stderr:
             combined = f"{combined}\n--- cli stderr ---\n{cli_stderr}"

--- a/cai_lib/subagent/cost_tracker.py
+++ b/cai_lib/subagent/cost_tracker.py
@@ -18,11 +18,6 @@ from datetime import datetime, timezone
 from claude_agent_sdk.types import ResultMessage
 from pydantic import BaseModel, ConfigDict, Field
 
-from cai_lib.utils.log import log_cost
-
-from .cost import _post_cost_comment
-from .fsm_state import _CURRENT_FSM_STATE
-
 
 class CostTracker(BaseModel):
     """Accumulates cost rows for a SubAgent and mirrors them as GH comments.
@@ -144,9 +139,6 @@ class CostTracker(BaseModel):
             row["parent_model"] = parent_model
         if subagent_counts:
             row["subagents"] = dict(subagent_counts)
-        fsm_state = _CURRENT_FSM_STATE.get()
-        if fsm_state:
-            row["fsm_state"] = fsm_state
         fp_src = (system_prompt or "") + "\n---\n" + (prompt or "")
         row["prompt_fingerprint"] = hashlib.sha256(
             fp_src.encode()
@@ -154,17 +146,5 @@ class CostTracker(BaseModel):
         return row
 
     def _emit(self, row: dict, agent: str) -> None:
-        """Append the cost row to the jsonl log and mirror as a GH comment."""
-        log_cost(row)
-        if self.target_kind is not None and self.target_number is not None:
-            _post_cost_comment(
-                self.target_kind, self.target_number, row, agent,
-            )
-        if (
-            self.extra_target_kind is not None
-            and self.extra_target_number is not None
-        ):
-            _post_cost_comment(
-                self.extra_target_kind, self.extra_target_number,
-                row, agent,
-            )
+        """No-op base implementation — override in repo-specific subclasses."""
+        pass

--- a/cai_lib/subagent/fsm_state.py
+++ b/cai_lib/subagent/fsm_state.py
@@ -1,45 +1,11 @@
-"""Per-invocation FSM state stamp for cost-log rows (issue #1203).
+"""Thin compatibility shim — re-exports from :mod:`cai_lib.fsm_state`.
 
-The dispatcher (``cai_lib/dispatcher.py``) wraps each handler call with
-``set_current_fsm_state(state.name)`` so that any ``_run_claude_p`` or
-``run_subagent`` call made inside the handler records the funnel position
-(e.g. ``"REFINING"``, ``"PLANNING"``, ``"IN_PROGRESS"``,
-``"REVIEWING_CODE"``) into the row's optional ``fsm_state`` key. Non-FSM
-call sites (``cmd_rescue``, ``cmd_unblock``, ``dup_check``,
-``audit/runner.py``, ``cmd_misc.init``) leave the contextvar unset; those
-rows simply omit the key, preserving back-compat for readers that only
-know ``category``.
+Previously located here; moved to :mod:`cai_lib.fsm_state` to decouple
+the base :mod:`cai_lib.subagent` package from repo-specific dependencies
+(issue #1269). This shim is retained because :mod:`cai_lib.subagent`
+``__init__.py`` re-exports :func:`set_current_fsm_state` from it.
 """
 
-from __future__ import annotations
+from cai_lib.fsm_state import _CURRENT_FSM_STATE, set_current_fsm_state
 
-import contextvars
-from contextlib import contextmanager
-
-
-_CURRENT_FSM_STATE: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    "cai_current_fsm_state", default=None,
-)
-
-
-@contextmanager
-def set_current_fsm_state(name: str | None):
-    """Set the FSM state stamp for every ``_run_claude_p`` or ``run_subagent`` call in the block.
-
-    ``name`` should be the ``.name`` of an :class:`IssueState` or
-    :class:`PRState` enum member (e.g. ``"REFINING"``). Passing ``None``
-    explicitly clears the stamp for the scoped block.
-
-    Usage::
-
-        with set_current_fsm_state(state.name):
-            handler(issue)
-
-    The stamp is scoped by ``contextvars.Token`` so nested wraps restore
-    the previous value cleanly on exit.
-    """
-    token = _CURRENT_FSM_STATE.set(name)
-    try:
-        yield
-    finally:
-        _CURRENT_FSM_STATE.reset(token)
+__all__ = ["_CURRENT_FSM_STATE", "set_current_fsm_state"]

--- a/cai_lib/subagent/legacy.py
+++ b/cai_lib/subagent/legacy.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import shutil
 import socket
 import subprocess
 import sys
@@ -22,12 +23,14 @@ from pathlib import Path
 from claude_agent_sdk import ClaudeAgentOptions
 
 from cai_lib.utils.log import log_cost
+from cai_lib.cost_comment import _post_cost_comment
+from cai_lib.fsm_state import _CURRENT_FSM_STATE
 
-from .core import _CLI_PATH, _collect_results
-from .cost import _post_cost_comment
+from .core import _collect_results
 from .errors import _sdk_error_summary
-from .fsm_state import _CURRENT_FSM_STATE
 from .stderr_sink import _captured_stderr_text, _make_stderr_sink
+
+_CLI_PATH = shutil.which("claude")
 
 
 def _argv_to_options(

--- a/cai_lib/subprocess_utils.py
+++ b/cai_lib/subprocess_utils.py
@@ -5,8 +5,8 @@ agent-SDK driver, cost-row emission and the cost-attribution comment
 poster. Issue #1230 extracted all of that into :mod:`cai_lib.subagent`;
 what remains here is the generic shell helper the rest of the codebase
 uses to shell out to ``gh``, ``git``, ``jq``, etc. Import the agent
-helpers from :mod:`cai_lib.subagent` (``run_subagent``, ``_run_claude_p``)
-or :mod:`cai_lib.subagent.fsm_state` (``set_current_fsm_state``) — this
+helpers from :mod:`cai_lib.cai_subagent` (``run_subagent``, ``_run_claude_p``)
+or :mod:`cai_lib.fsm_state` (``set_current_fsm_state``) — this
 module is shell-only now.
 """
 

--- a/docs/modules.yaml
+++ b/docs/modules.yaml
@@ -148,6 +148,7 @@ modules:
     summary: Agent invocation infrastructure — SDK execution, legacy argv facade, cost attribution, stderr capture, and FSM state stamping.
     globs:
       - "cai_lib/subagent/*.py"
+      - "cai_lib/cai_subagent.py"
     doc: "docs/modules/subagent.md"
 
   - name: config
@@ -156,6 +157,7 @@ modules:
       - "cai_lib/config.py"
       - "cai_lib/utils/*.py"
       - "cai_lib/subprocess_utils.py"
+      - "cai_lib/cost_comment.py"
       - "cai_lib/cost_summary.py"
       - "cai_lib/watchdog.py"
     doc: "docs/modules/config.md"

--- a/tests/test_cost_comment.py
+++ b/tests/test_cost_comment.py
@@ -453,7 +453,7 @@ class TestCostCommentPerModelDetail(unittest.TestCase):
 
     def test_split_cost_by_category_zero_tokens(self):
         """Zero tokens yields zero split, no DivisionByZero."""
-        from cai_lib.subagent.cost import _split_cost_by_category
+        from cai_lib.cost_comment import _split_cost_by_category
 
         self.assertEqual(
             _split_cost_by_category(0.0, 0, 0, 0, 0),

--- a/tests/test_sdk_spike_parity.py
+++ b/tests/test_sdk_spike_parity.py
@@ -70,8 +70,9 @@ class TestSdkSpikeParity(unittest.TestCase):
     """``run_subagent`` emits the same cost-row payload as ``_run_claude_p``."""
 
     def test_cost_rows_match_modulo_volatile_fields(self):
-        from cai_lib.subagent import _run_claude_p, core, legacy, run_subagent
-        from cai_lib.subagent import cost_tracker
+        import cai_lib.cai_subagent as cai_subagent_mod
+        from cai_lib.subagent import _run_claude_p, core, legacy
+        from cai_lib.cai_subagent import run_subagent
 
         prompt = "## test prompt\n\nfor parity check"
         captured: list[dict] = []
@@ -91,7 +92,7 @@ class TestSdkSpikeParity(unittest.TestCase):
 
         msg_b = _mk_result()
         with patch.object(core, "query", _mock_query(msg_b)), \
-             patch.object(cost_tracker, "log_cost", side_effect=_capture):
+             patch.object(cai_subagent_mod, "log_cost", side_effect=_capture):
             opts = ClaudeAgentOptions(extra_args={"agent": "cai-confirm"})
             run_subagent(
                 prompt,
@@ -110,7 +111,6 @@ class TestSdkSpikeParity(unittest.TestCase):
 
     def test_returncode_stdout_stderr_match_on_success(self):
         from cai_lib.subagent import _run_claude_p, core, legacy, run_subagent
-        from cai_lib.subagent import cost_tracker
 
         prompt = "## another fixture"
 
@@ -125,8 +125,7 @@ class TestSdkSpikeParity(unittest.TestCase):
             )
 
         msg_b = _mk_result(result="payload-text")
-        with patch.object(core, "query", _mock_query(msg_b)), \
-             patch.object(cost_tracker, "log_cost"):
+        with patch.object(core, "query", _mock_query(msg_b)):
             opts = ClaudeAgentOptions(extra_args={"agent": "cai-confirm"})
             native = run_subagent(
                 prompt,
@@ -141,7 +140,6 @@ class TestSdkSpikeParity(unittest.TestCase):
 
     def test_returncode_stdout_stderr_match_on_error(self):
         from cai_lib.subagent import _run_claude_p, core, legacy, run_subagent
-        from cai_lib.subagent import cost_tracker
 
         prompt = "## error fixture"
 
@@ -165,9 +163,7 @@ class TestSdkSpikeParity(unittest.TestCase):
             is_error=True,
             result="exhausted",
         )
-        with patch.object(core, "query", _mock_query(msg_b)), \
-             patch.object(cost_tracker, "log_cost"), \
-             patch("builtins.print"):
+        with patch.object(core, "query", _mock_query(msg_b)):
             opts = ClaudeAgentOptions(extra_args={"agent": "cai-confirm"})
             native = run_subagent(
                 prompt,


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1269

**Issue:** #1269 — [#1265 Step 1/2] Foundation — strip repo couplings from `subagent/`, relocate `cost.py`/`fsm_state.py`, add `CaiSubAgent`/`CaiCostTracker`

## PR Summary

### What this fixes
`cai_lib/subagent/` base classes (`CostTracker`, `SubAgent`, `run_subagent`) contained robotsix-cai repository-specific code (GH cost-comment posting, FSM-state stamping, npm CLI path pinning, cai-skills plugin injection), making them impossible to reuse outside the repo. Issue #1269 asked that these classes be stripped down to generic SDK wrappers and the repo-specific behavior relocated into a new `cai_lib/cai_subagent.py` module with subclasses.

### What was changed
- **`cai_lib/cost_comment.py`** (new) — relocated from `cai_lib/subagent/cost.py`; owns `_split_cost_by_category`, `_post_cost_comment`, and cost-comment constants
- **`cai_lib/fsm_state.py`** (new) — relocated from `cai_lib/subagent/fsm_state.py`; owns `_CURRENT_FSM_STATE` contextvar and `set_current_fsm_state`
- **`cai_lib/cai_subagent.py`** (new) — new repo-specific layer: `CaiCostTracker` (overrides `_emit` to stamp FSM state, call `log_cost`, post GH comment), `CaiSubAgent` (overrides `_prepare_options` to pin CLI path and inject cai-skills), and `run_subagent` shim
- **`.cai-staging/files-delete/cai_lib/subagent/cost.py`** — tombstone to delete the old file post-exit
- **`cai_lib/subagent/cost_tracker.py`** — stripped repo-specific imports; removed FSM-stamp lines from `_build_row`; `_emit` replaced with no-op `pass`
- **`cai_lib/subagent/core.py`** — removed `shutil`/`Path`/`sys` imports and `_CLI_PATH`; `_prepare_options` now only attaches stderr sink; `print` calls replaced with `logging.getLogger(__name__).warning`
- **`cai_lib/subagent/fsm_state.py`** — replaced with thin re-export shim pointing to `cai_lib.fsm_state` (retained to avoid breaking `__init__.py`)
- **`cai_lib/subagent/legacy.py`** — updated imports: `_post_cost_comment` from `cai_lib.cost_comment`, `_CURRENT_FSM_STATE` from `cai_lib.fsm_state`; added local `_CLI_PATH = shutil.which("claude")`
- **`cai_lib/dispatcher.py`** — `set_current_fsm_state` import updated to `cai_lib.fsm_state`
- **`cai_lib/actions/confirm.py`** — `run_subagent` import updated to `cai_lib.cai_subagent`
- **`tests/test_cost_comment.py`** — updated `_split_cost_by_category` import path
- **`tests/test_sdk_spike_parity.py`** — updated parity test to use `cai_lib.cai_subagent.run_subagent` and patch `cai_lib.cai_subagent.log_cost`; removed stale `cost_tracker.log_cost` patches from two tests
- **`cai_lib/subprocess_utils.py`**, **`cai_lib/cost_summary.py`** — docstring references updated

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
