### PR TITLE
auto-improve: Merge triplicated `_pr_fixture` test helper

### DIFF
--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,0 +1,23 @@
+"""Shared test helpers for the cai test suite.
+
+Avoids byte-identical fixture duplication across the merge-test
+trio (``test_merge_approach_mismatch``, ``test_merge_low_to_revision``,
+``test_merge_workflow_review_label``). See issue #1319.
+"""
+
+
+def _pr_fixture(number: int = 1234) -> dict:
+    return {
+        "number": number,
+        "title": "auto-improve: example",
+        "headRefName": f"auto-improve/{number}-example",
+        "headRefOid": "d7becb043dfd84c2796f35b7deb1353881435930",
+        "labels": [{"name": "pr:approved"}],
+        "state": "OPEN",
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "mergedAt": None,
+        "comments": [],
+        "reviews": [],
+        "createdAt": "2026-04-20T00:00:00Z",
+    }

--- a/tests/test_merge_approach_mismatch.py
+++ b/tests/test_merge_approach_mismatch.py
@@ -23,6 +23,8 @@ from cai_lib.dispatcher import HandlerResult
 from cai_lib.fsm_states import IssueState
 from cai_lib.fsm_transitions import ISSUE_TRANSITIONS
 
+from tests._helpers import _pr_fixture
+
 
 class TestPrToPlanApprovedTransition(unittest.TestCase):
     """The new issue FSM transition must be registered with the right shape."""
@@ -40,23 +42,6 @@ class TestPrToPlanApprovedTransition(unittest.TestCase):
         self.assertEqual(t.to_state, IssueState.PLAN_APPROVED)
         self.assertIn(LABEL_PR_OPEN, t.labels_remove)
         self.assertIn(LABEL_PLAN_APPROVED, t.labels_add)
-
-
-def _pr_fixture(number: int = 1234) -> dict:
-    return {
-        "number": number,
-        "title": "auto-improve: example",
-        "headRefName": f"auto-improve/{number}-example",
-        "headRefOid": "d7becb043dfd84c2796f35b7deb1353881435930",
-        "labels": [{"name": "pr:approved"}],
-        "state": "OPEN",
-        "mergeable": "MERGEABLE",
-        "mergeStateStatus": "CLEAN",
-        "mergedAt": None,
-        "comments": [],
-        "reviews": [],
-        "createdAt": "2026-04-20T00:00:00Z",
-    }
 
 
 class TestHandleMergeApproachMismatchRouting(unittest.TestCase):

--- a/tests/test_merge_low_to_revision.py
+++ b/tests/test_merge_low_to_revision.py
@@ -21,6 +21,8 @@ from cai_lib.actions.merge import _verdict_cites_concrete_code_bug
 from cai_lib.dispatcher import HandlerResult
 from cai_lib.fsm_transitions import PR_TRANSITIONS
 
+from tests._helpers import _pr_fixture
+
 
 class TestVerdictCitesConcreteCodeBug(unittest.TestCase):
     """The detector fires only on concrete, mechanically-fixable bugs."""
@@ -116,23 +118,6 @@ class TestApprovedToRevisionPendingTransition(unittest.TestCase):
         self.assertEqual(t.to_state, PRState.REVISION_PENDING)
         self.assertIn(LABEL_PR_APPROVED, t.labels_remove)
         self.assertIn(LABEL_PR_REVISION_PENDING, t.labels_add)
-
-
-def _pr_fixture(number: int = 1234) -> dict:
-    return {
-        "number": number,
-        "title": "auto-improve: example",
-        "headRefName": f"auto-improve/{number}-example",
-        "headRefOid": "d7becb043dfd84c2796f35b7deb1353881435930",
-        "labels": [{"name": "pr:approved"}],
-        "state": "OPEN",
-        "mergeable": "MERGEABLE",
-        "mergeStateStatus": "CLEAN",
-        "mergedAt": None,
-        "comments": [],
-        "reviews": [],
-        "createdAt": "2026-04-20T00:00:00Z",
-    }
 
 
 class TestHandleMergeLowHoldRouting(unittest.TestCase):

--- a/tests/test_merge_workflow_review_label.py
+++ b/tests/test_merge_workflow_review_label.py
@@ -20,6 +20,8 @@ from cai_lib.actions import merge as merge_mod
 from cai_lib.actions.merge import _pr_touches_workflow_files
 from cai_lib.config import LABEL_PR_NEEDS_WORKFLOW_REVIEW
 
+from tests._helpers import _pr_fixture
+
 
 class TestPrTouchesWorkflowFiles(unittest.TestCase):
     """The detector matches only `.github/workflows/` diff headers."""
@@ -76,30 +78,13 @@ class TestPrTouchesWorkflowFiles(unittest.TestCase):
         self.assertTrue(_pr_touches_workflow_files(diff))
 
 
-def _pr_fixture(number: int = 2000) -> dict:
-    return {
-        "number": number,
-        "title": "auto-improve: example",
-        "headRefName": f"auto-improve/{number}-example",
-        "headRefOid": "d7becb043dfd84c2796f35b7deb1353881435930",
-        "labels": [{"name": "pr:approved"}],
-        "state": "OPEN",
-        "mergeable": "MERGEABLE",
-        "mergeStateStatus": "CLEAN",
-        "mergedAt": None,
-        "comments": [],
-        "reviews": [],
-        "createdAt": "2026-04-20T00:00:00Z",
-    }
-
-
 class TestHandleMergeWorkflowReviewLabel(unittest.TestCase):
     """handle_merge must attach `needs-workflow-review` only on
     `medium + hold` verdicts for workflow-touching PRs."""
 
     def _invoke(self, confidence: str, action: str, reasoning: str,
                 diff_stdout: str) -> tuple[MagicMock, MagicMock]:
-        pr = _pr_fixture()
+        pr = _pr_fixture(2000)
 
         def run_side_effect(cmd, *args, **kwargs):
             result = MagicMock()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1319

**Issue:** #1319 — Merge triplicated `_pr_fixture` test helper

## PR Summary

### What this fixes
Three merge-test files contained byte-identical (except for the default `number` argument) `_pr_fixture` helper functions, causing ~42 lines of pure duplication that would silently diverge on any future fixture change.

### What was changed
- **`tests/_helpers.py`** (new): canonical `_pr_fixture(number: int = 1234) -> dict` helper shared across the merge-test trio.
- **`tests/test_merge_approach_mismatch.py`**: added `from tests._helpers import _pr_fixture`; removed local `_pr_fixture` definition (lines 45–59).
- **`tests/test_merge_low_to_revision.py`**: added `from tests._helpers import _pr_fixture`; removed local `_pr_fixture` definition (lines 121–135).
- **`tests/test_merge_workflow_review_label.py`**: added `from tests._helpers import _pr_fixture`; removed local `_pr_fixture` definition (lines 79–93); pinned the single `_invoke` call site to `_pr_fixture(2000)` to preserve the test's reliance on issue number 2000 (matching its `gh_json_side_effect` stub).

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
