### PR TITLE
auto-improve: Delete duplicate `Triggering a run ad-hoc` section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,16 +558,6 @@ in the generated `docker-compose.yml` (any valid 5-field cron expression, or `@h
 docker compose up -d
 ```
 
-### Triggering a run ad-hoc
-
-You don't have to wait for the next cron tick — any subcommand can be
-invoked directly against the running container, which is what
-GitHub Actions or a host cron job would use to kick off a task:
-
-```bash
-docker compose exec cai python /app/cai.py dispatch
-```
-
 ### One-shot smoke test (no install)
 
 If you just want to verify the published image works without writing


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1317

**Issue:** #1317 — Delete duplicate `Triggering a run ad-hoc` section in README

## PR Summary

### What this fixes
`README.md` contained a duplicate `### Triggering a run ad-hoc` section (lines 561–570) whose entire content was already covered by the earlier, more comprehensive `### Triggering tasks ad-hoc` section at lines 426–450.

### What was changed
- **README.md** — deleted the 10-line `### Triggering a run ad-hoc` section (including surrounding blank lines) between `### Changing the schedule` and `### One-shot smoke test (no install)`. The neighboring heading sequence is now clean with no orphaned cross-references.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
