### PR TITLE
Add GrepGuardrailAsRetry to interrupt zero-result grep loops

### DIFF
--- a/src/cai/agents/loader.py
+++ b/src/cai/agents/loader.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 __all__ = [
     "AGENT_DIR",
+    "GrepGuardrailAsRetry",
     "ModelRequestErrorAsRetry",
     "TOOL_FACTORIES",
     "TOOL_FLAGS",
@@ -78,6 +79,58 @@ class ToolErrorAsRetry(AbstractCapability):
             f"Tool {call.tool_name!r} raised {type(error).__name__}: {error}. "
             f"Adjust the arguments and try again."
         )
+
+
+class GrepGuardrailAsRetry(AbstractCapability):
+    """Break the model out of a repeated zero-result ``grep`` loop.
+
+    Models sometimes spiral on minor regex variations that all return
+    zero matches, burning context without progress. After
+    ``_THRESHOLD`` consecutive empty grep results, raise ``ModelRetry``
+    so the agent gets a recovery prompt telling it to stop searching
+    globally. Any non-empty grep result resets the counter, so a single
+    productive search clears the streak.
+
+    State lives on the instance, but ``for_run`` returns a fresh
+    instance per run so concurrent runs of the same agent don't share
+    the counter.
+    """
+
+    _THRESHOLD = 3
+    _NO_MATCH_PREFIX = "No matches for"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._empty_grep_count = 0
+
+    async def for_run(self, ctx: Any) -> "GrepGuardrailAsRetry":
+        return GrepGuardrailAsRetry()
+
+    async def after_tool_execute(
+        self,
+        ctx: Any,
+        *,
+        call: Any,
+        tool_def: Any,
+        args: Any,
+        result: Any,
+    ) -> Any:
+        if call.tool_name != "grep":
+            return result
+        text = result if isinstance(result, str) else ""
+        stripped = text.strip()
+        is_empty = not stripped or stripped.startswith(self._NO_MATCH_PREFIX)
+        if not is_empty:
+            self._empty_grep_count = 0
+            return result
+        self._empty_grep_count += 1
+        if self._empty_grep_count >= self._THRESHOLD:
+            self._empty_grep_count = 0
+            raise ModelRetry(
+                "Repeated zero-result grep queries detected. "
+                "Stop searching globally and trust your local edits."
+            )
+        return result
 
 
 class ModelRequestErrorAsRetry(AbstractCapability):
@@ -509,7 +562,12 @@ def build_deep_agent(
     # Tool implementations sometimes raise on bad model inputs (invalid
     # glob, malformed regex). Without this capability such a single-call
     # failure aborts the whole run.
-    extra["capabilities"] = [*(extra.get("capabilities") or []), ToolErrorAsRetry(), ModelRequestErrorAsRetry()]
+    extra["capabilities"] = [
+        *(extra.get("capabilities") or []),
+        ToolErrorAsRetry(),
+        ModelRequestErrorAsRetry(),
+        GrepGuardrailAsRetry(),
+    ]
 
     agent = create_deep_agent(
         build_model(config),

--- a/tests/agents/test_loader.py
+++ b/tests/agents/test_loader.py
@@ -1,7 +1,11 @@
+import asyncio
+from types import SimpleNamespace
+
 import pytest
 from pathlib import Path
+from pydantic_ai.exceptions import ModelRetry
 
-from cai.agents.loader import resolve_agent_path
+from cai.agents.loader import GrepGuardrailAsRetry, resolve_agent_path
 
 def test_resolve_agent_path_finds_file(monkeypatch, tmp_path):
     monkeypatch.setattr("cai.agents.loader.AGENT_DIR", tmp_path)
@@ -46,3 +50,85 @@ def test_resolve_agent_path_ambiguous(monkeypatch, tmp_path):
 def test_resolve_agent_path_exported():
     import cai.agents.loader as loader
     assert "resolve_agent_path" in loader.__all__
+
+
+def _grep_call(name="grep"):
+    return SimpleNamespace(tool_name=name)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_grep_guardrail_passes_through_non_grep_tool():
+    cap = GrepGuardrailAsRetry()
+    result = _run(cap.after_tool_execute(
+        None, call=_grep_call("read_file"), tool_def=None, args={}, result="x",
+    ))
+    assert result == "x"
+    assert cap._empty_grep_count == 0
+
+
+def test_grep_guardrail_increments_on_empty_result():
+    cap = GrepGuardrailAsRetry()
+    _run(cap.after_tool_execute(
+        None, call=_grep_call(), tool_def=None, args={},
+        result="No matches for 'foo'",
+    ))
+    assert cap._empty_grep_count == 1
+
+
+def test_grep_guardrail_resets_on_match():
+    cap = GrepGuardrailAsRetry()
+    cap._empty_grep_count = 2
+    _run(cap.after_tool_execute(
+        None, call=_grep_call(), tool_def=None, args={},
+        result="Files containing 'foo':\n  a.py",
+    ))
+    assert cap._empty_grep_count == 0
+
+
+def test_grep_guardrail_raises_at_threshold():
+    cap = GrepGuardrailAsRetry()
+    for _ in range(GrepGuardrailAsRetry._THRESHOLD - 1):
+        _run(cap.after_tool_execute(
+            None, call=_grep_call(), tool_def=None, args={},
+            result="No matches for 'foo'",
+        ))
+    with pytest.raises(ModelRetry, match="Repeated zero-result grep"):
+        _run(cap.after_tool_execute(
+            None, call=_grep_call(), tool_def=None, args={},
+            result="No matches for 'bar'",
+        ))
+    # counter resets after triggering so the next streak starts fresh
+    assert cap._empty_grep_count == 0
+
+
+def test_grep_guardrail_for_run_returns_fresh_instance():
+    cap = GrepGuardrailAsRetry()
+    cap._empty_grep_count = 5
+    fresh = _run(cap.for_run(None))
+    assert fresh is not cap
+    assert fresh._empty_grep_count == 0
+
+
+def test_grep_guardrail_wired_into_build_deep_agent_capabilities(monkeypatch):
+    import cai.agents.loader as loader
+
+    captured: dict = {}
+
+    def fake_create_deep_agent(model, **kwargs):
+        captured["capabilities"] = kwargs.get("capabilities")
+        return object()
+
+    monkeypatch.setattr(
+        "pydantic_deep.create_deep_agent", fake_create_deep_agent
+    )
+    monkeypatch.setattr(loader, "build_model", lambda config: object())
+    monkeypatch.setattr(loader, "_prune_toolsets", lambda agent, requested: None)
+
+    config = {"name": "test-agent", "model": "anthropic/claude-sonnet-4-6"}
+    loader.build_deep_agent(config, "instructions")
+
+    cap_types = [type(c).__name__ for c in captured["capabilities"]]
+    assert "GrepGuardrailAsRetry" in cap_types


### PR DESCRIPTION
## Summary
- Add `GrepGuardrailAsRetry` capability in `src/cai/agents/loader.py` that tracks consecutive empty `grep` results and raises `ModelRetry` after 3 in a row, telling the model to stop searching globally and trust local edits.
- Per-run state isolation via `for_run` so concurrent runs of the same agent don't share the counter.
- Wired into `build_deep_agent` alongside `ToolErrorAsRetry` and `ModelRequestErrorAsRetry`.

Closes #1456

## Test plan
- [x] `pytest tests/agents/test_loader.py` — 11 tests pass, covering threshold, reset on match, non-grep passthrough, fresh-instance per run, and wiring into `build_deep_agent`.
- [x] `pytest tests/` — full suite (67 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)