### PR TITLE
auto-improve: Surface `total_cost_usd` / `costUSD` estimate caveat in `CostRow` / `ModelUsage` field descriptions

### DIFF
--- a/cai_lib/cost_comment.py
+++ b/cai_lib/cost_comment.py
@@ -26,10 +26,11 @@ _COST_COMMENT_MAX_CHARS = 800
 # Claude 4.x pricing ratios relative to the input-token rate. These
 # hold across Opus / Sonnet / Haiku and across 200k / 1M context
 # windows because Anthropic scales all four rates uniformly per model.
-# Used to split a known ``costUSD`` into per-category dollars without
-# having to hardcode per-model prices (which drift with new model
-# releases). The breakdown is informational — the authoritative total
-# is still ``costUSD`` as reported by the SDK.
+# Used to split a known ``costUSD`` (a client-side estimate) into
+# per-category dollars without having to hardcode per-model prices
+# (which drift with new model releases). The breakdown is informational —
+# ``costUSD`` itself is a client-side estimate based on the SDK's
+# price table at build time, not authoritative billing data.
 _TOKEN_COST_RATIOS = {
     "input": 1.0,
     "output": 5.0,

--- a/cai_lib/subagent/cost_tracker.py
+++ b/cai_lib/subagent/cost_tracker.py
@@ -75,7 +75,7 @@ class ModelUsage(BaseModel):
     )
     costUSD: float | None = Field(
         default=None,
-        description="SDK model_usage[m].costUSD (omitted when absent)",
+        description="SDK model_usage[m].costUSD — client-side estimate (see CostRow.cost_usd); omitted when absent.",
     )
     cacheHitRate: float | None = Field(
         default=None,
@@ -110,7 +110,7 @@ class CostRow(BaseModel):
         ..., description="subagent name (e.g. 'cai-refine')",
     )
     cost_usd: float = Field(
-        ..., description="SDK result.total_cost_usd",
+        ..., description="SDK result.total_cost_usd — client-side estimate (price-table at SDK build time); not authoritative billing data, do not use for end-user billing.",
     )
     duration_ms: int = Field(
         ..., description="SDK result.duration_ms (wall)",


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1285

**Issue:** #1285 — Surface `total_cost_usd` / `costUSD` estimate caveat in `CostRow` / `ModelUsage` field descriptions

## PR Summary

### What this fixes
`CostRow.cost_usd` and `ModelUsage.costUSD` had terse field descriptions that didn't warn developers these are client-side estimates computed from a bundled price table — not authoritative billing data. This could mislead anyone reading the JSON schema into treating these values as billing-accurate figures.

### What was changed
- **`cai_lib/subagent/cost_tracker.py` line 78**: `ModelUsage.costUSD` description updated to `"SDK model_usage[m].costUSD — client-side estimate (see CostRow.cost_usd); omitted when absent."`
- **`cai_lib/subagent/cost_tracker.py` line 113**: `CostRow.cost_usd` description updated to `"SDK result.total_cost_usd — client-side estimate (price-table at SDK build time); not authoritative billing data, do not use for end-user billing."`

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
