### PR TITLE
auto-improve: Delete unused CLI entry-point in cost_audit.py

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -67,7 +67,7 @@ an FSM issue/PR state transition.
 | Agent | Description | Tools | Model | Lifecycle trigger | Mode |
 |---|---|---|---|---|---|
 | `cai-audit-code-reduction` | On-demand code-reduction audit for a `robotsix-cai` module — surfaces dead code, near-duplicate functions, over-abstraction, and inlineable helpers, and writes concrete line-count reduction proposals to findings.json | Read, Grep, Glob, Agent, Write | opus | On-demand | Worktree |
-| `cai-audit-cost-reduction` | On-demand cost-reduction audit for a module — analyzes token/dollar spend of agent invocations and proposes concrete savings | Read, Grep, Glob, Agent, Write, cost_query, cost_issue | opus | On-demand | Worktree |
+| `cai-audit-cost-reduction` | On-demand cost-reduction audit for a module — analyzes token/dollar spend of agent invocations and proposes concrete savings | Read, Grep, Glob, Agent, Write, cost_query | opus | On-demand | Worktree |
 | `cai-audit-external-libs` | On-demand auditor for spotting in-house code replaceable by mature open-source libraries — external-libs audit for a declared module scope | Read, Grep, Glob, Agent, Write, WebSearch, WebFetch | opus | On-demand | Worktree |
 | `cai-audit-good-practices` | On-demand auditor for Claude Code best practices and documentation-vs-implementation drift in a declared module scope | Read, Grep, Glob, Agent, Write | opus | On-demand | Worktree |
 | `cai-audit-workflow-enhancement` | On-demand workflow-enhancement audit for a module — identifies recurring inefficiencies in agent workflows and proposes targeted remediations | Read, Grep, Glob, Agent, Write | opus | On-demand | Worktree |

--- a/docs/modules/plugins.md
+++ b/docs/modules/plugins.md
@@ -11,16 +11,17 @@ and supporting Python implementation code.
   Plugin package metadata defining the plugin name, version, and skill
   discovery path.
 - [`.claude/plugins/cai-skills/skills/cost-audit/`](../../.claude/plugins/cai-skills/skills/cost-audit/) —
-  Cost exploration and auditing skills (`cost_query`, `cost_issue`)
-  used by `cai-audit-cost-reduction` to analyze agent spend patterns.
-  Includes `SKILL.md` definitions and `cost_audit.py` implementation.
+  Cost exploration and auditing skill (`cost_query`, with optional
+  `issue_number` routing for per-issue lookups) used by
+  `cai-audit-cost-reduction` to analyze agent spend patterns.
+  Includes `SKILL.md` definition and `cost_audit.py` implementation.
 
 ## Inter-module dependencies
 
 - **Consumed by audit** — The `cai-audit-cost-reduction` agent
-  (`audit` module) depends on `cost_query` and `cost_issue` skills
-  defined in this module. The agent frontmatter declares these skills
-  in its `tools:` line.
+  (`audit` module) depends on the `cost_query` skill defined in this
+  module (per-issue lookups are routed via the `issue_number` parameter).
+  The agent frontmatter declares the skill in its `tools:` line.
 - **Loaded by Claude Code harness** — The harness automatically discovers
   plugins under `.claude/plugins/` at startup; each plugin's manifest
   is read and skills are registered before any agent invocation.


### PR DESCRIPTION
Refs damien-robotsix/robotsix-cai#1329

**Issue:** #1329 — Delete unused CLI entry-point in cost_audit.py

## PR Summary

### What this fixes
`docs/agents.md` and `docs/modules/plugins.md` still referenced `cost_issue` as a registered skill for `cai-audit-cost-reduction`, even though the `cost_issue` skill section was deleted from `SKILL.md` and the agent's `tools:` frontmatter was updated to only `cost_query` in PR #1360. This left stale documentation behind that incorrectly described the plugin's skill set.

### What was changed
- **`docs/agents.md` line 70** — removed `, cost_issue` from the Tools column of the `cai-audit-cost-reduction` row in the agent catalog table
- **`docs/modules/plugins.md` lines 13–16** — updated the cost-audit Key entry points bullet from plural "skills (`cost_query`, `cost_issue`)" to the single `cost_query` skill with `issue_number` routing noted
- **`docs/modules/plugins.md` lines 20–23** — updated the Consumed by audit inter-module dependency bullet to reference only the `cost_query` skill (with `issue_number` parameter for per-issue lookups)

---
_Auto-generated by `cai implement`. The implement subagent runs autonomously with full tool permissions — please review the diff carefully._
