### PR TITLE
auto-improve: Delete duplicated efficiency guidance points 1-4 in cai-review-pr.md and cai-review-docs.md

### DIFF
--- a/.claude/agents/review/cai-review-docs.md
+++ b/.claude/agents/review/cai-review-docs.md
@@ -346,25 +346,7 @@ them inline — they are automatically converted to separate GitHub issues.
 
 ## Agent-specific efficiency guidance
 
-1. **Grep before Read.** Use Grep to locate the relevant file(s)
-   and line numbers before opening them with Read. Do not
-   sequentially Read files to search for content — reserve Read for
-   files whose paths and relevance are already known.
-2. **Verify paths with Glob before Read.** When a file path is
-   constructed or inferred (not hard-coded), confirm the file exists
-   using Glob before attempting to Read it. If a Read fails, do not
-   retry the same path — use Glob to find the correct filename
-   first.
-3. **Batch independent Read calls.** When you need to read multiple
-   files and the reads are independent, issue all Read calls in a
-   single turn rather than one at a time.
-4. **Batch Grep calls.** When searching for multiple patterns or
-   across multiple paths, combine them into a single Grep call using
-   regex alternation (`pat1|pat2`) or issue independent Grep calls
-   in parallel rather than sequentially. Use Glob first to narrow
-   the file set, then Grep the results, instead of running
-   exploratory Grep calls one at a time.
-5. **Read tool parameter types.** The `offset` and `limit` parameters
+1. **Read tool parameter types.** The `offset` and `limit` parameters
    on the Read tool must be raw integers — e.g., `offset: 200`, never
    `offset: "200"`. Passing a quoted string causes an
    `InputValidationError: The parameter 'offset' type is expected as

--- a/.claude/agents/review/cai-review-pr.md
+++ b/.claude/agents/review/cai-review-pr.md
@@ -170,25 +170,7 @@ GitHub issue will be created automatically instead.
 
 ## Agent-specific efficiency guidance
 
-1. **Grep before Read.** Use Grep to locate the relevant file(s)
-   and line numbers before opening them with Read. Do not
-   sequentially Read files to search for content — reserve Read for
-   files whose paths and relevance are already known.
-2. **Verify paths with Glob before Read.** When a file path is
-   constructed or inferred (not hard-coded), confirm the file exists
-   using Glob before attempting to Read it. If a Read fails, do not
-   retry the same path — use Glob to find the correct filename
-   first.
-3. **Batch independent Read calls.** When you need to read multiple
-   files and the reads are independent, issue all Read calls in a
-   single turn rather than one at a time.
-4. **Batch Grep calls.** When searching for multiple patterns or
-   across multiple paths, combine them into a single Grep call using
-   regex alternation (`pat1|pat2`) or issue independent Grep calls
-   in parallel rather than sequentially. Use Glob first to narrow
-   the file set, then Grep the results, instead of running
-   exploratory Grep calls one at a time.
-5. **Read tool parameter types.** The `offset` and `limit` parameters
+1. **Read tool parameter types.** The `offset` and `limit` parameters
    on the Read tool must be raw integers — e.g., `offset: 200`, never
    `offset: "200"`. Passing a quoted string causes an
    `InputValidationError: The parameter 'offset' type is expected as


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1304

**Issue:** #1304 — Delete duplicated efficiency guidance points 1-4 in cai-review-pr.md and cai-review-docs.md

## PR Summary

### What this fixes
Both `cai-review-pr.md` and `cai-review-docs.md` had an `## Agent-specific efficiency guidance` section whose points 1–4 ("Grep before Read", "Verify paths with Glob before Read", "Batch independent Read calls", "Batch Grep calls") were verbatim copies of `CLAUDE.md:14-31`. Since `CLAUDE.md` is loaded by every subagent invocation, these four points were redundant dead weight costing prompt tokens on content the model had already seen.

### What was changed
- **`.claude/agents/review/cai-review-pr.md`** (via staging): deleted lines 173–190 (the four duplicate efficiency guidance points); renumbered the remaining "Read tool parameter types" point from 5 → 1. Net: 18 lines removed.
- **`.claude/agents/review/cai-review-docs.md`** (via staging): deleted lines 349–366 (the four duplicate efficiency guidance points); renumbered the remaining "Read tool parameter types" point from 5 → 1. Net: 18 lines removed.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
