### PR TITLE
auto-improve: Delete deprecated resume_transition_for / resume_pr_transition_for

### DIFF
--- a/cai_lib/fsm_transitions.py
+++ b/cai_lib/fsm_transitions.py
@@ -985,51 +985,6 @@ def _render_human_divert_reason(
     return "\n".join(lines)
 
 
-def resume_transition_for(target_state_name: str) -> Optional[Transition]:
-    """Map a ``ResumeTo: <STATE>`` token to the matching ``human_to_<state>`` transition.
-
-    Only transitions whose ``from_state`` is :attr:`IssueState.HUMAN_NEEDED`
-    are considered. Returns ``None`` when the name does not correspond to
-    a known IssueState or no resume transition lands on that state.
-    """
-    if not target_state_name:
-        return None
-    try:
-        target = IssueState[target_state_name.upper()]
-    except KeyError:
-        return None
-    for t in ISSUE_TRANSITIONS:
-        if t.from_state == IssueState.HUMAN_NEEDED and t.to_state == target:
-            return t
-    return None
-
-
-def resume_pr_transition_for(target_state_name: str) -> Optional[Transition]:
-    """PR-submachine counterpart of :func:`resume_transition_for`.
-
-    Maps a ``ResumeTo: <STATE>`` token to the matching
-    ``pr_human_to_<state>`` transition whose ``from_state`` is
-    :attr:`PRState.PR_HUMAN_NEEDED`. Returns ``None`` when the name is
-    not a known :class:`PRState` member or no resume transition lands
-    on that state.
-
-    The two resolvers are split (rather than unified) because
-    :attr:`IssueState.MERGED` and :attr:`PRState.MERGED` share a name —
-    the caller already knows whether it's acting on an issue or a PR,
-    so each side stays unambiguous by construction.
-    """
-    if not target_state_name:
-        return None
-    try:
-        target = PRState[target_state_name.upper()]
-    except KeyError:
-        return None
-    for t in PR_TRANSITIONS:
-        if t.from_state == PRState.PR_HUMAN_NEEDED and t.to_state == target:
-            return t
-    return None
-
-
 class _SentinelModel:
     """Empty model passed to :class:`GraphMachine` for diagram-only use.
 

--- a/docs/modules/fsm.md
+++ b/docs/modules/fsm.md
@@ -66,11 +66,10 @@ to detect progress. Handlers return a `HandlerResult` NamedTuple
 The catalog currently still contains every intermediate
 transition the pre-inline pipeline relied on. A catalog trim to
 a structural subset (Pattern A entry, approve, divert, resume)
-is tracked on parent issue #1037 via sibling issue #1129; as of
-#1172, `cmd_unblock` and `cmd_rescue` no longer call the
-FSM-side helpers `resume_transition_for` and `resume_pr_transition_for`
-(replaced with local state-name → trigger-name dicts), though the
-helpers remain callable for now until they are deleted by #1129.
+is tracked on parent issue #1037. As of #1172, `cmd_unblock` and
+`cmd_rescue` route resume targets through local state-name →
+trigger-name dicts (`_ISSUE_RESUME_TRANSITIONS` /
+`_PR_RESUME_TRANSITIONS`) instead of FSM-side resolver helpers.
 
 Resume paths do not consult a fixed label-to-step table. The
 [`cai-resume-locator`](../../.claude/agents/lifecycle/cai-resume-locator.md)

--- a/tests/test_fsm.py
+++ b/tests/test_fsm.py
@@ -12,7 +12,6 @@ from cai_lib.fsm import (
     get_issue_state, render_fsm_mermaid,
     find_transition,
     parse_confidence, parse_confidence_reason, parse_resume_target,
-    resume_transition_for, resume_pr_transition_for,
     fire_trigger,
 )
 from cai_lib.config import (
@@ -583,65 +582,6 @@ class TestResumeFromHuman(unittest.TestCase):
     def test_parse_resume_target_missing(self):
         self.assertIsNone(parse_resume_target(""))
         self.assertIsNone(parse_resume_target("no resume line here"))
-
-    def test_resume_transition_for_known_targets(self):
-        for name in ("RAISED", "REFINING", "PLAN_APPROVED",
-                     "NEEDS_EXPLORATION", "SOLVED"):
-            t = resume_transition_for(name)
-            self.assertIsNotNone(t, f"no resume transition for {name}")
-            self.assertEqual(t.from_state, IssueState.HUMAN_NEEDED)
-            self.assertEqual(t.to_state, IssueState[name])
-
-    def test_resume_transition_for_unknown_returns_none(self):
-        self.assertIsNone(resume_transition_for("NOT_A_STATE"))
-        self.assertIsNone(resume_transition_for(""))
-        # States that exist but have no human_to_* path must return None.
-        self.assertIsNone(resume_transition_for("IN_PROGRESS"))
-        self.assertIsNone(resume_transition_for("MERGED"))
-        # REFINED and PLANNED are auto-advance waypoints — admins resume
-        # into the transient work states (REFINING / PLANNING) or into
-        # PLAN_APPROVED, never into the stable waypoints themselves.
-        self.assertIsNone(resume_transition_for("REFINED"))
-        self.assertIsNone(resume_transition_for("PLANNED"))
-        self.assertIsNone(resume_transition_for("PLANNING"))
-
-    def test_every_widened_transition_is_reachable(self):
-        """Every human_to_<state> transition must be discoverable via resume_transition_for."""
-        widened = [
-            t for t in ISSUE_TRANSITIONS
-            if t.from_state == IssueState.HUMAN_NEEDED
-        ]
-        self.assertGreaterEqual(len(widened), 5)
-        for t in widened:
-            resolved = resume_transition_for(t.to_state.name)
-            self.assertIs(resolved, t,
-                f"resume_transition_for({t.to_state.name}) did not return {t.name}")
-
-
-class TestResumePRTransition(unittest.TestCase):
-
-    def test_known_pr_targets(self):
-        for name in ("REVIEWING_CODE", "REVISION_PENDING", "REVIEWING_DOCS"):
-            t = resume_pr_transition_for(name)
-            self.assertIsNotNone(t, f"no PR resume transition for {name}")
-            self.assertEqual(t.from_state, PRState.PR_HUMAN_NEEDED)
-            self.assertEqual(t.to_state, PRState[name])
-
-    def test_unknown_returns_none(self):
-        self.assertIsNone(resume_pr_transition_for("NOT_A_STATE"))
-        self.assertIsNone(resume_pr_transition_for(""))
-        # PRState has no OPEN→from-PR_HUMAN_NEEDED path.
-        self.assertIsNone(resume_pr_transition_for("OPEN"))
-        # MERGED is deliberately excluded — PRs must funnel through
-        # the review states; admins never merge from PR_HUMAN_NEEDED
-        # directly.
-        self.assertIsNone(resume_pr_transition_for("MERGED"))
-
-    def test_issue_and_pr_resolvers_are_disjoint(self):
-        # Passing a PRState name to the issue resolver must return None.
-        self.assertIsNone(resume_transition_for("REVIEWING_CODE"))
-        # Passing an IssueState-only name to the PR resolver must return None.
-        self.assertIsNone(resume_pr_transition_for("REFINING"))
 
 
 class TestRefineNextStepParser(unittest.TestCase):


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1292

**Issue:** #1292 — Delete deprecated resume_transition_for / resume_pr_transition_for

## PR Summary

### What this fixes
`resume_transition_for` and `resume_pr_transition_for` in `cai_lib/fsm_transitions.py` were deprecated since issue #1172 (replaced by local `_ISSUE_RESUME_TRANSITIONS` / `_PR_RESUME_TRANSITIONS` dicts in `cmd_unblock.py` and `cmd_rescue.py`) but were never deleted, leaving ~43 lines of dead code and ~35 lines of orphaned tests in the repo.

### What was changed
- **`cai_lib/fsm_transitions.py`**: deleted the two deprecated function definitions `resume_transition_for` (lines 988–1004) and `resume_pr_transition_for` (lines 1007–1030); the wildcard re-export in `cai_lib/fsm.py` propagates the removal automatically
- **`tests/test_fsm.py`**: removed both symbols from the `from cai_lib.fsm import (...)` block; deleted three deprecated test methods from `TestResumeFromHuman` (`test_resume_transition_for_known_targets`, `test_resume_transition_for_unknown_returns_none`, `test_every_widened_transition_is_reachable`) and the entire `TestResumePRTransition` class; kept `parse_resume_target` tests intact (different, live helper)
- **`docs/modules/fsm.md`**: rewrote the deprecation paragraph (lines 66–73) to drop the "helpers remain callable for now until they are deleted by #1129" sentence — they are now gone

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
