### PR TITLE
auto-improve: Merge duplicated `cai-test-runner` invocation recipe

### DIFF
--- a/.claude/agents/implementation/cai-implement.md
+++ b/.claude/agents/implementation/cai-implement.md
@@ -325,38 +325,7 @@ the `## PR Summary` block. This replaces the old
 "guess-and-hope" behaviour (rule 4's exception) with an actual
 measurement so you know what your change broke.
 
-Invoke it with the absolute path of the work directory:
-
-~~~
-Agent(
-  subagent_type="cai-test-runner",
-  description="Run regression tests",
-  prompt="work_dir=<work_dir>"
-)
-~~~
-
-Parse the reply's `## Test Result` header. On `PASS`, proceed to the
-dossier. On `FAIL`:
-
-1. Read the `## Failures` block to identify which tests broke and why.
-2. Decide which side is correct:
-   - **Your change is wrong** — fix the code.
-   - **The test pins obsolete behavior** — update the test (rule 4's
-     exception permits this).
-3. Re-invoke `cai-test-runner` to confirm the fix.
-4. **Cap yourself at two iterations.** If the same or a new failure is
-   still present after two fix attempts, stop and exit anyway — do
-   not burn the rest of your turn budget chasing a test you cannot
-   reason about. The wrapper will push the PR regardless and re-run
-   the suite post-exit; if it still fails, the wrapper posts the
-   failure summary as a top-level PR comment and routes the PR to
-   `:pr-revision-pending` so `cai-revise` picks it up as a
-   reviewer finding.
-
-A green run is strongly preferred but not mandatory. Your goal is to
-hand off a PR with the smallest number of failing tests possible, not
-to guarantee zero — the PR-side `cai-revise` handoff is the safety
-net, not a reason to skip this step.
+Use the standard `cai-test-runner` invocation recipe in `CLAUDE.md`.
 
 Do not invoke `cai-test-runner` on a zero-diff exit path (ambiguous
 issue, `## Needs Spike` bail, memory-overlap bail). There is nothing

--- a/.claude/agents/implementation/cai-revise.md
+++ b/.claude/agents/implementation/cai-revise.md
@@ -148,37 +148,7 @@ re-entering the same routing loop on the next review cycle.
   failed` marker — no trigger fired, and a haiku call with no
   signal is waste.
 
-Invoke the runner with the absolute path of the work directory:
-
-~~~
-Agent(
-  subagent_type="cai-test-runner",
-  description="Run regression tests",
-  prompt="work_dir=<work_dir>"
-)
-~~~
-
-Parse the reply's `## Test Result` header. On `PASS`, proceed to the
-dossier update. On `FAIL`:
-
-1. Read the `## Failures` block to identify which tests broke and why.
-2. Decide which side is correct:
-   - **Your fix is wrong** — edit the code again.
-   - **The test pins obsolete behavior** — update the failing test
-     (hard rule 6 under "editing and efficiency" permits this when
-     your change legitimately changed behavior).
-3. Re-invoke `cai-test-runner` to confirm the fix.
-4. **Cap yourself at two iterations.** If the same or a new failure
-   is still present after two fix attempts, stop and exit anyway —
-   do not burn the rest of your turn budget chasing a test you
-   cannot reason about. The wrapper pushes the PR regardless; if
-   tests still fail post-push, the next review cycle catches it
-   via the same `## Local regression tests failed` marker that
-   triggered this run.
-
-A green run is strongly preferred but not mandatory. Your goal is
-to avoid re-entering the same routing loop on the next review
-cycle — not to guarantee zero failures.
+Use the standard `cai-test-runner` invocation recipe in `CLAUDE.md`.
 
 ### Update the PR context dossier before you exit
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,3 +213,33 @@ Example of deleting an arbitrary repo file:
 
   - GOOD: `Write("<work_dir>/.cai-staging/files-delete/cai_lib/cmd_agents.py", "")`
   - BAD:  Stubbing the file with `raise ImportError(...)` as a workaround
+
+## Invoking cai-test-runner
+
+When your agent definition file directs you to "use the standard
+`cai-test-runner` invocation recipe in `CLAUDE.md`", use this block:
+
+~~~
+Agent(
+  subagent_type="cai-test-runner",
+  description="Run regression tests",
+  prompt="work_dir=<work_dir>"
+)
+~~~
+
+Parse the reply's `## Test Result` header. On `PASS`, proceed to the
+next step. On `FAIL`:
+
+1. Read the `## Failures` block to identify which tests broke and why.
+2. Decide which side is correct:
+   - **Your change is wrong** — fix the code.
+   - **The test pins obsolete behavior** — update the test.
+3. Re-invoke `cai-test-runner` to confirm the fix.
+4. **Cap yourself at two iterations.** If the same or a new failure is
+   still present after two fix attempts, stop and exit anyway — do
+   not burn the rest of your turn budget chasing a test you cannot
+   reason about. The wrapper will push the PR regardless and handle
+   downstream routing if tests still fail post-push.
+
+A green run is strongly preferred but not mandatory. Your goal is to
+hand off the cleanest tree possible — not to guarantee zero failures.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1301

**Issue:** #1301 — Merge duplicated `cai-test-runner` invocation recipe

## PR Summary

### What this fixes
`cai-implement.md` and `cai-revise.md` both contained near-verbatim copies of the same `cai-test-runner` invocation recipe (7-line `Agent(...)` block + 4-step Parse/On FAIL/Re-invoke/Cap protocol), creating a maintenance hazard where changes to the recipe must be applied in two places.

### What was changed
- **`CLAUDE.md`** — added a new `## Invoking cai-test-runner` section at the end containing the shared 7-line `Agent(...)` invocation template and the complete 4-step parse/iterate/cap protocol with generic wording that covers both agent contexts
- **`.claude/agents/implementation/cai-implement.md`** — replaced the duplicated invocation block + protocol + "A green run..." paragraph (lines 328–359) with a single reference line `"Use the standard `cai-test-runner` invocation recipe in `CLAUDE.md`."`, keeping the handler-specific intro paragraph and the zero-diff exclusion sentence
- **`.claude/agents/implementation/cai-revise.md`** — replaced the duplicated invocation block + protocol + "A green run..." paragraph (lines 151–181) with the same single reference line, keeping the handler-specific intro, the `(a)/(b)` trigger conditions, and the three skip conditions

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
