### PR TITLE
auto-improve: Drop redundant Anti-pattern 2 example in cai-plan.md

### DIFF
--- a/.claude/agents/implementation/cai-plan.md
+++ b/.claude/agents/implementation/cai-plan.md
@@ -267,38 +267,6 @@ the "anti-pattern" shapes.
     """
     ```
 
-✗ **Anti-pattern 2 (natural-language-only edit target — the same MEDIUM cap applies even for a one-line import addition):**
-
-    #### Step 2 — Edit `/tmp/work/bar.py`
-    Locate the `from cai_lib.github import` block near the top
-    of the file and append `_strip_cost_comments` to its import
-    list.
-
-✓ **Correct 2 (verbatim `old_string` / `new_string`, even for a single-line import addition):**
-
-    #### Step 2 — Edit `/tmp/work/bar.py`
-
-    **Locate:** top-of-file import block, line 12.
-
-    **old_string:**
-
-    ```
-    from cai_lib.github import (
-        _foo,
-        _bar,
-    )
-    ```
-
-    **new_string:**
-
-    ```
-    from cai_lib.github import (
-        _foo,
-        _bar,
-        _strip_cost_comments,
-    )
-    ```
-
 Be concrete and specific. Name functions, variables, and line
 numbers. The fix agent will follow your plan literally and copy
 your `new_string` / file body directly into the Edit / Write call


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1302

**Issue:** #1302 — Drop redundant Anti-pattern 2 example in cai-plan.md

## PR Summary

### What this fixes
`cai-plan.md` documented the verbatim-bytes-for-Edit rule three times: once in Hard Rule 4 (prose), once via Anti-pattern 1 + Correct 1 (docstring-rewrite scenario), and once via Anti-pattern 2 + Correct 2 (import-list-append scenario). Anti-pattern 2 reproduced the exact same `from cai_lib.github import … _strip_cost_comments` example already given word-for-word in Hard Rule 4, adding no new coverage.

### What was changed
- **`.claude/agents/implementation/cai-plan.md`** (via staging): removed lines 270–300 — the 31-line Anti-pattern 2 + Correct 2 block. Hard Rule 4 (lines 79–92), Anti-pattern 1 + Correct 1 (lines 235–268), and the closing paragraph (lines 302–307) are all preserved verbatim.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
