### PR TITLE
refactor: move stderr-capture sink out of SubAgent into claude_argv.py

### DIFF
--- a/cai_lib/cai_subagent.py
+++ b/cai_lib/cai_subagent.py
@@ -97,8 +97,7 @@ class CaiCostTracker(CostTracker):
 class CaiSubAgent(SubAgent):
     """SubAgent subclass that pins the CLI path and injects the cai-skills plugin.
 
-    Overrides :meth:`_prepare_options` to call the parent's stderr-sink
-    setup, then additionally:
+    Overrides :meth:`_prepare_options` to:
 
     * Pin ``options.cli_path`` to the npm-installed ``claude`` binary so
       the SDK reuses the binary audited in the Dockerfile.
@@ -107,10 +106,7 @@ class CaiSubAgent(SubAgent):
     """
 
     def _prepare_options(self) -> None:
-        """Pin cli_path, auto-inject cai-skills plugin, attach stderr sink."""
-        # Base: reset captured stderr and attach fresh stderr sink.
-        super()._prepare_options()
-
+        """Pin cli_path and auto-inject the cai-skills plugin."""
         _cli_path = shutil.which("claude")
         if _cli_path and not getattr(self.options, "cli_path", None):
             self.options.cli_path = _cli_path

--- a/cai_lib/claude_argv.py
+++ b/cai_lib/claude_argv.py
@@ -9,6 +9,14 @@ returned :class:`~cai_lib.subagent.core.RunResult` to a
 :class:`subprocess.CompletedProcess` with ``args=cmd`` so existing
 callers that inspect the argv see their original command.
 
+This facade also owns the stderr-capture sink — it allocates a
+local buffer and wires it onto ``options.stderr`` before driving the
+SDK so the back-compat ``CompletedProcess.stderr`` carries the real
+``claude -p`` subprocess crash tail. SDK-native callers (which read
+:class:`~cai_lib.subagent.core.RunResult` directly) do not need it,
+so :class:`~cai_lib.subagent.core.SubAgent` itself does no stderr
+capture.
+
 Do not add new call sites; port existing ones to
 :func:`cai_lib.cai_subagent.run_subagent` instead.
 """
@@ -23,7 +31,7 @@ from claude_agent_sdk import ClaudeAgentOptions
 
 from cai_lib.cai_subagent import CaiCostTracker, CaiSubAgent
 from cai_lib.subagent.core import RunResult, RunStatus
-from cai_lib.subagent.stderr_sink import _captured_stderr_text
+from cai_lib.subagent.stderr_sink import _captured_stderr_text, _make_stderr_sink
 
 
 def _argv_to_options(
@@ -103,7 +111,7 @@ def _argv_to_options(
 
 
 def _to_completed_process(
-    rr: RunResult, cmd: list[str],
+    rr: RunResult, cmd: list[str], cli_stderr_buf: list[str],
 ) -> subprocess.CompletedProcess:
     """Adapt a :class:`RunResult` to a :class:`subprocess.CompletedProcess`.
 
@@ -119,6 +127,11 @@ def _to_completed_process(
           * ``error_summary + "\\n--- cli stderr ---\\n" + cli_stderr``
             on EXCEPTION and NO_RESULT, matching the pre-refactor
             ``combined`` string byte-for-byte.
+
+    ``cli_stderr_buf`` is the buffer wired into ``options.stderr`` by
+    :func:`_run_claude_p` for this run — its captured CLI tail is
+    appended to ``stderr`` on the EXCEPTION/NO_RESULT paths so the
+    real subprocess crash reason still surfaces to back-compat callers.
     """
     if rr.status == RunStatus.OK:
         return subprocess.CompletedProcess(
@@ -130,7 +143,7 @@ def _to_completed_process(
             stderr=rr.error_summary or "",
         )
     combined = rr.error_summary or ""
-    cli_stderr = _captured_stderr_text(rr.captured_stderr)
+    cli_stderr = _captured_stderr_text(cli_stderr_buf)
     if cli_stderr:
         combined = f"{combined}\n--- cli stderr ---\n{cli_stderr}"
     return subprocess.CompletedProcess(
@@ -201,6 +214,13 @@ def _run_claude_p(
     options, positional_prompt = _argv_to_options(cmd[2:], cwd=cwd)
     prompt = input if input is not None else positional_prompt
 
+    # Wire a stderr-capture sink onto options before driving the SDK.
+    # SDK-native callers do not need this — only the back-compat
+    # ``CompletedProcess.stderr`` adapter consumes the buffer so the real
+    # ``claude -p`` subprocess crash reason still surfaces.
+    cli_stderr_buf: list[str] = []
+    options.stderr = _make_stderr_sink(cli_stderr_buf)
+
     tracker = CaiCostTracker(
         target_kind=target_kind,
         target_number=target_number,
@@ -218,4 +238,4 @@ def _run_claude_p(
         timeout=timeout,
         cost_tracker=tracker,
     ).run(prompt)
-    return _to_completed_process(rr, cmd)
+    return _to_completed_process(rr, cmd, cli_stderr_buf)

--- a/cai_lib/subagent/core.py
+++ b/cai_lib/subagent/core.py
@@ -5,8 +5,8 @@
 :meth:`run` call takes a fresh prompt. One instance can be reused
 across many prompts — its cost history accumulates on the embedded
 :class:`~cai_lib.subagent.cost_tracker.CostTracker`. Instance state
-(``runs``, ``last_result``, ``last_captured_stderr``) survives between
-runs and can be introspected between calls.
+(``runs``, ``last_result``) survives between runs and can be
+introspected between calls.
 
 """
 
@@ -30,7 +30,6 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from .cost_tracker import CostRow, CostTracker
 from .errors import _sdk_error_summary
-from .stderr_sink import _captured_stderr_text, _make_stderr_sink
 from .transcript import (
     AssistantTextEvent,
     RunTranscript,
@@ -57,9 +56,9 @@ class RunResult(BaseModel):
     """Typed result returned by :meth:`SubAgent.run`.
 
     Replaces the legacy :class:`subprocess.CompletedProcess` shape so
-    callers can inspect the structured :class:`ResultMessage`, the error
-    subtype, and the raw CLI stderr lines directly — without re-parsing
-    opaque ``.stdout`` / ``.stderr`` strings.
+    callers can inspect the structured :class:`ResultMessage` and the
+    error subtype directly — without re-parsing opaque ``.stdout`` /
+    ``.stderr`` strings.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -75,10 +74,6 @@ class RunResult(BaseModel):
             "_sdk_error_summary(result) on SDK_ERROR; str(exc) on EXCEPTION; "
             "no_ResultMessage preview on NO_RESULT; None on OK."
         ),
-    )
-    captured_stderr: list[str] = Field(
-        default_factory=list,
-        description="Raw CLI stderr lines collected during this run.",
     )
     transcript: RunTranscript | None = Field(
         default=None,
@@ -194,9 +189,6 @@ class SubAgent(BaseModel):
       exception and no-ResultMessage paths).
     - :attr:`last_result` — the final :class:`ResultMessage` from the
       most recent successful run, or ``None``.
-    - :attr:`last_captured_stderr` — CLI stderr lines from the most
-      recent run. Replaced on every run (not accumulated) so callers
-      can introspect a single run's sink.
 
     The returned :class:`RunResult` contract:
 
@@ -223,7 +215,6 @@ class SubAgent(BaseModel):
     runs: int = 0
     last_result: ResultMessage | None = None
     last_assistant: str = ""
-    last_captured_stderr: list[str] = Field(default_factory=list)
 
     def run(self, prompt: str) -> RunResult:
         """Drive one full run against ``prompt`` and return the RunResult."""
@@ -263,15 +254,13 @@ class SubAgent(BaseModel):
         )
 
     def _prepare_options(self) -> None:
-        """Attach a fresh stderr sink and reset :attr:`last_captured_stderr`.
+        """Per-run options hook for subclasses.
 
-        Resets :attr:`last_captured_stderr` to a fresh list each run so a
-        reused instance does not leak stderr lines across runs. Subclasses
-        (e.g. :class:`cai_lib.cai_subagent.CaiSubAgent`) call ``super()``
-        first and then add repo-specific setup (CLI path pin, plugin inject).
+        No-op in the base class. Subclasses (e.g.
+        :class:`cai_lib.cai_subagent.CaiSubAgent`) override to perform
+        repo-specific setup such as pinning ``options.cli_path`` or
+        injecting a local plugin.
         """
-        self.last_captured_stderr = []
-        self.options.stderr = _make_stderr_sink(self.last_captured_stderr)
 
     def _drive_query(
         self,
@@ -326,44 +315,31 @@ class SubAgent(BaseModel):
         because the failure happened before / during the SDK stream was
         drained (issue #1280).
         """
-        captured = list(self.last_captured_stderr)
         if exc is not None:
             preview = str(exc)[:200].replace("\n", " ")
-            cli_text = _captured_stderr_text(captured)
-            cli_preview = cli_text.replace("\n", " | ")[:400]
-            msg = (
-                f"[cai cost] claude-agent-sdk query failed "
-                f"({self.category}/{self.agent}): {preview}"
+            logging.getLogger(__name__).warning(
+                "[cai cost] claude-agent-sdk query failed (%s/%s): %s",
+                self.category, self.agent, preview,
             )
-            if cli_preview:
-                msg += f" | cli_stderr={cli_preview!r}"
-            logging.getLogger(__name__).warning(msg)
             return RunResult(
                 status=RunStatus.EXCEPTION,
                 stdout="",
                 result=None,
                 error_summary=str(exc),
-                captured_stderr=captured,
                 transcript=transcript,
             )
         if result is None:
             preview = (self.last_assistant or "")[:120].replace("\n", " ")
-            cli_text = _captured_stderr_text(captured)
-            cli_preview = cli_text.replace("\n", " | ")[:400]
-            msg = (
-                f"[cai cost] no ResultMessage from claude-agent-sdk "
-                f"({self.category}/{self.agent}); last assistant starts with: "
-                f"{preview!r}"
+            logging.getLogger(__name__).warning(
+                "[cai cost] no ResultMessage from claude-agent-sdk "
+                "(%s/%s); last assistant starts with: %r",
+                self.category, self.agent, preview,
             )
-            if cli_preview:
-                msg += f" | cli_stderr={cli_preview!r}"
-            logging.getLogger(__name__).warning(msg)
             return RunResult(
                 status=RunStatus.NO_RESULT,
                 stdout=stdout,
                 result=None,
                 error_summary=f"no_ResultMessage last_assistant={preview!r}",
-                captured_stderr=captured,
                 transcript=transcript,
             )
         if result.is_error:
@@ -372,7 +348,6 @@ class SubAgent(BaseModel):
                 stdout=stdout,
                 result=result,
                 error_summary=_sdk_error_summary(result),
-                captured_stderr=captured,
                 transcript=transcript,
             )
         return RunResult(
@@ -380,6 +355,5 @@ class SubAgent(BaseModel):
             stdout=stdout,
             result=result,
             error_summary=None,
-            captured_stderr=captured,
             transcript=transcript,
         )

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -220,9 +220,13 @@ class TestCliStderrCapture(unittest.TestCase):
     reason vanished into the parent's inherited stderr and we could not
     diagnose the intermittent failures breaking the cycle loop.
 
-    These tests verify that ``_run_claude_p`` now attaches a stderr sink
-    and surfaces the captured lines in both the logged message and the
-    returned ``CompletedProcess.stderr``.
+    The sink is wired by the back-compat ``_run_claude_p`` facade
+    itself — :class:`~cai_lib.subagent.core.SubAgent` does no stderr
+    capture, since SDK-native callers read structured fields off
+    :class:`~cai_lib.subagent.core.RunResult` instead.
+
+    These tests verify that ``_run_claude_p`` still surfaces the
+    captured CLI tail in the returned ``CompletedProcess.stderr``.
     """
 
     def test_exception_path_includes_captured_cli_stderr(self):
@@ -248,8 +252,8 @@ class TestCliStderrCapture(unittest.TestCase):
             )
             yield  # pragma: no cover — make it an async generator
 
-        with self.assertLogs("cai_lib.subagent.core", level="WARNING") as cm:
-            with patch.object(core, "query", _fake_query):
+        with patch.object(core, "query", _fake_query):
+            with patch("builtins.print"):
                 proc = _run_claude_p(
                     ["claude", "-p", "--agent", "cai-implement"],
                     category="implement", agent="cai-implement",
@@ -259,11 +263,6 @@ class TestCliStderrCapture(unittest.TestCase):
         self.assertIn("unexpected end of stream", proc.stderr)
         self.assertIn("cli.js:42", proc.stderr)
         self.assertIn("--- cli stderr ---", proc.stderr)
-        # Log line must also mention cli_stderr=... so grepping the
-        # wrapper's own log surfaces the real cause.
-        log_text = "\n".join(cm.output)
-        self.assertIn("cli_stderr=", log_text)
-        self.assertIn("unexpected end of stream", log_text)
 
     def test_exception_without_captured_stderr_falls_back(self):
         """When the CLI emitted no stderr, behaviour matches the pre-#1 contract."""


### PR DESCRIPTION
## Summary

The CLI stderr-capture sink is back-compat-only — it exists to populate `_run_claude_p`'s `CompletedProcess.stderr`. SDK-native callers read `error_summary` / `status` off `RunResult` and never inspect raw CLI stderr. Moves the sink wiring from `SubAgent` into `claude_argv.py`, where it belongs.

- Drop `SubAgent.last_captured_stderr` and `RunResult.captured_stderr`.
- `SubAgent._prepare_options` is now a no-op subclass hook (only `CaiSubAgent` overrides it for cli_path/plugin pin).
- `_to_run_result` log warnings no longer carry a `cli_stderr=...` suffix on EXCEPTION/NO_RESULT — SDK-native callers never had a use for it.
- `_run_claude_p` allocates the buffer locally, attaches `options.stderr = _make_stderr_sink(buf)` before driving the SDK, and threads `buf` into `_to_completed_process`.

`CompletedProcess.stderr` contract for back-compat callers is unchanged.

## Test plan

- [x] `pytest tests/test_subprocess_utils.py` — 28 passed
- [x] Full unittest suite — 761 passed (1 pre-existing lint failure on origin/main, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)