### PR TITLE
auto-improve: Merge duplicated `_rsync_available` sync-test helper

### DIFF
--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -7,7 +7,20 @@ trio (``test_merge_approach_mismatch``, ``test_merge_low_to_revision``,
 ``_mock_query`` is a shared async-iterator replacement for
 ``cai_lib.subagent.core.query`` used across the SDK-level tests. See
 issue #1320.
+
+``_rsync_available`` gates rsync-dependent tests in ``test_cost_sync``
+and ``test_transcript_sync``. See issue #1321.
 """
+
+import subprocess
+
+
+def _rsync_available() -> bool:
+    try:
+        subprocess.run(["rsync", "--version"], check=True, capture_output=True)
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
 
 
 def _mock_query(*messages):

--- a/tests/test_cost_sync.py
+++ b/tests/test_cost_sync.py
@@ -8,7 +8,6 @@ test_transcript_sync.py.
 from __future__ import annotations
 
 import os
-import subprocess
 import sys
 import tempfile
 import unittest

--- a/tests/test_cost_sync.py
+++ b/tests/test_cost_sync.py
@@ -20,14 +20,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 from cai_lib import config, transcript_sync  # noqa: E402
-
-
-def _rsync_available() -> bool:
-    try:
-        subprocess.run(["rsync", "--version"], check=True, capture_output=True)
-        return True
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        return False
+from tests._helpers import _rsync_available  # noqa: E402
 
 
 class TestCostSyncDisabled(unittest.TestCase):

--- a/tests/test_transcript_sync.py
+++ b/tests/test_transcript_sync.py
@@ -21,14 +21,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 from cai_lib import config, transcript_sync  # noqa: E402
-
-
-def _rsync_available() -> bool:
-    try:
-        subprocess.run(["rsync", "--version"], check=True, capture_output=True)
-        return True
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        return False
+from tests._helpers import _rsync_available  # noqa: E402
 
 
 class TestDisabled(unittest.TestCase):

--- a/tests/test_transcript_sync.py
+++ b/tests/test_transcript_sync.py
@@ -9,7 +9,6 @@ in ``cai_lib.cmd_unblock``).
 from __future__ import annotations
 
 import os
-import subprocess
 import sys
 import tempfile
 import unittest


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1321

**Issue:** #1321 — Merge duplicated `_rsync_available` sync-test helper

## PR Summary

### What this fixes
Two test files (`tests/test_cost_sync.py` and `tests/test_transcript_sync.py`) each contained an identical 6-line `_rsync_available()` helper function that gates rsync-dependent tests. This duplication is consolidated into the shared `tests/_helpers.py` module.

### What was changed
- **`tests/_helpers.py`**: Added `import subprocess` and `_rsync_available() -> bool` function (checks if rsync binary is present via `subprocess.run`)
- **`tests/test_cost_sync.py`**: Removed the local 6-line `_rsync_available` definition; added `from tests._helpers import _rsync_available`
- **`tests/test_transcript_sync.py`**: Removed the local 6-line `_rsync_available` definition; added `from tests._helpers import _rsync_available`

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
