### PR TITLE
auto-improve: Merge near-duplicate `_build_unblock_message` / `_build_rescue_message`

### DIFF
--- a/cai_lib/cmd_helpers_issues.py
+++ b/cai_lib/cmd_helpers_issues.py
@@ -4,7 +4,7 @@ import re
 import subprocess
 import sys
 
-from cai_lib.config import REPO, LABEL_RAISED
+from cai_lib.config import REPO, LABEL_RAISED, is_admin_login
 from cai_lib.github import _gh_json, _strip_cost_comments
 from cai_lib.subprocess_utils import _run
 
@@ -234,3 +234,46 @@ def _strip_stored_plan_block(issue_body: str) -> str:
     while after < len(issue_body) and issue_body[after] == "\n":
         after += 1
     return issue_body[:start] + issue_body[after:]
+
+
+def _build_target_message(*, kind: str, target: dict, mark_admin: bool = True) -> str:
+    """Format the user message for cai-unblock and cai-rescue agents.
+
+    Includes the target's labels, body, and the full comment thread
+    (chronological, all authors). When *mark_admin* is ``True`` (default),
+    admin comments are annotated with ``[admin]`` — used by cai-unblock so
+    the agent can identify the admin resume signal. Set *mark_admin* to
+    ``False`` for cai-rescue, which does not need the annotation.
+    """
+    body = target.get("body") or "(no body)"
+    labels = [
+        (lb.get("name") if isinstance(lb, dict) else lb)
+        for lb in target.get("labels", [])
+    ]
+    labels_line = ", ".join(labels) if labels else "(none)"
+
+    comments = target.get("comments") or []
+    comments_block = ""
+    for c in comments:
+        author = (c.get("author") or {}).get("login") or "unknown"
+        created = c.get("createdAt", "") or c.get("created_at", "")
+        if mark_admin:
+            marker = " [admin]" if is_admin_login(author) else ""
+        else:
+            marker = ""
+        text = c.get("body", "") or ""
+        comments_block += f"\n**{author}**{marker} ({created}):\n{text}\n"
+
+    return (
+        f"Kind: {kind}\n"
+        f"\n"
+        f"## Labels\n"
+        f"{labels_line}\n"
+        f"\n"
+        f"## Body\n\n"
+        f"### #{target['number']} — {target.get('title', '')}\n\n"
+        f"{body}\n"
+        f"\n"
+        f"## Comments\n"
+        f"{comments_block or '(no comments)'}\n"
+    )

--- a/cai_lib/cmd_rescue.py
+++ b/cai_lib/cmd_rescue.py
@@ -24,7 +24,7 @@ import sys
 import time
 from typing import Optional
 
-from cai_lib.cmd_helpers_issues import _extract_stored_plan
+from cai_lib.cmd_helpers_issues import _build_target_message, _extract_stored_plan
 
 from cai_lib.config import (
     REPO,
@@ -257,44 +257,6 @@ def _list_unresolved_pr_human_needed_prs() -> list[dict]:
     return out
 
 
-def _build_rescue_message(target: dict, *, kind: str) -> str:
-    """Format the user message for the cai-rescue agent.
-
-    Same shape as :func:`cmd_unblock._build_unblock_message` but with a
-    ``Kind: issue-rescue`` or ``Kind: pr-rescue`` header so the agent
-    knows it is the autonomous-rescue mode rather than the admin-resume
-    mode, and which submachine's resume targets apply.
-    """
-    body = target.get("body") or "(no body)"
-    labels = [
-        (lb.get("name") if isinstance(lb, dict) else lb)
-        for lb in target.get("labels", [])
-    ]
-    labels_line = ", ".join(labels) if labels else "(none)"
-
-    comments = target.get("comments") or []
-    comments_block = ""
-    for c in comments:
-        author = (c.get("author") or {}).get("login") or "unknown"
-        created = c.get("createdAt", "") or c.get("created_at", "")
-        text = c.get("body", "") or ""
-        comments_block += f"\n**{author}** ({created}):\n{text}\n"
-
-    return (
-        f"Kind: {kind}\n"
-        f"\n"
-        f"## Labels\n"
-        f"{labels_line}\n"
-        f"\n"
-        f"## Body\n\n"
-        f"### #{target['number']} — {target.get('title', '')}\n\n"
-        f"{body}\n"
-        f"\n"
-        f"## Comments\n"
-        f"{comments_block or '(no comments)'}\n"
-    )
-
-
 def _post_rescue_comment(
     issue_number: int, *, target: str, reasoning: str,
 ) -> bool:
@@ -515,7 +477,7 @@ def _try_rescue_issue(
     """
     issue_number = issue["number"]
 
-    user_message = _build_rescue_message(issue, kind="issue-rescue")
+    user_message = _build_target_message(kind="issue-rescue", target=issue, mark_admin=False)
     result = _run_claude_p(
         ["claude", "-p", "--agent", "cai-rescue",
          "--dangerously-skip-permissions",
@@ -653,7 +615,7 @@ def _try_rescue_pr(
     """
     pr_number = pr["number"]
 
-    user_message = _build_rescue_message(pr, kind="pr-rescue")
+    user_message = _build_target_message(kind="pr-rescue", target=pr, mark_admin=False)
     result = _run_claude_p(
         ["claude", "-p", "--agent", "cai-rescue",
          "--dangerously-skip-permissions",

--- a/cai_lib/cmd_unblock.py
+++ b/cai_lib/cmd_unblock.py
@@ -37,6 +37,7 @@ from cai_lib.fsm import (
     fire_trigger,
 )
 from cai_lib.cmd_helpers_issues import (
+    _build_target_message,
     _extract_stored_plan,
     _strip_stored_plan_block,
 )
@@ -161,44 +162,6 @@ def _extract_admin_comments(issue: dict) -> list[dict]:
     return out
 
 
-def _build_unblock_message(*, kind: str, issue: dict) -> str:
-    """Format the user message for the cai-unblock agent.
-
-    Includes the target's labels, body, and the full comment thread
-    (chronological, all authors) — the agent uses the admin's most recent
-    comment as the resume signal and the rest as context.
-    """
-    body = issue.get("body") or "(no body)"
-    labels = [
-        (lb.get("name") if isinstance(lb, dict) else lb)
-        for lb in issue.get("labels", [])
-    ]
-    labels_line = ", ".join(labels) if labels else "(none)"
-
-    comments = issue.get("comments") or []
-    comments_block = ""
-    for c in comments:
-        author = (c.get("author") or {}).get("login") or "unknown"
-        created = c.get("createdAt", "") or c.get("created_at", "")
-        marker = " [admin]" if is_admin_login(author) else ""
-        text = c.get("body", "") or ""
-        comments_block += f"\n**{author}**{marker} ({created}):\n{text}\n"
-
-    return (
-        f"Kind: {kind}\n"
-        f"\n"
-        f"## Labels\n"
-        f"{labels_line}\n"
-        f"\n"
-        f"## Body\n\n"
-        f"### #{issue['number']} — {issue.get('title', '')}\n\n"
-        f"{body}\n"
-        f"\n"
-        f"## Comments\n"
-        f"{comments_block or '(no comments)'}\n"
-    )
-
-
 # Minimum comment length to treat as a "substantive" admin amendment.
 # Short acknowledgments ("ok", "approved", "lgtm") are noise — skip them
 # so the stored plan block stays useful. Empirically, anything a human
@@ -307,7 +270,7 @@ def _try_unblock_issue(issue: dict) -> Optional[str]:
         # parked. The label stays on so we retry once a comment lands.
         return "no_admin_comment"
 
-    user_message = _build_unblock_message(kind="issue", issue=issue)
+    user_message = _build_target_message(kind="issue", target=issue)
     result = _run_claude_p(
         ["claude", "-p", "--agent", "cai-unblock",
          "--dangerously-skip-permissions",
@@ -494,7 +457,7 @@ def _try_unblock_pr(pr: dict) -> Optional[str]:
     if not admin_comments:
         return "no_admin_comment"
 
-    user_message = _build_unblock_message(kind="pr", issue=pr)
+    user_message = _build_target_message(kind="pr", target=pr)
     result = _run_claude_p(
         ["claude", "-p", "--agent", "cai-unblock",
          "--dangerously-skip-permissions",

--- a/tests/test_unblock.py
+++ b/tests/test_unblock.py
@@ -19,6 +19,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 # place so is_admin_login sees our test logins.
 from cai_lib import cmd_unblock as U  # noqa: E402
 from cai_lib import config as _config  # noqa: E402
+from cai_lib.cmd_helpers_issues import _build_target_message  # noqa: E402
 _config.ADMIN_LOGINS = frozenset({"alice", "bob"})
 
 
@@ -72,7 +73,7 @@ class TestBuildUnblockMessage(unittest.TestCase):
 
     def test_contains_required_sections(self):
         issue = self._fixture()
-        msg = U._build_unblock_message(kind="issue", issue=issue)
+        msg = _build_target_message(kind="issue", target=issue)
         self.assertIn("Kind: issue", msg)
         self.assertIn("## Labels", msg)
         self.assertIn("auto-improve:human-needed", msg)
@@ -94,7 +95,7 @@ class TestBuildUnblockMessage(unittest.TestCase):
             "labels": [],
             "comments": [],
         }
-        msg = U._build_unblock_message(kind="issue", issue=issue)
+        msg = _build_target_message(kind="issue", target=issue)
         self.assertIn("(no comments)", msg)
 
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1289

**Issue:** #1289 — Merge near-duplicate `_build_unblock_message` / `_build_rescue_message`

## PR Summary

### What this fixes
`_build_unblock_message` (in `cmd_unblock.py`) and `_build_rescue_message` (in `cmd_rescue.py`) were near-identical 36-line functions — same label parsing, comments loop, and return template — differing only in that the rescue version omits the `[admin]` marker annotation on comments.

### What was changed
- **`cai_lib/cmd_helpers_issues.py`**: Added `is_admin_login` to the config import; added merged helper `_build_target_message(*, kind, target, mark_admin=True)` — the unblock body with the admin-marker line guarded by `if mark_admin:`.
- **`cai_lib/cmd_unblock.py`**: Added `_build_target_message` to the `cmd_helpers_issues` import; removed `_build_unblock_message` (36 lines); updated 2 call sites to `_build_target_message(kind=..., target=...)`.
- **`cai_lib/cmd_rescue.py`**: Added `_build_target_message` to the `cmd_helpers_issues` import; removed `_build_rescue_message` (36 lines); updated 2 call sites to `_build_target_message(kind=..., target=..., mark_admin=False)`.
- **`tests/test_unblock.py`**: Updated the `TestBuildUnblockMessage` test class to import and call `_build_target_message` directly (the function no longer lives on the `U` module).

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
