### PR TITLE
auto-improve: Inline single-caller `_was_merged` in dispatcher

### DIFF
--- a/cai_lib/dispatcher.py
+++ b/cai_lib/dispatcher.py
@@ -595,10 +595,6 @@ def _pr_close_actor(pr_number: int) -> Optional[str]:
     return login or None
 
 
-def _was_merged(pr: dict) -> bool:
-    return bool(pr.get("mergedAt")) or pr.get("state") == "MERGED"
-
-
 def _resolve_pr_state(issue: dict) -> Union[int, HandlerResult]:
     """Decide what to do for an issue at ``IssueState.PR``.
 
@@ -616,7 +612,7 @@ def _resolve_pr_state(issue: dict) -> Union[int, HandlerResult]:
 
     closed_pr = _find_recent_closed_linked_pr(issue_number)
     if closed_pr is not None:
-        if _was_merged(closed_pr):
+        if bool(closed_pr.get("mergedAt")) or closed_pr.get("state") == "MERGED":
             print(
                 f"[cai dispatch] issue #{issue_number}: linked PR "
                 f"#{closed_pr['number']} merged but issue still at :pr-open — "


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1291

**Issue:** #1291 — Inline single-caller `_was_merged` in dispatcher

## PR Summary

### What this fixes
`_was_merged` in `cai_lib/dispatcher.py` was a 2-line private helper with exactly one caller 4 lines below its definition, making it unnecessary indirection that adds cognitive overhead without adding clarity.

### What was changed
- **`cai_lib/dispatcher.py`**: Deleted the `_was_merged` function definition (lines 598–600, including trailing blank line) and replaced the single call site `if _was_merged(closed_pr):` with the inlined expression `if bool(closed_pr.get("mergedAt")) or closed_pr.get("state") == "MERGED":`. All 775 tests pass.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
