### PR TITLE
Strip cai:raised from refine sub-issues after the first

### DIFF
--- a/src/cai/workflows/refine.py
+++ b/src/cai/workflows/refine.py
@@ -63,9 +63,11 @@ class RefineNode(BaseNode[IssueState]):
         push(state.bot, json_path)
 
         assert new_meta.number is not None
-        labels = list(new_meta.labels)
+        parent_labels = list(new_meta.labels)
+        followup_labels = [lbl for lbl in parent_labels if lbl != "cai:raised"]
         for idx, sub_title in enumerate(out.sub_issues):
-            sub_meta = IssueMeta(repo=new_meta.repo, title=sub_title, labels=labels)
+            sub_labels = parent_labels if idx == 0 else followup_labels
+            sub_meta = IssueMeta(repo=new_meta.repo, title=sub_title, labels=sub_labels)
             sub_base = state.body_path.parent / f"sub_issue_{idx}"
             sub_json = sub_base.with_suffix(".json")
             sub_md = sub_base.with_suffix(".md")

--- a/tests/workflows/test_refine.py
+++ b/tests/workflows/test_refine.py
@@ -48,8 +48,8 @@ def _run(node, state):
 @patch("cai.workflows.refine.add_sub_issue")
 @patch("cai.workflows.refine.push")
 @patch("cai.workflows.refine.refine_agent")
-def test_sub_issues_inherit_parent_labels(mock_agent_factory, mock_push, mock_add_sub_issue, state, tmp_path):
-    """Each sub-issue IssueMeta should receive the parent's labels."""
+def test_only_first_sub_issue_gets_cai_raised(mock_agent_factory, mock_push, mock_add_sub_issue, state, tmp_path):
+    """Only the first sub-issue inherits ``cai:raised``; followups have it stripped."""
     # Set up the agent mock to return two sub-issues
     agent_instance = MagicMock()
     mock_agent_factory.return_value = agent_instance
@@ -92,14 +92,14 @@ def test_sub_issues_inherit_parent_labels(mock_agent_factory, mock_push, mock_ad
     meta_1 = IssueMeta.model_validate_json(sub_json_1.read_text())
 
     assert meta_0.labels == ["cai:raised"]
-    assert meta_1.labels == ["cai:raised"]
+    assert meta_1.labels == []
 
 
 @patch("cai.workflows.refine.add_sub_issue")
 @patch("cai.workflows.refine.push")
 @patch("cai.workflows.refine.refine_agent")
-def test_sub_issues_inherit_all_parent_labels(mock_agent_factory, mock_push, mock_add_sub_issue, tmp_path):
-    """Sub-issues inherit multiple labels from the parent."""
+def test_followup_sub_issues_drop_cai_raised_but_keep_other_labels(mock_agent_factory, mock_push, mock_add_sub_issue, tmp_path):
+    """First sub-issue keeps all parent labels; followups keep everything except ``cai:raised``."""
     body = tmp_path / "42.md"
     body.write_text("## Issue body\n")
     meta = IssueMeta(
@@ -149,10 +149,11 @@ def test_sub_issues_inherit_all_parent_labels(mock_agent_factory, mock_push, moc
 
     assert isinstance(result, End)
 
-    for i in range(3):
-        sub_json = tmp_path / f"sub_issue_{i}.json"
-        sub_meta = IssueMeta.model_validate_json(sub_json.read_text())
-        assert sub_meta.labels == ["cai:raised", "bug", "priority:high"]
+    sub_meta_0 = IssueMeta.model_validate_json((tmp_path / "sub_issue_0.json").read_text())
+    assert sub_meta_0.labels == ["cai:raised", "bug", "priority:high"]
+    for i in (1, 2):
+        sub_meta = IssueMeta.model_validate_json((tmp_path / f"sub_issue_{i}.json").read_text())
+        assert sub_meta.labels == ["bug", "priority:high"]
 
 
 @patch("cai.workflows.refine.add_sub_issue")


### PR DESCRIPTION
## Summary
- Refine fans out into N sub-issues, all inheriting the parent's labels — including `cai:raised` — so cai-solve was triggered on every sub-issue at once.
- Keep `cai:raised` on `sub_issue_0` only; followups inherit the rest of the parent labels but are queued until explicitly raised.

## Test plan
- [x] `pytest tests/workflows/test_refine.py`
- Updated tests assert: first sub keeps `cai:raised`, followups drop it but keep other parent labels (e.g. `bug`, `priority:high`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)