### PR TITLE
auto-improve: Delete dead `_select_plan_target` issue picker

### DIFF
--- a/cai_lib/actions/plan.py
+++ b/cai_lib/actions/plan.py
@@ -732,61 +732,6 @@ def _run_post_plan_resplit(issue, plan_text):
 # Helpers (moved from cai.py — only used by the plan phase).
 # ---------------------------------------------------------------------------
 
-def _select_plan_target(issue_number: int | None = None):
-    """Return the oldest open :refined issue eligible for planning, or None.
-
-    If *issue_number* is given, fetch that issue directly (validating it is
-    open and not locked).  Otherwise query for the oldest :refined issue
-    that is not :in-progress or :pr-open.
-    """
-    import subprocess  # local import — keeps module-level deps tight
-
-    if issue_number is not None:
-        try:
-            issue = _gh_json([
-                "issue", "view", str(issue_number),
-                "--repo", REPO,
-                "--json", "number,title,body,labels,state,createdAt,comments",
-            ])
-        except subprocess.CalledProcessError as e:
-            print(f"[cai plan] gh issue view #{issue_number} failed:\n{e.stderr}",
-                  file=sys.stderr)
-            return None
-        if issue.get("state", "").upper() != "OPEN":
-            print(f"[cai plan] issue #{issue_number} is not open; nothing to do",
-                  flush=True)
-            return None
-        label_names = {lbl["name"] for lbl in issue.get("labels", [])}
-        if LABEL_IN_PROGRESS in label_names or LABEL_PR_OPEN in label_names:
-            print(f"[cai plan] issue #{issue_number} is locked; skipping",
-                  flush=True)
-            return None
-        return issue
-
-    # Queue-based: oldest :refined issue not locked.
-    try:
-        candidates = _gh_json([
-            "issue", "list",
-            "--repo", REPO,
-            "--label", LABEL_REFINED,
-            "--state", "open",
-            "--json", "number,title,body,labels,createdAt,comments",
-            "--limit", "100",
-        ]) or []
-    except subprocess.CalledProcessError as e:
-        print(f"[cai plan] gh issue list failed:\n{e.stderr}",
-              file=sys.stderr)
-        return None
-    candidates = [
-        c for c in candidates
-        if not {lbl["name"] for lbl in c.get("labels", [])}
-            & {LABEL_IN_PROGRESS, LABEL_PR_OPEN}
-    ]
-    if not candidates:
-        return None
-    return min(candidates, key=lambda c: c.get("createdAt", ""))
-
-
 def _run_plan_agent(issue: dict, plan_index: int, work_dir: Path, attempt_history_block: str = "", first_plan: str = "") -> str:
     """Run a single cai-plan agent and return its stdout.
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1297

**Issue:** #1297 — Delete dead `_select_plan_target` issue picker

## PR Summary

### What this fixes
`_select_plan_target` in `cai_lib/actions/plan.py` was a dead 53-line function — a leftover from the pre-FSM `cmd_plan` era — with zero callers anywhere in the codebase. Issue #1297 asks for its removal.

### What was changed
- **`cai_lib/actions/plan.py`**: deleted the entire `_select_plan_target` function (lines 735-787), including its docstring and the local `import subprocess` that only it used. The section header comment at lines 731-733 (`# Helpers (moved from cai.py…)`) was preserved as it still applies to the remaining helpers. All 767 tests pass.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
