### PR TITLE
auto-improve: Inline single-caller `_ensure_local_bucket` helper

### DIFF
--- a/cai_lib/transcript_sync.py
+++ b/cai_lib/transcript_sync.py
@@ -143,18 +143,6 @@ def _run_rsync(args: list[str], *, label: str) -> int:
     return result.returncode
 
 
-def _ensure_local_bucket() -> None:
-    """In local mode, create this host's bucket directory if missing.
-
-    SSH mode uses rsync's ``--mkpath`` to auto-create remote intermediate
-    directories; local mode hits the filesystem directly, so we make sure
-    the target exists.
-    """
-    if not _is_local_url(config.TRANSCRIPT_SYNC_URL):
-        return
-    Path(_server_bucket()).mkdir(parents=True, exist_ok=True)
-
-
 def push() -> int:
     """Push the local transcript tree into this host's server bucket.
 
@@ -170,7 +158,8 @@ def push() -> int:
         return 0
     if not _ensure_rsync():
         return 0
-    _ensure_local_bucket()
+    if _is_local_url(config.TRANSCRIPT_SYNC_URL):
+        Path(_server_bucket()).mkdir(parents=True, exist_ok=True)
     return _run_rsync(
         [
             "-az",


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1307

**Issue:** #1307 — Inline single-caller `_ensure_local_bucket` helper

## PR Summary

### What this fixes
`_ensure_local_bucket()` was a 10-line helper (5-line docstring + 2 real statements) with exactly one call site in `push()`. The sibling function `push_cost()` already inlined the equivalent logic directly, making the helper an unnecessary layer of indirection.

### What was changed
- **`cai_lib/transcript_sync.py`**: Deleted the `_ensure_local_bucket()` function definition (lines 146–155). At the single call site in `push()` (line 173), replaced `_ensure_local_bucket()` with the inlined two-line form `if _is_local_url(config.TRANSCRIPT_SYNC_URL): Path(_server_bucket()).mkdir(parents=True, exist_ok=True)`, matching the pattern already used in `push_cost()`.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
