### PR TITLE
auto-improve: Delete unused `_load_outcome_stats`

### DIFF
--- a/cai_lib/__init__.py
+++ b/cai_lib/__init__.py
@@ -57,7 +57,6 @@ from cai_lib.utils.log import (
     log_cost,
     _get_issue_category,
     _log_outcome,
-    _load_outcome_stats,
 )
 from cai_lib.audit.cost import (
     _load_outcome_counts,
@@ -112,7 +111,7 @@ __all__ = [
     # logging
     "log_run", "log_cost",
     "_get_issue_category", "_log_outcome", "_load_outcome_counts",
-    "_load_outcome_stats", "_load_cost_log", "_row_ts", "_build_cost_summary",
+    "_load_cost_log", "_row_ts", "_build_cost_summary",
     # subprocess
     "_run", "_run_claude_p",
     # github

--- a/cai_lib/utils/log.py
+++ b/cai_lib/utils/log.py
@@ -5,7 +5,6 @@ import re
 from datetime import datetime, timezone
 
 from cai_lib.config import LOG_PATH, COST_LOG_PATH, OUTCOME_LOG_PATH
-from cai_lib.audit.cost import _load_outcome_counts
 
 
 def log_run(category: str, **fields) -> None:
@@ -68,19 +67,3 @@ def _log_outcome(issue_number: int, category: str, outcome: str, fix_attempt_cou
             f.flush()
     except Exception:
         pass
-
-
-def _load_outcome_stats(days: int = 90) -> dict:
-    """Load per-category success rates from the trailing `days` days of outcome data.
-
-    Returns a dict mapping category name to success rate (0.0–1.0).
-    Categories with fewer than 3 observations get a neutral prior of 0.60.
-    """
-    counts = _load_outcome_counts(days)
-    rates: dict = {}
-    for cat, c in counts.items():
-        if c["total"] < 3:
-            rates[cat] = 0.60
-        else:
-            rates[cat] = c["solved"] / c["total"]
-    return rates

--- a/docs/modules/config.md
+++ b/docs/modules/config.md
@@ -19,8 +19,7 @@ ripple everywhere.
 - [`cai_lib/utils/log.py`](../../cai_lib/utils/log.py) —
   `log_run(category, **fields)` appends a structured row to
   `LOG_PATH`; `log_cost(row)` writes cost events;
-  `_get_issue_category(issue)`, `_log_outcome(…)`,
-  `_load_outcome_stats(days)` power the audit helpers.
+  `_get_issue_category(issue)`, `_log_outcome(…)` power the audit helpers.
 - [`cai_lib/subprocess_utils.py`](../../cai_lib/subprocess_utils.py)
   — `_run(cmd, **kwargs)` is the thin subprocess wrapper for shell
   operations (gh, git, jq). Agent invocation infrastructure has been


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1326

**Issue:** #1326 — Delete unused `_load_outcome_stats`

## PR Summary

### What this fixes
`_load_outcome_stats` in `cai_lib/utils/log.py` was a dead function with no call sites anywhere in the codebase. Its sole upstream dependency (`from cai_lib.audit.cost import _load_outcome_counts`) was also only used inside the dead function, making the import unused once the function is removed. A stale doc bullet and two re-export entries in `cai_lib/__init__.py` also needed cleanup.

### What was changed
- **`cai_lib/utils/log.py`** — removed the unused `from cai_lib.audit.cost import _load_outcome_counts` import (line 8) and deleted the entire `_load_outcome_stats` function (lines 73–86)
- **`cai_lib/__init__.py`** — removed `_load_outcome_stats` from the `from cai_lib.utils.log import (…)` block and from the `__all__` list
- **`docs/modules/config.md`** — removed the stale `_load_outcome_stats(days)` reference from the `cai_lib/utils/log.py` bullet

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
