### PR TITLE
auto-improve: Delete dead `_select_ci_fix_targets` queue scanner and its now-unused imports

### DIFF
--- a/cai_lib/actions/fix_ci.py
+++ b/cai_lib/actions/fix_ci.py
@@ -23,7 +23,7 @@ from cai_lib.config import (
 )
 from cai_lib.dispatcher import HandlerResult
 from cai_lib.fsm import PRState
-from cai_lib.github import _gh_json, _set_labels, _strip_cost_comments
+from cai_lib.github import _gh_json, _set_labels
 from cai_lib.claude_argv import _run_claude_p
 from cai_lib.subprocess_utils import _run
 from cai_lib.utils.log import log_run
@@ -33,153 +33,11 @@ from cai_lib.cmd_helpers import (
     _work_directory_block,
     _setup_agent_edit_staging,
     _apply_agent_edit_staging,
-    _parse_iso_ts,
-    _fetch_review_comments,
     _fetch_previous_fix_attempts,
 )
-from cai_lib.actions.revise import _filter_comments_with_haiku
 
 
-# Marker posted on a PR after each CI-fix subagent attempt. The per-SHA loop
-# guard in _select_ci_fix_targets checks whether any comment starting with
-# this prefix was posted AFTER the current HEAD commit — if so, one attempt
-# has already been made on this SHA and we skip until the SHA advances.
 _CI_FIX_ATTEMPT_MARKER = "## CI-fix subagent: fix attempt"
-
-
-def _select_ci_fix_targets() -> list[dict]:
-    """Return PRs with failing CI checks that are eligible for auto-fix.
-
-    Eligible = branch matches auto-improve/<N>-* AND linked issue has
-    label auto-improve:pr-open AND does NOT have :needs-human-review or
-    :merge-blocked AND does NOT have :revising (avoid contention) AND
-    the PR has at least one failing check AND the PR has no unaddressed
-    review comments (those belong to cai revise) AND no prior CI fix
-    attempt was posted after the current HEAD commit.
-
-    Returns a list of dicts with keys: pr_number, issue_number, branch,
-    head_sha, failing_checks (list of {name, detailsUrl}).
-    """
-    try:
-        prs = _gh_json([
-            "pr", "list",
-            "--repo", REPO,
-            "--state", "open",
-            "--json", "number,headRefName,comments,labels",
-            "--limit", "50",
-        ]) or []
-    except subprocess.CalledProcessError as e:
-        print(f"[cai fix-ci] gh pr list failed:\n{e.stderr}", file=sys.stderr)
-        return []
-
-    targets = []
-    for pr in prs:
-        branch = pr.get("headRefName", "")
-        m = re.match(r"^auto-improve/(\d+)-", branch)
-        if not m:
-            continue
-        issue_number = int(m.group(1))
-
-        # Check issue eligibility.
-        try:
-            issue = _gh_json([
-                "issue", "view", str(issue_number),
-                "--repo", REPO,
-                "--json", "labels,state",
-            ])
-        except subprocess.CalledProcessError:
-            continue
-        if not issue or issue.get("state", "").upper() != "OPEN":
-            continue
-        label_names = {lbl["name"] for lbl in issue.get("labels", [])}
-        if LABEL_PR_OPEN not in label_names:
-            continue
-        if LABEL_REVISING in label_names:
-            print(
-                f"[cai fix-ci] PR #{pr['number']}: skipping — "
-                f"issue has :{LABEL_REVISING} (revise in progress)",
-                flush=True,
-            )
-            continue
-        if LABEL_PR_NEEDS_HUMAN in label_names or LABEL_MERGE_BLOCKED in label_names:
-            continue
-
-        # Fetch PR detail: CI status, commits, per-PR labels.
-        try:
-            pr_detail = _gh_json([
-                "pr", "view", str(pr["number"]),
-                "--repo", REPO,
-                "--json", "statusCheckRollup,commits,labels",
-            ])
-        except subprocess.CalledProcessError:
-            continue
-
-        # Secondary per-PR label check (stale list data).
-        detail_label_names = {lbl["name"] for lbl in pr_detail.get("labels", [])}
-        if LABEL_PR_NEEDS_HUMAN in detail_label_names:
-            continue
-
-        # Collect failing checks.
-        checks = pr_detail.get("statusCheckRollup") or []
-        failing = [
-            {"name": c.get("name", ""), "detailsUrl": c.get("detailsUrl") or c.get("url", "")}
-            for c in checks
-            if (c.get("conclusion") or c.get("status") or "").upper() == "FAILURE"
-        ]
-        if not failing:
-            continue
-
-        # Get latest commit date and SHA for the loop guard.
-        commits = pr_detail.get("commits") or []
-        if not commits:
-            continue
-        last_commit = commits[-1]
-        last_commit_date = last_commit.get("committedDate", "")
-        head_sha = last_commit.get("oid", "")
-        commit_ts = _parse_iso_ts(last_commit_date)
-        if commit_ts is None:
-            continue
-
-        # Skip if there are unaddressed review comments — leave for cai revise.
-        # Strip cost-attribution marker comments so they never reach the
-        # haiku comment filter or cai-fix-ci's prompt downstream.
-        issue_comments = _strip_cost_comments(pr.get("comments", []))
-        line_comments = _fetch_review_comments(pr["number"])
-        all_comments = issue_comments + line_comments
-        unaddressed = _filter_comments_with_haiku(all_comments, pr["number"])
-        if unaddressed:
-            print(
-                f"[cai fix-ci] PR #{pr['number']}: skipping — "
-                f"{len(unaddressed)} unaddressed review comment(s) "
-                "(leaving for cai revise)",
-                flush=True,
-            )
-            continue
-
-        # Per-SHA loop guard: skip if a CI-fix attempt was already posted
-        # after the current HEAD commit.
-        already_attempted = any(
-            (c.get("body") or "").lstrip().startswith(_CI_FIX_ATTEMPT_MARKER)
-            and (_parse_iso_ts(c.get("createdAt")) or commit_ts) > commit_ts
-            for c in all_comments
-        )
-        if already_attempted:
-            print(
-                f"[cai fix-ci] PR #{pr['number']}: prior CI fix attempt "
-                "since last commit; skipping",
-                flush=True,
-            )
-            continue
-
-        targets.append({
-            "pr_number": pr["number"],
-            "issue_number": issue_number,
-            "branch": branch,
-            "head_sha": head_sha,
-            "failing_checks": failing,
-        })
-
-    return targets
 
 
 def _fetch_ci_failure_log(detail_url: str) -> str:
@@ -445,9 +303,9 @@ def handle_fix_ci(pr: dict) -> HandlerResult:
             else:
                 print(f"[cai fix-ci] pushed fix for PR #{pr_number}", flush=True)
                 # Exit CI_FAILING now that new commits are up; the
-                # next tick re-evaluates check status, and if still
-                # red _select_ci_fix_targets re-queues the PR
-                # (which re-enters CI_FAILING via step 1a above).
+                # dispatcher's next tick re-evaluates check status
+                # and re-enters CI_FAILING via PRState selection if
+                # checks are still red.
                 pending_transition = "ci_failing_to_reviewing_code"
         else:
             print(

--- a/cai_lib/actions/fix_ci.py
+++ b/cai_lib/actions/fix_ci.py
@@ -17,9 +17,6 @@ from pathlib import Path
 from cai_lib.config import (
     REPO,
     LABEL_REVISING,
-    LABEL_PR_OPEN,
-    LABEL_PR_NEEDS_HUMAN,
-    LABEL_MERGE_BLOCKED,
 )
 from cai_lib.dispatcher import HandlerResult
 from cai_lib.fsm import PRState


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1296

**Issue:** #1296 — Delete dead `_select_ci_fix_targets` queue scanner and its now-unused imports

## PR Summary

### What this fixes
`_select_ci_fix_targets` (133 lines) was a dead queue-scanner in `cai_lib/actions/fix_ci.py` that was never called — the FSM dispatcher passes a PR dict directly to `handle_fix_ci`. The function also contained a stale `_filter_comments_with_haiku` call with the wrong arity that would raise `TypeError` at runtime. Four imports it exclusively used were orphaned alongside it.

### What was changed
- **`cai_lib/actions/fix_ci.py`**: deleted the entire `_select_ci_fix_targets` function (lines 50–182); deleted its orphaned 4-line doc comment (lines 43–46); updated a stale prose comment in `handle_fix_ci`'s push-success branch that referenced the dead function; dropped four now-unused imports (`_strip_cost_comments` from `cai_lib.github`; `_parse_iso_ts`, `_fetch_review_comments` from `cai_lib.cmd_helpers`; `_filter_comments_with_haiku` from `cai_lib.actions.revise`). All 767 tests pass.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
