### PR TITLE
auto-improve: Inline single-caller `_resolve_manifest_path`

### DIFF
--- a/cai_lib/audit/runner.py
+++ b/cai_lib/audit/runner.py
@@ -32,8 +32,6 @@ from cai_lib.claude_argv import _run_claude_p
 from cai_lib.subprocess_utils import _run
 
 
-MODULES_YAML_REL = Path("docs/modules.yaml")
-
 # Map CLI ``--kind`` argument to the on-demand audit agent that must
 # run once per module. Each kind has a matching publish namespace of
 # the form ``audit-<kind>`` registered in :mod:`cai_lib.publish`.
@@ -43,15 +41,6 @@ KIND_TO_AGENT = {
     "cost-reduction":       "cai-audit-cost-reduction",
     "workflow-enhancement": "cai-audit-workflow-enhancement",
 }
-
-
-def _resolve_manifest_path() -> Path:
-    """Return the absolute path to ``docs/modules.yaml`` at the repo root.
-
-    ``cai_lib/audit/runner.py`` -> parents[0]=audit, parents[1]=cai_lib,
-    parents[2]=repo root.
-    """
-    return Path(__file__).resolve().parents[2] / MODULES_YAML_REL
 
 
 def _build_module_prompt(entry, findings_file: Path) -> str:  # type: ignore[no-untyped-def]
@@ -285,7 +274,7 @@ def run_module_audit(kind: str) -> tuple[int, int]:
         )
 
     agent = KIND_TO_AGENT[kind]
-    manifest = _resolve_manifest_path()
+    manifest = Path(__file__).resolve().parents[2] / "docs/modules.yaml"
     modules = load_modules(manifest)
 
     t0 = time.monotonic()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1299

**Issue:** #1299 — Inline single-caller `_resolve_manifest_path`

## PR Summary

### What this fixes
`_resolve_manifest_path` was a 7-line single-caller helper whose entire body was a one-liner, and `MODULES_YAML_REL` was a module constant used only by that function — both were dead abstraction that added indirection without value.

### What was changed
- **`cai_lib/audit/runner.py`**: Removed the `MODULES_YAML_REL = Path("docs/modules.yaml")` module constant (line 35), deleted the `_resolve_manifest_path()` function (lines 48–54, 7 lines), and replaced its sole call site (`manifest = _resolve_manifest_path()`) with the inlined expression `manifest = Path(__file__).resolve().parents[2] / "docs/modules.yaml"`. Net reduction: 8 lines.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
