### PR TITLE
auto-improve: Delete unused `_primary_model` (tests-only, no production caller)

### DIFF
--- a/cai_lib/audit/cost.py
+++ b/cai_lib/audit/cost.py
@@ -115,15 +115,6 @@ def _row_ts(row: dict) -> float:
         return 0.0
 
 
-def _primary_model(row: dict) -> str:
-    """Return the model name with the most output tokens, or ''."""
-    models = row.get("models")
-    if not models or not isinstance(models, dict):
-        return ""
-    best = max(models.items(), key=lambda kv: kv[1].get("outputTokens", 0))
-    return best[0] if best else ""
-
-
 def _load_outcome_index(days: int = 90) -> dict[int, dict]:
     """Return a mapping of issue_number -> {outcome, fix_attempt_count}
     from the outcome log. Used by _build_cost_summary for §3 and §4 joins.

--- a/docs/modules/audit.md
+++ b/docs/modules/audit.md
@@ -11,7 +11,7 @@ function in `cai_lib/cmd_agents.py` or `cai_lib/cmd_misc.py`.
 ## Key entry points
 - [`cai_lib/audit/cost.py`](../../cai_lib/audit/cost.py) — `_iter_outcome_rows` (shared
   outcome-log iterator consolidating duplicate readers), `_load_outcome_counts`,
-  `_load_cost_log`, `_load_outcome_index`, `_row_ts`, `_primary_model`,
+  `_load_cost_log`, `_load_outcome_index`, `_row_ts`,
   `_build_module_index`, `_infer_module_from_files`, `_build_cost_summary`; 
   token/cost helpers consumed by `cmd_cost_report`, `cmd_cost_optimize`, 
   and `runner.py` for per-module audit context.

--- a/tests/test_audit_cost.py
+++ b/tests/test_audit_cost.py
@@ -1,4 +1,4 @@
-"""Tests for cai_lib/audit/cost.py — _primary_model and _load_cost_log."""
+"""Tests for cai_lib/audit/cost.py — _load_cost_log."""
 import json
 import os
 import sys
@@ -10,52 +10,7 @@ from unittest import mock
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import cai_lib.audit.cost as _cost_module  # noqa: E402
-from cai_lib.audit.cost import _load_cost_log, _primary_model  # noqa: E402
-
-
-class TestPrimaryModel(unittest.TestCase):
-    def test_empty_row(self):
-        self.assertEqual(_primary_model({}), "")
-
-    def test_no_models_key(self):
-        self.assertEqual(_primary_model({"cost": 1.0}), "")
-
-    def test_models_not_dict(self):
-        self.assertEqual(_primary_model({"models": []}), "")
-
-    def test_single_model(self):
-        row = {"models": {"claude-sonnet-4-6": {"outputTokens": 500, "inputTokens": 100}}}
-        self.assertEqual(_primary_model(row), "claude-sonnet-4-6")
-
-    def test_picks_highest_output_tokens(self):
-        """Haiku has small outputTokens (SDK overhead); Sonnet has large (agent work)."""
-        row = {
-            "models": {
-                "claude-haiku-4-5-20251001": {"inputTokens": 39463, "outputTokens": 20},
-                "claude-sonnet-4-6": {"inputTokens": 60, "outputTokens": 33600},
-            }
-        }
-        self.assertEqual(_primary_model(row), "claude-sonnet-4-6")
-
-    def test_haiku_wins_when_it_has_more_tokens(self):
-        """If Haiku genuinely produced more output tokens, return it."""
-        row = {
-            "models": {
-                "claude-haiku-4-5-20251001": {"inputTokens": 1000, "outputTokens": 5000},
-                "claude-sonnet-4-6": {"inputTokens": 60, "outputTokens": 100},
-            }
-        }
-        self.assertEqual(_primary_model(row), "claude-haiku-4-5-20251001")
-
-    def test_missing_output_tokens_defaults_to_zero(self):
-        """Models missing outputTokens key default to 0."""
-        row = {
-            "models": {
-                "model-a": {"inputTokens": 100},
-                "model-b": {"outputTokens": 10},
-            }
-        }
-        self.assertEqual(_primary_model(row), "model-b")
+from cai_lib.audit.cost import _load_cost_log  # noqa: E402
 
 
 class TestLoadCostLogAggregation(unittest.TestCase):


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1298

**Issue:** #1298 — Delete unused `_primary_model` (tests-only, no production caller)

## PR Summary

### What this fixes
`_primary_model()` in `cai_lib/audit/cost.py` was a dead helper with zero production callers — it was exercised only by its own 7-test `TestPrimaryModel` class and referenced only in `docs/modules/audit.md`. This PR removes the function and all associated artefacts (~50 lines total).

### What was changed
- **`cai_lib/audit/cost.py`** — deleted `_primary_model()` function (lines 118–124, 7 lines)
- **`tests/test_audit_cost.py`** — removed `_primary_model` from the import statement, deleted the entire `TestPrimaryModel` class (43 lines / 7 tests), and stripped `_primary_model and ` from the module docstring
- **`docs/modules/audit.md`** — removed `_primary_model,` from the key entry-points list

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
