### PR TITLE
auto-improve: Merge duplicated `pull` and `pull_cost` into a parameterized helper

### DIFF
--- a/cai_lib/transcript_sync.py
+++ b/cai_lib/transcript_sync.py
@@ -178,6 +178,20 @@ def push() -> int:
     )
 
 
+def _pull_inner(source_slug: str, dest_dir: Path, *, label: str) -> int:
+    if not config.transcript_sync_enabled():
+        return 0
+    if not _ensure_rsync():
+        return 0
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    if _is_local_url(config.TRANSCRIPT_SYNC_URL) and not Path(source_slug).exists():
+        return 0
+    return _run_rsync(
+        ["-az", *_transport_args(), f"{source_slug}/", f"{dest_dir}/"],
+        label=label,
+    )
+
+
 def pull() -> int:
     """Pull every machine's bucket into the local aggregate mirror.
 
@@ -185,26 +199,7 @@ def pull() -> int:
     missing. Does NOT use ``--delete`` so a transient server outage can't
     empty the local mirror mid-run.
     """
-    if not config.transcript_sync_enabled():
-        return 0
-    if not _ensure_rsync():
-        return 0
-    config.TRANSCRIPT_AGGREGATE_DIR.mkdir(parents=True, exist_ok=True)
-    if _is_local_url(config.TRANSCRIPT_SYNC_URL):
-        # In local mode the source may not exist yet (no machine has
-        # pushed). rsync would emit "No such file or directory" and
-        # return non-zero — harmless but noisy. Skip gracefully.
-        if not Path(_server_slug()).exists():
-            return 0
-    return _run_rsync(
-        [
-            "-az",
-            *_transport_args(),
-            f"{_server_slug()}/",
-            f"{config.TRANSCRIPT_AGGREGATE_DIR}/",
-        ],
-        label="pull",
-    )
+    return _pull_inner(_server_slug(), config.TRANSCRIPT_AGGREGATE_DIR, label="pull")
 
 
 def sync() -> int:
@@ -300,23 +295,7 @@ def pull_cost() -> int:
     No-op (returns 0) when disabled. Creates the aggregate directory if
     missing. Does NOT use ``--delete`` for the same reason as ``pull()``.
     """
-    if not config.transcript_sync_enabled():
-        return 0
-    if not _ensure_rsync():
-        return 0
-    config.COST_LOG_AGGREGATE_DIR.mkdir(parents=True, exist_ok=True)
-    if _is_local_url(config.TRANSCRIPT_SYNC_URL):
-        if not Path(_cost_server_slug()).exists():
-            return 0
-    return _run_rsync(
-        [
-            "-az",
-            *_transport_args(),
-            f"{_cost_server_slug()}/",
-            f"{config.COST_LOG_AGGREGATE_DIR}/",
-        ],
-        label="cost-pull",
-    )
+    return _pull_inner(_cost_server_slug(), config.COST_LOG_AGGREGATE_DIR, label="cost-pull")
 
 
 def parse_source() -> Path:


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1308

**Issue:** #1308 — Merge duplicated `pull` and `pull_cost` into a parameterized helper

## PR Summary

### What this fixes
`pull()` and `pull_cost()` in `cai_lib/transcript_sync.py` were structural near-duplicates (~27 and ~23 lines respectively), differing only in slug source, destination directory, and rsync label — creating a maintenance hazard where a bug fix or behavior change in one must be manually mirrored to the other.

### What was changed
- **`cai_lib/transcript_sync.py`**: Added private helper `_pull_inner(source_slug: str, dest_dir: Path, *, label: str) -> int` that encapsulates the shared logic (sync-enabled gate, rsync gate, dest-dir creation, local-URL source-exists check, rsync invocation). Replaced the bodies of `pull()` and `pull_cost()` with single-line calls to `_pull_inner`. Public signatures and docstrings are preserved unchanged. All 760 tests pass.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
