### PR TITLE
auto-improve: Inline single-line `_build_implement_user_message` pass-through

### DIFF
--- a/cai_lib/__init__.py
+++ b/cai_lib/__init__.py
@@ -77,7 +77,6 @@ from cai_lib.github import (
     _set_labels,
     _issue_has_label,
     _build_issue_block,
-    _build_implement_user_message,
 )
 
 from cai_lib.watchdog import (
@@ -118,7 +117,7 @@ __all__ = [
     "_run", "_run_claude_p",
     # github
     "_gh_json", "check_gh_auth", "check_claude_auth", "_transcript_dir_is_empty",
-    "_set_labels", "_issue_has_label", "_build_issue_block", "_build_implement_user_message",
+    "_set_labels", "_issue_has_label", "_build_issue_block",
     # watchdog
     "_rollback_stale_in_progress",
     "_rollback_stale_pr_locks",

--- a/cai_lib/actions/implement.py
+++ b/cai_lib/actions/implement.py
@@ -48,7 +48,7 @@ _OPUS_MODEL_ID = "claude-opus-4-7"
 from cai_lib.github import (
     _gh_json,
     _set_labels,
-    _build_implement_user_message,
+    _build_issue_block,
     close_issue_not_planned,
 )
 from cai_lib.claude_argv import _run_claude_p
@@ -1186,7 +1186,7 @@ def handle_implement(issue: dict) -> int:
         user_message = (
             _work_directory_block(work_dir, issue.get("body") or "")
             + "\n"
-            + _build_implement_user_message(issue, attempt_history_block)
+            + _build_issue_block(issue) + attempt_history_block
         )
         if selected_plan:
             user_message = (
@@ -1198,7 +1198,7 @@ def handle_implement(issue: dict) -> int:
                 + "Follow this plan to implement the fix.\n\n"
                 + f"{selected_plan}\n\n"
                 + "---\n\n"
-                + _build_implement_user_message(issue, attempt_history_block)
+                + _build_issue_block(issue) + attempt_history_block
             )
         claude_cmd = ["claude", "-p", "--agent", "cai-implement"]
         if opus_escalation:

--- a/cai_lib/github.py
+++ b/cai_lib/github.py
@@ -242,18 +242,6 @@ def _fetch_linked_issue_block(pr_body: str) -> str:
     )
 
 
-def _build_implement_user_message(issue: dict, attempt_history_block: str = "") -> str:
-    """Build the dynamic per-run user message for the cai-implement agent.
-
-    The system prompt, tool allowlist, and hard rules live in
-    `.claude/agents/cai-implement.md`; durable per-agent learnings live
-    in its `memory: project` pool. The wrapper passes the issue
-    body, reviewer comments, and (when available) a summary of
-    prior closed PRs for this issue.
-    """
-    return _build_issue_block(issue) + attempt_history_block
-
-
 def close_issue_not_planned(
     issue_number: int,
     comment: str,

--- a/docs/modules/github-glue.md
+++ b/docs/modules/github-glue.md
@@ -12,8 +12,7 @@ through this module.
   `check_claude_auth` are the readiness gates; label/comment
   helpers `_set_labels`, `_set_pr_labels`, `_post_issue_comment`,
   `_post_pr_comment`, `_issue_has_label`; message builders
-  `_build_issue_block`, `_fetch_linked_issue_block`,
-  `_build_implement_user_message`; closure helpers
+  `_build_issue_block`, `_fetch_linked_issue_block`; closure helpers
   `close_issue_not_planned`, `close_issue_completed`;
   stale-PR recovery `_recover_stale_pr_open`,
   `_close_orphaned_prs`; remote-lock primitives


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1314

**Issue:** #1314 — Inline single-line `_build_implement_user_message` pass-through

## PR Summary

### What this fixes
`_build_implement_user_message` in `cai_lib/github.py` was a pass-through function whose entire body was `return _build_issue_block(issue) + attempt_history_block` — adding no behaviour over the inlined expression. It had exactly two call sites in `implement.py` and unnecessary re-exports in `cai_lib/__init__.py`.

### What was changed
- **`cai_lib/github.py`**: Deleted the `_build_implement_user_message` function (10 lines including docstring)
- **`cai_lib/actions/implement.py`**: Replaced the `_build_implement_user_message` import with `_build_issue_block`; inlined `_build_issue_block(issue) + attempt_history_block` at both former call sites (lines ~1189 and ~1201)
- **`cai_lib/__init__.py`**: Removed `_build_implement_user_message` from the import list and from `__all__`
- **`docs/modules/github-glue.md`**: Removed the stale `_build_implement_user_message` reference from the module narrative

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
