### PR TITLE
auto-improve: Defensive None-handling for `CostRow.cost_usd` (SDK `total_cost_usd` is `float | None`)

### DIFF
--- a/cai_lib/subagent/cost_tracker.py
+++ b/cai_lib/subagent/cost_tracker.py
@@ -300,7 +300,7 @@ class CostRow(BaseModel):
             ts=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             category=category,
             agent=agent,
-            cost_usd=result.total_cost_usd,
+            cost_usd=result.total_cost_usd or 0.0,
             duration_ms=result.duration_ms,
             duration_api_ms=result.duration_api_ms,
             num_turns=result.num_turns,

--- a/tests/subagent/test_cost_tracker.py
+++ b/tests/subagent/test_cost_tracker.py
@@ -1,0 +1,51 @@
+"""Tests for CostRow.from_result_message() in cai_lib/subagent/cost_tracker.py."""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from tests._helpers import _mk_result
+from cai_lib.subagent.cost_tracker import CostRow
+
+
+class TestCostRowNoneCostHandling(unittest.TestCase):
+    """CostRow.from_result_message handles total_cost_usd=None gracefully."""
+
+    def test_none_total_cost_usd_coerced_to_zero(self):
+        """total_cost_usd=None must not raise ValidationError; coerced to 0.0.
+
+        The SDK's ResultMessage.total_cost_usd is typed float | None.
+        CostRow.cost_usd is a required float field — passing None straight
+        through crashes Pydantic validation.  The coercion
+        ``result.total_cost_usd or 0.0`` in from_result_message must
+        convert None to 0.0.
+        """
+        result = _mk_result(total_cost_usd=None)
+
+        with patch("cai_lib.subagent.cost_tracker.socket.gethostname", return_value="test-host"):
+            row = CostRow.from_result_message(
+                category="test",
+                agent="cai-test",
+                result=result,
+            )
+
+        self.assertEqual(row.cost_usd, 0.0)
+
+    def test_normal_cost_usd_passes_through(self):
+        """A normal float total_cost_usd value is preserved unchanged."""
+        result = _mk_result(total_cost_usd=0.5678)
+
+        with patch("cai_lib.subagent.cost_tracker.socket.gethostname", return_value="test-host"):
+            row = CostRow.from_result_message(
+                category="test",
+                agent="cai-test",
+                result=result,
+            )
+
+        self.assertAlmostEqual(row.cost_usd, 0.5678)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1284

**Issue:** #1284 — Defensive None-handling for `CostRow.cost_usd` (SDK `total_cost_usd` is `float | None`)

## PR Summary

### What this fixes
`CostRow.cost_usd` is declared as a required `float`, but the SDK's `ResultMessage.total_cost_usd` is typed `float | None`. When the SDK returns `None`, Pydantic validation raises `ValidationError` and silently breaks the cost-recording path.

### What was changed
- **`cai_lib/subagent/cost_tracker.py` (line 303):** Changed `cost_usd=result.total_cost_usd,` to `cost_usd=result.total_cost_usd or 0.0,` to coerce `None` at the boundary before Pydantic validation.
- **`tests/subagent/test_cost_tracker.py` (new file):** Added two unit tests — one verifying that `total_cost_usd=None` is coerced to `0.0` without raising `ValidationError`, and one confirming normal float values pass through unchanged. All 760 tests pass.

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
