### PR TITLE
auto-improve: Merge `_sum_float` and `_sum_int` in cost_summary

### DIFF
--- a/cai_lib/cost_summary.py
+++ b/cai_lib/cost_summary.py
@@ -106,21 +106,11 @@ def _stage_key(row: dict) -> str:
     return "(unknown)"
 
 
-def _sum_float(rows: list[dict], key: str) -> float:
-    total = 0.0
+def _sum_field(rows: list[dict], key: str, cast=int):
+    total = cast(0)
     for r in rows:
         try:
-            total += float(r.get(key) or 0.0)
-        except (TypeError, ValueError):
-            continue
-    return total
-
-
-def _sum_int(rows: list[dict], key: str) -> int:
-    total = 0
-    for r in rows:
-        try:
-            total += int(r.get(key) or 0)
+            total += cast(r.get(key) or 0)
         except (TypeError, ValueError):
             continue
     return total
@@ -140,13 +130,13 @@ def _build_final_cost_summary(
     if not rows:
         return ("", "")
 
-    total_usd = _sum_float(rows, "cost_usd")
-    total_turns = _sum_int(rows, "num_turns")
-    total_duration_ms = _sum_int(rows, "duration_ms")
-    total_input = _sum_int(rows, "input_tokens")
-    total_output = _sum_int(rows, "output_tokens")
-    total_cache_read = _sum_int(rows, "cache_read_input_tokens")
-    total_cache_create = _sum_int(rows, "cache_creation_input_tokens")
+    total_usd = _sum_field(rows, "cost_usd", float)
+    total_turns = _sum_field(rows, "num_turns")
+    total_duration_ms = _sum_field(rows, "duration_ms")
+    total_input = _sum_field(rows, "input_tokens")
+    total_output = _sum_field(rows, "output_tokens")
+    total_cache_read = _sum_field(rows, "cache_read_input_tokens")
+    total_cache_create = _sum_field(rows, "cache_creation_input_tokens")
     n_rows = len(rows)
     seconds = total_duration_ms / 1000.0
 


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1328

**Issue:** #1328 — Merge `_sum_float` and `_sum_int` in cost_summary

## PR Summary

### What this fixes
`cai_lib/cost_summary.py` contained two nearly byte-identical private helpers (`_sum_float` and `_sum_int`) that differed only in their cast type, causing unnecessary duplication.

### What was changed
- **`cai_lib/cost_summary.py`**: Replaced `_sum_float` (lines 109–116) and `_sum_int` (lines 119–126) with a single parametric helper `_sum_field(rows, key, cast=int)`. Updated all seven call sites in `_build_final_cost_summary` — `_sum_float(rows, "cost_usd")` becomes `_sum_field(rows, "cost_usd", float)` and the six `_sum_int(...)` calls become `_sum_field(...)` using the default `cast=int`. Net: −10 lines, no behavior change. All 760 tests pass.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
